### PR TITLE
feat: add Report Issue dialog to Help menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Report Issue dialog (Help menu) - quickly report bugs or request features directly to GitHub with auto-collected system info
 - Per-sound volume control in Sound Pack Manager - adjust volume for individual sounds directly in the UI, with live preview at the selected volume level
 - Model browser dialog - browse and select from 300+ OpenRouter AI models directly in Settings instead of opening a web browser. Filter by provider (OpenAI, Anthropic, Meta, Google, etc.), search by name, and toggle free-only models. Provider list updates dynamically based on your filters
 - Weather model selection for Open-Meteo - choose from 11 forecast models including ECMWF, GFS, ICON, Météo-France, and more. Find it in Settings > Data Sources when using Open-Meteo or Auto mode

--- a/src/accessiweather/ui/dialogs/report_issue_dialog.py
+++ b/src/accessiweather/ui/dialogs/report_issue_dialog.py
@@ -1,0 +1,160 @@
+"""Dialog for reporting issues to GitHub."""
+
+from __future__ import annotations
+
+import platform
+import sys
+import urllib.parse
+import webbrowser
+
+import wx
+
+from accessiweather import __version__
+
+GITHUB_REPO = "Orinks/AccessiWeather"
+ISSUE_URL = f"https://github.com/{GITHUB_REPO}/issues/new"
+
+
+class ReportIssueDialog(wx.Dialog):
+    """Dialog for reporting issues to GitHub."""
+
+    def __init__(self, parent: wx.Window | None = None):
+        """Initialize the report issue dialog."""
+        super().__init__(
+            parent,
+            title="Report Issue",
+            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
+        )
+
+        self._create_controls()
+        self._do_layout()
+        self._bind_events()
+
+        self.SetSize((500, 400))
+        self.CenterOnParent()
+
+    def _create_controls(self) -> None:
+        """Create dialog controls."""
+        # Issue type
+        self.type_label = wx.StaticText(self, label="Issue Type:")
+        self.type_choice = wx.Choice(
+            self,
+            choices=["Bug Report", "Feature Request"],
+        )
+        self.type_choice.SetSelection(0)
+
+        # Title
+        self.title_label = wx.StaticText(self, label="Title:")
+        self.title_input = wx.TextCtrl(self)
+        self.title_input.SetHint("Brief summary of the issue")
+
+        # Description
+        self.desc_label = wx.StaticText(self, label="Description:")
+        self.desc_input = wx.TextCtrl(
+            self,
+            style=wx.TE_MULTILINE,
+        )
+        self.desc_input.SetHint(
+            "Describe the issue or feature request.\n"
+            "For bugs: What happened? What did you expect?"
+        )
+
+        # System info preview
+        self.info_label = wx.StaticText(self, label="System info (auto-collected):")
+        self.info_text = wx.TextCtrl(
+            self,
+            style=wx.TE_MULTILINE | wx.TE_READONLY,
+        )
+        self.info_text.SetValue(self._get_system_info())
+
+        # Buttons
+        self.submit_btn = wx.Button(self, wx.ID_OK, label="Open in Browser")
+        self.cancel_btn = wx.Button(self, wx.ID_CANCEL, label="Cancel")
+
+    def _do_layout(self) -> None:
+        """Layout dialog controls."""
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+
+        # Type row
+        type_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        type_sizer.Add(self.type_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        type_sizer.Add(self.type_choice, 1)
+        main_sizer.Add(type_sizer, 0, wx.EXPAND | wx.ALL, 10)
+
+        # Title
+        main_sizer.Add(self.title_label, 0, wx.LEFT | wx.RIGHT, 10)
+        main_sizer.Add(self.title_input, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
+
+        # Description
+        main_sizer.Add(self.desc_label, 0, wx.LEFT | wx.RIGHT, 10)
+        main_sizer.Add(self.desc_input, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
+
+        # System info
+        main_sizer.Add(self.info_label, 0, wx.LEFT | wx.RIGHT, 10)
+        main_sizer.Add(
+            self.info_text, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10
+        )
+        self.info_text.SetMinSize((-1, 60))
+
+        # Buttons
+        btn_sizer = wx.StdDialogButtonSizer()
+        btn_sizer.AddButton(self.submit_btn)
+        btn_sizer.AddButton(self.cancel_btn)
+        btn_sizer.Realize()
+        main_sizer.Add(btn_sizer, 0, wx.EXPAND | wx.ALL, 10)
+
+        self.SetSizer(main_sizer)
+
+    def _bind_events(self) -> None:
+        """Bind event handlers."""
+        self.submit_btn.Bind(wx.EVT_BUTTON, self._on_submit)
+
+    def _get_system_info(self) -> str:
+        """Collect system information."""
+        return (
+            f"- App Version: {__version__}\n"
+            f"- OS: {platform.system()} {platform.release()}\n"
+            f"- Python: {sys.version.split()[0]}"
+        )
+
+    def _on_submit(self, event: wx.CommandEvent) -> None:
+        """Handle submit button click."""
+        title = self.title_input.GetValue().strip()
+        if not title:
+            wx.MessageBox(
+                "Please enter a title for the issue.",
+                "Title Required",
+                wx.OK | wx.ICON_WARNING,
+            )
+            self.title_input.SetFocus()
+            return
+
+        # Build issue body
+        description = self.desc_input.GetValue().strip()
+        system_info = self.info_text.GetValue()
+
+        body_parts = []
+        if description:
+            body_parts.append(description)
+        body_parts.append("\n---\n**System Information:**\n```")
+        body_parts.append(system_info)
+        body_parts.append("```")
+
+        body = "\n".join(body_parts)
+
+        # Determine label
+        issue_type = self.type_choice.GetSelection()
+        label = "bug" if issue_type == 0 else "enhancement"
+
+        # Build URL with query parameters
+        params = {
+            "title": title,
+            "body": body,
+            "labels": label,
+        }
+        url = f"{ISSUE_URL}?{urllib.parse.urlencode(params)}"
+
+        # Open in browser
+        webbrowser.open(url)
+
+        self.EndModal(wx.ID_OK)

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -226,6 +226,10 @@ class MainWindow(SizedFrame):
 
         # Help menu
         help_menu = wx.Menu()
+        report_issue_item = help_menu.Append(
+            wx.ID_ANY, "&Report Issue...", "Report a bug or request a feature"
+        )
+        help_menu.AppendSeparator()
         about_item = help_menu.Append(wx.ID_ABOUT, "&About", "About AccessiWeather")
         menu_bar.Append(help_menu, "&Help")
 
@@ -244,6 +248,7 @@ class MainWindow(SizedFrame):
         self.Bind(wx.EVT_MENU, lambda e: self._on_air_quality(), air_quality_item)
         self.Bind(wx.EVT_MENU, lambda e: self._on_uv_index(), uv_index_item)
         self.Bind(wx.EVT_MENU, lambda e: self._on_soundpack_manager(), soundpack_item)
+        self.Bind(wx.EVT_MENU, lambda e: self._on_report_issue(), report_issue_item)
         self.Bind(wx.EVT_MENU, lambda e: self._on_about(), about_item)
 
     def _on_location_changed(self, event) -> None:
@@ -347,6 +352,14 @@ class MainWindow(SizedFrame):
         from .dialogs import show_soundpack_manager_dialog
 
         show_soundpack_manager_dialog(self, self.app)
+
+    def _on_report_issue(self) -> None:
+        """Open the report issue dialog."""
+        from .dialogs.report_issue_dialog import ReportIssueDialog
+
+        dialog = ReportIssueDialog(self)
+        dialog.ShowModal()
+        dialog.Destroy()
 
     def _on_about(self) -> None:
         """Show about dialog."""

--- a/tests/test_report_issue_dialog.py
+++ b/tests/test_report_issue_dialog.py
@@ -1,0 +1,57 @@
+"""Tests for the Report Issue dialog."""
+
+from __future__ import annotations
+
+import platform
+import sys
+from unittest.mock import patch
+
+
+class TestReportIssueDialog:
+    """Test ReportIssueDialog functionality."""
+
+    def test_get_system_info_contains_version(self):
+        """System info should contain app version."""
+        from accessiweather import __version__
+        from accessiweather.ui.dialogs.report_issue_dialog import ReportIssueDialog
+
+        # Mock wx.Dialog to avoid GUI initialization
+        with patch.object(ReportIssueDialog, "__init__", lambda self, parent: None):
+            dialog = ReportIssueDialog(None)
+            dialog._get_system_info = ReportIssueDialog._get_system_info.__get__(
+                dialog, ReportIssueDialog
+            )
+            info = dialog._get_system_info()
+
+            assert __version__ in info
+            assert platform.system() in info
+            assert sys.version.split()[0] in info
+
+    def test_github_url_constants(self):
+        """GitHub URL constants should be correct."""
+        from accessiweather.ui.dialogs.report_issue_dialog import (
+            GITHUB_REPO,
+            ISSUE_URL,
+        )
+
+        assert GITHUB_REPO == "Orinks/AccessiWeather"
+        assert "github.com" in ISSUE_URL
+        assert GITHUB_REPO in ISSUE_URL
+        assert "issues/new" in ISSUE_URL
+
+
+class TestBuildIssueUrl:
+    """Test URL building for GitHub issues."""
+
+    def test_url_encoding(self):
+        """URL should properly encode special characters."""
+        import urllib.parse
+
+        title = "Test & Title"
+        body = "Description with <special> chars"
+
+        params = {"title": title, "body": body, "labels": "bug"}
+        url = f"https://github.com/test/repo/issues/new?{urllib.parse.urlencode(params)}"
+
+        assert "Test+%26+Title" in url or "Test%20%26%20Title" in url
+        assert "%3Cspecial%3E" in url


### PR DESCRIPTION
## Summary
Adds a simple dialog to report bugs or request features directly to GitHub.

## How it works
1. **Help > Report Issue** opens a dialog
2. User fills in:
   - Issue type (Bug Report / Feature Request)
   - Title
   - Description
3. System info is auto-collected (app version, OS, Python version)
4. Click "Open in Browser" → Opens GitHub's new issue page with everything pre-filled
5. User reviews and submits on GitHub (no auth required)

## Changes
- New `report_issue_dialog.py` with the dialog UI
- Added menu item in Help menu (before About)
- Added `_on_report_issue` handler in main_window.py
- Tests for system info collection and URL building
- Changelog updated

## Testing
- [x] Lint passes
- [x] All tests pass (564 total)
- [x] Dialog imports correctly
- [x] New tests pass