### PR TITLE
Add Escape key functionality to hide app to system tray

### DIFF
--- a/src/accessiweather/gui/weather_app_handlers.py
+++ b/src/accessiweather/gui/weather_app_handlers.py
@@ -81,9 +81,18 @@ class WeatherAppHandlers:
             event: Key event
         """
         # Handle key events for accessibility
-        # For example, F5 to refresh
-        if event.GetKeyCode() == wx.WXK_F5:
+        key_code = event.GetKeyCode()
+
+        if key_code == wx.WXK_F5:
+            # F5 to refresh
             self.OnRefresh(event)
+        elif key_code == wx.WXK_ESCAPE:
+            # Escape to hide to system tray
+            logger.debug("Escape key pressed, hiding to system tray")
+            if hasattr(self, "taskbar_icon") and self.taskbar_icon:
+                self.Hide()
+            else:
+                event.Skip()
         else:
             event.Skip()
 


### PR DESCRIPTION
This PR adds the ability to hide the app to the system tray by pressing the Escape key when the app is focused. This enhances usability by providing a quick keyboard shortcut for minimizing to tray.