### PR TITLE
feat(pages): add macOS download links, fix dev commit SHA display

### DIFF
--- a/.github/workflows/update-pages.yml
+++ b/.github/workflows/update-pages.yml
@@ -177,6 +177,7 @@ jobs:
             echo "main_commit="
             echo "main_installer_url="
             echo "main_portable_url="
+            echo "main_macos_installer_url="
             echo "⚠ No stable releases found (release_info was null or empty)" >&2
             return
           fi
@@ -211,12 +212,22 @@ jobs:
               ][0] // ""
             ')
 
+            # Extract macOS asset URLs - look for .dmg files
+            local macos_installer_url=$(echo "$release_info" | jq -r '
+              [
+                .assets[]?
+                | select((.name // "" | ascii_downcase) | endswith(".dmg"))
+                | .browser_download_url
+              ][0] // ""
+            ')
+
             echo "main_version=${version}"
             echo "main_date=${formatted_date}"
             echo "main_run_id="
             echo "main_commit=${target_commitish}"
             echo "main_installer_url=${installer_url}"
             echo "main_portable_url=${portable_url}"
+            echo "main_macos_installer_url=${macos_installer_url}"
 
             echo "✓ Found stable release: version=$version, date=$formatted_date" >&2
 
@@ -231,6 +242,7 @@ jobs:
             echo "main_commit="
             echo "main_installer_url="
             echo "main_portable_url="
+            echo "main_macos_installer_url="
             echo "⚠ No stable releases found (tag_name was empty)" >&2
           fi
         }
@@ -255,6 +267,16 @@ jobs:
           local target_commitish=$(echo "$release_json" | jq -r '.target_commitish // empty')
           local release_url=$(echo "$release_json" | jq -r '.html_url // empty')
 
+          # Get actual commit SHA from tag reference (target_commitish often just returns branch name)
+          if [ -n "$tag_name" ]; then
+            local tag_ref=$(curl -s -H "Authorization: token ${{ github.token }}" \
+              "https://api.github.com/repos/${{ github.repository }}/git/refs/tags/${tag_name}")
+            local tag_sha=$(echo "$tag_ref" | jq -r '.object.sha // empty')
+            if [ -n "$tag_sha" ] && [ "$tag_sha" != "null" ]; then
+              target_commitish="$tag_sha"
+            fi
+          fi
+
           local version=$(echo "$tag_name" | sed 's/^v//')
           [ -z "$version" ] && version="pre-release"
 
@@ -276,12 +298,22 @@ jobs:
             ][0] // empty
           ')
 
+          # Extract macOS asset URLs - look for .dmg files
+          local macos_installer_url=$(echo "$release_json" | jq -r '
+            [
+              .assets[]?
+              | select((.name // "" | ascii_downcase) | endswith(".dmg"))
+              | .browser_download_url
+            ][0] // empty
+          ')
+
           echo "dev_version=${version}"
           echo "dev_date=${formatted_date}"
           echo "dev_commit=${target_commitish}"
           echo "dev_release_url=${release_url}"
           echo "dev_installer_url=${installer_url}"
           echo "dev_portable_url=${portable_url}"
+          echo "dev_macos_installer_url=${macos_installer_url}"
           echo "dev_tag=${tag_name}"
 
           echo "✓ Found pre-release: tag=$tag_name, version=$version" >&2
@@ -323,6 +355,7 @@ jobs:
             echo "${branch}_release_url="
             echo "${branch}_installer_url="
             echo "${branch}_portable_url="
+            echo "${branch}_macos_installer_url="
 
             echo "✓ Found build for $branch: version=$version, date=$formatted_date" >&2
           else
@@ -333,6 +366,7 @@ jobs:
             echo "${branch}_release_url="
             echo "${branch}_installer_url="
             echo "${branch}_portable_url="
+            echo "${branch}_macos_installer_url="
             echo "⚠ No successful builds found for $branch" >&2
           fi
         }
@@ -415,6 +449,7 @@ jobs:
         MAIN_COMMIT="${{ steps.build-info.outputs.main_commit }}"
         MAIN_INSTALLER_URL="${{ steps.build-info.outputs.main_installer_url }}"
         MAIN_PORTABLE_URL="${{ steps.build-info.outputs.main_portable_url }}"
+        MAIN_MACOS_INSTALLER_URL="${{ steps.build-info.outputs.main_macos_installer_url }}"
         MAIN_HAS_RELEASE="${{ steps.build-info.outputs.main_has_release }}"
 
         # Always use dev branch information for development section when available
@@ -425,6 +460,7 @@ jobs:
         DEV_RELEASE_URL="${{ steps.build-info.outputs.dev_release_url }}"
         DEV_INSTALLER_URL="${{ steps.build-info.outputs.dev_installer_url }}"
         DEV_PORTABLE_URL="${{ steps.build-info.outputs.dev_portable_url }}"
+        DEV_MACOS_INSTALLER_URL="${{ steps.build-info.outputs.dev_macos_installer_url }}"
         DEV_HAS_RELEASE="${{ steps.build-info.outputs.dev_has_release }}"
 
         # If dev branch info is not available, fall back to target branch or generic values
@@ -453,6 +489,8 @@ jobs:
         [ -z "$DEV_RELEASE_URL" ] && DEV_RELEASE_URL="https://github.com/Orinks/AccessiWeather/releases"
         [ -z "$DEV_INSTALLER_URL" ] && DEV_INSTALLER_URL="$DEV_RELEASE_URL"
         [ -z "$DEV_PORTABLE_URL" ] && DEV_PORTABLE_URL="$DEV_RELEASE_URL"
+        [ -z "$MAIN_MACOS_INSTALLER_URL" ] && MAIN_MACOS_INSTALLER_URL="https://github.com/Orinks/AccessiWeather/releases"
+        [ -z "$DEV_MACOS_INSTALLER_URL" ] && DEV_MACOS_INSTALLER_URL="$DEV_RELEASE_URL"
 
         # Escape special characters for sed (but preserve HTML in release notes)
         escape_for_sed() {
@@ -467,11 +505,13 @@ jobs:
         DEV_RELEASE_URL_ESC=$(escape_for_sed "$DEV_RELEASE_URL")
         DEV_INSTALLER_URL_ESC=$(escape_for_sed "$DEV_INSTALLER_URL")
         DEV_PORTABLE_URL_ESC=$(escape_for_sed "$DEV_PORTABLE_URL")
+        DEV_MACOS_INSTALLER_URL_ESC=$(escape_for_sed "$DEV_MACOS_INSTALLER_URL")
         LAST_UPDATED_ESCAPED=$(escape_for_sed "$LAST_UPDATED")
 
         # Escape URLs for sed
         MAIN_INSTALLER_URL_ESC=$(escape_for_sed "$MAIN_INSTALLER_URL")
         MAIN_PORTABLE_URL_ESC=$(escape_for_sed "$MAIN_PORTABLE_URL")
+        MAIN_MACOS_INSTALLER_URL_ESC=$(escape_for_sed "$MAIN_MACOS_INSTALLER_URL")
 
         # Substitute template variables with actual values
         sed -i "s@{{MAIN_VERSION}}@$MAIN_VERSION@g" index.html
@@ -479,6 +519,7 @@ jobs:
         sed -i "s@{{MAIN_COMMIT}}@$MAIN_COMMIT@g" index.html
         sed -i "s@{{MAIN_INSTALLER_URL}}@$MAIN_INSTALLER_URL_ESC@g" index.html
         sed -i "s@{{MAIN_PORTABLE_URL}}@$MAIN_PORTABLE_URL_ESC@g" index.html
+        sed -i "s@{{MAIN_MACOS_INSTALLER_URL}}@$MAIN_MACOS_INSTALLER_URL_ESC@g" index.html
         sed -i "s@{{MAIN_HAS_RELEASE}}@$MAIN_HAS_RELEASE@g" index.html
         sed -i "s@{{DEV_VERSION}}@$DEV_VERSION@g" index.html
         sed -i "s@{{DEV_DATE}}@$DEV_DATE@g" index.html
@@ -486,6 +527,7 @@ jobs:
         sed -i "s@{{DEV_RELEASE_URL}}@$DEV_RELEASE_URL_ESC@g" index.html
         sed -i "s@{{DEV_INSTALLER_URL}}@$DEV_INSTALLER_URL_ESC@g" index.html
         sed -i "s@{{DEV_PORTABLE_URL}}@$DEV_PORTABLE_URL_ESC@g" index.html
+        sed -i "s@{{DEV_MACOS_INSTALLER_URL}}@$DEV_MACOS_INSTALLER_URL_ESC@g" index.html
         sed -i "s@{{DEV_HAS_RELEASE}}@$DEV_HAS_RELEASE@g" index.html
         sed -i "s@{{LAST_UPDATED}}@$LAST_UPDATED_ESCAPED@g" index.html
 

--- a/docs/index.template.html
+++ b/docs/index.template.html
@@ -127,8 +127,52 @@
             box-shadow: 0 6px 20px rgba(74, 85, 104, 0.6);
         }
 
+        .download-btn.macos {
+            background: linear-gradient(135deg, #1d1d1f 0%, #3a3a3c 100%);
+            box-shadow: 0 4px 15px rgba(29, 29, 31, 0.4);
+        }
+
+        .download-btn.macos:hover {
+            box-shadow: 0 6px 20px rgba(29, 29, 31, 0.6);
+        }
+
+        .download-btn.macos.secondary {
+            background: linear-gradient(135deg, #636366 0%, #48484a 100%);
+            box-shadow: 0 4px 15px rgba(99, 99, 102, 0.4);
+        }
+
+        .download-btn.macos.secondary:hover {
+            box-shadow: 0 6px 20px rgba(99, 99, 102, 0.6);
+        }
+
         .download-btn svg {
             margin-right: 8px;
+        }
+
+        .platform-group {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        .platform-label {
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: #4a5568;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .platform-buttons {
+            display: flex;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+
+        @media (max-width: 768px) {
+            .platform-buttons {
+                flex-direction: column;
+            }
         }
 
         .info-section {
@@ -291,20 +335,34 @@
              </div>
 
              <div class="download-buttons" id="main-downloads">
-                 <a href="{{MAIN_INSTALLER_URL}}" id="main-installer" class="download-btn">
-                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                         <path
-                             d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z" />
-                     </svg>
-                     Download Installer
-                 </a>
-                 <a href="{{MAIN_PORTABLE_URL}}" id="main-portable" class="download-btn secondary">
-                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                         <path
-                             d="M12,17.5L10.25,16H13.75L12,17.5M10,4.5C10,3.67 10.67,3 11.5,3H12.5C13.33,3 14,3.67 14,4.5V5.5H10V4.5M4,7V6H20V7H19V19A2,2 0 0,1 17,21H7A2,2 0 0,1 5,19V7H4Z" />
-                     </svg>
-                     Download Portable
-                 </a>
+                 <div class="platform-group">
+                     <span class="platform-label">Windows</span>
+                     <div class="platform-buttons">
+                         <a href="{{MAIN_INSTALLER_URL}}" id="main-installer" class="download-btn" aria-label="Download Windows Installer">
+                             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                                 <path d="M3,12V6.75L9,5.43V11.91L3,12M20,3V11.75L10,11.9V5.21L20,3M3,13L9,13.09V19.9L3,18.75V13M20,13.25V22L10,20.09V13.1L20,13.25Z" />
+                             </svg>
+                             Installer (.msi)
+                         </a>
+                         <a href="{{MAIN_PORTABLE_URL}}" id="main-portable" class="download-btn secondary" aria-label="Download Windows Portable">
+                             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                                 <path d="M12,17.5L10.25,16H13.75L12,17.5M10,4.5C10,3.67 10.67,3 11.5,3H12.5C13.33,3 14,3.67 14,4.5V5.5H10V4.5M4,7V6H20V7H19V19A2,2 0 0,1 17,21H7A2,2 0 0,1 5,19V7H4Z" />
+                             </svg>
+                             Portable (.zip)
+                         </a>
+                     </div>
+                 </div>
+                 <div class="platform-group">
+                     <span class="platform-label">macOS</span>
+                     <div class="platform-buttons">
+                         <a href="{{MAIN_MACOS_INSTALLER_URL}}" id="main-macos-installer" class="download-btn macos" aria-label="Download macOS Installer">
+                             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                                 <path d="M18.71,19.5C17.88,20.74 17,21.95 15.66,21.97C14.32,22 13.89,21.18 12.37,21.18C10.84,21.18 10.37,21.95 9.1,22C7.79,22.05 6.8,20.68 5.96,19.47C4.25,17 2.94,12.45 4.7,9.39C5.57,7.87 7.13,6.91 8.82,6.88C10.1,6.86 11.32,7.75 12.11,7.75C12.89,7.75 14.37,6.68 15.92,6.84C16.57,6.87 18.39,7.1 19.56,8.82C19.47,8.88 17.39,10.1 17.41,12.63C17.44,15.65 20.06,16.66 20.09,16.67C20.06,16.74 19.67,18.11 18.71,19.5M13,3.5C13.73,2.67 14.94,2.04 15.94,2C16.07,3.17 15.6,4.35 14.9,5.19C14.21,6.04 13.07,6.7 11.95,6.61C11.8,5.46 12.36,4.26 13,3.5Z" />
+                             </svg>
+                             Installer (.dmg)
+                         </a>
+                     </div>
+                 </div>
              </div>
 
             <!-- Release Notes Section -->
@@ -330,20 +388,34 @@
             </div>
 
             <div class="download-buttons" id="dev-downloads">
-                <a href="#" id="dev-installer" class="download-btn">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                        <path
-                            d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z" />
-                    </svg>
-                    Download Installer
-                </a>
-                <a href="#" id="dev-portable" class="download-btn secondary">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                        <path
-                            d="M12,17.5L10.25,16H13.75L12,17.5M10,4.5C10,3.67 10.67,3 11.5,3H12.5C13.33,3 14,3.67 14,4.5V5.5H10V4.5M4,7V6H20V7H19V19A2,2 0 0,1 17,21H7A2,2 0 0,1 5,19V7H4Z" />
-                    </svg>
-                    Download Portable
-                </a>
+                <div class="platform-group">
+                    <span class="platform-label">Windows</span>
+                    <div class="platform-buttons">
+                        <a href="#" id="dev-installer" class="download-btn" aria-label="Download Windows Installer (Dev)">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M3,12V6.75L9,5.43V11.91L3,12M20,3V11.75L10,11.9V5.21L20,3M3,13L9,13.09V19.9L3,18.75V13M20,13.25V22L10,20.09V13.1L20,13.25Z" />
+                            </svg>
+                            Installer (.msi)
+                        </a>
+                        <a href="#" id="dev-portable" class="download-btn secondary" aria-label="Download Windows Portable (Dev)">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M12,17.5L10.25,16H13.75L12,17.5M10,4.5C10,3.67 10.67,3 11.5,3H12.5C13.33,3 14,3.67 14,4.5V5.5H10V4.5M4,7V6H20V7H19V19A2,2 0 0,1 17,21H7A2,2 0 0,1 5,19V7H4Z" />
+                            </svg>
+                            Portable (.zip)
+                        </a>
+                    </div>
+                </div>
+                <div class="platform-group">
+                    <span class="platform-label">macOS</span>
+                    <div class="platform-buttons">
+                        <a href="#" id="dev-macos-installer" class="download-btn macos" aria-label="Download macOS Installer (Dev)">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M18.71,19.5C17.88,20.74 17,21.95 15.66,21.97C14.32,22 13.89,21.18 12.37,21.18C10.84,21.18 10.37,21.95 9.1,22C7.79,22.05 6.8,20.68 5.96,19.47C4.25,17 2.94,12.45 4.7,9.39C5.57,7.87 7.13,6.91 8.82,6.88C10.1,6.86 11.32,7.75 12.11,7.75C12.89,7.75 14.37,6.68 15.92,6.84C16.57,6.87 18.39,7.1 19.56,8.82C19.47,8.88 17.39,10.1 17.41,12.63C17.44,15.65 20.06,16.66 20.09,16.67C20.06,16.74 19.67,18.11 18.71,19.5M13,3.5C13.73,2.67 14.94,2.04 15.94,2C16.07,3.17 15.6,4.35 14.9,5.19C14.21,6.04 13.07,6.7 11.95,6.61C11.8,5.46 12.36,4.26 13,3.5Z" />
+                            </svg>
+                            Installer (.dmg)
+                        </a>
+                    </div>
+                </div>
             </div>
 
             <!-- Recent Commits Section -->
@@ -363,13 +435,13 @@
             <div class="info-grid">
                 <div class="info-card">
                     <h3>🛡️ Installer Version</h3>
-                    <p>Full installation package that integrates with Windows. Includes automatic updates and system
-                        integration. Recommended for most users.</p>
+                    <p>Full installation package (.msi for Windows, .dmg for macOS). Includes system integration.
+                        Recommended for most users.</p>
                 </div>
                 <div class="info-card">
                     <h3>📦 Portable Version</h3>
-                    <p>Standalone executable that doesn't require installation. Perfect for USB drives or temporary use.
-                        Settings are saved locally.</p>
+                    <p>Standalone package that doesn't require installation. Available for Windows only. Perfect for USB
+                        drives or temporary use.</p>
                 </div>
                 <div class="info-card">
                     <h3>🔄 Stable vs Development</h3>
@@ -378,7 +450,7 @@
                 </div>
                 <div class="info-card">
                     <h3>💻 System Requirements</h3>
-                    <p>Windows 10 or later (64-bit). Requires internet connection for weather data. Screen reader
+                    <p>Windows 10+ or macOS 11+ (64-bit). Requires internet connection for weather data. Screen reader
                         compatible for accessibility.</p>
                 </div>
             </div>
@@ -439,7 +511,8 @@
              main: {
                  version: '{{MAIN_VERSION}}',
                  date: '{{MAIN_DATE}}',
-                 commit: '{{MAIN_COMMIT}}'
+                 commit: '{{MAIN_COMMIT}}',
+                 macosInstallerUrl: '{{MAIN_MACOS_INSTALLER_URL}}'
              },
              dev: {
                  version: '{{DEV_VERSION}}',
@@ -447,7 +520,8 @@
                  commit: '{{DEV_COMMIT}}',
                  releaseUrl: '{{DEV_RELEASE_URL}}',
                  installerUrl: '{{DEV_INSTALLER_URL}}',
-                 portableUrl: '{{DEV_PORTABLE_URL}}'
+                 portableUrl: '{{DEV_PORTABLE_URL}}',
+                 macosInstallerUrl: '{{DEV_MACOS_INSTALLER_URL}}'
              },
              lastUpdated: '{{LAST_UPDATED}}'
          };
@@ -484,8 +558,10 @@
             // Dev branch
             const devInstallerLink = buildInfo.dev.installerUrl || buildInfo.dev.releaseUrl || '#';
             const devPortableLink = buildInfo.dev.portableUrl || buildInfo.dev.releaseUrl || devInstallerLink;
+            const devMacosInstallerLink = buildInfo.dev.macosInstallerUrl || buildInfo.dev.releaseUrl || '#';
             document.getElementById('dev-installer').href = devInstallerLink;
             document.getElementById('dev-portable').href = devPortableLink;
+            document.getElementById('dev-macos-installer').href = devMacosInstallerLink;
             document.getElementById('dev-version').textContent = buildInfo.dev.version;
             if (devDateEl) {
                 devDateEl.textContent = buildInfo.dev.date;

--- a/pytest.ini
+++ b/pytest.ini
@@ -39,6 +39,8 @@ norecursedirs = __pycache__
 markers =
     unit: Unit tests - fast, isolated tests
     integration: Integration tests - test component interactions
+    ci: CI-related tests
+    property: Property-based tests using Hypothesis
     asyncio: marks tests as async
     slow: marks tests as slow
     accessibility: marks tests related to accessibility features

--- a/tests/ci/__init__.py
+++ b/tests/ci/__init__.py
@@ -1,0 +1,1 @@
+"""CI-related tests for GitHub Pages and workflow validation."""

--- a/tests/ci/test_github_pages.py
+++ b/tests/ci/test_github_pages.py
@@ -1,0 +1,270 @@
+"""
+Tests for GitHub Pages template and workflow validation.
+
+These tests validate the GitHub Pages HTML template structure,
+template variable substitution, and download link generation.
+
+Marked with 'ci' marker to separate from main application tests.
+Run with: pytest tests/ci/ -v
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.ci
+
+
+@pytest.fixture
+def template_path():
+    return Path(__file__).parent.parent.parent / "docs" / "index.template.html"
+
+
+@pytest.fixture
+def template_content(template_path):
+    return template_path.read_text()
+
+
+@pytest.fixture
+def template_variables():
+    return [
+        "MAIN_VERSION",
+        "MAIN_DATE",
+        "MAIN_COMMIT",
+        "MAIN_INSTALLER_URL",
+        "MAIN_PORTABLE_URL",
+        "MAIN_MACOS_INSTALLER_URL",
+        "MAIN_HAS_RELEASE",
+        "MAIN_RELEASE_NOTES",
+        "DEV_VERSION",
+        "DEV_DATE",
+        "DEV_COMMIT",
+        "DEV_INSTALLER_URL",
+        "DEV_PORTABLE_URL",
+        "DEV_MACOS_INSTALLER_URL",
+        "DEV_HAS_RELEASE",
+        "DEV_RECENT_COMMITS",
+        "DEV_RELEASE_URL",
+        "LAST_UPDATED",
+    ]
+
+
+class TestTemplateStructure:
+    """Tests for the HTML template file structure."""
+
+    def test_template_exists(self, template_path):
+        """Verify the template file exists."""
+        assert template_path.exists(), f"Template file not found at {template_path}"
+
+    def test_template_is_valid_html(self, template_content):
+        """Verify the template has basic HTML structure."""
+        assert "<!DOCTYPE html>" in template_content
+        assert "<html" in template_content
+        assert "</html>" in template_content
+        assert "<head>" in template_content
+        assert "</head>" in template_content
+        assert "<body>" in template_content
+        assert "</body>" in template_content
+
+    def test_all_template_variables_defined(self, template_content, template_variables):
+        """Verify all expected template variables are present in the template."""
+        for var in template_variables:
+            pattern = f"{{{{{var}}}}}"
+            assert pattern in template_content, f"Template variable {{{{{var}}}}} not found"
+
+    def test_html_structure_valid(self, template_content):
+        """Verify the HTML has proper structure with required elements."""
+        assert "<title>" in template_content
+        assert "</title>" in template_content
+        assert "AccessiWeather" in template_content
+
+    def test_stable_section_exists(self, template_content):
+        """Verify the stable release section exists."""
+        assert 'class="download-section stable"' in template_content
+        assert 'id="main-section"' in template_content
+        assert "Stable Release" in template_content
+
+    def test_dev_section_exists(self, template_content):
+        """Verify the development build section exists."""
+        assert 'class="download-section dev"' in template_content
+        assert 'id="dev-section"' in template_content
+        assert "Development Build" in template_content
+
+    def test_footer_exists(self, template_content):
+        """Verify footer section with links exists."""
+        assert "<footer" in template_content
+        assert "View on GitHub" in template_content
+        assert "github.com/Orinks/AccessiWeather" in template_content
+
+
+class TestDownloadUrls:
+    """Tests for download button and URL structure."""
+
+    def test_windows_installer_button_exists(self, template_content):
+        """Verify Windows installer download buttons exist for both sections."""
+        assert 'id="main-installer"' in template_content
+        assert 'id="dev-installer"' in template_content
+        assert "Installer (.msi)" in template_content
+
+    def test_windows_portable_button_exists(self, template_content):
+        """Verify Windows portable download buttons exist."""
+        assert 'id="main-portable"' in template_content
+        assert 'id="dev-portable"' in template_content
+        assert "Portable (.zip)" in template_content
+
+    def test_macos_download_buttons_exist(self, template_content):
+        """Verify macOS download buttons exist for both sections."""
+        assert 'id="main-macos-installer"' in template_content
+        assert 'id="dev-macos-installer"' in template_content
+        assert "Installer (.dmg)" in template_content
+
+    def test_main_installer_url_uses_template_variable(self, template_content):
+        """Verify main installer URL uses the correct template variable."""
+        assert 'href="{{MAIN_INSTALLER_URL}}"' in template_content
+
+    def test_main_portable_url_uses_template_variable(self, template_content):
+        """Verify main portable URL uses the correct template variable."""
+        assert 'href="{{MAIN_PORTABLE_URL}}"' in template_content
+
+    def test_main_macos_url_uses_template_variable(self, template_content):
+        """Verify main macOS URL uses the correct template variable."""
+        assert 'href="{{MAIN_MACOS_INSTALLER_URL}}"' in template_content
+
+    def test_download_buttons_have_aria_labels(self, template_content):
+        """Verify download buttons have accessibility labels."""
+        assert 'aria-label="Download Windows Installer"' in template_content
+        assert 'aria-label="Download Windows Portable"' in template_content
+        assert 'aria-label="Download macOS Installer"' in template_content
+        assert 'aria-label="Download Windows Installer (Dev)"' in template_content
+        assert 'aria-label="Download Windows Portable (Dev)"' in template_content
+        assert 'aria-label="Download macOS Installer (Dev)"' in template_content
+
+    def test_platform_groups_exist(self, template_content):
+        """Verify platform groupings exist for Windows and macOS."""
+        assert 'class="platform-label">Windows</span>' in template_content.replace("\n", "")
+        assert 'class="platform-label">macOS</span>' in template_content.replace("\n", "")
+
+
+class TestTemplateVariables:
+    """Tests for template variable patterns and substitution."""
+
+    def test_variable_pattern_format(self, template_content):
+        """Verify all template variables use the {{VAR}} pattern."""
+        pattern = r"\{\{([A-Z_]+)\}\}"
+        matches = re.findall(pattern, template_content)
+        assert len(matches) > 0, "No template variables found"
+        for match in matches:
+            assert match.isupper(), f"Variable {match} should be uppercase"
+            assert "_" in match or match.isalpha(), f"Variable {match} has invalid format"
+
+    def test_no_malformed_template_variables(self, template_content):
+        """Verify there are no malformed template variables (single braces, lowercase)."""
+        single_brace_pattern = r"(?<!\{)\{[A-Z_]+\}(?!\})"
+        matches = re.findall(single_brace_pattern, template_content)
+        assert len(matches) == 0, f"Found malformed single-brace variables: {matches}"
+
+    def test_all_template_variables_properly_closed(self, template_content):
+        """Verify all template variables have proper {{VAR}} format."""
+        pattern = r"\{\{([A-Z_]+)\}\}"
+        matches = re.findall(pattern, template_content)
+        for match in matches:
+            full_var = f"{{{{{match}}}}}"
+            opening_idx = template_content.find(full_var)
+            assert opening_idx != -1, f"Variable {full_var} not properly formatted"
+
+    def test_javascript_build_info_contains_variables(self, template_content):
+        """Verify the JavaScript buildInfo object contains template variables."""
+        assert "const buildInfo = {" in template_content
+        assert "main:" in template_content
+        assert "dev:" in template_content
+        assert "version: '{{MAIN_VERSION}}'" in template_content
+        assert "version: '{{DEV_VERSION}}'" in template_content
+
+    def test_version_info_sections_exist(self, template_content):
+        """Verify version info sections contain all required fields."""
+        assert 'id="main-version"' in template_content
+        assert 'id="dev-version"' in template_content
+        assert 'id="main-date"' in template_content
+        assert 'id="dev-date"' in template_content
+        assert 'id="main-commit"' in template_content
+        assert 'id="dev-commit"' in template_content
+
+    def test_last_updated_field_exists(self, template_content):
+        """Verify the last updated field uses template variable."""
+        assert 'id="last-updated"' in template_content
+        assert "{{LAST_UPDATED}}" in template_content
+
+
+class TestReleaseNotesSection:
+    """Tests for release notes and commit history sections."""
+
+    def test_main_release_notes_section_exists(self, template_content):
+        """Verify main release notes section exists."""
+        assert "Release Notes" in template_content
+        assert "{{MAIN_RELEASE_NOTES}}" in template_content
+
+    def test_dev_recent_commits_section_exists(self, template_content):
+        """Verify dev recent commits section exists."""
+        assert "Recent Changes" in template_content
+        assert "{{DEV_RECENT_COMMITS}}" in template_content
+
+    def test_commit_list_styling_exists(self, template_content):
+        """Verify commit list has proper CSS styling."""
+        assert "commit-list" in template_content
+
+
+class TestHasReleaseFlags:
+    """Tests for release availability flags."""
+
+    def test_main_has_release_flag_exists(self, template_content):
+        """Verify main section has release availability flag."""
+        assert 'data-has-release="{{MAIN_HAS_RELEASE}}"' in template_content
+
+    def test_dev_has_release_flag_exists(self, template_content):
+        """Verify dev section has release availability flag."""
+        assert 'data-has-release="{{DEV_HAS_RELEASE}}"' in template_content
+
+    def test_hide_downloads_function_exists(self, template_content):
+        """Verify JavaScript function to hide downloads when no release exists."""
+        assert "hideDownloadsIfNoRelease" in template_content
+
+
+class TestAccessibility:
+    """Tests for accessibility features in the template."""
+
+    def test_html_has_lang_attribute(self, template_content):
+        """Verify HTML element has lang attribute for accessibility."""
+        assert 'lang="en"' in template_content
+
+    def test_all_images_have_viewbox(self, template_content):
+        """Verify SVG icons have viewBox for proper scaling."""
+        svg_pattern = r"<svg[^>]*>"
+        svgs = re.findall(svg_pattern, template_content)
+        for svg in svgs:
+            assert "viewBox" in svg, f"SVG missing viewBox: {svg}"
+
+    def test_download_buttons_have_download_btn_class(self, template_content):
+        """Verify all download buttons use consistent styling class."""
+        download_links = re.findall(r'<a[^>]*class="download-btn[^"]*"[^>]*>', template_content)
+        assert len(download_links) >= 6, "Expected at least 6 download buttons"
+
+
+class TestUrlFormatValidation:
+    """Tests for URL format validation patterns."""
+
+    def test_github_repo_links_format(self, template_content):
+        """Verify GitHub repository links are properly formatted."""
+        github_links = re.findall(
+            r'href="(https://github\.com/Orinks/AccessiWeather[^"]*)"', template_content
+        )
+        assert len(github_links) >= 3, "Expected at least 3 GitHub links"
+        for link in github_links:
+            assert link.startswith("https://github.com/Orinks/AccessiWeather")
+
+    def test_external_links_have_target_blank(self, template_content):
+        """Verify external links open in new tab."""
+        github_link_pattern = r'<a[^>]*href="https://github\.com[^"]*"[^>]*>'
+        github_links = re.findall(github_link_pattern, template_content)
+        for link in github_links:
+            assert 'target="_blank"' in link, f"External link missing target='_blank': {link}"

--- a/tests/ci/test_github_pages_properties.py
+++ b/tests/ci/test_github_pages_properties.py
@@ -1,0 +1,190 @@
+"""
+Property-based tests for GitHub Pages template substitution.
+
+Uses Hypothesis to test template substitution with edge cases.
+"""
+
+import html
+import re
+
+import pytest
+from hypothesis import (
+    given,
+    settings,
+    strategies as st,
+)
+
+pytestmark = [pytest.mark.ci, pytest.mark.property]
+
+version_strategy = st.from_regex(r"[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9]+)?", fullmatch=True)
+
+sha_strategy = st.from_regex(r"[0-9a-f]{7,40}", fullmatch=True)
+
+date_strategy = st.from_regex(r"[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2} UTC", fullmatch=True)
+
+url_strategy = st.from_regex(r"https://[a-z0-9./-]+", fullmatch=True)
+
+
+class TestTemplateSubstitutionProperties:
+    """Property-based tests for template substitution safety."""
+
+    @given(version=version_strategy)
+    @settings(max_examples=50)
+    def test_version_substitution_never_contains_braces(self, version: str) -> None:
+        """Substituted version values should never reintroduce template syntax."""
+        result = f"Version {version}"
+        assert "{{" not in result
+        assert "}}" not in result
+
+    @given(sha=sha_strategy)
+    @settings(max_examples=50)
+    def test_sha_truncation_consistent(self, sha: str) -> None:
+        """SHA should be truncated to 7 chars for display."""
+        truncated = sha[:7]
+        assert len(truncated) == 7
+        assert re.match(r"^[0-9a-f]+$", truncated)
+
+    @given(text=st.text())
+    @settings(max_examples=100)
+    def test_sed_escape_handles_special_chars(self, text: str) -> None:
+        """Special chars should not break sed substitution."""
+        escaped = text.replace("\\", "\\\\").replace("&", "\\&").replace("@", "\\@")
+        assert isinstance(escaped, str)
+
+    @given(url=url_strategy)
+    @settings(max_examples=50)
+    def test_url_substitution_preserves_structure(self, url: str) -> None:
+        """URLs should remain valid after substitution."""
+        assert url.startswith("https://")
+
+    @given(date=date_strategy)
+    @settings(max_examples=50)
+    def test_date_format_consistent(self, date: str) -> None:
+        """Date strings should maintain expected format."""
+        assert date.endswith("UTC")
+        assert len(date) == 20
+
+    @given(
+        version=version_strategy,
+        sha=sha_strategy,
+        date=date_strategy,
+    )
+    @settings(max_examples=50)
+    def test_combined_substitution_safe(self, version: str, sha: str, date: str) -> None:
+        """Combined substitutions should produce safe output."""
+        template = "Release {{VERSION}} ({{SHA}}) at {{DATE}}"
+        result = (
+            template.replace("{{VERSION}}", version)
+            .replace("{{SHA}}", sha[:7])
+            .replace("{{DATE}}", date)
+        )
+        assert "{{VERSION}}" not in result
+        assert "{{SHA}}" not in result
+        assert "{{DATE}}" not in result
+
+
+class TestHtmlSafetyProperties:
+    """Property-based tests for HTML content safety."""
+
+    @given(content=st.text(alphabet=st.characters(blacklist_categories=["Cs"])))
+    @settings(max_examples=50)
+    def test_html_content_escapable(self, content: str) -> None:
+        """All text content should be escapable for HTML."""
+        escaped = html.escape(content)
+        assert "<" not in escaped or "&lt;" in escaped
+        assert ">" not in escaped or "&gt;" in escaped
+
+    @given(content=st.text(min_size=1, max_size=1000))
+    @settings(max_examples=50)
+    def test_html_escape_roundtrip_preserves_length(self, content: str) -> None:
+        """HTML escaping should not produce shorter output."""
+        escaped = html.escape(content)
+        assert len(escaped) >= len(content)
+
+    @given(
+        content=st.lists(
+            st.sampled_from(["<", ">", "&", '"', "'"]),
+            min_size=1,
+            max_size=20,
+        ).map("".join)
+    )
+    @settings(max_examples=50)
+    def test_dangerous_chars_escaped(self, content: str) -> None:
+        """Dangerous HTML characters should be escaped."""
+        escaped = html.escape(content, quote=True)
+        assert "<" not in escaped
+        assert ">" not in escaped
+
+
+class TestTemplateEdgeCases:
+    """Property-based tests for edge cases in template handling."""
+
+    @given(st.text(min_size=0, max_size=0))
+    @settings(max_examples=10)
+    def test_empty_string_substitution(self, text: str) -> None:
+        """Empty strings should substitute safely."""
+        template = "Value: {{VALUE}}"
+        result = template.replace("{{VALUE}}", text)
+        assert result == "Value: "
+
+    @given(st.text(min_size=1000, max_size=1000))
+    @settings(max_examples=5)
+    def test_very_long_string_substitution(self, text: str) -> None:
+        """Very long strings should substitute without error."""
+        template = "Content: {{CONTENT}}"
+        result = template.replace("{{CONTENT}}", text)
+        assert len(result) == len("Content: ") + len(text)
+
+    @given(st.text(alphabet=st.characters(whitelist_categories=["Lu", "Ll", "Lo", "Nd"])))
+    @settings(max_examples=50)
+    def test_unicode_substitution(self, text: str) -> None:
+        """Unicode characters should substitute correctly."""
+        template = "Text: {{TEXT}}"
+        result = template.replace("{{TEXT}}", text)
+        assert text in result
+
+    @given(st.sampled_from(["{{", "}}", "{{VALUE}}", "{{ nested }}"]))
+    @settings(max_examples=10)
+    def test_template_syntax_in_values(self, text: str) -> None:
+        """Values containing template syntax should be handled."""
+        escaped = html.escape(text)
+        assert isinstance(escaped, str)
+        assert "{{" in text or "}}" in text
+
+    @given(url=st.from_regex(r"https://example\.com/path\?q=[a-z0-9%&=]+", fullmatch=True))
+    @settings(max_examples=50)
+    def test_url_with_query_params(self, url: str) -> None:
+        """URLs with query parameters should remain valid."""
+        assert "?" in url
+        assert url.startswith("https://")
+
+
+class TestSedSubstitutionSafety:
+    """Property-based tests for sed command safety."""
+
+    @given(st.text())
+    @settings(max_examples=100)
+    def test_sed_delimiter_escape(self, text: str) -> None:
+        """Sed delimiter characters should be escaped."""
+        escaped = text.replace("/", "\\/")
+        assert "/" not in escaped or "\\/" in escaped
+
+    @given(st.text(alphabet=st.sampled_from(["/", "\\", "&", "\n", "\t"])))
+    @settings(max_examples=50)
+    def test_sed_special_chars_all_escaped(self, text: str) -> None:
+        """All sed special characters should be escapable."""
+        escaped = (
+            text.replace("\\", "\\\\")
+            .replace("/", "\\/")
+            .replace("&", "\\&")
+            .replace("\n", "\\n")
+            .replace("\t", "\\t")
+        )
+        assert isinstance(escaped, str)
+
+    @given(st.from_regex(r"[a-zA-Z0-9_.-]+", fullmatch=True))
+    @settings(max_examples=50)
+    def test_safe_chars_unchanged(self, text: str) -> None:
+        """Safe characters should remain unchanged after escaping."""
+        escaped = text.replace("\\", "\\\\").replace("/", "\\/").replace("&", "\\&")
+        assert escaped == text


### PR DESCRIPTION
## Summary

This PR improves the GitHub Pages download page with macOS support and fixes the dev commit SHA display.

### Changes

#### 1. Fixed Dev Commit SHA Display
- The dev build section was showing "Commit: main" instead of the actual commit SHA
- Modified `get_pre_release_info()` to fetch the actual commit SHA from the tag reference

#### 2. Added macOS Download Links
- Added macOS installer buttons for both stable and dev releases
- Created platform-grouped button layout (Windows/macOS sections)
- Updated system requirements to mention macOS 11+ support
- Added template variables: `{{MAIN_MACOS_INSTALLER_URL}}`, `{{DEV_MACOS_INSTALLER_URL}}`

#### 3. Created Separate CI Tests (49 tests)
- **Location**: `tests/ci/` (separate from main app tests)
- `test_github_pages.py` - 32 unit tests for template structure, URLs, accessibility
- `test_github_pages_properties.py` - 17 property-based tests using Hypothesis
- Run separately: `pytest tests/ci/ -v`

#### 4. Added Test Markers
- Added `ci` and `property` markers to pytest.ini

### Testing
- All 49 new CI tests pass
- YAML validation passes
- Pre-commit hooks pass