### PR TITLE
Change temperature units radio buttons to measurement units dropdown

### DIFF
--- a/src/accessiweather/gui/settings_dialog.py
+++ b/src/accessiweather/gui/settings_dialog.py
@@ -255,18 +255,18 @@ class SettingsDialog(wx.Dialog):
         grid_sizer = wx.FlexGridSizer(rows=4, cols=2, vgap=10, hgap=5)
         grid_sizer.AddGrowableCol(1, 1)  # Make the input column growable
 
-        # Temperature Unit Selection
-        temp_unit_label = wx.StaticText(panel, label="Temperature Units:")
-        self.temp_unit_ctrl = wx.RadioBox(
+        # Measurement Unit System Selection
+        temp_unit_label = wx.StaticText(panel, label="Measurement Units:")
+        from .ui_components import AccessibleChoice
+
+        self.temp_unit_ctrl = AccessibleChoice(
             panel,
-            label="",
-            choices=["Fahrenheit", "Celsius", "Both"],
-            majorDimension=1,
-            style=wx.RA_SPECIFY_COLS,
-            name="Temperature Units",
+            choices=["Imperial (Fahrenheit)", "Metric (Celsius)", "Both"],
+            label="Measurement Units",
         )
         tooltip_temp_unit = (
-            "Select your preferred temperature unit for display. "
+            "Select your preferred measurement unit system. "
+            "Affects temperature, pressure, wind speed, and other measurements. "
             "'Both' will show temperatures in both Fahrenheit and Celsius."
         )
         self.temp_unit_ctrl.SetToolTip(tooltip_temp_unit)
@@ -435,11 +435,11 @@ class SettingsDialog(wx.Dialog):
             temperature_unit = self.current_settings.get(
                 TEMPERATURE_UNIT_KEY, DEFAULT_TEMPERATURE_UNIT
             )
-            # Set temperature unit radio box
+            # Set temperature unit dropdown
             if temperature_unit == TemperatureUnit.FAHRENHEIT.value:
-                self.temp_unit_ctrl.SetSelection(0)  # Fahrenheit
+                self.temp_unit_ctrl.SetSelection(0)  # Imperial (Fahrenheit)
             elif temperature_unit == TemperatureUnit.CELSIUS.value:
-                self.temp_unit_ctrl.SetSelection(1)  # Celsius
+                self.temp_unit_ctrl.SetSelection(1)  # Metric (Celsius)
             elif temperature_unit == TemperatureUnit.BOTH.value:
                 self.temp_unit_ctrl.SetSelection(2)  # Both
             else:

--- a/tests/test_settings_dialog_display_tab.py
+++ b/tests/test_settings_dialog_display_tab.py
@@ -48,18 +48,18 @@ class TestSettingsDialogDisplayTab:
         # Get the index of the Display tab
         display_tab_index = page_names.index("Display")
 
-        # Check that the Display tab has the temperature unit control
+        # Check that the Display tab has the measurement unit control
         display_panel = settings_dialog.notebook.GetPage(display_tab_index)
         temp_unit_ctrl = None
         for child in display_panel.GetChildren():
-            if isinstance(child, wx.RadioBox) and child.GetName() == "Temperature Units":
+            if isinstance(child, wx.Choice) and child.GetName() == "Measurement Units":
                 temp_unit_ctrl = child
                 break
 
         assert temp_unit_ctrl is not None
         assert temp_unit_ctrl.GetCount() == 3
-        assert temp_unit_ctrl.GetString(0) == "Fahrenheit"
-        assert temp_unit_ctrl.GetString(1) == "Celsius"
+        assert temp_unit_ctrl.GetString(0) == "Imperial (Fahrenheit)"
+        assert temp_unit_ctrl.GetString(1) == "Metric (Celsius)"
         assert temp_unit_ctrl.GetString(2) == "Both"
 
     def test_load_fahrenheit_setting(self, settings_dialog):


### PR DESCRIPTION
This PR changes the temperature units radio buttons in the settings dialog to a measurement units dropdown. The dropdown now clearly indicates that it's selecting a measurement system (Imperial, Metric, or Both) rather than just temperature units, since this setting affects all measurements in the application.