### PR TITLE
Fix integration tests: use pre-built wxPython wheels

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,18 +41,24 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
-      - name: Install system dependencies
+      - name: Install system dependencies (wxPython)
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            libcairo2-dev \
-            libgirepository-2.0-dev \
+            gcc \
             pkg-config \
-            python3-dev
+            python3-dev \
+            libgtk-3-dev \
+            libnotify-dev \
+            libsdl2-dev \
+            libwebkit2gtk-4.1-dev \
+            freeglut3-dev
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          # Install wxPython from extras repo for faster/reliable builds
+          pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04 wxPython
           pip install -r requirements-dev.txt
           pip install -e .
 


### PR DESCRIPTION
## Problem
Integration tests have been failing since Jan 22 due to wxPython failing to build from source. The workflow was missing GTK dependencies needed for compilation.

## Solution
Updated the integration tests workflow to match the main CI workflow:
- Install proper GTK system dependencies (libgtk-3-dev, etc.)
- Use pre-built wxPython wheel from extras.wxpython.org instead of building from source

## Testing
✅ Manually triggered workflow on this branch - all 54 integration tests pass

Fixes the daily integration test failures.