### PR TITLE
fix: streamline release workflow to collect artifacts from build job

### DIFF
--- a/.github/workflows/briefcase-release.yml
+++ b/.github/workflows/briefcase-release.yml
@@ -31,6 +31,8 @@ jobs:
           path: dist
           pattern: "*-installer-*"
           merge-multiple: true
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Windows Portable
         uses: actions/download-artifact@v4
@@ -38,6 +40,8 @@ jobs:
           path: dist
           pattern: "windows-portable-*"
           merge-multiple: true
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare release assets
         run: |


### PR DESCRIPTION
Updates the release workflow to be triggered by the completion of the build workflow. It now downloads all artifacts (installers and portable zip) generated by the matrix build and creates a GitHub release with them.