### PR TITLE
Clean main branch: Remove dev commits and keep only essential workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,365 @@
+name: Build and Package
+
+on:
+  push:
+    branches: [ main, dev ]
+  workflow_dispatch:
+    inputs:
+      version_override:
+        description: 'Override version (optional)'
+        required: false
+        type: string
+      skip_cache:
+        description: 'Skip build cache'
+        required: false
+        type: boolean
+        default: false
+  workflow_run:
+    workflows: ["Continuous Integration"]
+    types:
+      - completed
+    branches: [ main, dev ]
+
+env:
+  # Build configuration
+  PYTHON_VERSION: "3.12"
+  PYINSTALLER_CACHE_DIR: "~/.cache/pyinstaller"
+
+jobs:
+  build:
+    name: Build Windows Application
+    runs-on: windows-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'push' }}
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch full history for build metadata
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Cache pip dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-build-pip-${{ hashFiles('**/requirements*.txt', '**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-build-pip-
+
+    - name: Cache PyInstaller build cache
+      uses: actions/cache@v3
+      if: ${{ !github.event.inputs.skip_cache }}
+      with:
+        path: |
+          ${{ env.PYINSTALLER_CACHE_DIR }}
+          build/
+          *.toc
+        key: ${{ runner.os }}-pyinstaller-${{ hashFiles('src/**/*.py', 'AccessiWeather.spec') }}
+        restore-keys: |
+          ${{ runner.os }}-pyinstaller-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+        pip install PyInstaller
+
+    - name: Extract version
+      id: version
+      run: |
+        if [ -n "${{ github.event.inputs.version_override }}" ]; then
+          VERSION="${{ github.event.inputs.version_override }}"
+          # Remove 'v' prefix if present
+          VERSION=${VERSION#v}
+        else
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+        fi
+
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Building version: $VERSION"
+      shell: bash
+
+    - name: Update version files
+      run: |
+        VERSION="${{ steps.version.outputs.version }}"
+
+        # Update version.py with current version
+        sed -i "s/__version__ = \"[^\"]*\"/__version__ = \"$VERSION\"/" src/accessiweather/version.py
+
+        echo "Updated version to: $VERSION"
+      shell: bash
+
+    - name: Build with PyInstaller
+      run: |
+        if (Test-Path "AccessiWeather.spec") {
+          Write-Host "Using spec file: AccessiWeather.spec"
+          python -m PyInstaller --clean --noconfirm AccessiWeather.spec
+        } else {
+          Write-Host "Building with command line arguments"
+          python -m PyInstaller --clean --noconfirm --onedir --windowed --name AccessiWeather `
+            --hidden-import=plyer.platforms.win.notification `
+            --hidden-import=dateutil.parser `
+            --hidden-import=httpx `
+            --hidden-import=attrs `
+            --exclude-module=IPython `
+            --exclude-module=jedi `
+            --exclude-module=parso `
+            --exclude-module=black `
+            --exclude-module=mypy `
+            --exclude-module=django `
+            --exclude-module=Django `
+            --exclude-module=rapidfuzz `
+            src/accessiweather/main.py
+        }
+
+    - name: Verify build
+      run: |
+        if (Test-Path "dist/AccessiWeather/AccessiWeather.exe") {
+          Write-Host "Build successful - executable found"
+          Get-ChildItem "dist/AccessiWeather" | Select-Object Name, Length
+        } else {
+          Write-Host "Build failed - executable not found"
+          exit 1
+        }
+
+    - name: Create portable ZIP
+      run: |
+        $VERSION = "${{ steps.version.outputs.version }}"
+        $ZipName = "AccessiWeather_Portable_v$VERSION.zip"
+        Compress-Archive -Path "dist/AccessiWeather/*" -DestinationPath "dist/$ZipName" -Force
+        Write-Host "Created portable archive: $ZipName"
+
+    - name: Generate checksums
+      run: |
+        $VERSION = "${{ steps.version.outputs.version }}"
+
+        # Generate checksums for artifacts
+        $ExePath = "dist/AccessiWeather/AccessiWeather.exe"
+        $ZipPath = "dist/AccessiWeather_Portable_v$VERSION.zip"
+
+        if (Test-Path $ExePath) {
+          $ExeHash = (Get-FileHash $ExePath -Algorithm SHA256).Hash
+          Write-Host "Executable SHA256: $($ExeHash.Substring(0,16))..."
+        }
+
+        if (Test-Path $ZipPath) {
+          $ZipHash = (Get-FileHash $ZipPath -Algorithm SHA256).Hash
+          Write-Host "Portable ZIP SHA256: $($ZipHash.Substring(0,16))..."
+        }
+
+        # Create simple checksums file
+        $ChecksumsContent = "AccessiWeather v$VERSION - Build Checksums`n`n$ExeHash  AccessiWeather.exe`n$ZipHash  AccessiWeather_Portable_v$VERSION.zip"
+        $ChecksumsContent | Out-File -FilePath "dist/checksums.txt" -Encoding UTF8
+        Write-Host "Checksums saved to checksums.txt"
+
+    - name: Upload portable build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows-portable-${{ steps.version.outputs.version }}
+        path: |
+          dist/AccessiWeather_Portable_v${{ steps.version.outputs.version }}.zip
+          dist/checksums.txt
+        retention-days: 30
+
+    - name: Upload application files for installer
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows-build-${{ steps.version.outputs.version }}
+        path: |
+          dist/AccessiWeather/
+        retention-days: 30
+
+  installer:
+    name: Create Windows Installer
+    runs-on: windows-latest
+    needs: build
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Download portable build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: windows-portable-${{ needs.build.outputs.version }}
+        path: dist/
+
+    - name: Download application files for installer
+      uses: actions/download-artifact@v4
+      with:
+        name: windows-build-${{ needs.build.outputs.version }}
+        path: build-files/
+
+    - name: Copy application files to dist
+      run: |
+        # Copy the application directory for installer creation
+        if (Test-Path "build-files/AccessiWeather") {
+          Copy-Item -Path "build-files/AccessiWeather" -Destination "dist/" -Recurse -Force
+          Write-Host "Copied application files for installer"
+        } else {
+          Write-Host "Warning: Application files not found"
+          Get-ChildItem "build-files/" -Recurse
+        }
+
+    - name: Install Inno Setup
+      run: |
+        # Use chocolatey to install Inno Setup (more reliable)
+        choco install innosetup -y
+
+        # Add Inno Setup to PATH
+        $InnoSetupPath = "${env:ProgramFiles(x86)}\Inno Setup 6"
+        if (Test-Path $InnoSetupPath) {
+          $env:PATH += ";$InnoSetupPath"
+          echo "$InnoSetupPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          Write-Host "Inno Setup installed and added to PATH: $InnoSetupPath"
+        } else {
+          Write-Host "Warning: Inno Setup installation path not found"
+          Get-ChildItem "${env:ProgramFiles(x86)}" -Filter "*Inno*" -Directory
+        }
+
+    - name: Verify Inno Setup installation
+      run: |
+        # Check if iscc.exe is available (help command returns exit code 1, which is normal)
+        try {
+          $output = & iscc.exe /? 2>&1
+          if ($output -match "Inno Setup.*Command-Line Compiler") {
+            Write-Host "✓ Inno Setup compiler verified successfully"
+            Write-Host "Version info: $($output | Select-String 'Inno Setup.*Command-Line Compiler')"
+            exit 0  # Explicitly set success exit code
+          } else {
+            Write-Host "✗ Inno Setup verification failed"
+            exit 1
+          }
+        } catch {
+          Write-Host "✗ Inno Setup not found or not accessible"
+          exit 1
+        }
+
+    - name: Set installer environment variables
+      run: |
+        $VERSION = "${{ needs.build.outputs.version }}"
+
+        # Set environment variables that the Inno Setup script expects
+        echo "ACCESSIWEATHER_VERSION=$VERSION" >> $env:GITHUB_ENV
+        echo "ACCESSIWEATHER_ROOT_DIR=$PWD" >> $env:GITHUB_ENV
+        echo "ACCESSIWEATHER_DIST_DIR=$PWD\dist" >> $env:GITHUB_ENV
+
+        Write-Host "Set installer environment variables:"
+        Write-Host "  ACCESSIWEATHER_VERSION=$VERSION"
+        Write-Host "  ACCESSIWEATHER_ROOT_DIR=$PWD"
+        Write-Host "  ACCESSIWEATHER_DIST_DIR=$PWD\dist"
+
+    - name: Build installer
+      run: |
+        $VERSION = "${{ needs.build.outputs.version }}"
+        $IssFile = "installer/AccessiWeather.iss"
+
+        if (Test-Path $IssFile) {
+          iscc.exe $IssFile
+          Write-Host "Installer build completed"
+
+          # Check if installer was created
+          $InstallerPath = "installer/dist/AccessiWeather_Setup_v$VERSION.exe"
+          if (Test-Path $InstallerPath) {
+            Write-Host "Installer created successfully: $InstallerPath"
+            # Move to main dist directory
+            Move-Item $InstallerPath "dist/AccessiWeather_Setup_v$VERSION.exe"
+          } else {
+            Write-Host "Warning: Installer not found at expected location"
+            Get-ChildItem "installer/" -Recurse -Filter "*.exe"
+          }
+        } else {
+          Write-Host "Skipping installer build - no Inno Setup script found"
+        }
+
+    - name: Generate installer checksum
+      run: |
+        $VERSION = "${{ needs.build.outputs.version }}"
+        $InstallerPath = "dist/AccessiWeather_Setup_v$VERSION.exe"
+
+        if (Test-Path $InstallerPath) {
+          $InstallerHash = (Get-FileHash $InstallerPath -Algorithm SHA256).Hash
+
+          # Add installer checksum to file
+          Add-Content "dist/checksums.txt" "$InstallerHash  AccessiWeather_Setup_v$VERSION.exe"
+
+          Write-Host "Installer checksum added: $($InstallerHash.Substring(0,16))..."
+        }
+
+    - name: Upload installer artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows-installer-${{ needs.build.outputs.version }}
+        path: |
+          dist/AccessiWeather_Setup_v${{ needs.build.outputs.version }}.exe
+          dist/checksums.txt
+        retention-days: 90
+
+  validate:
+    name: Validate Build
+    runs-on: windows-latest
+    needs: [build, installer]
+
+    steps:
+    - name: Download installer artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: windows-installer-${{ needs.build.outputs.version }}
+        path: artifacts/installer/
+
+    - name: Download portable artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: windows-portable-${{ needs.build.outputs.version }}
+        path: artifacts/portable/
+
+    - name: Validate build artifacts
+      run: |
+        $VERSION = "${{ needs.build.outputs.version }}"
+
+        Write-Host "=== Build Validation ==="
+        Write-Host "Version: $VERSION"
+
+        # Check installer artifacts
+        $InstallerFile = "artifacts/installer/AccessiWeather_Setup_v$VERSION.exe"
+        $InstallerChecksums = "artifacts/installer/checksums.txt"
+
+        # Check portable artifacts
+        $PortableFile = "artifacts/portable/AccessiWeather_Portable_v$VERSION.zip"
+        $PortableChecksums = "artifacts/portable/checksums.txt"
+
+        $AllFilesPresent = $true
+
+        Write-Host "Checking installer artifacts:"
+        if (Test-Path $InstallerFile) {
+          $FileSize = (Get-Item $InstallerFile).Length
+          $FileSizeMB = [math]::Round($FileSize / 1MB, 2)
+          Write-Host "✓ AccessiWeather_Setup_v$VERSION.exe ($FileSizeMB MB)"
+        } else {
+          Write-Host "✗ Missing: AccessiWeather_Setup_v$VERSION.exe"
+          $AllFilesPresent = $false
+        }
+
+        Write-Host "Checking portable artifacts:"
+        if (Test-Path $PortableFile) {
+          $FileSize = (Get-Item $PortableFile).Length
+          $FileSizeMB = [math]::Round($FileSize / 1MB, 2)
+          Write-Host "✓ AccessiWeather_Portable_v$VERSION.zip ($FileSizeMB MB)"
+        } else {
+          Write-Host "✗ Missing: AccessiWeather_Portable_v$VERSION.zip"
+          $AllFilesPresent = $false
+        }
+
+        if ($AllFilesPresent) {
+          Write-Host "✅ Build validation successful - separate artifacts created"
+        } else {
+          Write-Host "❌ Build validation failed"
+          exit 1
+        }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,354 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [ main, dev ]
+  pull_request:
+    branches: [ main, dev ]
+  workflow_dispatch:
+
+env:
+  # Quality gate thresholds - relaxed for small open source project
+  MAX_COMPLEXITY: 30
+  SECURITY_SEVERITY_THRESHOLD: "medium"
+
+jobs:
+  test:
+    name: Test Suite
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Cache pip dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt', '**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+        pip install -r requirements-dev.txt
+
+    - name: Set up virtual display for GUI tests
+      run: |
+        # Set environment variable to prevent wxPython from requiring a display
+        echo "DISPLAY=" >> $GITHUB_ENV
+        echo "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1" >> $GITHUB_ENV
+
+    - name: Run unit tests with coverage
+      run: |
+        # Run fast unit tests with coverage, excluding integration tests
+        python -m pytest -m "unit or (not slow and not integration and not e2e and not gui)" -v --tb=short --cov=src/accessiweather --cov-report=xml --cov-report=html --cov-report=term-missing --ignore=tests/test_integration_comprehensive.py --ignore=tests/test_integration_gui.py --ignore=tests/test_integration_performance.py
+      env:
+        # Prevent wxPython from trying to create a display
+        DISPLAY: ""
+        # Disable GUI-related warnings
+        PYTHONPATH: src
+        ACCESSIWEATHER_TEST_MODE: "1"
+
+    - name: Upload coverage reports
+      uses: codecov/codecov-action@v3
+      if: matrix.python-version == '3.12'
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+
+    - name: Upload coverage artifacts
+      uses: actions/upload-artifact@v4
+      if: matrix.python-version == '3.12'
+      with:
+        name: coverage-report-${{ matrix.python-version }}
+        path: htmlcov/
+
+  code-quality:
+    name: Code Quality & Pre-commit Hooks
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
+
+    - name: Cache pip dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-lint-pip-${{ hashFiles('**/requirements*.txt', '**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-lint-pip-
+
+    - name: Install quality tools
+      run: |
+        python -m pip install --upgrade pip
+        pip install pre-commit black isort flake8 mypy radon xenon
+        pip install -e .[dev]
+
+    - name: Run pre-commit hooks (includes black, isort, flake8, mypy)
+      run: |
+        pre-commit install --install-hooks
+        pre-commit run --all-files
+
+    - name: Generate code complexity report
+      run: |
+        # Generate cyclomatic complexity report (excluding auto-generated code)
+        radon cc src/accessiweather --json --exclude="*/weather_gov_api_client/*" > complexity-report.json
+        radon cc src/accessiweather --min C --show-complexity --exclude="*/weather_gov_api_client/*"
+
+        # Check for high complexity functions (excluding auto-generated weather_gov_api_client)
+        # Continue on error for small open source project but still report issues
+        xenon --max-absolute ${{ env.MAX_COMPLEXITY }} --max-modules A --max-average A --exclude="*/weather_gov_api_client/*" src/accessiweather || echo "Complexity check found issues but continuing for small open source project"
+      continue-on-error: true
+
+    - name: Generate maintainability index
+      run: |
+        radon mi src/accessiweather --json > maintainability-report.json
+        radon mi src/accessiweather --show
+
+    - name: Upload quality reports
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: code-quality-reports
+        path: |
+          complexity-report.json
+          maintainability-report.json
+
+  security:
+    name: Security Scan
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
+
+    - name: Cache pip dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-security-pip-${{ hashFiles('**/requirements*.txt', '**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-security-pip-
+
+    - name: Install security scanning tools
+      run: |
+        python -m pip install --upgrade pip
+        pip install bandit safety semgrep pip-audit
+        pip install -e .[dev]
+
+    - name: Run bandit security linting
+      run: |
+        # Generate JSON report for artifacts
+        bandit -r src/accessiweather -f json -o bandit-report.json || true
+
+        # Run bandit with severity threshold (fail on medium+ issues)
+        bandit -r src/accessiweather --severity-level ${{ env.SECURITY_SEVERITY_THRESHOLD }} --confidence-level medium
+      continue-on-error: false
+
+    - name: Run pip-audit for dependency vulnerabilities
+      run: |
+        # Check for known vulnerabilities in dependencies
+        pip-audit --format=json --output=pip-audit-report.json || true
+        pip-audit --desc
+
+    - name: Run safety check for dependency vulnerabilities
+      run: |
+        # Generate JSON report
+        safety check --json --output safety-report.json || true
+
+        # Run safety check (fail on vulnerabilities)
+        safety check --short-report
+      continue-on-error: false
+
+    - name: Run semgrep security analysis
+      run: |
+        # Run semgrep with security rules
+        semgrep --config=auto --json --output=semgrep-report.json src/accessiweather || true
+        semgrep --config=auto --error src/accessiweather
+      continue-on-error: false
+
+    - name: Upload security reports
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: security-reports
+        path: |
+          bandit-report.json
+          safety-report.json
+          pip-audit-report.json
+          semgrep-report.json
+
+  integration:
+    name: Integration Tests
+    runs-on: windows-latest
+    needs: [test, code-quality]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+        pip install -r requirements-dev.txt
+
+    - name: Run integration tests
+      run: |
+        # Run comprehensive integration test suite
+        python -m pytest tests/test_integration_comprehensive.py -v --tb=short --maxfail=5
+      env:
+        # Prevent wxPython from trying to create a display
+        DISPLAY: ""
+        PYTHONPATH: src
+        ACCESSIWEATHER_TEST_MODE: "1"
+
+    - name: Run GUI integration tests (headless)
+      run: |
+        # Run GUI integration tests in headless mode
+        python -m pytest tests/test_integration_gui.py -v --tb=short --maxfail=3
+      env:
+        DISPLAY: ""
+        PYTHONPATH: src
+        ACCESSIWEATHER_TEST_MODE: "1"
+      continue-on-error: true  # GUI tests may be flaky in CI
+
+    - name: Run performance integration tests
+      run: |
+        # Run performance integration tests (subset for CI)
+        python -m pytest tests/test_integration_performance.py -v --tb=short --maxfail=3
+      env:
+        DISPLAY: ""
+        PYTHONPATH: src
+        ACCESSIWEATHER_TEST_MODE: "1"
+
+    - name: Run comprehensive integration test suite
+      run: |
+        # Run our custom integration test runner for comprehensive reporting
+        python tests/run_integration_tests.py --type comprehensive --no-coverage --quiet
+      env:
+        DISPLAY: ""
+        PYTHONPATH: src
+        ACCESSIWEATHER_TEST_MODE: "1"
+      continue-on-error: true  # Don't fail CI if integration tests have issues
+
+    - name: Test application startup (headless)
+      run: |
+        # Test import without creating GUI
+        python -c "
+        import os
+        os.environ['DISPLAY'] = ''
+        try:
+            import src.accessiweather.main
+            print('[OK] Application imports successfully')
+        except Exception as e:
+            print(f'[ERROR] Import failed: {e}')
+            raise
+        "
+      env:
+        DISPLAY: ""
+        PYTHONPATH: src
+
+  smoke:
+    name: Smoke Tests
+    runs-on: windows-latest
+    needs: [test]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+
+    - name: Run smoke tests
+      run: |
+        python -m pytest -m "smoke" -v --tb=short
+      env:
+        DISPLAY: ""
+        PYTHONPATH: src
+        ACCESSIWEATHER_TEST_MODE: "1"
+
+  quality-gate:
+    name: Quality Gate
+    runs-on: windows-latest
+    needs: [test, code-quality, security, integration, smoke]
+    if: always()
+
+    steps:
+    - name: Check all jobs status
+      run: |
+        echo "Test job status: ${{ needs.test.result }}"
+        echo "Code Quality job status: ${{ needs.code-quality.result }}"
+        echo "Security job status: ${{ needs.security.result }}"
+        echo "Integration job status: ${{ needs.integration.result }}"
+        echo "Smoke job status: ${{ needs.smoke.result }}"
+
+        if [ "${{ needs.test.result }}" != "success" ] ||
+           [ "${{ needs.code-quality.result }}" != "success" ] ||
+           [ "${{ needs.security.result }}" != "success" ] ||
+           [ "${{ needs.integration.result }}" != "success" ] ||
+           [ "${{ needs.smoke.result }}" != "success" ]; then
+          echo "Quality gate failed - one or more checks did not pass"
+          exit 1
+        fi
+
+        echo "Quality gate passed - all checks successful"
+      shell: bash
+
+    - name: Generate quality summary report
+      run: |
+        echo "# Quality Gate Summary" > quality-summary.md
+        echo "" >> quality-summary.md
+        echo "## Job Results" >> quality-summary.md
+        echo "- **Test Suite**: ${{ needs.test.result }}" >> quality-summary.md
+        echo "- **Code Quality**: ${{ needs.code-quality.result }}" >> quality-summary.md
+        echo "- **Security Scan**: ${{ needs.security.result }}" >> quality-summary.md
+        echo "- **Integration Tests**: ${{ needs.integration.result }}" >> quality-summary.md
+        echo "- **Smoke Tests**: ${{ needs.smoke.result }}" >> quality-summary.md
+        echo "" >> quality-summary.md
+        echo "## Quality Thresholds" >> quality-summary.md
+        echo "- **Maximum Complexity**: ${{ env.MAX_COMPLEXITY }}" >> quality-summary.md
+        echo "- **Security Severity**: ${{ env.SECURITY_SEVERITY_THRESHOLD }}+" >> quality-summary.md
+
+    - name: Upload quality summary
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: quality-gate-summary
+        path: quality-summary.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,263 @@
+name: Release
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '.gitignore'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., v1.0.0)'
+        required: true
+        type: string
+      prerelease:
+        description: 'Mark as pre-release'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  check-version:
+    name: Check Version
+    runs-on: windows-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      should_release: ${{ steps.check.outputs.should_release }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch all history for version comparison
+
+    - name: Extract version
+      id: version
+      run: |
+        if [ -n "${{ github.event.inputs.version }}" ]; then
+          VERSION="${{ github.event.inputs.version }}"
+          # Remove 'v' prefix if present
+          VERSION=${VERSION#v}
+        else
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+        fi
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Detected version: $VERSION"
+      shell: bash
+
+    - name: Check if version already released
+      id: check
+      run: |
+        VERSION="${{ steps.version.outputs.version }}"
+
+        # Check if tag already exists
+        if git tag -l | grep -q "^v$VERSION$"; then
+          echo "Version v$VERSION already exists as a tag"
+          echo "should_release=false" >> $GITHUB_OUTPUT
+        else
+          echo "Version v$VERSION is new"
+          echo "should_release=true" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+
+  build-for-release:
+    name: Build Release Artifacts
+    runs-on: windows-latest
+    needs: check-version
+    if: needs.check-version.outputs.should_release == 'true'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+        pip install PyInstaller
+
+    - name: Build application
+      run: |
+        VERSION="${{ needs.check-version.outputs.version }}"
+
+        # Update version in files
+        sed -i "s/version=\"[^\"]*\"/version=\"$VERSION\"/" setup.py
+        sed -i "s/__version__ = \"[^\"]*\"/__version__ = \"$VERSION\"/" src/accessiweather/version.py
+
+        # Build with PyInstaller
+        if (Test-Path "AccessiWeather.spec") {
+          python -m PyInstaller --clean --noconfirm AccessiWeather.spec
+        } else {
+          python -m PyInstaller --clean --noconfirm --onedir --windowed --name AccessiWeather `
+            --hidden-import=plyer.platforms.win.notification `
+            --hidden-import=dateutil.parser `
+            --hidden-import=httpx `
+            --hidden-import=attrs `
+            --exclude-module=IPython `
+            --exclude-module=jedi `
+            --exclude-module=parso `
+            --exclude-module=black `
+            --exclude-module=mypy `
+            --exclude-module=django `
+            --exclude-module=Django `
+            --exclude-module=rapidfuzz `
+            src/accessiweather/main.py
+        }
+
+        # Create portable ZIP
+        Compress-Archive -Path "dist/AccessiWeather/*" -DestinationPath "dist/AccessiWeather_Portable_v$VERSION.zip" -Force
+      shell: pwsh
+
+    - name: Install Inno Setup and build installer
+      run: |
+        # Install Inno Setup
+        $InnoSetupUrl = "https://jrsoftware.org/download.php/is.exe"
+        Invoke-WebRequest -Uri $InnoSetupUrl -OutFile "innosetup.exe"
+        Start-Process -FilePath "innosetup.exe" -ArgumentList "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART" -Wait
+
+        # Add to PATH
+        $InnoSetupPath = "${env:ProgramFiles(x86)}\Inno Setup 6"
+        $env:PATH += ";$InnoSetupPath"
+
+        # Build installer
+        $VERSION = "${{ needs.check-version.outputs.version }}"
+        $IssFile = "installer/AccessiWeather.iss"
+
+        if (Test-Path $IssFile) {
+          (Get-Content $IssFile) -replace '#define MyAppVersion ".*"', "#define MyAppVersion `"$VERSION`"" | Set-Content $IssFile
+          & "$InnoSetupPath\iscc.exe" $IssFile
+
+          # Move installer to dist directory
+          $InstallerSource = "installer/dist/AccessiWeather_Setup_v$VERSION.exe"
+          if (Test-Path $InstallerSource) {
+            Move-Item $InstallerSource "dist/AccessiWeather_Setup_v$VERSION.exe"
+          }
+        }
+
+    - name: Generate checksums
+      run: |
+        $VERSION = "${{ needs.check-version.outputs.version }}"
+
+        # Generate SHA256 checksums
+        $Files = @(
+          "dist/AccessiWeather_Setup_v$VERSION.exe",
+          "dist/AccessiWeather_Portable_v$VERSION.zip"
+        )
+
+        $ChecksumFile = "dist/checksums.txt"
+        foreach ($File in $Files) {
+          if (Test-Path $File) {
+            $Hash = Get-FileHash -Path $File -Algorithm SHA256
+            $FileName = Split-Path $File -Leaf
+            "$($Hash.Hash)  $FileName" | Add-Content $ChecksumFile
+          }
+        }
+
+        Write-Host "Generated checksums:"
+        Get-Content $ChecksumFile
+
+    - name: Upload release artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: release-artifacts-${{ needs.check-version.outputs.version }}
+        path: |
+          dist/AccessiWeather_Setup_v${{ needs.check-version.outputs.version }}.exe
+          dist/AccessiWeather_Portable_v${{ needs.check-version.outputs.version }}.zip
+          dist/checksums.txt
+        retention-days: 365
+
+  create-release:
+    name: Create GitHub Release
+    runs-on: windows-latest
+    needs: [check-version, build-for-release]
+    if: needs.check-version.outputs.should_release == 'true'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Download release artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: release-artifacts-${{ needs.check-version.outputs.version }}
+        path: release-assets/
+
+    - name: Generate release notes
+      id: release_notes
+      run: |
+        VERSION="${{ needs.check-version.outputs.version }}"
+
+        # Create release notes
+        cat > release_notes.md << EOF
+        # AccessiWeather v$VERSION
+
+        ## What's New
+
+        This release includes improvements and bug fixes for AccessiWeather.
+
+        ## Downloads
+
+        - **Windows Installer**: \`AccessiWeather_Setup_v$VERSION.exe\`
+        - **Portable Version**: \`AccessiWeather_Portable_v$VERSION.zip\`
+
+        ## Installation
+
+        ### Windows Installer
+        1. Download \`AccessiWeather_Setup_v$VERSION.exe\`
+        2. Run the installer and follow the setup wizard
+        3. Launch AccessiWeather from the Start Menu
+
+        ### Portable Version
+        1. Download \`AccessiWeather_Portable_v$VERSION.zip\`
+        2. Extract to your desired location
+        3. Run \`AccessiWeather.exe\` from the extracted folder
+
+        ## Checksums
+
+        \`\`\`
+        $(cat release-assets/checksums.txt)
+        \`\`\`
+
+        ## System Requirements
+
+        - Windows 10 or later
+        - Internet connection for weather data
+
+        ---
+
+        For support and documentation, visit the [AccessiWeather repository](https://github.com/Orinks/AccessiWeather).
+        EOF
+
+        echo "Generated release notes:"
+        cat release_notes.md
+      shell: bash
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: v${{ needs.check-version.outputs.version }}
+        name: AccessiWeather v${{ needs.check-version.outputs.version }}
+        body_path: release_notes.md
+        files: |
+          release-assets/AccessiWeather_Setup_v${{ needs.check-version.outputs.version }}.exe
+          release-assets/AccessiWeather_Portable_v${{ needs.check-version.outputs.version }}.zip
+          release-assets/checksums.txt
+        prerelease: ${{ github.event.inputs.prerelease || false }}
+        draft: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Notify release completion
+      run: |
+        VERSION="${{ needs.check-version.outputs.version }}"
+        echo "✅ Successfully created release v$VERSION"
+        echo "🔗 Release URL: https://github.com/${{ github.repository }}/releases/tag/v$VERSION"

--- a/.github/workflows/update-pages.yml
+++ b/.github/workflows/update-pages.yml
@@ -1,0 +1,194 @@
+name: Update GitHub Pages
+
+on:
+  workflow_run:
+    workflows: ["Build and Package"]
+    types:
+      - completed
+    branches: [ main, dev ]
+  workflow_dispatch:
+    inputs:
+      force_update:
+        description: 'Force update pages'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  update-build-info:
+    name: Update Build Information
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
+
+    - name: Get latest build information
+      id: build-info
+      run: |
+        # Get latest successful workflow runs for main and dev branches
+        echo "Fetching build information..."
+
+        # Function to get latest successful run info
+        get_build_info() {
+          local branch=$1
+          local run_info=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/build.yml/runs?branch=${branch}&status=success&per_page=1")
+
+          local run_id=$(echo "$run_info" | jq -r '.workflow_runs[0].id // empty')
+          local run_date=$(echo "$run_info" | jq -r '.workflow_runs[0].created_at // empty')
+          local commit_sha=$(echo "$run_info" | jq -r '.workflow_runs[0].head_sha // empty')
+
+          if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
+            # Get artifacts for this run
+            local artifacts=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/runs/${run_id}/artifacts")
+
+            # Extract version from artifact name (assumes format: windows-installer-X.Y.Z)
+            local version=$(echo "$artifacts" | jq -r '.artifacts[] | select(.name | startswith("windows-installer-")) | .name' | sed 's/windows-installer-//')
+
+            if [ -z "$version" ] || [ "$version" = "null" ]; then
+              # Fallback: try to get version from pyproject.toml
+              version=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])" 2>/dev/null || echo "unknown")
+            fi
+
+            echo "${branch}_version=${version}"
+            echo "${branch}_date=${run_date}"
+            echo "${branch}_run_id=${run_id}"
+            echo "${branch}_commit=${commit_sha}"
+          else
+            echo "${branch}_version=No builds available"
+            echo "${branch}_date=N/A"
+            echo "${branch}_run_id="
+            echo "${branch}_commit="
+          fi
+        }
+
+        # Get info for both branches
+        get_build_info "main" >> $GITHUB_OUTPUT
+        get_build_info "dev" >> $GITHUB_OUTPUT
+
+    - name: Generate build info JSON
+      run: |
+        # Create build-info.json for the website
+        cat > docs/build-info.json << EOF
+        {
+          "main": {
+            "version": "${{ steps.build-info.outputs.main_version }}",
+            "date": "${{ steps.build-info.outputs.main_date }}",
+            "commit": "${{ steps.build-info.outputs.main_commit }}",
+            "installerUrl": "https://nightly.link/Orinks/AccessiWeather/workflows/build/main/windows-installer-${{ steps.build-info.outputs.main_version }}.zip",
+            "portableUrl": "https://nightly.link/Orinks/AccessiWeather/workflows/build/main/windows-portable-${{ steps.build-info.outputs.main_version }}.zip"
+          },
+          "dev": {
+            "version": "${{ steps.build-info.outputs.dev_version }}",
+            "date": "${{ steps.build-info.outputs.dev_date }}",
+            "commit": "${{ steps.build-info.outputs.dev_commit }}",
+            "installerUrl": "https://nightly.link/Orinks/AccessiWeather/workflows/build/dev/windows-installer-${{ steps.build-info.outputs.dev_version }}.zip",
+            "portableUrl": "https://nightly.link/Orinks/AccessiWeather/workflows/build/dev/windows-portable-${{ steps.build-info.outputs.dev_version }}.zip"
+          },
+          "lastUpdated": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+        }
+        EOF
+
+        echo "Generated build-info.json:"
+        cat docs/build-info.json
+
+    - name: Create nightly.link URLs documentation
+      run: |
+        cat > docs/download-links.md << 'EOF'
+        # AccessiWeather Download Links
+
+        ## Stable Release (Main Branch)
+
+        ### Direct Downloads:
+        - **Installer**: https://nightly.link/Orinks/AccessiWeather/workflows/build/main/windows-installer-${{ steps.build-info.outputs.main_version }}.zip
+        - **Portable**: https://nightly.link/Orinks/AccessiWeather/workflows/build/main/windows-portable-${{ steps.build-info.outputs.main_version }}.zip
+
+        ## Development Release (Dev Branch)
+
+        ### Direct Downloads:
+        - **Installer**: https://nightly.link/Orinks/AccessiWeather/workflows/build/dev/windows-installer-${{ steps.build-info.outputs.dev_version }}.zip
+        - **Portable**: https://nightly.link/Orinks/AccessiWeather/workflows/build/dev/windows-portable-${{ steps.build-info.outputs.dev_version }}.zip
+
+        ## How to Use
+
+        1. Choose your preferred download:
+           - **Installer**: Download and run for guided installation
+           - **Portable**: Download and extract for no-install usage
+        2. No GitHub login required for public downloads
+        3. Links always point to the latest successful build
+        4. Each download is a separate, focused package
+
+        ## Build Information
+
+        - **Main Version**: ${{ steps.build-info.outputs.main_version }}
+        - **Main Build Date**: ${{ steps.build-info.outputs.main_date }}
+        - **Dev Version**: ${{ steps.build-info.outputs.dev_version }}
+        - **Dev Build Date**: ${{ steps.build-info.outputs.dev_date }}
+        - **Last Updated**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+
+        EOF
+
+    - name: Commit and push changes
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+
+        # Check if there are changes to commit
+        if git diff --quiet docs/build-info.json docs/download-links.md; then
+          echo "No changes to commit"
+        else
+          git add docs/build-info.json docs/download-links.md
+          git commit -m "Update build information and download links
+
+          - Main: ${{ steps.build-info.outputs.main_version }} (${{ steps.build-info.outputs.main_date }})
+          - Dev: ${{ steps.build-info.outputs.dev_version }} (${{ steps.build-info.outputs.dev_date }})"
+          git push
+        fi
+
+  deploy-pages:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: update-build-info
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref }}
+
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: './docs'
+
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Purpose
This PR cleans up the main branch by removing 56 commits that came from dev branch and shouldn't be on main.

## What This Does
- **Resets main branch to commit 25d688e** (the last clean main commit)
- **Restores only essential GitHub Actions workflows**:
  - `build.yml` - For building and packaging releases
  - `ci.yml` - For continuous integration testing  
  - `release.yml` - For creating releases
  - `update-pages.yml` - For updating GitHub Pages with build information

## What This Removes
- 56 commits that were merged from dev branch inappropriately
- Extra workflow files that aren't needed on main (like `pages.yml`, `test-nightly-link.yml`)
- All the dev branch content that shouldn't be on main

## Result
- **Clean main branch** with proper separation from dev
- **Essential automation preserved** - builds, releases, CI, and GitHub Pages will continue working
- **Proper branch hygiene** - main will only contain stable release content

## Safety
- All essential workflows have been backed up and restored
- GitHub Pages workflow will continue to work for main branch builds
- No functionality will be lost

This is necessary to maintain proper branch separation and prevent main from having dev commits.