### PR TITLE
fix(audio): try Toga-style shutdown flow for exit sound

### DIFF
--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -625,10 +625,8 @@ class AccessiWeatherApp(wx.App):
         if self._async_loop:
             self._async_loop.call_soon_threadsafe(self._async_loop.stop)
 
-        # Close main window and exit
-        if self.main_window:
-            self.main_window.Destroy()
-
+        # Let wx handle window teardown via main loop exit (closer to old Toga flow)
+        # instead of force-destroying the window first.
         self.ExitMainLoop()
 
     def refresh_runtime_settings(self) -> None:


### PR DESCRIPTION
## Summary
- keep non-blocking `play_exit_sound(...)` behavior
- remove forced `main_window.Destroy()` during exit
- let wx main-loop shutdown manage window teardown (closer to historical Toga flow)

## Why
Exit sound is getting cut off in wx builds. Toga behavior felt better without explicit blocking. This tests whether force-destroying the window is truncating playback.

## Testing
- exit app with sounds enabled
- verify whether exit sound completes more consistently
- compare perceived exit speed to current dev build
