### PR TITLE
feat(a11y): add accessible names to dialog controls missing SetName

### DIFF
--- a/src/accessiweather/ui/dialogs/air_quality_dialog.py
+++ b/src/accessiweather/ui/dialogs/air_quality_dialog.py
@@ -136,6 +136,7 @@ class AirQualityDialog(wx.Dialog):
         button_sizer.AddStretchSpacer()
 
         close_btn = wx.Button(panel, wx.ID_CLOSE, "Close")
+        close_btn.SetName("Close air quality dialog")
         close_btn.Bind(wx.EVT_BUTTON, self._on_close)
         button_sizer.Add(close_btn, 0)
 
@@ -229,6 +230,7 @@ class AirQualityDialog(wx.Dialog):
             style=wx.TE_MULTILINE | wx.TE_READONLY,
             size=(-1, 100),
         )
+        forecast_display.SetName("Hourly air quality forecast")
         sizer.Add(forecast_display, 1, wx.EXPAND)
 
         return sizer
@@ -284,6 +286,7 @@ class AirQualityDialog(wx.Dialog):
             style=wx.TE_MULTILINE | wx.TE_READONLY,
             size=(-1, 100),
         )
+        pollutant_display.SetName("Current pollutant levels")
         sizer.Add(pollutant_display, 1, wx.EXPAND)
 
         return sizer

--- a/src/accessiweather/ui/dialogs/community_packs_dialog.py
+++ b/src/accessiweather/ui/dialogs/community_packs_dialog.py
@@ -76,11 +76,13 @@ class CommunityPacksBrowserDialog(wx.Dialog):
             5,
         )
         self.search_input = wx.TextCtrl(panel, size=(250, -1))
+        self.search_input.SetName("Filter community packs")
         self.search_input.SetHint("Search by name or author")
         self.search_input.Bind(wx.EVT_TEXT, self._on_search)
         header_sizer.Add(self.search_input, 1, wx.RIGHT, 10)
 
         self.refresh_btn = wx.Button(panel, label="Refresh")
+        self.refresh_btn.SetName("Refresh community packs")
         self.refresh_btn.Bind(wx.EVT_BUTTON, self._on_refresh)
         header_sizer.Add(self.refresh_btn, 0)
 
@@ -108,11 +110,13 @@ class CommunityPacksBrowserDialog(wx.Dialog):
         button_sizer.AddStretchSpacer()
 
         self.install_btn = wx.Button(panel, label="Download && Install")
+        self.install_btn.SetName("Download and install selected pack")
         self.install_btn.Bind(wx.EVT_BUTTON, self._on_install)
         self.install_btn.Enable(False)
         button_sizer.Add(self.install_btn, 0, wx.RIGHT, 5)
 
         close_btn = wx.Button(panel, wx.ID_CLOSE, label="Close")
+        close_btn.SetName("Close community packs dialog")
         close_btn.Bind(wx.EVT_BUTTON, lambda e: self.EndModal(wx.ID_CLOSE))
         button_sizer.Add(close_btn, 0)
 
@@ -131,6 +135,7 @@ class CommunityPacksBrowserDialog(wx.Dialog):
         sizer.Add(label, 0, wx.BOTTOM, 5)
 
         self.pack_listbox = wx.ListBox(parent, style=wx.LB_SINGLE)
+        self.pack_listbox.SetName("Available community packs list")
         self.pack_listbox.Bind(wx.EVT_LISTBOX, self._on_pack_selected)
         sizer.Add(self.pack_listbox, 1, wx.EXPAND)
 
@@ -174,6 +179,7 @@ class CommunityPacksBrowserDialog(wx.Dialog):
             style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_WORDWRAP,
             size=(-1, 150),
         )
+        self.description_text.SetName("Selected pack description")
         sizer.Add(self.description_text, 1, wx.EXPAND)
 
         return sizer

--- a/src/accessiweather/ui/dialogs/discussion_dialog.py
+++ b/src/accessiweather/ui/dialogs/discussion_dialog.py
@@ -69,6 +69,7 @@ class DiscussionDialog(wx.Dialog):
             style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH2,
             name="Forecast discussion text",
         )
