### PR TITLE
Refactor WeatherClient into modular components

### DIFF
--- a/src/accessiweather/display/weather_presenter.py
+++ b/src/accessiweather/display/weather_presenter.py
@@ -115,11 +115,22 @@ class WeatherPresentation:
 
     location_name: str
     summary_text: str
-    current: CurrentConditionsPresentation | None = None
+    current_conditions: CurrentConditionsPresentation | None = None
     forecast: ForecastPresentation | None = None
     alerts: AlertsPresentation | None = None
     trend_summary: list[str] = field(default_factory=list)
     status_messages: list[str] = field(default_factory=list)
+
+    @property
+    def current(self) -> CurrentConditionsPresentation | None:  # pragma: no cover - compat
+        """Backward-compatible alias for older presentation attribute name."""
+        return self.current_conditions
+
+    @current.setter
+    def current(
+        self, value: CurrentConditionsPresentation | None
+    ) -> None:  # pragma: no cover - compat
+        self.current_conditions = value
 
 
 class WeatherPresenter:
@@ -175,7 +186,7 @@ class WeatherPresenter:
         return WeatherPresentation(
             location_name=weather_data.location.name,
             summary_text=summary_text,
-            current=current,
+            current_conditions=current,
             forecast=forecast,
             alerts=alerts,
             trend_summary=trend_summary,

--- a/src/accessiweather/display/weather_presenter.py
+++ b/src/accessiweather/display/weather_presenter.py
@@ -72,6 +72,7 @@ class CurrentConditionsPresentation:
     description: str
     metrics: list[Metric] = field(default_factory=list)
     fallback_text: str = ""
+    trends: list[str] = field(default_factory=list)
 
 
 @dataclass(slots=True)
@@ -345,6 +346,12 @@ class WeatherPresenter:
             if legacy_pressure_trend:
                 metrics.append(Metric("Pressure trend", legacy_pressure_trend["value"]))
 
+        trend_lines = self._format_trend_lines(
+            trends,
+            current=current,
+            hourly_forecast=hourly_forecast,
+        )
+
         fallback_lines = [f"Current Conditions: {description}", f"Temperature: {temperature_str}"]
         for metric in metrics[1:]:  # already added temperature
             fallback_lines.append(f"{metric.label}: {metric.value}")
@@ -355,6 +362,7 @@ class WeatherPresenter:
             description=description,
             metrics=metrics,
             fallback_text=fallback_text,
+            trends=trend_lines,
         )
 
     def _build_forecast(

--- a/src/accessiweather/weather_client.py
+++ b/src/accessiweather/weather_client.py
@@ -6,17 +6,21 @@ from NWS and OpenMeteo APIs without complex service layer abstractions.
 
 import logging
 from collections.abc import Sequence
-from datetime import datetime, timedelta
+from datetime import datetime
 
-import httpx
-
+from . import (
+    weather_client_nws as nws_client,
+    weather_client_openmeteo as openmeteo_client,
+    weather_client_parsers as parsers,
+    weather_client_trends as trends,
+    weather_client_visualcrossing as vc_alerts,
+)
 from .cache import WeatherDataCache
 from .models import (
     AppSettings,
     CurrentConditions,
     EnvironmentalConditions,
     Forecast,
-    ForecastPeriod,
     HourlyForecast,
     HourlyForecastPeriod,
     Location,
@@ -26,7 +30,6 @@ from .models import (
     WeatherData,
 )
 from .services import EnvironmentalDataClient, MeteoAlarmClient
-from .utils.temperature_utils import TemperatureUnit, calculate_dewpoint
 from .visual_crossing_client import VisualCrossingApiError, VisualCrossingClient
 
 logger = logging.getLogger(__name__)
@@ -315,60 +318,11 @@ class WeatherClient:
 
         return weather_data
 
-    async def _process_visual_crossing_alerts(self, alerts: WeatherAlerts, location: Location):
-        """Process Visual Crossing alerts for notifications."""
-        try:
-            # Import the alert notification system
-            # Create config directory for alert state
-            import os
-            import tempfile
-
-            from .alert_manager import AlertManager
-            from .alert_notification_system import AlertNotificationSystem
-
-            config_dir = os.path.join(tempfile.gettempdir(), "accessiweather_alerts")
-
-            # Create alert manager with more permissive settings for testing
-            from .alert_manager import AlertSettings
-
-            # Create settings that will allow all alerts through
-            settings = AlertSettings()
-            settings.min_severity_priority = 1  # Allow all severities including "unknown"
-            settings.notifications_enabled = True
-
-            alert_manager = AlertManager(config_dir, settings)
-            notification_system = AlertNotificationSystem(alert_manager)
-
-            # Add debugging information
-            logger.info(f"Processing Visual Crossing alerts for {location.name}")
-            logger.info(f"Number of alerts to process: {len(alerts.alerts)}")
-
-            # Log alert details for debugging
-            for i, alert in enumerate(alerts.alerts):
-                logger.info(f"Alert {i + 1}: {alert.event} - {alert.severity} - {alert.headline}")
-
-            # Check notification settings
-            settings = notification_system.get_settings()
-            logger.info(
-                f"Notification settings - enabled: {settings.notifications_enabled}, min_severity: {settings.min_severity_priority}"
-            )
-
-            # Process and send notifications
-            notifications_sent = await notification_system.process_and_notify(alerts)
-
-            if notifications_sent > 0:
-                logger.info(
-                    f"✅ Sent {notifications_sent} Visual Crossing alert notifications for {location.name}"
-                )
-            else:
-                logger.warning(f"⚠️ No Visual Crossing alert notifications sent for {location.name}")
-
-                # Get statistics for debugging
-                stats = notification_system.get_statistics()
-                logger.info(f"Alert statistics: {stats}")
-
-        except Exception as e:
-            logger.error(f"Failed to process Visual Crossing alerts for notifications: {e}")
+    async def _process_visual_crossing_alerts(
+        self, alerts: WeatherAlerts, location: Location
+    ) -> None:
+        """Delegate Visual Crossing alert processing to the dedicated module."""
+        await vc_alerts.process_visual_crossing_alerts(alerts, location)
 
     def _determine_api_choice(self, location: Location) -> str:
         """Determine which API to use for the given location."""
@@ -411,561 +365,78 @@ class WeatherClient:
         weather_data.alerts = WeatherAlerts(alerts=[])
 
     async def _get_nws_current_conditions(self, location: Location) -> CurrentConditions | None:
-        """Get current conditions from NWS API."""
-        try:
-            # Get grid point for location
-            grid_url = f"{self.nws_base_url}/points/{location.latitude},{location.longitude}"
-
-            async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
-                headers = {"User-Agent": self.user_agent}
-
-                # Get grid point
-                response = await client.get(grid_url, headers=headers)
-                response.raise_for_status()
-                grid_data = response.json()
-
-                # Get observation stations
-                stations_url = grid_data["properties"]["observationStations"]
-                response = await client.get(stations_url, headers=headers)
-                response.raise_for_status()
-                stations_data = response.json()
-
-                if not stations_data["features"]:
-                    logger.warning("No observation stations found")
-                    return None
-
-                # Get latest observation from first station
-                station_id = stations_data["features"][0]["properties"]["stationIdentifier"]
-                obs_url = f"{self.nws_base_url}/stations/{station_id}/observations/latest"
-
-                response = await client.get(obs_url, headers=headers)
-                response.raise_for_status()
-                obs_data = response.json()
-
-                return self._parse_nws_current_conditions(obs_data)
-
-        except Exception as e:
-            logger.error(f"Failed to get NWS current conditions: {e}")
-            return None
+        """Delegate to the NWS client module."""
+        return await nws_client.get_nws_current_conditions(
+            location, self.nws_base_url, self.user_agent, self.timeout
+        )
 
     async def _get_nws_forecast_and_discussion(
         self, location: Location
     ) -> tuple[Forecast | None, str | None]:
-        """Get forecast and discussion from NWS API."""
-        try:
-            # Get grid point for location
-            grid_url = f"{self.nws_base_url}/points/{location.latitude},{location.longitude}"
-
-            async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
-                headers = {"User-Agent": self.user_agent}
-
-                # Get grid point
-                response = await client.get(grid_url, headers=headers)
-                response.raise_for_status()
-                grid_data = response.json()
-
-                # Get forecast
-                forecast_url = grid_data["properties"]["forecast"]
-                response = await client.get(forecast_url, headers=headers)
-                response.raise_for_status()
-                forecast_data = response.json()
-
-                # Get forecast discussion (AFD)
-                discussion = await self._get_nws_discussion(client, headers, grid_data)
-
-                return self._parse_nws_forecast(forecast_data), discussion
-
-        except Exception as e:
-            logger.error(f"Failed to get NWS forecast and discussion: {e}")
-            return None, None
-
-    async def _get_nws_discussion(self, client, headers, grid_data) -> str:
-        """Get NWS Area Forecast Discussion (AFD) for the location."""
-        try:
-            # Get forecast URL to extract office ID
-            forecast_url = grid_data.get("properties", {}).get("forecast")
-            if not forecast_url:
-                logger.warning("No forecast URL found in grid data")
-                return "Forecast discussion not available."
-
-            # Extract office ID from forecast URL
-            # URL format: https://api.weather.gov/gridpoints/PHI/49,75/forecast
-            parts = forecast_url.split("/")
-            if len(parts) < 6:
-                logger.warning(f"Unexpected forecast URL format: {forecast_url}")
-                return "Forecast discussion not available."
-
-            office_id = parts[-3]  # Extract office ID (e.g., "PHI")
-            logger.info(f"Fetching AFD for office: {office_id}")
-
-            # Get AFD products for this office
-            products_url = f"{self.nws_base_url}/products/types/AFD/locations/{office_id}"
-            response = await client.get(products_url, headers=headers)
-
-            if response.status_code != 200:
-                logger.warning(f"Failed to get AFD products: HTTP {response.status_code}")
-                return "Forecast discussion not available."
-
-            products_data = response.json()
-
-            # Check if we have any AFD products
-            if not products_data.get("@graph") or not products_data["@graph"]:
-                logger.warning(f"No AFD products found for office {office_id}")
-                return "Forecast discussion not available for this location."
-
-            # Get the latest AFD product
-            latest_product = products_data["@graph"][0]
-            latest_product_id = latest_product.get("id")
-
-            if not latest_product_id:
-                logger.warning("No product ID found in latest AFD product")
-                return "Forecast discussion not available."
-
-            # Fetch the actual AFD text
-            product_url = f"{self.nws_base_url}/products/{latest_product_id}"
-            response = await client.get(product_url, headers=headers)
-
-            if response.status_code != 200:
-                logger.warning(f"Failed to get AFD product text: HTTP {response.status_code}")
-                return "Forecast discussion not available."
-
-            product_data = response.json()
-            product_text = product_data.get("productText")
-
-            if not product_text:
-                logger.warning("No product text found in AFD product")
-                return "Forecast discussion not available."
-
-            logger.info(f"Successfully fetched AFD for office {office_id}")
-            return product_text
-
-        except Exception as e:
-            logger.error(f"Failed to get NWS discussion: {e}")
-            return "Forecast discussion not available due to error."
+        """Delegate to the NWS client module."""
+        return await nws_client.get_nws_forecast_and_discussion(
+            location, self.nws_base_url, self.user_agent, self.timeout
+        )
 
     async def _get_nws_alerts(self, location: Location) -> WeatherAlerts | None:
-        """Get weather alerts from NWS API."""
-        try:
-            alerts_url = f"{self.nws_base_url}/alerts/active"
-            params = {
-                "point": f"{location.latitude},{location.longitude}",
-                "status": "actual",
-                "message_type": "alert",
-            }
-
-            async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
-                headers = {"User-Agent": self.user_agent}
-                response = await client.get(alerts_url, params=params, headers=headers)
-                response.raise_for_status()
-                alerts_data = response.json()
-
-                return self._parse_nws_alerts(alerts_data)
-
-        except Exception as e:
-            logger.error(f"Failed to get NWS alerts: {e}")
-            return WeatherAlerts(alerts=[])
+        """Delegate to the NWS client module."""
+        return await nws_client.get_nws_alerts(
+            location, self.nws_base_url, self.user_agent, self.timeout
+        )
 
     async def _get_nws_hourly_forecast(self, location: Location) -> HourlyForecast | None:
-        """Get hourly forecast from NWS API."""
-        try:
-            # Get grid point data first
-            grid_url = f"{self.nws_base_url}/points/{location.latitude},{location.longitude}"
-
-            async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
-                headers = {"User-Agent": self.user_agent}
-                response = await client.get(grid_url, headers=headers)
-                response.raise_for_status()
-                grid_data = response.json()
-
-                # Get hourly forecast URL
-                hourly_forecast_url = grid_data.get("properties", {}).get("forecastHourly")
-                if not hourly_forecast_url:
-                    logger.warning("No hourly forecast URL found in grid data")
-                    return None
-
-                # Fetch hourly forecast
-                response = await client.get(hourly_forecast_url, headers=headers)
-                response.raise_for_status()
-                hourly_data = response.json()
-
-                return self._parse_nws_hourly_forecast(hourly_data)
-
-        except Exception as e:
-            logger.error(f"Failed to get NWS hourly forecast: {e}")
-            return None
+        """Delegate to the NWS client module."""
+        return await nws_client.get_nws_hourly_forecast(
+            location, self.nws_base_url, self.user_agent, self.timeout
+        )
 
     async def _get_openmeteo_current_conditions(
         self, location: Location
     ) -> CurrentConditions | None:
-        """Get current conditions from OpenMeteo API."""
-        try:
-            url = f"{self.openmeteo_base_url}/forecast"
-            params = {
-                "latitude": location.latitude,
-                "longitude": location.longitude,
-                "current": "temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m,pressure_msl",
-                "temperature_unit": "fahrenheit",
-                "wind_speed_unit": "mph",
-                "precipitation_unit": "inch",
-                "timezone": "auto",
-            }
-
-            async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
-                response = await client.get(url, params=params)
-                response.raise_for_status()
-                data = response.json()
-
-                current = self._parse_openmeteo_current_conditions(data)
-                if isinstance(current.wind_direction, (int, float)):
-                    current.wind_direction = self._degrees_to_cardinal(current.wind_direction)
-                return current
-
-        except Exception as e:
-            logger.error(f"Failed to get OpenMeteo current conditions: {e}")
-            return None
+        """Delegate to the Open-Meteo client module."""
+        return await openmeteo_client.get_openmeteo_current_conditions(
+            location, self.openmeteo_base_url, self.timeout
+        )
 
     async def _get_openmeteo_forecast(self, location: Location) -> Forecast | None:
-        """Get forecast from OpenMeteo API."""
-        try:
-            url = f"{self.openmeteo_base_url}/forecast"
-            params = {
-                "latitude": location.latitude,
-                "longitude": location.longitude,
-                "daily": "temperature_2m_max,temperature_2m_min,weather_code,wind_speed_10m_max,wind_direction_10m_dominant",
-                "temperature_unit": "fahrenheit",
-                "wind_speed_unit": "mph",
-                "timezone": "auto",
-                "forecast_days": 7,
-            }
-
-            async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
-                response = await client.get(url, params=params)
-                response.raise_for_status()
-                data = response.json()
-
-                return self._parse_openmeteo_forecast(data)
-
-        except Exception as e:
-            logger.error(f"Failed to get OpenMeteo forecast: {e}")
-            return None
+        """Delegate to the Open-Meteo client module."""
+        return await openmeteo_client.get_openmeteo_forecast(
+            location, self.openmeteo_base_url, self.timeout
+        )
 
     async def _get_openmeteo_hourly_forecast(self, location: Location) -> HourlyForecast | None:
-        """Get hourly forecast from OpenMeteo API."""
-        try:
-            url = f"{self.openmeteo_base_url}/forecast"
-            params = {
-                "latitude": location.latitude,
-                "longitude": location.longitude,
-                "hourly": "temperature_2m,weather_code,wind_speed_10m,wind_direction_10m,pressure_msl",
-                "temperature_unit": "fahrenheit",
-                "wind_speed_unit": "mph",
-                "timezone": "auto",
-                "forecast_days": 2,  # Get 48 hours of data
-            }
-
-            async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
-                response = await client.get(url, params=params)
-                response.raise_for_status()
-                data = response.json()
-
-                return self._parse_openmeteo_hourly_forecast(data)
-
-        except Exception as e:
-            logger.error(f"Failed to get OpenMeteo hourly forecast: {e}")
-            return None
+        """Delegate to the Open-Meteo client module."""
+        return await openmeteo_client.get_openmeteo_hourly_forecast(
+            location, self.openmeteo_base_url, self.timeout
+        )
 
     def _parse_nws_current_conditions(self, data: dict) -> CurrentConditions:
-        """Parse NWS current conditions data."""
-        props = data.get("properties", {})
-
-        temp_c = props.get("temperature", {}).get("value")
-        temp_f = (temp_c * 9 / 5) + 32 if temp_c is not None else None
-
-        humidity = props.get("relativeHumidity", {}).get("value")
-        humidity = round(humidity) if humidity is not None else None
-
-        dewpoint_c = props.get("dewpoint", {}).get("value")
-        dewpoint_f = (dewpoint_c * 9 / 5) + 32 if dewpoint_c is not None else None
-
-        visibility_m = props.get("visibility", {}).get("value")
-        visibility_miles = visibility_m / 1609.344 if visibility_m is not None else None
-        visibility_km = visibility_m / 1000 if visibility_m is not None else None
-
-        wind_speed = props.get("windSpeed", {})
-        wind_speed_value = wind_speed.get("value")
-        wind_speed_unit = wind_speed.get("unitCode")
-        wind_speed_mph, wind_speed_kph = self._convert_wind_speed_to_mph_and_kph(
-            wind_speed_value, wind_speed_unit
-        )
-
-        wind_direction = props.get("windDirection", {}).get("value")
-
-        pressure_pa = props.get("barometricPressure", {}).get("value")
-        pressure_in = self._convert_pa_to_inches(pressure_pa)
-
-        timestamp = props.get("timestamp")
-        last_updated = None
-        if timestamp:
-            try:
-                last_updated = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-            except ValueError:
-                logger.debug(f"Failed to parse observation timestamp: {timestamp}")
-
-        return CurrentConditions(
-            temperature_f=temp_f,
-            temperature_c=temp_c,
-            condition=props.get("textDescription"),
-            humidity=humidity,
-            dewpoint_f=dewpoint_f,
-            dewpoint_c=dewpoint_c,
-            wind_speed_mph=wind_speed_mph,
-            wind_speed_kph=wind_speed_kph,
-            wind_direction=wind_direction,
-            pressure_in=pressure_in,
-            pressure_mb=self._convert_pa_to_mb(pressure_pa),
-            feels_like_f=None,
-            feels_like_c=None,
-            visibility_miles=visibility_miles,
-            visibility_km=visibility_km,
-            last_updated=last_updated or datetime.now(),
-        )
+        """Delegate to the NWS client module."""
+        return nws_client.parse_nws_current_conditions(data)
 
     def _parse_nws_forecast(self, data: dict) -> Forecast:
-        """Parse NWS forecast data."""
-        periods = []
-
-        for period_data in data.get("properties", {}).get("periods", []):
-            period = ForecastPeriod(
-                name=period_data.get("name", ""),
-                temperature=period_data.get("temperature"),
-                temperature_unit=period_data.get("temperatureUnit", "F"),
-                short_forecast=period_data.get("shortForecast"),
-                detailed_forecast=period_data.get("detailedForecast"),
-                wind_speed=period_data.get("windSpeed"),
-                wind_direction=period_data.get("windDirection"),
-                icon=period_data.get("icon"),
-            )
-            periods.append(period)
-
-        return Forecast(periods=periods, generated_at=datetime.now())
+        """Delegate to the NWS client module."""
+        return nws_client.parse_nws_forecast(data)
 
     def _parse_nws_alerts(self, data: dict) -> WeatherAlerts:
-        """Parse NWS alerts data."""
-        alerts = []
-
-        for alert_data in data.get("features", []):
-            props = alert_data.get("properties", {})
-
-            # Extract alert ID from the NWS API response
-            # The ID can be in different places depending on the API response format
-            alert_id = None
-            if "id" in alert_data:
-                alert_id = alert_data["id"]
-            elif "identifier" in props:
-                alert_id = props["identifier"]
-            elif "@id" in props:
-                alert_id = props["@id"]
-
-            # Parse onset and expires times
-            onset = None
-            expires = None
-
-            if props.get("onset"):
-                try:
-                    onset = datetime.fromisoformat(props["onset"].replace("Z", "+00:00"))
-                except ValueError:
-                    logger.warning(f"Failed to parse onset time: {props['onset']}")
-
-            if props.get("expires"):
-                try:
-                    expires = datetime.fromisoformat(props["expires"].replace("Z", "+00:00"))
-                except ValueError:
-                    logger.warning(f"Failed to parse expires time: {props['expires']}")
-
-            alert = WeatherAlert(
-                title=props.get("headline", "Weather Alert"),
-                description=props.get("description", ""),
-                severity=props.get("severity", "Unknown"),
-                urgency=props.get("urgency", "Unknown"),
-                certainty=props.get("certainty", "Unknown"),
-                event=props.get("event"),
-                headline=props.get("headline"),
-                instruction=props.get("instruction"),
-                onset=onset,
-                expires=expires,
-                areas=props.get("areaDesc", "").split("; ") if props.get("areaDesc") else [],
-                id=alert_id,  # Store the NWS alert ID for unique identification
-            )
-            alerts.append(alert)
-
-            if alert_id:
-                logger.debug(f"Parsed alert with ID: {alert_id}")
-            else:
-                logger.debug(f"Parsed alert without ID, will generate: {alert.get_unique_id()}")
-
-        logger.info(f"Parsed {len(alerts)} alerts from NWS API")
-        return WeatherAlerts(alerts=alerts)
+        """Delegate to the NWS client module."""
+        return nws_client.parse_nws_alerts(data)
 
     def _parse_nws_hourly_forecast(self, data: dict) -> HourlyForecast:
-        """Parse NWS hourly forecast data."""
-        periods = []
-
-        for period_data in data.get("properties", {}).get("periods", []):
-            # Parse start time
-            start_time_str = period_data.get("startTime")
-            start_time = None
-            if start_time_str:
-                try:
-                    # Parse ISO format: "2024-01-01T12:00:00-05:00"
-                    start_time = datetime.fromisoformat(start_time_str.replace("Z", "+00:00"))
-                except ValueError:
-                    logger.warning(f"Failed to parse start time: {start_time_str}")
-
-            # Parse end time
-            end_time_str = period_data.get("endTime")
-            end_time = None
-            if end_time_str:
-                try:
-                    end_time = datetime.fromisoformat(end_time_str.replace("Z", "+00:00"))
-                except ValueError:
-                    logger.warning(f"Failed to parse end time: {end_time_str}")
-
-            period = HourlyForecastPeriod(
-                start_time=start_time or datetime.now(),
-                end_time=end_time,
-                temperature=period_data.get("temperature"),
-                temperature_unit=period_data.get("temperatureUnit", "F"),
-                short_forecast=period_data.get("shortForecast"),
-                wind_speed=period_data.get("windSpeed"),
-                wind_direction=period_data.get("windDirection"),
-                icon=period_data.get("icon"),
-            )
-            periods.append(period)
-
-        return HourlyForecast(periods=periods, generated_at=datetime.now())
+        """Delegate to the NWS client module."""
+        return nws_client.parse_nws_hourly_forecast(data)
 
     def _parse_openmeteo_current_conditions(self, data: dict) -> CurrentConditions:
-        """Parse OpenMeteo current conditions data."""
-        current = data.get("current", {})
-        units = data.get("current_units", {})
-
-        temp_f, temp_c = self._normalize_temperature(
-            current.get("temperature_2m"), units.get("temperature_2m")
-        )
-
-        humidity = current.get("relative_humidity_2m")
-        humidity = round(humidity) if humidity is not None else None
-
-        dewpoint_f = None
-        dewpoint_c = None
-        if temp_f is not None and humidity is not None:
-            dewpoint_f = calculate_dewpoint(temp_f, humidity, unit=TemperatureUnit.FAHRENHEIT)
-            if dewpoint_f is not None:
-                dewpoint_c = self._convert_f_to_c(dewpoint_f)
-
-        wind_speed_mph, wind_speed_kph = self._convert_wind_speed_to_mph_and_kph(
-            current.get("wind_speed_10m"), units.get("wind_speed_10m")
-        )
-
-        pressure_in, pressure_mb = self._normalize_pressure(
-            current.get("pressure_msl"), units.get("pressure_msl")
-        )
-
-        feels_like_f, feels_like_c = self._normalize_temperature(
-            current.get("apparent_temperature"), units.get("apparent_temperature")
-        )
-
-        timestamp = current.get("time")
-        last_updated = None
-        if timestamp:
-            try:
-                last_updated = datetime.fromisoformat(timestamp)
-            except ValueError:
-                logger.debug(f"Failed to parse OpenMeteo timestamp: {timestamp}")
-
-        return CurrentConditions(
-            temperature_f=temp_f,
-            temperature_c=temp_c,
-            condition=self._weather_code_to_description(current.get("weather_code")),
-            humidity=humidity,
-            dewpoint_f=dewpoint_f,
-            dewpoint_c=dewpoint_c,
-            wind_speed_mph=wind_speed_mph,
-            wind_speed_kph=wind_speed_kph,
-            wind_direction=current.get("wind_direction_10m"),
-            pressure_in=pressure_in,
-            pressure_mb=pressure_mb,
-            feels_like_f=feels_like_f,
-            feels_like_c=feels_like_c,
-            last_updated=last_updated or datetime.now(),
-        )
+        """Delegate to the Open-Meteo client module."""
+        return openmeteo_client.parse_openmeteo_current_conditions(data)
 
     def _parse_openmeteo_forecast(self, data: dict) -> Forecast:
-        """Parse OpenMeteo forecast data."""
-        daily = data.get("daily", {})
-        periods = []
-
-        dates = daily.get("time", [])
-        max_temps = daily.get("temperature_2m_max", [])
-        # min_temps = daily.get("temperature_2m_min", [])  # Not currently used
-        weather_codes = daily.get("weather_code", [])
-
-        for i, date in enumerate(dates):
-            if i < len(max_temps) and i < len(weather_codes):
-                period = ForecastPeriod(
-                    name=self._format_date_name(date, i),
-                    temperature=max_temps[i],
-                    temperature_unit="F",
-                    short_forecast=self._weather_code_to_description(weather_codes[i]),
-                )
-                periods.append(period)
-
-        return Forecast(periods=periods, generated_at=datetime.now())
+        """Delegate to the Open-Meteo client module."""
+        return openmeteo_client.parse_openmeteo_forecast(data)
 
     def _parse_openmeteo_hourly_forecast(self, data: dict) -> HourlyForecast:
-        """Parse OpenMeteo hourly forecast data."""
-        periods = []
-        hourly = data.get("hourly", {})
-
-        times = hourly.get("time", [])
-        temperatures = hourly.get("temperature_2m", [])
-        weather_codes = hourly.get("weather_code", [])
-        wind_speeds = hourly.get("wind_speed_10m", [])
-        wind_directions = hourly.get("wind_direction_10m", [])
-        pressures = hourly.get("pressure_msl", [])
-
-        for i, time_str in enumerate(times):
-            # Parse time
-            start_time = None
-            if time_str:
-                try:
-                    # OpenMeteo format: "2024-01-01T12:00"
-                    start_time = datetime.fromisoformat(time_str)
-                except ValueError:
-                    logger.warning(f"Failed to parse OpenMeteo time: {time_str}")
-                    start_time = datetime.now()
-
-            # Get values for this hour (with bounds checking)
-            temperature = temperatures[i] if i < len(temperatures) else None
-            weather_code = weather_codes[i] if i < len(weather_codes) else None
-            wind_speed = wind_speeds[i] if i < len(wind_speeds) else None
-            wind_direction = wind_directions[i] if i < len(wind_directions) else None
-            pressure_mb = pressures[i] if i < len(pressures) else None
-            pressure_in = pressure_mb * 0.0295299830714 if pressure_mb is not None else None
-
-            period = HourlyForecastPeriod(
-                start_time=start_time or datetime.now(),
-                temperature=temperature,
-                temperature_unit="F",
-                short_forecast=self._weather_code_to_description(weather_code),
-                wind_speed=f"{wind_speed} mph" if wind_speed is not None else None,
-                wind_direction=self._degrees_to_cardinal(wind_direction),
-                pressure_mb=pressure_mb,
-                pressure_in=pressure_in,
-            )
-            periods.append(period)
-
-        return HourlyForecast(periods=periods, generated_at=datetime.now())
+        """Delegate to the Open-Meteo client module."""
+        return openmeteo_client.parse_openmeteo_hourly_forecast(data)
 
     async def _populate_environmental_metrics(
         self, weather_data: WeatherData, location: Location
@@ -1020,18 +491,7 @@ class WeatherClient:
         weather_data.alerts = WeatherAlerts(alerts=list(combined.values()))
 
     def _apply_trend_insights(self, weather_data: WeatherData) -> None:
-        if not self.trend_insights_enabled:
-            weather_data.trend_insights = []
-            return
-
-        insights: list[TrendInsight] = []
-        temp_insight = self._compute_temperature_trend(weather_data)
-        if temp_insight:
-            insights.append(temp_insight)
-        pressure_insight = self._compute_pressure_trend(weather_data)
-        if pressure_insight:
-            insights.append(pressure_insight)
-        weather_data.trend_insights = insights
+        trends.apply_trend_insights(weather_data, self.trend_insights_enabled, self.trend_hours)
 
     def _persist_weather_data(self, location: Location, weather_data: WeatherData) -> None:
         if not self.offline_cache:
@@ -1089,277 +549,65 @@ class WeatherClient:
         return "Unknown"
 
     def _compute_temperature_trend(self, weather_data: WeatherData) -> TrendInsight | None:
-        current = weather_data.current
-        hourly = weather_data.hourly_forecast.periods if weather_data.hourly_forecast else []
-        if current is None or not hourly:
-            return None
-
-        base = current.temperature_f
-        unit = "°F"
-        if base is None:
-            base = current.temperature_c
-            unit = "°C"
-        if base is None:
-            return None
-
-        target_period = self._period_for_hours_ahead(hourly, self.trend_hours)
-        if not target_period or target_period.temperature is None:
-            return None
-
-        change = target_period.temperature - base
-        direction, sparkline = self._trend_descriptor(
-            change, minor=1.0 if unit == "°F" else 0.5, strong=3.0 if unit == "°F" else 1.5
-        )
-        summary = f"Temperature {direction} {change:+.1f}{unit} over {self.trend_hours}h"
-        return TrendInsight(
-            metric="temperature",
-            direction=direction,
-            change=round(change, 1),
-            unit=unit,
-            timeframe_hours=self.trend_hours,
-            summary=summary,
-            sparkline=sparkline,
-        )
+        return trends.compute_temperature_trend(weather_data, self.trend_hours)
 
     def _compute_pressure_trend(self, weather_data: WeatherData) -> TrendInsight | None:
-        current = weather_data.current
-        hourly = weather_data.hourly_forecast.periods if weather_data.hourly_forecast else []
-        if current is None or not hourly:
-            return None
-
-        base_mb = current.pressure_mb
-        base_in = current.pressure_in
-        target_period = self._period_for_hours_ahead(hourly, self.trend_hours)
-        if not target_period:
-            return None
-
-        future_mb = target_period.pressure_mb
-        future_in = target_period.pressure_in
-
-        value_pairs = []
-        if base_mb is not None and future_mb is not None:
-            value_pairs.append((base_mb, future_mb, "mb"))
-        if base_in is not None and future_in is not None:
-            value_pairs.append((base_in, future_in, "inHg"))
-        if not value_pairs:
-            return None
-
-        base, future, unit = value_pairs[0]
-        change = future - base
-        direction, sparkline = self._trend_descriptor(
-            change,
-            minor=0.5 if unit == "mb" else 0.02,
-            strong=1.5 if unit == "mb" else 0.05,
-        )
-        summary = f"Pressure {direction} {change:+.2f}{unit} over {self.trend_hours}h"
-        return TrendInsight(
-            metric="pressure",
-            direction=direction,
-            change=round(change, 2),
-            unit=unit,
-            timeframe_hours=self.trend_hours,
-            summary=summary,
-            sparkline=sparkline,
-        )
+        return trends.compute_pressure_trend(weather_data, self.trend_hours)
 
     def _trend_descriptor(self, change: float, *, minor: float, strong: float) -> tuple[str, str]:
-        if change >= strong:
-            return "rising", "↑↑"
-        if change >= minor:
-            return "rising", "↑"
-        if change <= -strong:
-            return "falling", "↓↓"
-        if change <= -minor:
-            return "falling", "↓"
-        return "steady", "→"
+        return trends.trend_descriptor(change, minor=minor, strong=strong)
 
     def _period_for_hours_ahead(
-        self, periods: Sequence[HourlyForecastPeriod], hours_ahead: int
+        self, periods: list[HourlyForecastPeriod] | Sequence[HourlyForecastPeriod], hours_ahead: int
     ) -> HourlyForecastPeriod | None:
-        if not periods:
-            return None
-        target = self._normalize_datetime(datetime.now()) + timedelta(hours=hours_ahead)
-        closest = None
-        best_delta = None
-        for period in periods:
-            start = self._normalize_datetime(period.start_time)
-            if start is None:
-                continue
-            delta = abs((start - target).total_seconds())
-            if best_delta is None or delta < best_delta:
-                closest = period
-                best_delta = delta
-        return closest
+        return trends.period_for_hours_ahead(periods, hours_ahead)
 
     def _normalize_datetime(self, value: datetime | None) -> datetime | None:
-        if value is None:
-            return None
-        if value.tzinfo is None:
-            return value
-        return value.astimezone().replace(tzinfo=None)
+        return trends.normalize_datetime(value)
 
     # Utility methods
     def _convert_mps_to_mph(self, mps: float | None) -> float | None:
-        """Convert meters per second to miles per hour."""
-        return mps * 2.237 if mps is not None else None
+        return parsers.convert_mps_to_mph(mps)
 
     def _convert_wind_speed_to_mph(
         self, value: float | None, unit_code: str | None
     ) -> float | None:
-        """Normalize WMO wind speed units to miles per hour."""
-        if value is None:
-            return None
-        if not unit_code:
-            return value
-        unit_code = unit_code.lower()
-        if unit_code.endswith(("m_s-1", "mps")):
-            return value * 2.237
-        if unit_code.endswith(("km_h-1", "kmh", "km/h")):
-            return value * 0.621371
-        if unit_code.endswith(("mi_h-1", "mph", "mp/h")):
-            return value
-        if unit_code.endswith(("kn", "kt")):
-            return value * 1.15078
-        return value
+        return parsers.convert_wind_speed_to_mph(value, unit_code)
 
     def _convert_wind_speed_to_kph(
         self, value: float | None, unit_code: str | None
     ) -> float | None:
-        if value is None:
-            return None
-        if not unit_code:
-            return value
-        unit_code = unit_code.lower()
-        if unit_code.endswith(("m_s-1", "mps")):
-            return value * 3.6
-        if unit_code.endswith(("km_h-1", "kmh", "km/h")):
-            return value
-        if unit_code.endswith(("mi_h-1", "mph", "mp/h")):
-            return value * 1.60934
-        if unit_code.endswith(("kn", "kt")):
-            return value * 1.852
-        return value
+        return parsers.convert_wind_speed_to_kph(value, unit_code)
 
     def _convert_wind_speed_to_mph_and_kph(
         self, value: float | None, unit_code: str | None
     ) -> tuple[float | None, float | None]:
-        return (
-            self._convert_wind_speed_to_mph(value, unit_code),
-            self._convert_wind_speed_to_kph(value, unit_code),
-        )
+        return parsers.convert_wind_speed_to_mph_and_kph(value, unit_code)
 
     def _convert_pa_to_inches(self, pa: float | None) -> float | None:
-        """Convert pascals to inches of mercury."""
-        return pa * 0.0002953 if pa is not None else None
+        return parsers.convert_pa_to_inches(pa)
 
     def _convert_pa_to_mb(self, pa: float | None) -> float | None:
-        return pa / 100 if pa is not None else None
+        return parsers.convert_pa_to_mb(pa)
 
     def _normalize_temperature(
         self, value: float | None, unit: str | None
     ) -> tuple[float | None, float | None]:
-        if value is None:
-            return None, None
-
-        unit_lower = (unit or "").lower()
-        if "f" in unit_lower:
-            temp_f = value
-            temp_c = self._convert_f_to_c(temp_f)
-        elif "c" in unit_lower:
-            temp_c = value
-            temp_f = (temp_c * 9 / 5) + 32
-        else:
-            temp_f = value
-            temp_c = self._convert_f_to_c(temp_f)
-        return temp_f, temp_c
+        return parsers.normalize_temperature(value, unit)
 
     def _normalize_pressure(
         self, value: float | None, unit: str | None
     ) -> tuple[float | None, float | None]:
-        if value is None:
-            return None, None
-
-        unit_lower = (unit or "").lower()
-        if "hpa" in unit_lower or "mb" in unit_lower:
-            pressure_mb = value
-            pressure_in = value * 0.0295299830714
-        elif "pa" in unit_lower:
-            pressure_mb = value / 100
-            pressure_in = self._convert_pa_to_inches(value)
-        elif "inch" in unit_lower or unit_lower.endswith("in"):
-            pressure_in = value
-            pressure_mb = value * 33.8639
-        else:
-            pressure_mb = value
-            pressure_in = None
-        return pressure_in, pressure_mb
+        return parsers.normalize_pressure(value, unit)
 
     def _convert_f_to_c(self, fahrenheit: float | None) -> float | None:
-        """Convert Fahrenheit to Celsius."""
-        return (fahrenheit - 32) * 5 / 9 if fahrenheit is not None else None
+        return parsers.convert_f_to_c(fahrenheit)
 
     def _degrees_to_cardinal(self, degrees: float | None) -> str | None:
-        """Convert wind direction degrees to cardinal direction."""
-        if degrees is None:
-            return None
-
-        directions = [
-            "N",
-            "NNE",
-            "NE",
-            "ENE",
-            "E",
-            "ESE",
-            "SE",
-            "SSE",
-            "S",
-            "SSW",
-            "SW",
-            "WSW",
-            "W",
-            "WNW",
-            "NW",
-            "NNW",
-        ]
-        index = round(degrees / 22.5) % 16
-        return directions[index]
+        return parsers.degrees_to_cardinal(degrees)
 
     def _weather_code_to_description(self, code: int | None) -> str | None:
-        """Convert OpenMeteo weather code to description."""
-        if code is None:
-            return None
-
-        # Simplified weather code mapping
-        code_map = {
-            0: "Clear sky",
-            1: "Mainly clear",
-            2: "Partly cloudy",
-            3: "Overcast",
-            45: "Fog",
-            48: "Depositing rime fog",
-            51: "Light drizzle",
-            53: "Moderate drizzle",
-            55: "Dense drizzle",
-            61: "Slight rain",
-            63: "Moderate rain",
-            65: "Heavy rain",
-            71: "Slight snow",
-            73: "Moderate snow",
-            75: "Heavy snow",
-            95: "Thunderstorm",
-        }
-
-        return code_map.get(code, f"Weather code {code}")
+        return parsers.weather_code_to_description(code)
 
     def _format_date_name(self, date_str: str, index: int) -> str:
-        """Format date string to readable name."""
-        if index == 0:
-            return "Today"
-        if index == 1:
-            return "Tomorrow"
-        # Parse date and format as day name
-        try:
-            date_obj = datetime.fromisoformat(date_str)
-            return date_obj.strftime("%A")
-        except (ValueError, TypeError):
-            return f"Day {index + 1}"
+        return parsers.format_date_name(date_str, index)

--- a/src/accessiweather/weather_client_nws.py
+++ b/src/accessiweather/weather_client_nws.py
@@ -1,0 +1,388 @@
+"""NWS API client methods for fetching and parsing weather data from the National Weather Service."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+from .models import (
+    CurrentConditions,
+    Forecast,
+    ForecastPeriod,
+    HourlyForecast,
+    HourlyForecastPeriod,
+    Location,
+    WeatherAlert,
+    WeatherAlerts,
+)
+from .weather_client_parsers import (
+    convert_pa_to_inches,
+    convert_pa_to_mb,
+    convert_wind_speed_to_mph_and_kph,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def get_nws_current_conditions(
+    location: Location,
+    nws_base_url: str,
+    user_agent: str,
+    timeout: float,
+) -> CurrentConditions | None:
+    """Fetch current conditions from the NWS API for the given location."""
+    try:
+        grid_url = f"{nws_base_url}/points/{location.latitude},{location.longitude}"
+
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+            headers = {"User-Agent": user_agent}
+
+            response = await client.get(grid_url, headers=headers)
+            response.raise_for_status()
+            grid_data = response.json()
+
+            stations_url = grid_data["properties"]["observationStations"]
+            response = await client.get(stations_url, headers=headers)
+            response.raise_for_status()
+            stations_data = response.json()
+
+            if not stations_data["features"]:
+                logger.warning("No observation stations found")
+                return None
+
+            station_id = stations_data["features"][0]["properties"]["stationIdentifier"]
+            obs_url = f"{nws_base_url}/stations/{station_id}/observations/latest"
+
+            response = await client.get(obs_url, headers=headers)
+            response.raise_for_status()
+            obs_data = response.json()
+
+            return parse_nws_current_conditions(obs_data)
+
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"Failed to get NWS current conditions: {exc}")
+        return None
+
+
+async def get_nws_forecast_and_discussion(
+    location: Location,
+    nws_base_url: str,
+    user_agent: str,
+    timeout: float,
+) -> tuple[Forecast | None, str | None]:
+    """Fetch forecast and discussion from the NWS API for the given location."""
+    try:
+        grid_url = f"{nws_base_url}/points/{location.latitude},{location.longitude}"
+
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+            headers = {"User-Agent": user_agent}
+
+            response = await client.get(grid_url, headers=headers)
+            response.raise_for_status()
+            grid_data = response.json()
+
+            forecast_url = grid_data["properties"]["forecast"]
+            response = await client.get(forecast_url, headers=headers)
+            response.raise_for_status()
+            forecast_data = response.json()
+
+            discussion = await get_nws_discussion(client, headers, grid_data, nws_base_url)
+
+            return parse_nws_forecast(forecast_data), discussion
+
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"Failed to get NWS forecast and discussion: {exc}")
+        return None, None
+
+
+async def get_nws_discussion(
+    client: httpx.AsyncClient,
+    headers: dict[str, str],
+    grid_data: dict[str, Any],
+    nws_base_url: str,
+) -> str:
+    """Fetch the NWS Area Forecast Discussion (AFD) for the given grid data."""
+    try:
+        forecast_url = grid_data.get("properties", {}).get("forecast")
+        if not forecast_url:
+            logger.warning("No forecast URL found in grid data")
+            return "Forecast discussion not available."
+
+        parts = forecast_url.split("/")
+        if len(parts) < 6:
+            logger.warning(f"Unexpected forecast URL format: {forecast_url}")
+            return "Forecast discussion not available."
+
+        office_id = parts[-3]
+        logger.info(f"Fetching AFD for office: {office_id}")
+
+        products_url = f"{nws_base_url}/products/types/AFD/locations/{office_id}"
+        response = await client.get(products_url, headers=headers)
+
+        if response.status_code != 200:
+            logger.warning(f"Failed to get AFD products: HTTP {response.status_code}")
+            return "Forecast discussion not available."
+
+        products_data = response.json()
+
+        if not products_data.get("@graph"):
+            logger.warning(f"No AFD products found for office {office_id}")
+            return "Forecast discussion not available for this location."
+
+        latest_product = products_data["@graph"][0]
+        latest_product_id = latest_product.get("id")
+        if not latest_product_id:
+            logger.warning("No product ID found in latest AFD product")
+            return "Forecast discussion not available."
+
+        product_url = f"{nws_base_url}/products/{latest_product_id}"
+        response = await client.get(product_url, headers=headers)
+
+        if response.status_code != 200:
+            logger.warning(f"Failed to get AFD product text: HTTP {response.status_code}")
+            return "Forecast discussion not available."
+
+        product_data = response.json()
+        product_text = product_data.get("productText")
+
+        if not product_text:
+            logger.warning("No product text found in AFD product")
+            return "Forecast discussion not available."
+
+        logger.info(f"Successfully fetched AFD for office {office_id}")
+        return product_text
+
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"Failed to get NWS discussion: {exc}")
+        return "Forecast discussion not available due to error."
+
+
+async def get_nws_alerts(
+    location: Location,
+    nws_base_url: str,
+    user_agent: str,
+    timeout: float,
+) -> WeatherAlerts | None:
+    """Fetch weather alerts from the NWS API."""
+    try:
+        alerts_url = f"{nws_base_url}/alerts/active"
+        params = {
+            "point": f"{location.latitude},{location.longitude}",
+            "status": "actual",
+            "message_type": "alert",
+        }
+
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+            headers = {"User-Agent": user_agent}
+            response = await client.get(alerts_url, params=params, headers=headers)
+            response.raise_for_status()
+            alerts_data = response.json()
+
+            return parse_nws_alerts(alerts_data)
+
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"Failed to get NWS alerts: {exc}")
+        return WeatherAlerts(alerts=[])
+
+
+async def get_nws_hourly_forecast(
+    location: Location,
+    nws_base_url: str,
+    user_agent: str,
+    timeout: float,
+) -> HourlyForecast | None:
+    """Fetch hourly forecast from the NWS API."""
+    try:
+        grid_url = f"{nws_base_url}/points/{location.latitude},{location.longitude}"
+
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+            headers = {"User-Agent": user_agent}
+            response = await client.get(grid_url, headers=headers)
+            response.raise_for_status()
+            grid_data = response.json()
+
+            hourly_forecast_url = grid_data.get("properties", {}).get("forecastHourly")
+            if not hourly_forecast_url:
+                logger.warning("No hourly forecast URL found in grid data")
+                return None
+
+            response = await client.get(hourly_forecast_url, headers=headers)
+            response.raise_for_status()
+            hourly_data = response.json()
+
+            return parse_nws_hourly_forecast(hourly_data)
+
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"Failed to get NWS hourly forecast: {exc}")
+        return None
+
+
+def parse_nws_current_conditions(data: dict) -> CurrentConditions:
+    """Parse NWS current conditions payload into a CurrentConditions model."""
+    props = data.get("properties", {})
+
+    temp_c = props.get("temperature", {}).get("value")
+    temp_f = (temp_c * 9 / 5) + 32 if temp_c is not None else None
+
+    humidity = props.get("relativeHumidity", {}).get("value")
+    humidity = round(humidity) if humidity is not None else None
+
+    dewpoint_c = props.get("dewpoint", {}).get("value")
+    dewpoint_f = (dewpoint_c * 9 / 5) + 32 if dewpoint_c is not None else None
+
+    visibility_m = props.get("visibility", {}).get("value")
+    visibility_miles = visibility_m / 1609.344 if visibility_m is not None else None
+    visibility_km = visibility_m / 1000 if visibility_m is not None else None
+
+    wind_speed = props.get("windSpeed", {})
+    wind_speed_value = wind_speed.get("value")
+    wind_speed_unit = wind_speed.get("unitCode")
+    wind_speed_mph, wind_speed_kph = convert_wind_speed_to_mph_and_kph(
+        wind_speed_value, wind_speed_unit
+    )
+
+    wind_direction = props.get("windDirection", {}).get("value")
+
+    pressure_pa = props.get("barometricPressure", {}).get("value")
+    pressure_in = convert_pa_to_inches(pressure_pa)
+
+    timestamp = props.get("timestamp")
+    last_updated = None
+    if timestamp:
+        try:
+            last_updated = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        except ValueError:
+            logger.debug(f"Failed to parse observation timestamp: {timestamp}")
+
+    return CurrentConditions(
+        temperature_f=temp_f,
+        temperature_c=temp_c,
+        condition=props.get("textDescription"),
+        humidity=humidity,
+        dewpoint_f=dewpoint_f,
+        dewpoint_c=dewpoint_c,
+        wind_speed_mph=wind_speed_mph,
+        wind_speed_kph=wind_speed_kph,
+        wind_direction=wind_direction,
+        pressure_in=pressure_in,
+        pressure_mb=convert_pa_to_mb(pressure_pa),
+        feels_like_f=None,
+        feels_like_c=None,
+        visibility_miles=visibility_miles,
+        visibility_km=visibility_km,
+        last_updated=last_updated or datetime.now(),
+    )
+
+
+def parse_nws_forecast(data: dict) -> Forecast:
+    """Parse NWS forecast payload into a Forecast model."""
+    periods = []
+
+    for period_data in data.get("properties", {}).get("periods", []):
+        period = ForecastPeriod(
+            name=period_data.get("name", ""),
+            temperature=period_data.get("temperature"),
+            temperature_unit=period_data.get("temperatureUnit", "F"),
+            short_forecast=period_data.get("shortForecast"),
+            detailed_forecast=period_data.get("detailedForecast"),
+            wind_speed=period_data.get("windSpeed"),
+            wind_direction=period_data.get("windDirection"),
+            icon=period_data.get("icon"),
+        )
+        periods.append(period)
+
+    return Forecast(periods=periods, generated_at=datetime.now())
+
+
+def parse_nws_alerts(data: dict) -> WeatherAlerts:
+    """Parse NWS alerts payload into a WeatherAlerts collection."""
+    alerts: list[WeatherAlert] = []
+
+    for alert_data in data.get("features", []):
+        props = alert_data.get("properties", {})
+
+        alert_id = None
+        if "id" in alert_data:
+            alert_id = alert_data["id"]
+        elif "identifier" in props:
+            alert_id = props["identifier"]
+        elif "@id" in props:
+            alert_id = props["@id"]
+
+        onset = None
+        expires = None
+
+        if props.get("onset"):
+            try:
+                onset = datetime.fromisoformat(props["onset"].replace("Z", "+00:00"))
+            except ValueError:
+                logger.warning(f"Failed to parse onset time: {props['onset']}")
+
+        if props.get("expires"):
+            try:
+                expires = datetime.fromisoformat(props["expires"].replace("Z", "+00:00"))
+            except ValueError:
+                logger.warning(f"Failed to parse expires time: {props['expires']}")
+
+        alert = WeatherAlert(
+            title=props.get("headline", "Weather Alert"),
+            description=props.get("description", ""),
+            severity=props.get("severity", "Unknown"),
+            urgency=props.get("urgency", "Unknown"),
+            certainty=props.get("certainty", "Unknown"),
+            event=props.get("event"),
+            headline=props.get("headline"),
+            instruction=props.get("instruction"),
+            onset=onset,
+            expires=expires,
+            areas=props.get("areaDesc", "").split("; ") if props.get("areaDesc") else [],
+            id=alert_id,
+        )
+        alerts.append(alert)
+
+        if alert_id:
+            logger.debug(f"Parsed alert with ID: {alert_id}")
+        else:
+            logger.debug("Parsed alert without ID, will generate unique ID")
+
+    logger.info(f"Parsed {len(alerts)} alerts from NWS API")
+    return WeatherAlerts(alerts=alerts)
+
+
+def parse_nws_hourly_forecast(data: dict) -> HourlyForecast:
+    """Parse NWS hourly forecast payload into an HourlyForecast model."""
+    periods = []
+
+    for period_data in data.get("properties", {}).get("periods", []):
+        start_time_str = period_data.get("startTime")
+        start_time = None
+        if start_time_str:
+            try:
+                start_time = datetime.fromisoformat(start_time_str.replace("Z", "+00:00"))
+            except ValueError:
+                logger.warning(f"Failed to parse start time: {start_time_str}")
+
+        end_time_str = period_data.get("endTime")
+        end_time = None
+        if end_time_str:
+            try:
+                end_time = datetime.fromisoformat(end_time_str.replace("Z", "+00:00"))
+            except ValueError:
+                logger.warning(f"Failed to parse end time: {end_time_str}")
+
+        period = HourlyForecastPeriod(
+            start_time=start_time or datetime.now(),
+            end_time=end_time,
+            temperature=period_data.get("temperature"),
+            temperature_unit=period_data.get("temperatureUnit", "F"),
+            short_forecast=period_data.get("shortForecast"),
+            wind_speed=period_data.get("windSpeed"),
+            wind_direction=period_data.get("windDirection"),
+            icon=period_data.get("icon"),
+        )
+        periods.append(period)
+
+    return HourlyForecast(periods=periods, generated_at=datetime.now())

--- a/src/accessiweather/weather_client_openmeteo.py
+++ b/src/accessiweather/weather_client_openmeteo.py
@@ -1,0 +1,244 @@
+"""Open-Meteo API client methods for fetching and parsing weather data from the Open-Meteo service."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+import httpx
+
+from .models import (
+    CurrentConditions,
+    Forecast,
+    ForecastPeriod,
+    HourlyForecast,
+    HourlyForecastPeriod,
+    Location,
+)
+from .utils.temperature_utils import TemperatureUnit, calculate_dewpoint
+from .weather_client_parsers import (
+    convert_f_to_c,
+    convert_wind_speed_to_mph_and_kph,
+    degrees_to_cardinal,
+    format_date_name,
+    normalize_pressure,
+    normalize_temperature,
+    weather_code_to_description,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def get_openmeteo_current_conditions(
+    location: Location,
+    openmeteo_base_url: str,
+    timeout: float,
+) -> CurrentConditions | None:
+    """Fetch current conditions from the Open-Meteo API."""
+    try:
+        url = f"{openmeteo_base_url}/forecast"
+        params = {
+            "latitude": location.latitude,
+            "longitude": location.longitude,
+            "current": "temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m,pressure_msl",
+            "temperature_unit": "fahrenheit",
+            "wind_speed_unit": "mph",
+            "precipitation_unit": "inch",
+            "timezone": "auto",
+        }
+
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+            response = await client.get(url, params=params)
+            response.raise_for_status()
+            data = response.json()
+
+            current = parse_openmeteo_current_conditions(data)
+            if isinstance(current.wind_direction, (int, float)):
+                current.wind_direction = degrees_to_cardinal(current.wind_direction)
+            return current
+
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"Failed to get OpenMeteo current conditions: {exc}")
+        return None
+
+
+async def get_openmeteo_forecast(
+    location: Location,
+    openmeteo_base_url: str,
+    timeout: float,
+) -> Forecast | None:
+    """Fetch daily forecast from the Open-Meteo API."""
+    try:
+        url = f"{openmeteo_base_url}/forecast"
+        params = {
+            "latitude": location.latitude,
+            "longitude": location.longitude,
+            "daily": "temperature_2m_max,temperature_2m_min,weather_code,wind_speed_10m_max,wind_direction_10m_dominant",
+            "temperature_unit": "fahrenheit",
+            "wind_speed_unit": "mph",
+            "timezone": "auto",
+            "forecast_days": 7,
+        }
+
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+            response = await client.get(url, params=params)
+            response.raise_for_status()
+            data = response.json()
+
+            return parse_openmeteo_forecast(data)
+
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"Failed to get OpenMeteo forecast: {exc}")
+        return None
+
+
+async def get_openmeteo_hourly_forecast(
+    location: Location,
+    openmeteo_base_url: str,
+    timeout: float,
+) -> HourlyForecast | None:
+    """Fetch hourly forecast from the Open-Meteo API."""
+    try:
+        url = f"{openmeteo_base_url}/forecast"
+        params = {
+            "latitude": location.latitude,
+            "longitude": location.longitude,
+            "hourly": "temperature_2m,weather_code,wind_speed_10m,wind_direction_10m,pressure_msl",
+            "temperature_unit": "fahrenheit",
+            "wind_speed_unit": "mph",
+            "timezone": "auto",
+            "forecast_days": 2,
+        }
+
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+            response = await client.get(url, params=params)
+            response.raise_for_status()
+            data = response.json()
+
+            return parse_openmeteo_hourly_forecast(data)
+
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"Failed to get OpenMeteo hourly forecast: {exc}")
+        return None
+
+
+def parse_openmeteo_current_conditions(data: dict) -> CurrentConditions:
+    """Parse Open-Meteo current condition payload into a CurrentConditions model."""
+    current = data.get("current", {})
+    units = data.get("current_units", {})
+
+    temp_f, temp_c = normalize_temperature(
+        current.get("temperature_2m"), units.get("temperature_2m")
+    )
+
+    humidity = current.get("relative_humidity_2m")
+    humidity = round(humidity) if humidity is not None else None
+
+    dewpoint_f = None
+    dewpoint_c = None
+    if temp_f is not None and humidity is not None:
+        dewpoint_f = calculate_dewpoint(temp_f, humidity, unit=TemperatureUnit.FAHRENHEIT)
+        if dewpoint_f is not None:
+            dewpoint_c = convert_f_to_c(dewpoint_f)
+
+    wind_speed_mph, wind_speed_kph = convert_wind_speed_to_mph_and_kph(
+        current.get("wind_speed_10m"), units.get("wind_speed_10m")
+    )
+
+    pressure_in, pressure_mb = normalize_pressure(
+        current.get("pressure_msl"), units.get("pressure_msl")
+    )
+
+    feels_like_f, feels_like_c = normalize_temperature(
+        current.get("apparent_temperature"), units.get("apparent_temperature")
+    )
+
+    timestamp = current.get("time")
+    last_updated = None
+    if timestamp:
+        try:
+            last_updated = datetime.fromisoformat(timestamp)
+        except ValueError:
+            logger.debug(f"Failed to parse OpenMeteo timestamp: {timestamp}")
+
+    return CurrentConditions(
+        temperature_f=temp_f,
+        temperature_c=temp_c,
+        condition=weather_code_to_description(current.get("weather_code")),
+        humidity=humidity,
+        dewpoint_f=dewpoint_f,
+        dewpoint_c=dewpoint_c,
+        wind_speed_mph=wind_speed_mph,
+        wind_speed_kph=wind_speed_kph,
+        wind_direction=current.get("wind_direction_10m"),
+        pressure_in=pressure_in,
+        pressure_mb=pressure_mb,
+        feels_like_f=feels_like_f,
+        feels_like_c=feels_like_c,
+        last_updated=last_updated or datetime.now(),
+    )
+
+
+def parse_openmeteo_forecast(data: dict) -> Forecast:
+    """Parse Open-Meteo daily forecast payload into a Forecast model."""
+    daily = data.get("daily", {})
+    periods = []
+
+    dates = daily.get("time", [])
+    max_temps = daily.get("temperature_2m_max", [])
+    weather_codes = daily.get("weather_code", [])
+
+    for i, date in enumerate(dates):
+        if i < len(max_temps) and i < len(weather_codes):
+            period = ForecastPeriod(
+                name=format_date_name(date, i),
+                temperature=max_temps[i],
+                temperature_unit="F",
+                short_forecast=weather_code_to_description(weather_codes[i]),
+            )
+            periods.append(period)
+
+    return Forecast(periods=periods, generated_at=datetime.now())
+
+
+def parse_openmeteo_hourly_forecast(data: dict) -> HourlyForecast:
+    """Parse Open-Meteo hourly forecast payload into an HourlyForecast model."""
+    periods: list[HourlyForecastPeriod] = []
+    hourly = data.get("hourly", {})
+
+    times = hourly.get("time", [])
+    temperatures = hourly.get("temperature_2m", [])
+    weather_codes = hourly.get("weather_code", [])
+    wind_speeds = hourly.get("wind_speed_10m", [])
+    wind_directions = hourly.get("wind_direction_10m", [])
+    pressures = hourly.get("pressure_msl", [])
+
+    for i, time_str in enumerate(times):
+        start_time = None
+        if time_str:
+            try:
+                start_time = datetime.fromisoformat(time_str)
+            except ValueError:
+                logger.warning(f"Failed to parse OpenMeteo time: {time_str}")
+                start_time = datetime.now()
+
+        temperature = temperatures[i] if i < len(temperatures) else None
+        weather_code = weather_codes[i] if i < len(weather_codes) else None
+        wind_speed = wind_speeds[i] if i < len(wind_speeds) else None
+        wind_direction = wind_directions[i] if i < len(wind_directions) else None
+        pressure_mb = pressures[i] if i < len(pressures) else None
+        pressure_in = pressure_mb * 0.0295299830714 if pressure_mb is not None else None
+
+        period = HourlyForecastPeriod(
+            start_time=start_time or datetime.now(),
+            temperature=temperature,
+            temperature_unit="F",
+            short_forecast=weather_code_to_description(weather_code),
+            wind_speed=f"{wind_speed} mph" if wind_speed is not None else None,
+            wind_direction=degrees_to_cardinal(wind_direction),
+            pressure_mb=pressure_mb,
+            pressure_in=pressure_in,
+        )
+        periods.append(period)
+
+    return HourlyForecast(periods=periods, generated_at=datetime.now())

--- a/src/accessiweather/weather_client_parsers.py
+++ b/src/accessiweather/weather_client_parsers.py
@@ -1,0 +1,197 @@
+"""Shared parsing and utility functions for weather data processing in AccessiWeather."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+__all__ = [
+    "convert_mps_to_mph",
+    "convert_wind_speed_to_mph",
+    "convert_wind_speed_to_kph",
+    "convert_wind_speed_to_mph_and_kph",
+    "convert_pa_to_inches",
+    "convert_pa_to_mb",
+    "normalize_temperature",
+    "normalize_pressure",
+    "convert_f_to_c",
+    "degrees_to_cardinal",
+    "weather_code_to_description",
+    "format_date_name",
+]
+
+logger = logging.getLogger(__name__)
+
+
+def convert_mps_to_mph(mps: float | None) -> float | None:
+    """Convert meters per second to miles per hour."""
+    return mps * 2.237 if mps is not None else None
+
+
+def convert_wind_speed_to_mph(value: float | None, unit_code: str | None) -> float | None:
+    """Normalize WMO wind speed units to miles per hour."""
+    if value is None:
+        return None
+    if not unit_code:
+        return value
+    unit_code = unit_code.lower()
+    if unit_code.endswith(("m_s-1", "mps")):
+        return value * 2.237
+    if unit_code.endswith(("km_h-1", "kmh", "km/h")):
+        return value * 0.621371
+    if unit_code.endswith(("mi_h-1", "mph", "mp/h")):
+        return value
+    if unit_code.endswith(("kn", "kt")):
+        return value * 1.15078
+    return value
+
+
+def convert_wind_speed_to_kph(value: float | None, unit_code: str | None) -> float | None:
+    """Normalize WMO wind speed units to kilometers per hour."""
+    if value is None:
+        return None
+    if not unit_code:
+        return value
+    unit_code = unit_code.lower()
+    if unit_code.endswith(("m_s-1", "mps")):
+        return value * 3.6
+    if unit_code.endswith(("km_h-1", "kmh", "km/h")):
+        return value
+    if unit_code.endswith(("mi_h-1", "mph", "mp/h")):
+        return value * 1.60934
+    if unit_code.endswith(("kn", "kt")):
+        return value * 1.852
+    return value
+
+
+def convert_wind_speed_to_mph_and_kph(
+    value: float | None, unit_code: str | None
+) -> tuple[float | None, float | None]:
+    """Return wind speed converted to both miles per hour and kilometers per hour."""
+    return (
+        convert_wind_speed_to_mph(value, unit_code),
+        convert_wind_speed_to_kph(value, unit_code),
+    )
+
+
+def convert_pa_to_inches(pa: float | None) -> float | None:
+    """Convert pressure from pascals to inches of mercury."""
+    return pa * 0.0002953 if pa is not None else None
+
+
+def convert_pa_to_mb(pa: float | None) -> float | None:
+    """Convert pressure from pascals to millibars (hectopascals)."""
+    return pa / 100 if pa is not None else None
+
+
+def normalize_temperature(
+    value: float | None, unit: str | None
+) -> tuple[float | None, float | None]:
+    """Return temperature normalized to both Fahrenheit and Celsius."""
+    if value is None:
+        return None, None
+
+    unit_lower = (unit or "").lower()
+    if "f" in unit_lower:
+        temp_f = value
+        temp_c = convert_f_to_c(temp_f)
+    elif "c" in unit_lower:
+        temp_c = value
+        temp_f = (temp_c * 9 / 5) + 32
+    else:
+        temp_f = value
+        temp_c = convert_f_to_c(temp_f)
+    return temp_f, temp_c
+
+
+def normalize_pressure(value: float | None, unit: str | None) -> tuple[float | None, float | None]:
+    """Return pressure normalized to both inches of mercury and millibars."""
+    if value is None:
+        return None, None
+
+    unit_lower = (unit or "").lower()
+    if "hpa" in unit_lower or "mb" in unit_lower:
+        pressure_mb = value
+        pressure_in = value * 0.0295299830714
+    elif "pa" in unit_lower:
+        pressure_mb = value / 100
+        pressure_in = convert_pa_to_inches(value)
+    elif "inch" in unit_lower or unit_lower.endswith("in"):
+        pressure_in = value
+        pressure_mb = value * 33.8639
+    else:
+        pressure_mb = value
+        pressure_in = None
+    return pressure_in, pressure_mb
+
+
+def convert_f_to_c(fahrenheit: float | None) -> float | None:
+    """Convert Fahrenheit to Celsius."""
+    return (fahrenheit - 32) * 5 / 9 if fahrenheit is not None else None
+
+
+def degrees_to_cardinal(degrees: float | None) -> str | None:
+    """Convert wind direction in degrees to its cardinal direction."""
+    if degrees is None:
+        return None
+
+    directions = [
+        "N",
+        "NNE",
+        "NE",
+        "ENE",
+        "E",
+        "ESE",
+        "SE",
+        "SSE",
+        "S",
+        "SSW",
+        "SW",
+        "WSW",
+        "W",
+        "WNW",
+        "NW",
+        "NNW",
+    ]
+    index = round(degrees / 22.5) % 16
+    return directions[index]
+
+
+def weather_code_to_description(code: int | None) -> str | None:
+    """Convert an Open-Meteo weather code to a human-readable description."""
+    if code is None:
+        return None
+
+    code_map = {
+        0: "Clear sky",
+        1: "Mainly clear",
+        2: "Partly cloudy",
+        3: "Overcast",
+        45: "Fog",
+        48: "Depositing rime fog",
+        51: "Light drizzle",
+        53: "Moderate drizzle",
+        55: "Dense drizzle",
+        61: "Slight rain",
+        63: "Moderate rain",
+        65: "Heavy rain",
+        71: "Slight snow",
+        73: "Moderate snow",
+        75: "Heavy snow",
+        95: "Thunderstorm",
+    }
+    return code_map.get(code, f"Weather code {code}")
+
+
+def format_date_name(date_str: str, index: int) -> str:
+    """Format a date string into a friendly name such as Today, Tomorrow, or weekday."""
+    if index == 0:
+        return "Today"
+    if index == 1:
+        return "Tomorrow"
+    try:
+        date_obj = datetime.fromisoformat(date_str)
+        return date_obj.strftime("%A")
+    except (ValueError, TypeError):
+        logger.debug("Failed to format date '%s' at index %s", date_str, index)
+        return f"Day {index + 1}"

--- a/src/accessiweather/weather_client_trends.py
+++ b/src/accessiweather/weather_client_trends.py
@@ -1,0 +1,171 @@
+"""Trend insight computation for weather data analysis in AccessiWeather."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from datetime import datetime, timedelta
+
+from .models import HourlyForecastPeriod, TrendInsight, WeatherData
+
+logger = logging.getLogger(__name__)
+
+
+def apply_trend_insights(
+    weather_data: WeatherData,
+    trend_insights_enabled: bool,
+    trend_hours: int,
+) -> None:
+    """Populate trend insights on the provided WeatherData instance."""
+    if not trend_insights_enabled:
+        logger.debug("Trend insights disabled; clearing insights")
+        weather_data.trend_insights = []
+        return
+
+    insights: list[TrendInsight] = []
+
+    temp_insight = compute_temperature_trend(weather_data, trend_hours)
+    if temp_insight:
+        insights.append(temp_insight)
+
+    pressure_insight = compute_pressure_trend(weather_data, trend_hours)
+    if pressure_insight:
+        insights.append(pressure_insight)
+
+    weather_data.trend_insights = insights
+
+
+def compute_temperature_trend(
+    weather_data: WeatherData,
+    trend_hours: int,
+) -> TrendInsight | None:
+    """Compute the projected temperature trend over the configured number of hours."""
+    current = weather_data.current
+    hourly = weather_data.hourly_forecast.periods if weather_data.hourly_forecast else []
+    if current is None or not hourly:
+        logger.debug("Insufficient data for temperature trend calculation")
+        return None
+
+    base = current.temperature_f
+    unit = "°F"
+    if base is None:
+        base = current.temperature_c
+        unit = "°C"
+    if base is None:
+        logger.debug("Missing base temperature for trend calculation")
+        return None
+
+    target_period = period_for_hours_ahead(hourly, trend_hours)
+    if not target_period or target_period.temperature is None:
+        logger.debug("Target period missing temperature for trend calculation")
+        return None
+
+    change = target_period.temperature - base
+    direction, sparkline = trend_descriptor(
+        change,
+        minor=1.0 if unit == "°F" else 0.5,
+        strong=3.0 if unit == "°F" else 1.5,
+    )
+    summary = f"Temperature {direction} {change:+.1f}{unit} over {trend_hours}h"
+    return TrendInsight(
+        metric="temperature",
+        direction=direction,
+        change=round(change, 1),
+        unit=unit,
+        timeframe_hours=trend_hours,
+        summary=summary,
+        sparkline=sparkline,
+    )
+
+
+def compute_pressure_trend(
+    weather_data: WeatherData,
+    trend_hours: int,
+) -> TrendInsight | None:
+    """Compute the projected pressure trend over the configured number of hours."""
+    current = weather_data.current
+    hourly = weather_data.hourly_forecast.periods if weather_data.hourly_forecast else []
+    if current is None or not hourly:
+        logger.debug("Insufficient data for pressure trend calculation")
+        return None
+
+    base_mb = current.pressure_mb
+    base_in = current.pressure_in
+    target_period = period_for_hours_ahead(hourly, trend_hours)
+    if not target_period:
+        logger.debug("No target period available for pressure trend calculation")
+        return None
+
+    future_mb = target_period.pressure_mb
+    future_in = target_period.pressure_in
+
+    value_pairs: list[tuple[float, float, str]] = []
+    if base_mb is not None and future_mb is not None:
+        value_pairs.append((base_mb, future_mb, "mb"))
+    if base_in is not None and future_in is not None:
+        value_pairs.append((base_in, future_in, "inHg"))
+    if not value_pairs:
+        logger.debug("No comparable pressure values available for trend")
+        return None
+
+    base, future, unit = value_pairs[0]
+    change = future - base
+    direction, sparkline = trend_descriptor(
+        change,
+        minor=0.5 if unit == "mb" else 0.02,
+        strong=1.5 if unit == "mb" else 0.05,
+    )
+    summary = f"Pressure {direction} {change:+.2f}{unit} over {trend_hours}h"
+    return TrendInsight(
+        metric="pressure",
+        direction=direction,
+        change=round(change, 2),
+        unit=unit,
+        timeframe_hours=trend_hours,
+        summary=summary,
+        sparkline=sparkline,
+    )
+
+
+def trend_descriptor(change: float, *, minor: float, strong: float) -> tuple[str, str]:
+    """Return the directional descriptor and sparkline for the given change magnitude."""
+    if change >= strong:
+        return "rising", "↑↑"
+    if change >= minor:
+        return "rising", "↑"
+    if change <= -strong:
+        return "falling", "↓↓"
+    if change <= -minor:
+        return "falling", "↓"
+    return "steady", "→"
+
+
+def period_for_hours_ahead(
+    periods: Sequence[HourlyForecastPeriod],
+    hours_ahead: int,
+) -> HourlyForecastPeriod | None:
+    """Return the forecast period closest to the target number of hours ahead."""
+    if not periods:
+        return None
+
+    target = normalize_datetime(datetime.now()) + timedelta(hours=hours_ahead)
+    closest = None
+    best_delta = None
+    for period in periods:
+        start = normalize_datetime(period.start_time)
+        if start is None:
+            continue
+        delta = abs((start - target).total_seconds())
+        if best_delta is None or delta < best_delta:
+            closest = period
+            best_delta = delta
+    return closest
+
+
+def normalize_datetime(value: datetime | None) -> datetime | None:
+    """Normalize datetimes by removing timezone information when present."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value
+    return value.astimezone().replace(tzinfo=None)

--- a/src/accessiweather/weather_client_visualcrossing.py
+++ b/src/accessiweather/weather_client_visualcrossing.py
@@ -1,0 +1,55 @@
+"""Visual Crossing alert processing and notification integration for AccessiWeather."""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+
+from .alert_manager import AlertManager, AlertSettings
+from .alert_notification_system import AlertNotificationSystem
+from .models import Location, WeatherAlerts
+
+logger = logging.getLogger(__name__)
+
+
+async def process_visual_crossing_alerts(alerts: WeatherAlerts, location: Location) -> None:
+    """Process Visual Crossing alerts and dispatch notifications."""
+    try:
+        config_dir = os.path.join(tempfile.gettempdir(), "accessiweather_alerts")
+
+        settings = AlertSettings()
+        settings.min_severity_priority = 1
+        settings.notifications_enabled = True
+
+        alert_manager = AlertManager(config_dir, settings)
+        notification_system = AlertNotificationSystem(alert_manager)
+
+        logger.info(f"Processing Visual Crossing alerts for {location.name}")
+        logger.info(f"Number of alerts to process: {len(alerts.alerts)}")
+
+        for i, alert in enumerate(alerts.alerts):
+            logger.info(f"Alert {i + 1}: {alert.event} - {alert.severity} - {alert.headline}")
+
+        system_settings = notification_system.get_settings()
+        logger.info(
+            "Notification settings - enabled: %s, min_severity: %s",
+            system_settings.notifications_enabled,
+            system_settings.min_severity_priority,
+        )
+
+        notifications_sent = await notification_system.process_and_notify(alerts)
+
+        if notifications_sent > 0:
+            logger.info(
+                "✅ Sent %s Visual Crossing alert notifications for %s",
+                notifications_sent,
+                location.name,
+            )
+        else:
+            logger.warning("⚠️ No Visual Crossing alert notifications sent for %s", location.name)
+            stats = notification_system.get_statistics()
+            logger.info("Alert statistics: %s", stats)
+
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"Failed to process Visual Crossing alerts for notifications: {exc}")


### PR DESCRIPTION
## Summary
- split NWS, Open-Meteo, trend, parser, and Visual Crossing helpers into dedicated modules
- keep WeatherClient as an orchestrator that delegates to the new modules to preserve private API
- add thin wrapper methods for utilities to maintain compatibility with existing tests

## Testing
- .venv/bin/pytest tests/test_simple_weather_client.py
- .venv/bin/pytest tests/test_toga_weather_client.py
