### PR TITLE
fix(ai): Area Forecast Discussion AI explainer now uses custom system prompt and instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Weather alerts now trigger desktop notifications - previously alerts showed in the UI but never sent notifications
 - Location switching now updates the weather display - switching locations was silently failing due to a type mismatch
 - Cleaned up Visual Crossing alert processing - removed orphaned AlertManager that was losing state between calls
+- Area Forecast Discussion AI summaries now respect your custom system prompt and instructions from Settings > AI
 
 ### Removed
 -

--- a/src/accessiweather/ui/dialogs/discussion_dialog.py
+++ b/src/accessiweather/ui/dialogs/discussion_dialog.py
@@ -264,8 +264,11 @@ class DiscussionDialog(wx.Dialog):
             settings = self.app.config_manager.get_settings()
             model = getattr(settings, "ai_model", None)
 
-            explainer = (
-                AIExplainer(api_key=api_key, model=model) if model else AIExplainer(api_key=api_key)
+            explainer = AIExplainer(
+                api_key=api_key,
+                model=model if model else None,
+                custom_system_prompt=getattr(settings, "custom_system_prompt", None),
+                custom_instructions=getattr(settings, "custom_instructions", None),
             )
 
             location = self.app.config_manager.get_current_location()

--- a/tests/test_discussion_dialog.py
+++ b/tests/test_discussion_dialog.py
@@ -6,6 +6,7 @@ Tests the DiscussionDialog class and its AI explanation integration.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -146,6 +147,90 @@ class TestExplainButtonState:
 
 class TestAIExplanationGeneration:
     """Tests for AI explanation generation in discussion dialog."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("ai_model", "expected_model"),
+        [
+            ("openrouter/auto", "openrouter/auto"),
+            (None, None),
+        ],
+    )
+    async def test_discussion_dialog_passes_custom_prompt_settings(
+        self,
+        ai_model,
+        expected_model,
+    ):
+        """Test discussion dialog passes custom AI prompt settings to explainer."""
+        from accessiweather.ai_explainer import ExplanationStyle
+        from accessiweather.ui.dialogs import discussion_dialog
+
+        settings = MagicMock()
+        settings.ai_model = ai_model
+        settings.custom_system_prompt = "System prompt"
+        settings.custom_instructions = "Custom instructions"
+
+        app = MagicMock()
+        app.config_manager = MagicMock()
+        app.config_manager.get_settings.return_value = settings
+        location = MagicMock()
+        location.name = "Test City"
+        app.config_manager.get_current_location.return_value = location
+
+        dialog = SimpleNamespace(
+            app=app,
+            _current_discussion="Discussion text",
+            _on_explain_error=MagicMock(),
+            _on_explain_complete=MagicMock(),
+        )
+
+        captured: dict[str, object] = {}
+
+        class FakeExplainer:
+            def __init__(
+                self,
+                api_key=None,
+                model=None,
+                custom_system_prompt=None,
+                custom_instructions=None,
+            ):
+                captured["init"] = {
+                    "api_key": api_key,
+                    "model": model,
+                    "custom_system_prompt": custom_system_prompt,
+                    "custom_instructions": custom_instructions,
+                }
+
+            async def explain_afd(self, discussion_text, location_name, style):
+                captured["call"] = {
+                    "discussion_text": discussion_text,
+                    "location_name": location_name,
+                    "style": style,
+                }
+                return MagicMock(text="Result text", model_used="test-model")
+
+        with (
+            patch(
+                "accessiweather.config.secure_storage.SecureStorage.get_password",
+                return_value="test-key",
+            ),
+            patch("accessiweather.ai_explainer.AIExplainer", FakeExplainer),
+            patch.object(
+                discussion_dialog.wx,
+                "CallAfter",
+                side_effect=lambda func, *args: func(*args),
+            ),
+        ):
+            await discussion_dialog.DiscussionDialog._do_explain(dialog)
+
+        assert captured["init"]["api_key"] == "test-key"
+        assert captured["init"]["model"] is expected_model
+        assert captured["init"]["custom_system_prompt"] == "System prompt"
+        assert captured["init"]["custom_instructions"] == "Custom instructions"
+        assert captured["call"]["discussion_text"] == "Discussion text"
+        assert captured["call"]["location_name"] == "Test City"
+        assert captured["call"]["style"] == ExplanationStyle.DETAILED
+        dialog._on_explain_complete.assert_called_once_with("Result text", "test-model")
 
     @pytest.mark.asyncio
     async def test_explain_afd_called_with_correct_params(self, sample_discussion):


### PR DESCRIPTION
Closes #210

## Changes
- Updated `discussion_dialog.py` to pass `custom_system_prompt` and `custom_instructions` to `AIExplainer`, matching the behavior of `explanation_dialog.py`
- Model parameter now explicitly set to `None` when unconfigured (consistent behavior)
- Added parametrized async tests covering both configured and unconfigured model cases
- Updated CHANGELOG.md under Unreleased > Fixed

## Testing
- All 18 discussion dialog tests pass
- New test verifies custom prompt settings are passed through with both model present and absent