### PR TITLE
fix: restore release version/tag extraction in release workflow

### DIFF
--- a/.github/workflows/briefcase-release.yml
+++ b/.github/workflows/briefcase-release.yml
@@ -25,6 +25,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Get version
+        id: version
+        run: |
+          # Extract version from pyproject.toml
+          VERSION=$(grep -m 1 'version = ' pyproject.toml | cut -d '"' -f 2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
       - name: Download All Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -59,6 +67,8 @@ jobs:
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
+          tag: v${{ steps.version.outputs.version }}
+          name: AccessiWeather v${{ steps.version.outputs.version }}
           artifacts: "release-assets/*"
           draft: true
           allowUpdates: true


### PR DESCRIPTION
The release action failed because it requires a 'tag' input when triggered by 'workflow_run' (as opposed to a tag push). This PR restores the step to extract the version from 'pyproject.toml' and passes it as the tag to 'ncipollo/release-action'.