### PR TITLE
fix(build): add installer/ to sys.path for spec_utils import in PyInstaller

### DIFF
--- a/installer/accessiweather.spec
+++ b/installer/accessiweather.spec
@@ -9,9 +9,13 @@ Usage:
 """
 
 import platform
+import sys
 from pathlib import Path
 
+# Ensure installer/ directory is on Python path so spec_utils can be imported
+sys.path.insert(0, SPECPATH)
 from spec_utils import filter_platform_binaries, filter_sound_lib_entries
+
 # Determine paths
 SPEC_DIR = Path(SPECPATH).resolve()
 PROJECT_ROOT = SPEC_DIR.parent

--- a/installer/spec_utils.py
+++ b/installer/spec_utils.py
@@ -8,7 +8,7 @@ avoid packaging obvious cross-platform binary artifacts.
 from __future__ import annotations
 
 import re
-from typing import Iterable
+from collections.abc import Iterable
 
 _BINARY_EXTS = (".dll", ".dylib", ".pyd", ".exe", ".bundle")
 _SOUND_LIB_ROOT = "sound_lib/lib/"


### PR DESCRIPTION
Closes the PyInstaller build failure introduced by #212.

PyInstaller provides `SPECPATH` but doesn't add it to `sys.path`, so `from spec_utils import ...` fails during CI builds with `ModuleNotFoundError: No module named 'spec_utils'`.

Changes:
- Add `sys.path.insert(0, SPECPATH)` before the spec_utils import in the spec file
- Fix ruff UP035: import `Iterable` from `collections.abc` instead of `typing`