### PR TITLE
fix: anchor next 6 hours to user local time (#341)

### DIFF
--- a/src/accessiweather/models/weather.py
+++ b/src/accessiweather/models/weather.py
@@ -352,20 +352,15 @@ class HourlyForecast:
         if not self.periods:
             return []
 
-        def _to_timestamp(dt: datetime | None, *, as_utc: bool) -> float | None:
+        def _to_timestamp(dt: datetime | None) -> float | None:
             if dt is None:
                 return None
-            if as_utc:
-                dt = dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt.astimezone(UTC)
-                return dt.timestamp()
             if dt.tzinfo is not None:
-                dt = dt.astimezone()
+                # Compare using wall-clock hour to avoid anchoring to the location offset.
+                dt = dt.replace(tzinfo=None)
             return dt.timestamp()
 
-        has_aware_times = any(
-            p.start_time and p.start_time.tzinfo is not None for p in self.periods
-        )
-        now_reference = datetime.now(UTC) if has_aware_times else datetime.now()
+        now_reference = datetime.now()
         now_ts = now_reference.timestamp()
         tolerance = timedelta(hours=1)
         tolerance_seconds = tolerance.total_seconds()
@@ -373,7 +368,7 @@ class HourlyForecast:
         sortable_periods: list[tuple[HourlyForecastPeriod, float]] = []
         unordered_periods: list[HourlyForecastPeriod] = []
         for period in self.periods:
-            ts = _to_timestamp(period.start_time, as_utc=has_aware_times)
+            ts = _to_timestamp(period.start_time)
             if ts is None:
                 unordered_periods.append(period)
             else:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,7 @@ Tests the core data models used throughout the application.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, timezone
 
 from accessiweather.models import (
     AppConfig,
@@ -171,6 +171,53 @@ class TestHourlyForecast:
             ]
         )
         assert with_periods.has_data() is True
+
+    def test_get_next_hours_anchors_to_user_local_time_not_location_time(self, monkeypatch):
+        """Aware location times should be compared using local wall-clock now."""
+        import os
+        import time
+
+        import accessiweather.models.weather as weather_models
+
+        class _MockDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                # Simulate user local time in EST: 8:30 PM.
+                if tz is None:
+                    return cls(2026, 1, 1, 20, 30, 0)
+                # Older UTC-based behavior would effectively align with 5:30 PM PST.
+                if tz is UTC:
+                    return cls(2026, 1, 2, 1, 30, 0, tzinfo=UTC)
+                return cls(2026, 1, 1, 20, 30, 0, tzinfo=tz)
+
+        monkeypatch.setattr(weather_models, "datetime", _MockDateTime)
+
+        original_tz = os.environ.get("TZ")
+        monkeypatch.setenv("TZ", "EST5EDT")
+        if hasattr(time, "tzset"):
+            time.tzset()
+
+        try:
+            pst = timezone(timedelta(hours=-8))
+            base = datetime(2026, 1, 1, 17, 0, 0, tzinfo=pst)
+            periods = [
+                HourlyForecastPeriod(start_time=base + timedelta(hours=i), temperature=60 + i)
+                for i in range(10)
+            ]
+
+            hourly = HourlyForecast(periods=periods)
+            next_hours = hourly.get_next_hours(6)
+
+            assert len(next_hours) == 6
+            # 8:30 PM local should align to the 8 PM hour in user's local timezone.
+            assert next_hours[0].start_time.hour == 20
+        finally:
+            if original_tz is None:
+                monkeypatch.delenv("TZ", raising=False)
+            else:
+                monkeypatch.setenv("TZ", original_tz)
+            if hasattr(time, "tzset"):
+                time.tzset()
 
 
 class TestWeatherAlert:


### PR DESCRIPTION
Fixes #341. Next 6 hours now starts from the user's local system time instead of the queried location's current time.