### PR TITLE
feat: use wxradio.org JSON API for dynamic NOAA stream discovery

### DIFF
--- a/src/accessiweather/noaa_radio/__init__.py
+++ b/src/accessiweather/noaa_radio/__init__.py
@@ -3,5 +3,6 @@
 from accessiweather.noaa_radio.station_db import StationDatabase
 from accessiweather.noaa_radio.stations import Station
 from accessiweather.noaa_radio.stream_url import StreamURLProvider
+from accessiweather.noaa_radio.wxradio_client import WxRadioClient
 
-__all__ = ["Station", "StationDatabase", "StreamURLProvider"]
+__all__ = ["Station", "StationDatabase", "StreamURLProvider", "WxRadioClient"]

--- a/src/accessiweather/noaa_radio/wxradio_client.py
+++ b/src/accessiweather/noaa_radio/wxradio_client.py
@@ -1,0 +1,214 @@
+"""Client for wxradio.org Icecast JSON API for dynamic NOAA stream discovery."""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Default API endpoint
+WXRADIO_API_URL = "https://wxradio.org/status-json.xsl"
+
+# Default cache TTL in seconds (30 minutes)
+DEFAULT_CACHE_TTL = 1800
+
+# Default request timeout in seconds
+DEFAULT_TIMEOUT = 10
+
+# Regex to extract call sign from mount name (last segment after final hyphen)
+_CALL_SIGN_RE = re.compile(r"-([A-Z]{2,3}\d{2,4}(?:-[Aa]lt\d*|-ALT\d*|-[A-Z])?)$", re.IGNORECASE)
+
+
+def _extract_call_sign(mount: str) -> str | None:
+    """
+    Extract a station call sign from an Icecast mount name.
+
+    Examples:
+        /FL-Tallahassee-KIH24 -> KIH24
+        /MI-MountPleasant-KZZ33-alt2 -> KZZ33
+        /NE-Omaha-KIH61-A -> KIH61
+
+    Args:
+        mount: The mount point string (e.g. "/FL-Tallahassee-KIH24").
+
+    Returns:
+        The call sign string, or None if not parseable.
+
+    """
+    # Strip leading slash
+    name = mount.lstrip("/")
+    if not name:
+        return None
+
+    # Split by hyphens; call sign is typically the 3rd segment
+    # Format: STATE-City-CALLSIGN or STATE-City-CALLSIGN-altN
+    parts = name.split("-")
+    if len(parts) < 3:
+        return None
+
+    # The call sign is the part that matches typical NWR call sign patterns
+    # (letters followed by digits, e.g. KIH24, WXK85, WNG553, XLF339)
+    call_sign_pattern = re.compile(r"^[A-Z]{2,4}\d{2,4}$", re.IGNORECASE)
+    for part in parts[2:]:  # Skip state and city
+        if call_sign_pattern.match(part):
+            return part.upper()
+
+    return None
+
+
+class WxRadioClient:
+    """
+    Client that fetches and caches live stream data from wxradio.org.
+
+    Queries the Icecast JSON status API to discover currently active
+    NOAA Weather Radio streams, extracts call signs from mount names,
+    and caches results with a configurable TTL.
+    """
+
+    def __init__(
+        self,
+        api_url: str = WXRADIO_API_URL,
+        cache_ttl: int = DEFAULT_CACHE_TTL,
+        timeout: int = DEFAULT_TIMEOUT,
+        session: requests.Session | None = None,
+    ) -> None:
+        """
+        Initialize the wxradio.org client.
+
+        Args:
+            api_url: URL of the Icecast JSON status endpoint.
+            cache_ttl: Cache time-to-live in seconds.
+            timeout: HTTP request timeout in seconds.
+            session: Optional requests.Session for connection pooling/testing.
+
+        """
+        self._api_url = api_url
+        self._cache_ttl = cache_ttl
+        self._timeout = timeout
+        self._session = session or requests.Session()
+        self._cache: dict[str, list[str]] | None = None
+        self._cache_time: float = 0.0
+
+    @property
+    def cache_ttl(self) -> int:
+        """Return the cache TTL in seconds."""
+        return self._cache_ttl
+
+    def _is_cache_valid(self) -> bool:
+        """Check whether the cached data is still fresh."""
+        return self._cache is not None and (time.monotonic() - self._cache_time) < self._cache_ttl
+
+    def get_streams(self) -> dict[str, list[str]]:
+        """
+        Get a mapping of call signs to stream URLs.
+
+        Returns cached data if still fresh, otherwise fetches from the API.
+        On error, returns cached data (even if stale) or an empty dict.
+
+        Returns:
+            Dictionary mapping uppercase call signs to lists of HTTPS stream URLs.
+
+        """
+        if self._is_cache_valid():
+            return dict(self._cache)  # type: ignore[arg-type]
+
+        try:
+            data = self._fetch()
+            streams = self._parse(data)
+            self._cache = streams
+            self._cache_time = time.monotonic()
+            return dict(streams)
+        except Exception:
+            logger.warning("Failed to fetch wxradio.org streams, using cached/empty data")
+            if self._cache is not None:
+                return dict(self._cache)
+            return {}
+
+    def _fetch(self) -> dict[str, Any]:
+        """
+        Fetch the Icecast JSON status from wxradio.org.
+
+        Returns:
+            The parsed JSON response as a dictionary.
+
+        Raises:
+            requests.RequestException: On network or HTTP errors.
+            ValueError: On malformed JSON.
+
+        """
+        response = self._session.get(self._api_url, timeout=self._timeout)
+        response.raise_for_status()
+        return response.json()  # type: ignore[no-any-return]
+
+    def _parse(self, data: dict[str, Any]) -> dict[str, list[str]]:
+        """
+        Parse the Icecast JSON response into a call sign -> URLs mapping.
+
+        Args:
+            data: The parsed JSON response from the Icecast server.
+
+        Returns:
+            Dictionary mapping call signs to lists of stream URLs.
+
+        """
+        streams: dict[str, list[str]] = {}
+
+        try:
+            icestats = data.get("icestats", {})
+            sources = icestats.get("source", [])
+        except (AttributeError, TypeError):
+            logger.warning("Malformed wxradio.org response: missing icestats/source")
+            return streams
+
+        # Icecast returns a single dict if only one source, list otherwise
+        if isinstance(sources, dict):
+            sources = [sources]
+
+        if not isinstance(sources, list):
+            return streams
+
+        for source in sources:
+            if not isinstance(source, dict):
+                continue
+
+            listenurl = source.get("listenurl", "")
+            server_name = source.get("server_name", "")
+
+            # Extract mount from listenurl or use server_name
+            mount = ""
+            if isinstance(listenurl, str) and listenurl:
+                # listenurl is like http://wxradio.org:8000/FL-Tallahassee-KIH24
+                parts = listenurl.rsplit("/", 1)
+                if len(parts) == 2:
+                    mount = "/" + parts[1]
+
+            if not mount and isinstance(server_name, str):
+                mount = "/" + server_name
+
+            if not mount:
+                continue
+
+            call_sign = _extract_call_sign(mount)
+            if not call_sign:
+                continue
+
+            # Build HTTPS URL
+            mount_path = mount.lstrip("/")
+            url = f"https://wxradio.org/{mount_path}"
+
+            if call_sign not in streams:
+                streams[call_sign] = []
+            if url not in streams[call_sign]:
+                streams[call_sign].append(url)
+
+        return streams
+
+    def invalidate_cache(self) -> None:
+        """Force the cache to be invalidated."""
+        self._cache = None
+        self._cache_time = 0.0

