### PR TITLE
ci: add coverage gating with diff-cover for PR quality checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,14 +172,18 @@ jobs:
         pip install -r requirements-dev.txt
         pip install -e .
 
-    - name: Run tests
+    - name: Run tests with coverage
       env:
         PYTHONPATH: src
         ACCESSIWEATHER_TEST_MODE: "1"
         HYPOTHESIS_PROFILE: ci  # Use fast CI profile (fewer examples, no deadline)
       run: |
         mkdir -p reports
-        pytest tests/ -n auto -v --tb=short -m "not integration" --junitxml=reports/junit.xml
+        pytest tests/ -n auto -v --tb=short -m "not integration" \
+          --junitxml=reports/junit.xml \
+          --cov=src/accessiweather \
+          --cov-report=xml:reports/coverage.xml \
+          --cov-report=term-missing
 
     - name: Upload test report
       if: always()
@@ -187,6 +191,14 @@ jobs:
       with:
         name: junit-${{ matrix.python-version }}
         path: reports/junit.xml
+        retention-days: 7
+
+    - name: Upload coverage report
+      if: always()
+      uses: actions/upload-artifact@v6
+      with:
+        name: coverage-${{ matrix.python-version }}
+        path: reports/coverage.xml
         retention-days: 7
 
     - name: CI Summary
@@ -202,3 +214,39 @@ jobs:
         else
           echo "❌ Some checks failed"
         fi
+
+  coverage-gate:
+    name: Coverage Gate
+    runs-on: ubuntu-latest
+    needs: tests
+    if: github.event_name == 'pull_request'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+        cache: pip
+
+    - name: Install diff-cover
+      run: pip install diff-cover>=9.0.0
+
+    - name: Download coverage report
+      uses: actions/download-artifact@v6
+      with:
+        name: coverage-3.12
+        path: reports
+
+    - name: Check coverage on changed lines
+      run: |
+        echo "Checking that new/changed code has test coverage..."
+        diff-cover reports/coverage.xml \
+          --compare-branch=origin/${{ github.base_ref }} \
+          --fail-under=80 \
+          --diff-range-notation='..'
+        echo "✅ New code meets coverage threshold!"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@ pytest-timeout>=2.3.0
 hypothesis>=6.0.0
 vcrpy>=6.0.0
 requests-mock>=1.10.0
+diff-cover>=9.0.0
 
 # Type stubs
 types-requests>=2.31.0


### PR DESCRIPTION
## Changes

- Add `diff-cover` to requirements-dev.txt
- Run pytest with `--cov` to generate coverage XML reports
- Upload coverage reports as CI artifacts
- New **Coverage Gate** job runs on PRs only: uses `diff-cover` to check that new/changed lines have at least 80% test coverage

## Why

Automated PRs from the nightly issue worker could ship untested code if no tests are written for new features. This coverage gate ensures:

1. Any new or modified code lines must have at least 80% test coverage
2. The check only applies to lines that changed in the PR (not the whole codebase)
3. If coverage is insufficient, the PR fails CI and won't auto-merge

## Notes

- The 80% threshold applies to **new/changed lines only** (via `diff-cover`)
- Existing uncovered code is not affected
- The coverage gate only runs on pull requests, not direct pushes