+        self.discussion_display.SetName("Forecast discussion text")
         main_sizer.Add(self.discussion_display, 1, wx.ALL | wx.EXPAND, 10)
 
         # AI Explanation section
@@ -80,18 +81,22 @@ class DiscussionDialog(wx.Dialog):
             style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH2,
             name="AI-generated plain language summary",
         )
+        self.explanation_display.SetName("Plain language summary")
         main_sizer.Add(self.explanation_display, 1, wx.ALL | wx.EXPAND, 10)
 
         # Button sizer
         button_sizer = wx.BoxSizer(wx.HORIZONTAL)
 
         self.refresh_button = wx.Button(panel, label="&Refresh")
+        self.refresh_button.SetName("Refresh forecast discussion")
         button_sizer.Add(self.refresh_button, 0, wx.RIGHT, 5)
 
         self.explain_button = wx.Button(panel, label="&Explain with AI")
+        self.explain_button.SetName("Explain forecast discussion with AI")
         button_sizer.Add(self.explain_button, 0, wx.RIGHT, 5)
 
         self.close_button = wx.Button(panel, wx.ID_CLOSE, label="&Close")
+        self.close_button.SetName("Close forecast discussion dialog")
         button_sizer.Add(self.close_button, 0)
 
         main_sizer.Add(button_sizer, 0, wx.ALL | wx.ALIGN_RIGHT, 10)

--- a/src/accessiweather/ui/dialogs/progress_dialog.py
+++ b/src/accessiweather/ui/dialogs/progress_dialog.py
@@ -62,6 +62,7 @@ class ProgressDialog(wx.Dialog):
             btn_sizer = wx.BoxSizer(wx.HORIZONTAL)
             btn_sizer.AddStretchSpacer()
             self.cancel_btn = wx.Button(panel, wx.ID_CANCEL, label="Cancel")
+            self.cancel_btn.SetName("Cancel download")
             self.cancel_btn.Bind(wx.EVT_BUTTON, self._on_cancel)
             btn_sizer.Add(self.cancel_btn, 0)
             btn_sizer.AddStretchSpacer()

--- a/src/accessiweather/ui/dialogs/report_issue_dialog.py
+++ b/src/accessiweather/ui/dialogs/report_issue_dialog.py
@@ -41,11 +41,13 @@ class ReportIssueDialog(wx.Dialog):
             self,
             choices=["Bug Report", "Feature Request"],
         )
+        self.type_choice.SetName("Issue type")
         self.type_choice.SetSelection(0)
 
         # Title
         self.title_label = wx.StaticText(self, label="Title:")
         self.title_input = wx.TextCtrl(self)
+        self.title_input.SetName("Issue title")
         self.title_input.SetHint("Brief summary of the issue")
 
         # Description
@@ -54,6 +56,7 @@ class ReportIssueDialog(wx.Dialog):
             self,
             style=wx.TE_MULTILINE,
         )
+        self.desc_input.SetName("Issue description")
         self.desc_input.SetHint(
             "Describe the issue or feature request.\nFor bugs: What happened? What did you expect?"
         )
@@ -64,11 +67,14 @@ class ReportIssueDialog(wx.Dialog):
             self,
             style=wx.TE_MULTILINE | wx.TE_READONLY,
         )
+        self.info_text.SetName("System information (read-only)")
         self.info_text.SetValue(self._get_system_info())
 
         # Buttons
         self.submit_btn = wx.Button(self, wx.ID_OK, label="Open in Browser")
         self.cancel_btn = wx.Button(self, wx.ID_CANCEL, label="Cancel")
+        self.submit_btn.SetName("Open report in browser")
+        self.cancel_btn.SetName("Cancel report issue")
 
     def _do_layout(self) -> None:
         """Layout dialog controls."""

--- a/src/accessiweather/ui/dialogs/soundpack_manager_dialog.py
+++ b/src/accessiweather/ui/dialogs/soundpack_manager_dialog.py
@@ -240,11 +240,13 @@ class SoundPackManagerDialog(wx.Dialog):
         sizer.Add(label, 0, wx.BOTTOM, 5)
 
         self.pack_listbox = wx.ListBox(parent, style=wx.LB_SINGLE)