--- a/tests/test_wxradio_client.py
+++ b/tests/test_wxradio_client.py
@@ -1,0 +1,268 @@
+"""Tests for WxRadioClient and wxradio.org integration with StreamURLProvider."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import requests
+
+from accessiweather.noaa_radio.stream_url import StreamURLProvider
+from accessiweather.noaa_radio.wxradio_client import (
+    WxRadioClient,
+    _extract_call_sign,
+)
+
+# -- Call sign extraction tests --
+
+
+class TestExtractCallSign:
+    """Tests for the _extract_call_sign helper."""
+
+    def test_standard_mount(self) -> None:
+        assert _extract_call_sign("/FL-Tallahassee-KIH24") == "KIH24"
+
+    def test_multi_word_city(self) -> None:
+        assert _extract_call_sign("/MI-MountPleasant-KZZ33") == "KZZ33"
+
+    def test_alt_suffix_ignored(self) -> None:
+        assert _extract_call_sign("/MI-MountPleasant-KZZ33-alt2") == "KZZ33"
+
+    def test_single_letter_suffix(self) -> None:
+        assert _extract_call_sign("/NE-Omaha-KIH61-A") == "KIH61"
+
+    def test_canadian_call_sign(self) -> None:
+        assert _extract_call_sign("/AB-Calgary-XLF339") == "XLF339"
+
+    def test_alt1_suffix(self) -> None:
+        assert _extract_call_sign("/NY-Middleville-WXM45-alt1") == "WXM45"
+
+    def test_no_leading_slash(self) -> None:
+        assert _extract_call_sign("FL-Tallahassee-KIH24") == "KIH24"
+
+    def test_too_few_parts(self) -> None:
+        assert _extract_call_sign("/SomeMount") is None
+
+    def test_empty_string(self) -> None:
+        assert _extract_call_sign("") is None
+
+    def test_no_call_sign_match(self) -> None:
+        assert _extract_call_sign("/XX-City-nocallsign") is None
+
+    def test_uppercase_normalization(self) -> None:
+        assert _extract_call_sign("/fl-tallahassee-kih24") == "KIH24"
+
+    def test_alt_suffix_with_ALT(self) -> None:
+        assert _extract_call_sign("/GA-Atlanta-KEC80-ALT") == "KEC80"
+
+
+# -- Sample Icecast JSON responses --
+
+SAMPLE_ICECAST_RESPONSE = {
+    "icestats": {
+        "source": [
+            {
+                "listenurl": "http://wxradio.org:8000/FL-Tallahassee-KIH24",
+                "server_name": "FL-Tallahassee-KIH24",
+            },
+            {
+                "listenurl": "http://wxradio.org:8000/GA-Atlanta-KEC80",
+                "server_name": "GA-Atlanta-KEC80",
+            },
+            {
+                "listenurl": "http://wxradio.org:8000/AB-Calgary-XLF339",
+                "server_name": "AB-Calgary-XLF339",
+            },
+        ]
+    }
+}
+
+SINGLE_SOURCE_RESPONSE = {
+    "icestats": {
+        "source": {
+            "listenurl": "http://wxradio.org:8000/FL-Tallahassee-KIH24",
+            "server_name": "FL-Tallahassee-KIH24",
+        }
+    }
+}
+
+EMPTY_RESPONSE: dict = {"icestats": {"source": []}}
+
+MALFORMED_RESPONSE: dict = {"unexpected": "data"}
+
+
+# -- WxRadioClient tests --
+
+
+class TestWxRadioClient:
+    """Tests for the WxRadioClient class."""
+
+    def _make_client(self, json_data: dict, **kwargs) -> WxRadioClient:
+        session = MagicMock(spec=requests.Session)
+        response = MagicMock()
+        response.json.return_value = json_data
+        response.raise_for_status.return_value = None
+        session.get.return_value = response
+        return WxRadioClient(session=session, **kwargs)
+
+    def test_parse_multiple_sources(self) -> None:
+        client = self._make_client(SAMPLE_ICECAST_RESPONSE)
+        streams = client.get_streams()
+        assert "KIH24" in streams
+        assert "KEC80" in streams
+        assert "XLF339" in streams
+        assert streams["KIH24"] == ["https://wxradio.org/FL-Tallahassee-KIH24"]
+
+    def test_parse_single_source(self) -> None:
+        client = self._make_client(SINGLE_SOURCE_RESPONSE)
+        streams = client.get_streams()
+        assert "KIH24" in streams
+
+    def test_empty_sources(self) -> None:
+        client = self._make_client(EMPTY_RESPONSE)
+        assert client.get_streams() == {}
+
+    def test_malformed_response(self) -> None:
+        client = self._make_client(MALFORMED_RESPONSE)
+        assert client.get_streams() == {}
+
+    def test_cache_returns_same_data(self) -> None:
+        client = self._make_client(SAMPLE_ICECAST_RESPONSE)
+        first = client.get_streams()
+        second = client.get_streams()
+        assert first == second
+        # Session.get should only be called once due to caching
+        client._session.get.assert_called_once()  # type: ignore[union-attr]
+
+    def test_cache_expiry(self) -> None:
+        client = self._make_client(SAMPLE_ICECAST_RESPONSE, cache_ttl=1)
+        client.get_streams()
+        # Manually expire the cache
+        client._cache_time = time.monotonic() - 2
+        client.get_streams()
+        assert client._session.get.call_count == 2  # type: ignore[union-attr]
+
+    def test_invalidate_cache(self) -> None:
+        client = self._make_client(SAMPLE_ICECAST_RESPONSE)
+        client.get_streams()
+        client.invalidate_cache()
+        assert client._cache is None
+
+    def test_network_error_returns_empty(self) -> None:
+        session = MagicMock(spec=requests.Session)
+        session.get.side_effect = requests.ConnectionError("fail")
+        client = WxRadioClient(session=session)
+        assert client.get_streams() == {}
+
+    def test_network_error_returns_stale_cache(self) -> None:
+        client = self._make_client(SAMPLE_ICECAST_RESPONSE, cache_ttl=0)
+        first = client.get_streams()
+        assert len(first) > 0
+
+        # Now make it fail
+        client._session.get.side_effect = requests.ConnectionError("fail")  # type: ignore[union-attr]
+        client._cache_time = 0  # Force stale
+        second = client.get_streams()
+        assert second == first
+
+    def test_timeout_error(self) -> None:
+        session = MagicMock(spec=requests.Session)
+        session.get.side_effect = requests.Timeout("timeout")
+        client = WxRadioClient(session=session)
+        assert client.get_streams() == {}
+
+    def test_duplicate_call_sign_deduplication(self) -> None:
+        """Multiple mounts for same call sign should deduplicate URLs."""
+        data = {
+            "icestats": {
+                "source": [
+                    {
+                        "listenurl": "http://wxradio.org:8000/FL-Tallahassee-KIH24",
+                        "server_name": "FL-Tallahassee-KIH24",
+                    },
+                    {
+                        "listenurl": "http://wxradio.org:8000/FL-Tallahassee-KIH24",
+                        "server_name": "FL-Tallahassee-KIH24",
+                    },
+                ]
+            }
+        }
+        client = self._make_client(data)
+        streams = client.get_streams()
+        assert len(streams["KIH24"]) == 1
+
+    def test_source_without_listenurl_uses_server_name(self) -> None:
+        data = {
+            "icestats": {
+                "source": [
+                    {"server_name": "FL-Tallahassee-KIH24"},
+                ]
+            }
+        }
+        client = self._make_client(data)
+        streams = client.get_streams()
+        assert "KIH24" in streams
+
+    def test_source_with_no_usable_fields_skipped(self) -> None:
+        data = {"icestats": {"source": [{"bitrate": 128}]}}
+        client = self._make_client(data)
+        assert client.get_streams() == {}
+
+
+# -- StreamURLProvider integration tests --
+
+
+class TestStreamURLProviderWithWxRadio:
+    """Tests for StreamURLProvider using WxRadioClient."""
+
+    def _make_mock_client(self, streams: dict[str, list[str]]) -> WxRadioClient:
+        client = MagicMock(spec=WxRadioClient)
+        client.get_streams.return_value = streams
+        return client
+
+    def test_dynamic_urls_first(self) -> None:
+        mock = self._make_mock_client({"KIH24": ["https://wxradio.org/FL-Tallahassee-KIH24"]})
+        provider = StreamURLProvider(wxradio_client=mock)
+        urls = provider.get_stream_urls("KIH24")
+        assert urls[0] == "https://wxradio.org/FL-Tallahassee-KIH24"
+        # Static URLs should follow
+        assert len(urls) > 1
+
+    def test_dynamic_dedup_with_static(self) -> None:
+        """Dynamic URL that's also in static should not appear twice."""
+        mock = self._make_mock_client({"KIH24": ["https://wxradio.org/FL-Tallahassee-KIH24"]})
+        provider = StreamURLProvider(wxradio_client=mock)
+        urls = provider.get_stream_urls("KIH24")
+        assert urls.count("https://wxradio.org/FL-Tallahassee-KIH24") == 1
+
+    def test_fallback_to_static_on_empty_dynamic(self) -> None:
+        mock = self._make_mock_client({})
+        provider = StreamURLProvider(wxradio_client=mock)
+        urls = provider.get_stream_urls("KIH24")
+        # Should return static URLs
+        assert len(urls) > 0
+        assert "wxradio.org/FL-Tallahassee-KIH24" in urls[0]
+
+    def test_fallback_on_client_error(self) -> None:
+        mock = MagicMock(spec=WxRadioClient)
+        mock.get_streams.side_effect = Exception("boom")
+        provider = StreamURLProvider(wxradio_client=mock)
+        urls = provider.get_stream_urls("KIH24")
+        assert len(urls) > 0
+
+    def test_no_wxradio_client_works_as_before(self) -> None:
+        provider = StreamURLProvider()
+        urls = provider.get_stream_urls("KIH24")
+        assert len(urls) > 0
+
+    def test_dynamic_only_station(self) -> None:
+        """Station only in dynamic data, not in static."""
+        mock = self._make_mock_client({"ZZTEST": ["https://wxradio.org/XX-Test-ZZTEST"]})
+        provider = StreamURLProvider(wxradio_client=mock, use_fallback=False)
+        urls = provider.get_stream_urls("ZZTEST")
+        assert urls == ["https://wxradio.org/XX-Test-ZZTEST"]
+
+    def test_has_known_url_unchanged(self) -> None:
+        provider = StreamURLProvider()
+        assert provider.has_known_url("KIH24") is True
+        assert provider.has_known_url("NONEXISTENT") is False


### PR DESCRIPTION
## Summary

Adds dynamic stream discovery from wxradio.org's Icecast JSON API, with graceful fallback to static URLs.

### Changes

- **New file: `wxradio_client.py`** — `WxRadioClient` class that:
  - Fetches `https://wxradio.org/status-json.xsl` (Icecast JSON API)
  - Parses mount names to extract station call signs (e.g. `/FL-Tallahassee-KIH24` → `KIH24`)
  - Returns HTTPS stream URLs
  - Caches results with configurable TTL (default 30 min)
  - Handles timeouts, network errors, malformed JSON gracefully

- **Updated: `stream_url.py`** — `StreamURLProvider` now:
  - Optionally accepts a `WxRadioClient` instance
  - Checks dynamic wxradio.org data first (if available)
  - Falls back to static `_STREAM_URLS` if API unreachable
  - Merges dynamic URLs first (known-live), then static (deduplicated)

### Testing

- 32 new tests covering call sign parsing, caching, error handling, URL merging
- All 1709 existing tests pass
- Lint and format checks pass

Closes #299