### PR TITLE
fix(ci): sync main nightly gating + notes filters from dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,10 +56,25 @@ jobs:
             echo "version=$VERSION" >> $GITHUB_OUTPUT
 
             LAST_TAG=$(git tag --list "nightly-*" --sort=-version:refname | head -1)
-            if [ -z "$LAST_TAG" ] || ! git diff --quiet "$LAST_TAG"..HEAD -- src/ pyproject.toml installer/; then
+
+            if [ -z "$LAST_TAG" ]; then
+              # No prior nightly: build once
               echo "should_build=true" >> $GITHUB_OUTPUT
             else
-              echo "should_build=false" >> $GITHUB_OUTPUT
+              RANGE="$LAST_TAG"..HEAD
+
+              # Build only when there is at least one user-facing commit.
+              # This avoids shipping nightlies for test/chore/ci-only changes.
+              USER_FACING_COUNT=$(git log "$RANGE" --pretty='%s' --no-merges --first-parent | \
+                grep -Ei '^(feat|fix|perf|security)(\([^)]+\))?:' | \
+                grep -Eiv '^fix\((test|ci|build|chore|docs|style|refactor)\):' | \
+                wc -l | tr -d ' ')
+
+              if [ "${USER_FACING_COUNT:-0}" -gt 0 ]; then
+                echo "should_build=true" >> $GITHUB_OUTPUT
+              else
+                echo "should_build=false" >> $GITHUB_OUTPUT
+              fi
             fi
           fi
 
@@ -85,8 +100,7 @@ jobs:
 
       - name: Build
         run: |
-          python scripts/generate_version.py
-          python scripts/generate_build_info.py ${{ needs.prepare.outputs.is_nightly == 'true' && needs.prepare.outputs.tag || '' }}
+          python scripts/generate_build_meta.py ${{ needs.prepare.outputs.is_nightly == 'true' && needs.prepare.outputs.tag || '' }}
           python installer/create_icons.py
           python -m PyInstaller --clean --noconfirm installer/accessiweather.spec
 
@@ -140,8 +154,7 @@ jobs:
 
       - name: Build
         run: |
-          python scripts/generate_version.py
-          python scripts/generate_build_info.py ${{ needs.prepare.outputs.is_nightly == 'true' && needs.prepare.outputs.tag || '' }}
+          python scripts/generate_build_meta.py ${{ needs.prepare.outputs.is_nightly == 'true' && needs.prepare.outputs.tag || '' }}
           python installer/create_icons.py
           python -m PyInstaller --clean --noconfirm installer/accessiweather.spec
 
@@ -212,14 +225,14 @@ jobs:
           if [ "$IS_NIGHTLY" = "true" ]; then
             LAST_TAG=$(git tag --list "nightly-*" --sort=-version:refname | head -1)
             if [ -n "$LAST_TAG" ]; then
-              # Filter out dev-only commits (test, chore, ci, build, style, refactor, docs)
-              # Use --first-parent to avoid duplicate entries from squash merges
+              # Keep nightly notes user-facing and consistent with build gating.
+              # Include only feat/fix/perf/security, excluding internal fix scopes.
               git log "$LAST_TAG"..HEAD --oneline --no-merges --first-parent | \
-                grep -viE '^[a-f0-9]+ (test|chore|ci|build|style|refactor|docs)(\(|:)' | \
-                grep -viE '^[a-f0-9]+ Merge' | \
+                grep -Ei '^[a-f0-9]+ (feat|fix|perf|security)(\([^)]+\))?:' | \
+                grep -Eiv '^[a-f0-9]+ fix\((test|ci|build|chore|docs|style|refactor)\):' | \
                 sed 's/^/- /' > notes.md
               # If all commits were filtered, add a placeholder
-              [ -s notes.md ] || echo "- Bug fixes and improvements" > notes.md
+              [ -s notes.md ] || echo "- No user-facing changes" > notes.md
             else
               echo "Initial nightly build" > notes.md
             fi


### PR DESCRIPTION
## Summary
- sync `.github/workflows/build.yml` from `dev` to `main`
- use user-facing commit gating for nightlies (feat/fix/perf/security with internal fix-scope exclusions)
- align nightly release notes filtering with the same logic

## Why
Nightly workflow execution uses the workflow file from the default branch (`main`) for scheduled/manual runs. `main` still had the old path-based gate + loose notes filter, which allowed test-only style changes into nightly builds/notes.

## Result
Nightly behavior on `main` now matches the intended filtered behavior already present on `dev`.