+        self.pack_listbox.SetName("Available sound packs list")
         self.pack_listbox.Bind(wx.EVT_LISTBOX, self._on_pack_selected)
         sizer.Add(self.pack_listbox, 1, wx.EXPAND | wx.BOTTOM, 10)
 
         # Import button
         import_btn = wx.Button(parent, label="Import Sound Pack...")
+        import_btn.SetName("Import sound pack")
         import_btn.Bind(wx.EVT_BUTTON, self._on_import_pack)
         sizer.Add(import_btn, 0, wx.EXPAND | wx.BOTTOM, 5)
 
@@ -283,12 +285,14 @@ class SoundPackManagerDialog(wx.Dialog):
         sizer.Add(sounds_label, 0, wx.BOTTOM, 5)
 
         self.sounds_listbox = wx.ListBox(parent)
+        self.sounds_listbox.SetName("Sounds in selected pack list")
         self.sounds_listbox.Bind(wx.EVT_LISTBOX, self._on_sound_selected)
         sizer.Add(self.sounds_listbox, 1, wx.EXPAND | wx.BOTTOM, 5)
 
         # Preview button
         preview_sizer = wx.BoxSizer(wx.HORIZONTAL)
         self.preview_btn = wx.Button(parent, label="Preview Selected Sound")
+        self.preview_btn.SetName("Preview selected sound")
         self.preview_btn.Bind(wx.EVT_BUTTON, self._on_preview_sound)
         self.preview_btn.Enable(False)
         preview_sizer.Add(self.preview_btn, 0)
@@ -306,13 +310,16 @@ class SoundPackManagerDialog(wx.Dialog):
         self.category_choice = wx.Choice(
             parent, choices=[name for name, _ in FRIENDLY_ALERT_CATEGORIES]
         )
+        self.category_choice.SetName("Alert category")
         self.category_choice.Bind(wx.EVT_CHOICE, self._on_category_changed)
         cat_row.Add(self.category_choice, 1, wx.RIGHT, 10)
 
         self.mapping_file_text = wx.TextCtrl(parent, style=wx.TE_READONLY)
+        self.mapping_file_text.SetName("Sound file for selected category")
         cat_row.Add(self.mapping_file_text, 1, wx.RIGHT, 5)
 
         browse_btn = wx.Button(parent, label="Browse...")
+        browse_btn.SetName("Browse sound file for selected category")
         browse_btn.Bind(wx.EVT_BUTTON, self._on_browse_mapping)
         cat_row.Add(browse_btn, 0, wx.RIGHT, 5)
 
@@ -321,10 +328,12 @@ class SoundPackManagerDialog(wx.Dialog):
         cat_row.Add(vol_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 2)
 
         self.volume_spin = wx.SpinCtrl(parent, min=0, max=100, initial=100, size=(60, -1))
+        self.volume_spin.SetName("Mapping volume percent")
         self.volume_spin.SetToolTip("Volume percentage (0-100%)")
         cat_row.Add(self.volume_spin, 0, wx.RIGHT, 5)
 
         self.set_volume_btn = wx.Button(parent, label="Set Vol")
+        self.set_volume_btn.SetName("Set volume for selected sound")
         self.set_volume_btn.SetToolTip("Apply volume to current sound")
         self.set_volume_btn.Bind(wx.EVT_BUTTON, self._on_set_volume)
         self.set_volume_btn.Enable(False)
