### PR TITLE
fix(ci): use cmd shell for Windows installer and zip steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,17 +91,18 @@ jobs:
           python -m PyInstaller --clean --noconfirm installer/accessiweather.spec
 
       - name: Create installer
+        shell: cmd
         run: |
-          echo "[version]" > dist/version.txt
-          echo "value=${{ needs.prepare.outputs.version }}" >> dist/version.txt
+          echo [version]> dist\version.txt
+          echo value=${{ needs.prepare.outputs.version }}>> dist\version.txt
           choco install innosetup -y --no-progress
-          "/c/Program Files (x86)/Inno Setup 6/ISCC.exe" installer/accessiweather.iss
+          "%ProgramFiles(x86)%\Inno Setup 6\ISCC.exe" installer\accessiweather.iss
 
       - name: Create portable ZIP
+        shell: cmd
         run: |
           cd dist
-          7z a -tzip "AccessiWeather_Portable_v${{ needs.prepare.outputs.version }}.zip" "AccessiWeather_dir/*" || \
-          7z a -tzip "AccessiWeather_Portable_v${{ needs.prepare.outputs.version }}.zip" "AccessiWeather.exe"
+          7z a -tzip "AccessiWeather_Portable_v${{ needs.prepare.outputs.version }}.zip" "AccessiWeather_dir\*" || 7z a -tzip "AccessiWeather_Portable_v${{ needs.prepare.outputs.version }}.zip" "AccessiWeather.exe"
 
       - uses: actions/upload-artifact@v6
         with:


### PR DESCRIPTION
PowerShell requires `&` operator for paths with spaces and has different line continuation syntax. Using `cmd` shell for the Inno Setup and 7z commands fixes the Windows build.

**Tested:** Full build workflow (dry_run) - all 4 jobs passed (Prepare, Windows, macOS, Release).