### PR TITLE
fix(notifications): toast notifications now work from installer shortcut (#344)

### DIFF
--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -713,6 +713,16 @@ def main(
         fake_nightly: Fake nightly tag for testing updates (e.g., 'nightly-20250101').
 
     """
+    if sys.platform == "win32":
+        try:
+            import ctypes
+
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
+                "Orinks.AccessiWeather"
+            )
+        except Exception:
+            pass
+
     app = AccessiWeatherApp(config_dir=config_dir, portable_mode=portable_mode, debug=debug)
 
     # Override version/build_tag for update testing

--- a/src/accessiweather/notifications/toast_notifier.py
+++ b/src/accessiweather/notifications/toast_notifier.py
@@ -94,7 +94,10 @@ class SafeDesktopNotifier:
             asyncio.set_event_loop(self._worker_loop)
 
             # Create the notifier once in this thread (proper COM init on Windows)
-            self._worker_notifier = DesktopNotifier(app_name=self.app_name)
+            self._worker_notifier = DesktopNotifier(
+                app_name=self.app_name,
+                app_id="Orinks.AccessiWeather",
+            )
             logger.debug("Desktop notifier created in worker thread")
 
             self._worker_ready.set()


### PR DESCRIPTION
Fixes #344.\n\nCalls SetCurrentProcessExplicitAppUserModelID("Orinks.AccessiWeather") at startup. Windows requires this registration to route toast notifications to background processes that were not launched from a terminal. Sound played correctly before because it uses winsound directly; only the visual toast was affected.