@@ -338,14 +347,17 @@ class SoundPackManagerDialog(wx.Dialog):
         custom_row.Add(custom_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
 
         self.custom_key_input = wx.TextCtrl(parent, size=(200, -1), style=wx.TE_PROCESS_ENTER)
+        self.custom_key_input.SetName("Custom alert key")
         self.custom_key_input.SetHint("e.g., excessive_heat_warning")
         custom_row.Add(self.custom_key_input, 1, wx.RIGHT, 5)
 
         add_mapping_btn = wx.Button(parent, label="Choose Sound...")
+        add_mapping_btn.SetName("Choose sound for custom key")
         add_mapping_btn.Bind(wx.EVT_BUTTON, self._on_add_custom_mapping)
         custom_row.Add(add_mapping_btn, 0, wx.RIGHT, 5)
 
         remove_mapping_btn = wx.Button(parent, label="Remove")
+        remove_mapping_btn.SetName("Remove custom sound mapping")
         remove_mapping_btn.Bind(wx.EVT_BUTTON, self._on_remove_mapping)
         custom_row.Add(remove_mapping_btn, 0)
 
@@ -361,35 +373,42 @@ class SoundPackManagerDialog(wx.Dialog):
 
         # Left side buttons
         self.create_btn = wx.Button(parent, label="Create Sound Pack...")
+        self.create_btn.SetName("Create sound pack")
         self.create_btn.Bind(wx.EVT_BUTTON, self._on_create_pack)
         sizer.Add(self.create_btn, 0, wx.RIGHT, 5)
 
         self.browse_community_btn = wx.Button(parent, label="Browse Community")
+        self.browse_community_btn.SetName("Browse community sound packs")
         self.browse_community_btn.Bind(wx.EVT_BUTTON, self._on_browse_community)
         self.browse_community_btn.Enable(self.community_service is not None)
         sizer.Add(self.browse_community_btn, 0, wx.RIGHT, 5)
 
         self.share_btn = wx.Button(parent, label="Share Pack")
+        self.share_btn.SetName("Share sound pack")
         self.share_btn.Bind(wx.EVT_BUTTON, self._on_share_pack)
         self.share_btn.Enable(False)
         sizer.Add(self.share_btn, 0, wx.RIGHT, 5)
 
         self.duplicate_btn = wx.Button(parent, label="Duplicate")
+        self.duplicate_btn.SetName("Duplicate sound pack")
         self.duplicate_btn.Bind(wx.EVT_BUTTON, self._on_duplicate_pack)
         self.duplicate_btn.Enable(False)
         sizer.Add(self.duplicate_btn, 0, wx.RIGHT, 5)
 
         self.edit_btn = wx.Button(parent, label="Edit...")
+        self.edit_btn.SetName("Edit sound pack")
         self.edit_btn.Bind(wx.EVT_BUTTON, self._on_edit_pack)
         self.edit_btn.Enable(False)
         sizer.Add(self.edit_btn, 0, wx.RIGHT, 5)
 
         self.delete_btn = wx.Button(parent, label="Delete")
+        self.delete_btn.SetName("Delete sound pack")
         self.delete_btn.Bind(wx.EVT_BUTTON, self._on_delete_pack)
         self.delete_btn.Enable(False)
         sizer.Add(self.delete_btn, 0, wx.RIGHT, 5)
 
         self.export_btn = wx.Button(parent, label="Export...")
+        self.export_btn.SetName("Export sound pack")
         self.export_btn.Bind(wx.EVT_BUTTON, self._on_export_pack)
         self.export_btn.Enable(False)
         sizer.Add(self.export_btn, 0)
@@ -398,6 +417,7 @@ class SoundPackManagerDialog(wx.Dialog):
 
         # Close button
         close_btn = wx.Button(parent, wx.ID_CLOSE, label="Close")
+        close_btn.SetName("Close sound pack manager")
         close_btn.Bind(wx.EVT_BUTTON, self._on_close)
         sizer.Add(close_btn, 0)
 
@@ -987,11 +1007,13 @@ class SoundPackManagerDialog(wx.Dialog):
         # Name
         sizer.Add(wx.StaticText(panel, label="Name:"), 0, wx.ALL, 5)
         name_input = wx.TextCtrl(panel, value=info.name)
+        name_input.SetName("Sound pack name")
         sizer.Add(name_input, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
 
         # Author
         sizer.Add(wx.StaticText(panel, label="Author:"), 0, wx.ALL, 5)
         author_input = wx.TextCtrl(panel, value=info.author)
+        author_input.SetName("Sound pack author")
         sizer.Add(author_input, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
 
         # Description
@@ -999,12 +1021,15 @@ class SoundPackManagerDialog(wx.Dialog):
         desc_input = wx.TextCtrl(
             panel, value=info.description, style=wx.TE_MULTILINE, size=(-1, 100)
         )
+        desc_input.SetName("Sound pack description")
         sizer.Add(desc_input, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
 
         # Buttons
         btn_sizer = wx.BoxSizer(wx.HORIZONTAL)
         save_btn = wx.Button(panel, wx.ID_SAVE, label="Save")
         cancel_btn = wx.Button(panel, wx.ID_CANCEL, label="Cancel")
+        save_btn.SetName("Save sound pack metadata")
+        cancel_btn.SetName("Cancel edit sound pack metadata")
         btn_sizer.Add(save_btn, 0, wx.RIGHT, 5)
         btn_sizer.Add(cancel_btn, 0)
         sizer.Add(btn_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, 10)

--- a/src/accessiweather/ui/dialogs/soundpack_wizard_dialog.py
+++ b/src/accessiweather/ui/dialogs/soundpack_wizard_dialog.py
@@ -78,14 +78,17 @@ class SoundPackWizardDialog(wx.Dialog):
         nav_sizer.AddStretchSpacer()
 
         self.prev_btn = wx.Button(self.panel, label="< Previous")
+        self.prev_btn.SetName("Previous step")
         self.prev_btn.Bind(wx.EVT_BUTTON, self._go_previous)
         nav_sizer.Add(self.prev_btn, 0, wx.RIGHT, 5)
 
         self.next_btn = wx.Button(self.panel, label="Next >")
+        self.next_btn.SetName("Next step or create pack")
         self.next_btn.Bind(wx.EVT_BUTTON, self._go_next)
         nav_sizer.Add(self.next_btn, 0, wx.RIGHT, 5)
 
         self.cancel_btn = wx.Button(self.panel, wx.ID_CANCEL, label="Cancel")
+        self.cancel_btn.SetName("Cancel sound pack wizard")
         self.cancel_btn.Bind(wx.EVT_BUTTON, self._on_cancel)
         nav_sizer.Add(self.cancel_btn, 0)
 
@@ -134,6 +137,7 @@ class SoundPackWizardDialog(wx.Dialog):
             3,
         )
         self.name_input = wx.TextCtrl(self.content_panel, value=self.state.pack_name)
+        self.name_input.SetName("Sound pack name")
         self.name_input.SetHint("e.g., My Weather Sounds")
         self.content_sizer.Add(self.name_input, 0, wx.EXPAND | wx.BOTTOM, 10)
 
@@ -145,6 +149,7 @@ class SoundPackWizardDialog(wx.Dialog):
             3,
         )
         self.author_input = wx.TextCtrl(self.content_panel, value=self.state.author)
+        self.author_input.SetName("Sound pack author")
         self.content_sizer.Add(self.author_input, 0, wx.EXPAND | wx.BOTTOM, 10)
 
         # Description
@@ -160,6 +165,7 @@ class SoundPackWizardDialog(wx.Dialog):
             style=wx.TE_MULTILINE,
             size=(-1, 100),
         )
+        self.desc_input.SetName("Sound pack description")
         self.content_sizer.Add(self.desc_input, 1, wx.EXPAND | wx.BOTTOM, 10)
 
         # Hint
@@ -188,6 +194,7 @@ class SoundPackWizardDialog(wx.Dialog):
         self.category_checks: list[tuple[str, wx.CheckBox]] = []
         for display_name, tech_key in FRIENDLY_ALERT_CATEGORIES:
             cb = wx.CheckBox(scroll, label=display_name)
+            cb.SetName(f"Alert category {display_name}")
             cb.SetValue(tech_key in self.state.selected_alert_keys)
             scroll_sizer.Add(cb, 0, wx.BOTTOM, 5)
             self.category_checks.append((tech_key, cb))
@@ -200,10 +207,12 @@ class SoundPackWizardDialog(wx.Dialog):
         btn_sizer = wx.BoxSizer(wx.HORIZONTAL)
 
         select_common_btn = wx.Button(self.content_panel, label="Select Common")
+        select_common_btn.SetName("Select common alert categories")
         select_common_btn.Bind(wx.EVT_BUTTON, self._select_common_alerts)
         btn_sizer.Add(select_common_btn, 0, wx.RIGHT, 5)
 
         clear_btn = wx.Button(self.content_panel, label="Clear All")
+        clear_btn.SetName("Clear all alert categories")
         clear_btn.Bind(wx.EVT_BUTTON, self._clear_all_alerts)
         btn_sizer.Add(clear_btn, 0)
 
@@ -259,6 +268,7 @@ class SoundPackWizardDialog(wx.Dialog):
 
             # File display
             file_ctrl = wx.TextCtrl(scroll, style=wx.TE_READONLY)
+            file_ctrl.SetName(f"Sound file for {friendly}")
             existing = self.state.sound_mappings.get(key)
             if existing:
                 file_ctrl.SetValue(Path(existing).name)
@@ -266,6 +276,7 @@ class SoundPackWizardDialog(wx.Dialog):
 
             # Choose button
             choose_btn = wx.Button(scroll, label="Choose...", size=(80, -1))
+            choose_btn.SetName(f"Choose sound file for {friendly}")
             choose_btn.Bind(
                 wx.EVT_BUTTON,
                 lambda evt, k=key, fc=file_ctrl: self._choose_sound_file(k, fc),
@@ -346,6 +357,7 @@ class SoundPackWizardDialog(wx.Dialog):
 
             # Preview button
             preview_btn = wx.Button(scroll, label="Preview", size=(70, -1))
+            preview_btn.SetName(f"Preview sound for {friendly}")
             preview_btn.Bind(
                 wx.EVT_BUTTON,
                 lambda evt, k=key: self._preview_sound(k),
@@ -359,6 +371,7 @@ class SoundPackWizardDialog(wx.Dialog):
 
         # Test button
         test_btn = wx.Button(self.content_panel, label="Test All Sounds")
+        test_btn.SetName("Test all sounds")
         test_btn.Bind(wx.EVT_BUTTON, self._test_all_sounds)
         self.content_sizer.Add(test_btn, 0)
 

--- a/src/accessiweather/ui/dialogs/uv_index_dialog.py
+++ b/src/accessiweather/ui/dialogs/uv_index_dialog.py
@@ -153,6 +153,7 @@ class UVIndexDialog(wx.Dialog):
         button_sizer.AddStretchSpacer()
 
         close_btn = wx.Button(panel, wx.ID_CLOSE, "Close")
+        close_btn.SetName("Close UV index dialog")
         close_btn.Bind(wx.EVT_BUTTON, self._on_close)
         button_sizer.Add(close_btn, 0)
 
@@ -239,6 +240,7 @@ class UVIndexDialog(wx.Dialog):
             style=wx.TE_MULTILINE | wx.TE_READONLY,
             size=(-1, 100),
         )
+        forecast_display.SetName("Hourly UV index forecast")
         sizer.Add(forecast_display, 1, wx.EXPAND)
 
         return sizer
@@ -267,6 +269,7 @@ class UVIndexDialog(wx.Dialog):
                 style=wx.TE_MULTILINE | wx.TE_READONLY,
                 size=(-1, 100),
             )
+            safety_display.SetName("Sun safety recommendations")
             sizer.Add(safety_display, 1, wx.EXPAND)
         else:
             no_data = wx.StaticText(panel, label="Sun safety recommendations are not available.")


### PR DESCRIPTION
## Summary

Adds `SetName()` calls to all interactive wx controls across 8 dialog files that previously had no accessible names. This ensures screen readers (NVDA, JAWS, VoiceOver) can properly identify and announce each control — critical for an app whose tagline is "Weather that speaks to you."

## Changes

**8 dialog files updated, 62 lines added:**

| File | Controls Named |
|------|---------------|
| `progress_dialog.py` | Cancel button |
| `report_issue_dialog.py` | Issue type choice, title input, description input, system info text, submit/cancel buttons |
| `air_quality_dialog.py` | Close button, forecast display, pollutant display |
| `uv_index_dialog.py` | Close button, forecast display, safety display |
| `community_packs_dialog.py` | Search input, refresh button, install button, close button, pack listbox, description text |
| `discussion_dialog.py` | Discussion display, explanation display, refresh/explain/close buttons |
| `soundpack_wizard_dialog.py` | Navigation buttons, info inputs, category checkboxes, file/choose/preview controls, test button |
| `soundpack_manager_dialog.py` | Pack/sounds listboxes, all action buttons, category choice, mapping controls, volume spin, custom key input, inline edit dialog controls |

## Testing

- All 607 tests pass ✅
- Ruff format + lint clean ✅
- No logic or layout changes — only `SetName()` additions

Closes #250