### PR TITLE
fix(ci): remove unsupported inputs from update-pages trigger

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -514,7 +514,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run update-pages.yml \
-            --repo ${{ github.repository }} \
-            -f force_update=true \
-            -f target_branch=both
+          gh workflow run update-pages.yml --repo ${{ github.repository }}


### PR DESCRIPTION
The nightly release workflow was passing `force_update` and `target_branch` inputs to `update-pages.yml`, but that workflow doesn't define any inputs.

This caused:
```
HTTP 422: Unexpected inputs provided: ["force_update", "target_branch"]
```

**Fix:** Remove the unused `-f` flags from the workflow dispatch call.