### PR TITLE
fix: show nightly date instead of stable version in update dialog

### DIFF
--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -389,13 +389,12 @@ class AccessiWeatherApp(wx.App):
                     if update_info:
                         # Show notification about available update
                         channel_label = "nightly" if update_info.is_nightly else "stable"
-                        display_version = current_nightly_date or current_version
                         logger.info(f"Update available: {update_info.version} ({channel_label})")
 
                         def show_update_notification():
                             result = wx.MessageBox(
                                 f"A new {channel_label} update is available!\n\n"
-                                f"Current: {display_version}\n"
+                                f"Current: {current_version}\n"
                                 f"Latest: {update_info.version}\n\n"
                                 "Download now?",
                                 "Update Available",

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -436,12 +436,11 @@ class MainWindow(SizedFrame):
                 else:
                     # Update available
                     channel_label = "nightly" if update_info.is_nightly else "stable"
-                    display_version = current_nightly_date or current_version
 
                     def prompt():
                         result = wx.MessageBox(
                             f"A new {channel_label} update is available!\n\n"
-                            f"Current: {display_version}\n"
+                            f"Current: {current_version}\n"
                             f"Latest: {update_info.version}\n\n"
                             "Download now?",
                             "Update Available",


### PR DESCRIPTION
When running a nightly build, the update dialog showed the base version (e.g., 0.4.3) instead of the nightly date (e.g., 20260202).

**Root cause:** The nightly-20260202 build was compiled before `_build_info.py` was added to PyInstaller's hiddenimports (fix landed in 38fbe0b, after the nightly was built). So the app falls back to `build_tag = None` and shows the stable version.

**Fix:** All three update dialog locations (startup, menu, settings) now show the nightly date when running a nightly build.

**Note:** Tonight's nightly (20260203) will also include the previously merged hiddenimports fix, so future nightlies won't have this issue at all.