### PR TITLE
test: add unit tests for paths and retry_utils modules

### DIFF
--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -124,8 +124,9 @@ class TestAppPath:
 
     def test_app_frozen(self):
         p = Paths()
-        with patch.object(sys, "frozen", True, create=True), patch.object(
-            sys, "executable", "/usr/bin/myapp"
+        with (
+            patch.object(sys, "frozen", True, create=True),
+            patch.object(sys, "executable", "/usr/bin/myapp"),
         ):
             result = p.app
         assert result == Path("/usr/bin")

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -67,28 +67,33 @@ class TestIsRetryableHttpError:
 
     def test_timeout_exception(self):
         import httpx
+
         assert is_retryable_http_error(httpx.ConnectTimeout("timeout")) is True
 
     def test_500_status_error(self):
         import httpx
+
         response = httpx.Response(500, request=httpx.Request("GET", "http://x"))
         exc = httpx.HTTPStatusError("fail", request=response.request, response=response)
         assert is_retryable_http_error(exc) is True
 
     def test_429_status_error(self):
         import httpx
+
         response = httpx.Response(429, request=httpx.Request("GET", "http://x"))
         exc = httpx.HTTPStatusError("fail", request=response.request, response=response)
         assert is_retryable_http_error(exc) is True
 
     def test_400_not_retryable(self):
         import httpx
+
         response = httpx.Response(400, request=httpx.Request("GET", "http://x"))
         exc = httpx.HTTPStatusError("fail", request=response.request, response=response)
         assert is_retryable_http_error(exc) is False
 
     def test_request_error_retryable(self):
         import httpx
+
         exc = httpx.ConnectError("connection refused")
         assert is_retryable_http_error(exc) is True
 


### PR DESCRIPTION
## Summary
Adds 43 new tests for two previously under-tested utility modules.

### paths.py (40% → ~100%)
- All platform paths (Windows with/without LOCALAPPDATA, macOS, Linux with/without XDG)
- Directory creation for data/config/cache/logs
- Frozen vs unfrozen app path detection
- Base path caching

### retry_utils.py (52% → ~90%)
- calculate_backoff_delay: exponential growth, max_delay cap, all jitter types (float, tuple, callable)
- is_retryable_http_error: timeout, 5xx, 429, 400, connection errors
- _should_retry: CancelledError rejection, matching, chained cause/context
- async_retry_with_backoff: success, retry, exhaustion, non-retryable passthrough, timeout, custom exceptions

Closes no issues (coverage improvement only).