### PR TITLE
fix(build): use PyInstaller hook for sound_lib instead of Rosetta workaround

### DIFF
--- a/.github/workflows/pyinstaller-build.yml
+++ b/.github/workflows/pyinstaller-build.yml
@@ -58,7 +58,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          architecture: x64
 
       - name: Cache pip dependencies
         uses: actions/cache@v4
@@ -96,7 +95,7 @@ jobs:
 
       - name: Build with PyInstaller
         run: |
-          arch -x86_64 python -m PyInstaller --clean --noconfirm installer/accessiweather.spec
+          python -m PyInstaller --clean --noconfirm installer/accessiweather.spec
 
       - name: Install Inno Setup
         run: |

--- a/installer/hooks/hook-sound_lib.py
+++ b/installer/hooks/hook-sound_lib.py
@@ -1,0 +1,28 @@
+# Custom PyInstaller hook for sound_lib
+# Excludes incompatible x86 (i386/ppc) binaries on macOS ARM64 runners.
+# Only includes x64 dylibs which work under Rosetta 2 on Apple Silicon.
+# Based on approach from https://github.com/masonasons/FastSM
+
+import sys
+from pathlib import Path
+
+binaries = []
+
+if sys.platform == "darwin":
+    # On macOS, only include x64 dylibs — the x86 directory contains old
+    # i386/ppc binaries that PyInstaller can't process on ARM64 runners.
+    try:
+        import sound_lib
+
+        sl_path = Path(sound_lib.__file__).parent
+        x64_lib = sl_path / "lib" / "x64"
+        if x64_lib.exists():
+            for dylib in x64_lib.glob("*.dylib"):
+                binaries.append((str(dylib), "sound_lib/lib/x64"))
+    except ImportError:
+        pass
+else:
+    # On Windows/Linux, use the default behavior
+    from PyInstaller.utils.hooks import collect_dynamic_libs
+
+    binaries = collect_dynamic_libs("sound_lib")


### PR DESCRIPTION
## Changes

Replaces the Rosetta workaround from #212 with a proper PyInstaller hook for sound_lib, based on [FastSM's approach](https://github.com/masonasons/FastSM).

### New: `installer/hooks/hook-sound_lib.py`
- On macOS: only collects x64 dylibs from sound_lib (skips x86 i386/ppc binaries)
- On Windows/Linux: uses PyInstaller's default `collect_dynamic_libs`
- Prevents the `AssertionError: Unhandled architecture!` during Analysis

### Fixed: workflow misplacements from #212
- Removed `arch -x86_64` from Windows build step (was macOS-only command, misplaced)
- Removed `architecture: x64` override from Windows Python setup (unnecessary)
- macOS build now runs natively without Rosetta forcing

### Result
The macOS build should now produce a working DMG without needing to force x86_64 Python.