### PR TITLE
fix: improve pressure and temperature display precision

### DIFF
--- a/src/accessiweather/display/presentation/formatters.py
+++ b/src/accessiweather/display/presentation/formatters.py
@@ -105,7 +105,7 @@ def format_pressure_value(
     pressure_mb = current.pressure_mb
     if pressure_in is None and pressure_mb is not None:
         pressure_in = pressure_mb / 33.8639
-    return format_pressure(pressure_in, unit_pref, pressure_mb=pressure_mb, precision=0)
+    return format_pressure(pressure_in, unit_pref, pressure_mb=pressure_mb, precision=1)
 
 
 def format_visibility_value(
@@ -510,8 +510,14 @@ def truncate(text: str, max_length: int) -> str:
 
 
 def get_temperature_precision(unit_pref: TemperatureUnit) -> int:
-    """Return the decimal precision to use for temperature display."""
-    return 0 if unit_pref == TemperatureUnit.BOTH else 1
+    """
+    Return the decimal precision to use for temperature display.
+
+    Uses 1 decimal place for all modes to avoid ambiguous rounding
+    (e.g., 42°F and 40°F both showing as 5°C with 0 decimals).
+    Smart precision in format_temperature still drops .0 for clean values.
+    """
+    return 1
 
 
 def format_temperature_with_feels_like(


### PR DESCRIPTION
## Problem

When using 'Both' temperature display mode:
- **Pressure** showed 0 decimal places: `29 inHg (995 hPa)` — not enough precision to be useful
- **Temperature** used 0 decimals in Both mode, causing different F values to round to the same C value (e.g., 42°F and 40°F both showing as 5°C)

Noticed while testing international locations (Preston, England).

## Fix

- **Pressure**: Changed precision from 0 to 1 decimal place → `29.4 inHg (995.0 hPa)`
- **Temperature**: Use 1 decimal for all unit modes including Both → `42°F (5.6°C)` vs `40°F (4.4°C)`
- Smart precision still drops trailing .0 for clean whole numbers (e.g., 32°F shows as `32°F (0°C)` not `32°F (0.0°C)`)

Applies to all data sources (NWS, Open-Meteo, VC) since formatting is in the presentation layer.

## Testing

All 1115 tests pass, no assertions broken.