### PR TITLE
fix(forecast): next 6 hours shows correct window for cross-timezone lookups (#341)

### DIFF
--- a/src/accessiweather/visual_crossing_client.py
+++ b/src/accessiweather/visual_crossing_client.py
@@ -440,11 +440,17 @@ class VisualCrossingClient:
                         # Add timezone info if available
                         if location_tz and start_time:
                             start_time = start_time.replace(tzinfo=location_tz)
+                        elif start_time and start_time.tzinfo is None:
+                            from datetime import timezone as dt_timezone
+
+                            start_time = start_time.replace(tzinfo=dt_timezone.utc)
                     except (ValueError, TypeError):
                         logger.warning(
                             f"Failed to parse Visual Crossing datetime: {full_datetime_str}"
                         )
-                        start_time = datetime.now()
+                        from datetime import timezone as dt_timezone
+
+                        start_time = datetime.now(dt_timezone.utc)
 
                 # Seasonal fields
                 precip_type = hour_data.get("preciptype")


### PR DESCRIPTION
Fixes #341.\n\nWhen Visual Crossing does not return a recognized timezone, hourly timestamps are now tagged as UTC rather than left naive. Previously, naive datetimes were misinterpreted by get_next_hours() as local time, causing the wrong 6-hour window to be shown.