### PR TITLE
fix: model combo boxes now load saved value on open (#342)

### DIFF
--- a/src/accessiweather/ui/dialogs/settings_dialog.py
+++ b/src/accessiweather/ui/dialogs/settings_dialog.py
@@ -13,6 +13,35 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+US_PRIORITY_OPTIONS: list[list[str]] = [
+    ["nws", "openmeteo", "visualcrossing"],
+    ["nws", "visualcrossing", "openmeteo"],
+    ["openmeteo", "nws", "visualcrossing"],
+]
+
+INTL_PRIORITY_OPTIONS: list[list[str]] = [
+    ["openmeteo", "visualcrossing"],
+    ["visualcrossing", "openmeteo"],
+]
+
+
+def _priority_selection_from_value(
+    value: list[str] | tuple[str, ...] | None, options: list[list[str]], default: int = 0
+) -> int:
+    """Map saved source priority ordering to combo selection index."""
+    normalized = list(value) if value else None
+    for idx, option in enumerate(options):
+        if normalized == option:
+            return idx
+    return default
+
+
+def _priority_value_from_selection(selection: int, options: list[list[str]]) -> list[str]:
+    """Map combo selection index to persisted source priority ordering."""
+    if 0 <= selection < len(options):
+        return list(options[selection])
+    return list(options[0]) if options else []
+
 
 class SettingsDialogSimple(wx.Dialog):
     """Comprehensive settings dialog matching Toga version functionality."""
@@ -936,8 +965,19 @@ class SettingsDialogSimple(wx.Dialog):
             self._controls["vc_key"].SetValue(str(vc_key))
 
             # Source priority (simplified - just use defaults for now)
-            self._controls["us_priority"].SetSelection(0)
-            self._controls["intl_priority"].SetSelection(0)
+            us_priority = getattr(
+                settings, "source_priority_us", ["nws", "openmeteo", "visualcrossing"]
+            )
+            self._controls["us_priority"].SetSelection(
+                _priority_selection_from_value(us_priority, US_PRIORITY_OPTIONS)
+            )
+
+            intl_priority = getattr(
+                settings, "source_priority_international", ["openmeteo", "visualcrossing"]
+            )
+            self._controls["intl_priority"].SetSelection(
+                _priority_selection_from_value(intl_priority, INTL_PRIORITY_OPTIONS)
+            )
 
             # Open-Meteo model
             model = getattr(settings, "openmeteo_weather_model", "best_match")
@@ -1110,6 +1150,14 @@ class SettingsDialogSimple(wx.Dialog):
                 "openmeteo_weather_model": model_values[
                     self._controls["openmeteo_model"].GetSelection()
                 ],
+                "source_priority_us": _priority_value_from_selection(
+                    self._controls["us_priority"].GetSelection(),
+                    US_PRIORITY_OPTIONS,
+                ),
+                "source_priority_international": _priority_value_from_selection(
+                    self._controls["intl_priority"].GetSelection(),
+                    INTL_PRIORITY_OPTIONS,
+                ),
                 # Notifications
                 "enable_alerts": self._controls["enable_alerts"].GetValue(),
                 "alert_notifications_enabled": self._controls["alert_notif"].GetValue(),

--- a/tests/test_settings_dialog_source_priority.py
+++ b/tests/test_settings_dialog_source_priority.py
@@ -1,0 +1,104 @@
+"""Tests for source priority combo box persistence in settings dialog."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+import sys
+import types
+from unittest.mock import MagicMock
+
+# Some dialog package imports require this optional wx module.
+if "wx.lib.scrolledpanel" not in sys.modules:
+    _scrolled = types.ModuleType("wx.lib.scrolledpanel")
+    _scrolled.ScrolledPanel = object
+    sys.modules["wx.lib.scrolledpanel"] = _scrolled
+
+from accessiweather.models import AppSettings
+from accessiweather.ui.dialogs.settings_dialog import (
+    INTL_PRIORITY_OPTIONS,
+    US_PRIORITY_OPTIONS,
+    SettingsDialogSimple,
+    _priority_selection_from_value,
+)
+
+
+class _DummyControl:
+    def __init__(self):
+        self._selection = 0
+        self._value = False
+        self._items: list[str] = []
+
+    def SetSelection(self, value: int):
+        self._selection = value
+
+    def GetSelection(self) -> int:
+        return self._selection
+
+    def SetValue(self, value):
+        self._value = value
+
+    def GetValue(self):
+        return self._value
+
+    def Append(self, item: str):
+        self._items.append(item)
+
+    def GetCount(self) -> int:
+        return len(self._items)
+
+    def SetString(self, index: int, value: str):
+        if index < len(self._items):
+            self._items[index] = value
+
+    def Clear(self):
+        self._items = []
+        self._selection = 0
+
+    def Enable(self, _enabled: bool):
+        return None
+
+    def SetName(self, _name: str):
+        return None
+
+
+def _build_dialog(settings: AppSettings) -> SettingsDialogSimple:
+    dialog = SettingsDialogSimple.__new__(SettingsDialogSimple)
+    dialog.config_manager = MagicMock()
+    dialog.config_manager.get_settings.return_value = settings
+    dialog.config_manager.update_settings.return_value = True
+    dialog._controls = defaultdict(_DummyControl)
+    dialog._sound_pack_ids = ["default"]
+    dialog._selected_specific_model = None
+    dialog._update_minimize_on_startup_state = lambda _enabled: None
+    return dialog
+
+
+def test_load_settings_initializes_source_priority_combo_boxes_from_saved_values():
+    settings = AppSettings(
+        source_priority_us=["openmeteo", "nws", "visualcrossing"],
+        source_priority_international=["visualcrossing", "openmeteo"],
+    )
+    dialog = _build_dialog(settings)
+
+    dialog._load_settings()
+
+    assert dialog._controls["us_priority"].GetSelection() == 2
+    assert dialog._controls["intl_priority"].GetSelection() == 1
+
+
+def test_save_settings_persists_selected_source_priority_values():
+    dialog = _build_dialog(AppSettings())
+    dialog._controls["us_priority"].SetSelection(1)
+    dialog._controls["intl_priority"].SetSelection(1)
+
+    assert dialog._save_settings() is True
+
+    call = dialog.config_manager.update_settings.call_args
+    assert call is not None
+    kwargs = call.kwargs
+    assert kwargs["source_priority_us"] == US_PRIORITY_OPTIONS[1]
+    assert kwargs["source_priority_international"] == INTL_PRIORITY_OPTIONS[1]
+
+
+def test_invalid_saved_priority_defaults_to_first_option():
+    assert _priority_selection_from_value(["bad", "order"], US_PRIORITY_OPTIONS) == 0


### PR DESCRIPTION
Fixes #342. Combo boxes for US and Other Locations default models now correctly initialize from saved settings instead of always showing the default.