### PR TITLE
fix: skip update checks when running from source

### DIFF
--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -356,6 +356,11 @@ class AccessiWeatherApp(wx.App):
     def _check_for_updates_on_startup(self) -> None:
         """Check for updates on startup if enabled in settings."""
         try:
+            # Skip update checks when running from source (not a frozen PyInstaller build)
+            if not getattr(sys, "frozen", False):
+                logger.debug("Running from source, skipping update check")
+                return
+
             settings = self.config_manager.get_settings()
             if not getattr(settings, "auto_update_enabled", True):
                 logger.debug("Automatic update check disabled")

--- a/src/accessiweather/ui/dialogs/settings_dialog.py
+++ b/src/accessiweather/ui/dialogs/settings_dialog.py
@@ -1382,6 +1382,13 @@ class SettingsDialogSimple(wx.Dialog):
 
     def _on_check_updates(self, event):
         """Check for updates using the UpdateService."""
+        import sys
+
+        # Skip update checks when running from source
+        if not getattr(sys, "frozen", False):
+            self._controls["update_status"].SetLabel("Running from source — use git pull to update")
+            return
+
         self._controls["update_status"].SetLabel("Checking for updates...")
 
         def do_update_check():

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -387,8 +387,19 @@ class MainWindow(SizedFrame):
     def _on_check_updates(self) -> None:
         """Check for updates from the Help menu."""
         import asyncio
+        import sys
 
         from ..services.simple_update import UpdateService, parse_nightly_date
+
+        # Skip update checks when running from source
+        if not getattr(sys, "frozen", False):
+            wx.MessageBox(
+                "Update checking is only available in installed builds.\n"
+                "You're running from source — use git pull to update.",
+                "Running from Source",
+                wx.OK | wx.ICON_INFORMATION,
+            )
+            return
 
         channel = self._get_update_channel()
         current_version = getattr(self.app, "version", "0.0.0")


### PR DESCRIPTION
Running from source has no _build_info.py, so the app can't detect
its nightly date and falsely prompts for updates. Now:
- Startup check: silently skipped
- Menu check: shows 'use git pull to update'
- Settings check: shows 'Running from source' in status label
