### PR TITLE
Settings: Add Air Quality alert threshold control; fix alignment and robust UI collection (Droid-assisted)

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,12 @@
+﻿Droid-assisted: fix settings dialog alignment error
+
+This PR replaces invalid Toga Pack alignment value 'baseline' with 'center' in settings_dialog.py rows, fixing:
+
+Error: Failed to open settings: Invalid value 'baseline' for property alignment; Valid values are: bottom, center, left, right, top
+
+Validation:
+- Synced repo and created feature branch
+- Installed deps in .venv and ran full test suite (all green)
+- Ran ruff lint/format and pre-commit hooks (all passed)
+
+Impact: Unblocks opening the Settings dialog on Toga 0.5.x (toga-winforms backend).

--- a/src/accessiweather/models.py
+++ b/src/accessiweather/models.py
@@ -300,6 +300,11 @@ class AppSettings:
     sound_enabled: bool = True
     sound_pack: str = "default"
 
+    # Environmental metrics
+    # AQI threshold at/above which to generate a local air quality alert
+    # (US AQI scale, typical useful values: 0-500; default kept low for backward compatibility)
+    air_quality_notify_threshold: int = 3
+
     # GitHub backend settings
     github_backend_url: str = ""
 
@@ -333,6 +338,7 @@ class AppSettings:
             "sound_enabled": self.sound_enabled,
             "sound_pack": self.sound_pack,
             "github_backend_url": self.github_backend_url,
+            "air_quality_notify_threshold": self.air_quality_notify_threshold,
             "alert_notifications_enabled": self.alert_notifications_enabled,
             "alert_notify_extreme": self.alert_notify_extreme,
             "alert_notify_severe": self.alert_notify_severe,
@@ -364,6 +370,7 @@ class AppSettings:
             sound_enabled=data.get("sound_enabled", True),
             sound_pack=data.get("sound_pack", "default"),
             github_backend_url=data.get("github_backend_url", ""),
+            air_quality_notify_threshold=data.get("air_quality_notify_threshold", 3),
             alert_notifications_enabled=data.get("alert_notifications_enabled", True),
             alert_notify_extreme=data.get("alert_notify_extreme", True),
             alert_notify_severe=data.get("alert_notify_severe", True),


### PR DESCRIPTION
This PR is Droid-assisted.\n\nSummary\n- Adds a user-configurable Air Quality alert threshold (US AQI) in the Settings > General tab.\n- Persists the new setting via AppSettings (air_quality_notify_threshold) with validation and clamping (0-500).\n- Applies current setting into the UI and collects value safely even if widget is missing.\n- Prior fixes retained: replace invalid Pack alignment 'baseline' with 'center'; use defensive getattr for missing alert widgets.\n\nImplementation\n- src/accessiweather/dialogs/settings_dialog.py: adds NumberInput + label; applies/collects value; clamps to 0..500.\n- src/accessiweather/models.py: ensures the field is included in to_dict/from_dict.\n\nValidation\n- Environment: .venv detected (Python 3.12).\n- Install: pip install -r requirements-dev.txt (no changes needed).\n- Lint/format: pre-commit (ruff, pyright, etc.) all passed.\n- Tests: pytest — full suite green.\n\nNotes\n- This enables users to adjust AQI threshold used for local air quality alerts.\n\nScreenshots\n- N/A (UI element added to General tab).