### PR TITLE
fix(notifications): use persistent worker thread for desktop toast notifications

### DIFF
--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -990,19 +990,16 @@ class MainWindow(SizedFrame):
             # Send notifications for each event
             for event in events:
                 try:
+                    # Pass sound_event and let send_notification handle sound
+                    # to avoid double-playing (send_notification plays sound
+                    # internally when play_sound=True)
                     success = notifier.send_notification(
                         title=event.title,
                         message=event.message,
                         timeout=10,
+                        sound_event=event.sound_event,
+                        play_sound=settings.sound_enabled,
                     )
-
-                    if success and settings.sound_enabled:
-                        import contextlib
-
-                        from ..notifications.sound_player import play_notification_sound
-
-                        with contextlib.suppress(Exception):
-                            play_notification_sound(event.sound_event, settings.sound_pack)
 
                     if success:
                         logger.info("Sent %s notification: %s", event.event_type, event.title)


### PR DESCRIPTION
## Problem

Discussion update notifications (and severe risk change notifications) only play the sound but never show the Windows toast notification.

## Root Cause

Two issues:

1. **Throwaway worker threads**: `SafeDesktopNotifier` created a brand new `DesktopNotifier` instance inside a temporary worker thread for every notification. On Windows, `desktop-notifier` uses COM for toast notifications. Creating a COM object in a thread that immediately exits means the notification never actually renders — the thread dies before Windows can display it.

2. **Double sound playback**: `_process_notification_events` in `main_window.py` called `send_notification()` (which plays sound internally with a default event) and then played sound *again* with the correct event key. Users heard the sound twice per notification.

## Fix

- **Persistent daemon worker thread**: A single background thread is started once, creates the `DesktopNotifier` with proper COM initialization, and keeps its event loop running via `run_forever()`. All notifications are dispatched to this thread using `asyncio.run_coroutine_threadsafe()`, ensuring the notifier stays alive long enough for Windows to render the toast.

- **Single sound path**: `_process_notification_events` now passes `sound_event` and `play_sound` directly to `send_notification()` instead of playing sound separately, eliminating the double-play bug.

## Testing

- Enable "Notify on Forecast Discussion update" in Settings > Notifications
- Wait for a discussion update (or manually trigger one)
- Verify: Windows toast notification appears AND sound plays (once, not twice)
- Also test weather alert notifications still work as before