### PR TITLE
feat: add Test Notification to regular tray menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
     - Main window integration for displaying discussion summaries.
     - AI summarization button in the nationwide dialog.
     - Shared `NationalDiscussionService` instance with caching.
+- Added a `Test Notification` item to the regular system tray menu so you can verify notifications from installed builds without launching in debug mode.
 - Bundled `prismatoid`/`prism` in PyInstaller nightly builds (PR #294).
 - Added missing tests for `national_discussion_service.py` to meet coverage gate requirements.
 - Updated Antfarm to v0.2.2 and configured feature-dev workflow for 80% diff-coverage.

--- a/src/accessiweather/ui/system_tray.py
+++ b/src/accessiweather/ui/system_tray.py
@@ -155,7 +155,7 @@ class SystemTrayIcon(wx.adv.TaskBarIcon):
         Create the context menu for the tray icon.
 
         Returns:
-            wx.Menu with Show, optional Test Notifications (debug), and Quit options
+            wx.Menu with Show, Test Notification, optional Debug submenu, and Quit options
 
         """
         menu = wx.Menu()
@@ -180,12 +180,19 @@ class SystemTrayIcon(wx.adv.TaskBarIcon):
             self.Bind(wx.EVT_MENU, self._on_test_notifications_menu, diag_item)
 
         menu.AppendSeparator()
+        test_notification_item = menu.Append(wx.ID_ANY, "&Test Notification")
+        self.Bind(wx.EVT_MENU, self._on_test_notification_menu, test_notification_item)
+        menu.AppendSeparator()
 
         # Quit item
         quit_item = menu.Append(wx.ID_EXIT, "&Quit")
         self.Bind(wx.EVT_MENU, self._on_quit_menu, quit_item)
 
         return menu
+
+    def _on_test_notification_menu(self, event: wx.CommandEvent) -> None:
+        """Handle Test Notification menu item click."""
+        self._on_tray_test_discussion(event)
 
     def _on_tray_test_discussion(self, event: wx.CommandEvent) -> None:
         """Fire a test discussion-update notification from the tray menu."""

--- a/tests/test_system_tray.py
+++ b/tests/test_system_tray.py
@@ -335,13 +335,15 @@ class TestDynamicTrayTooltip:
 class TestPopupMenu:
     """Tests for system tray popup menu."""
 
-    def test_popup_menu_has_show_and_quit(self):
-        """Test popup menu has Show and Quit items."""
+    def test_popup_menu_has_show_test_notification_and_quit(self):
+        """Test popup menu has Show, Test Notification, and Quit items."""
         # Test the menu creation logic
         menu_items = []
 
         def create_popup_menu():
             menu_items.append("Show AccessiWeather")
+            menu_items.append("separator")
+            menu_items.append("Test Notification")
             menu_items.append("separator")
             menu_items.append("Quit")
             return menu_items
@@ -349,6 +351,7 @@ class TestPopupMenu:
         result = create_popup_menu()
 
         assert "Show AccessiWeather" in result
+        assert "Test Notification" in result
         assert "Quit" in result
 
 


### PR DESCRIPTION
## Summary
- add an always-visible Test Notification item to the regular tray context menu
- place it near the bottom of the menu, directly above Quit
- wire it to the existing test notification path via _on_tray_test_discussion
- keep the debug submenu unchanged for diagnostics, alert dialog, and direct balloon test
- update system tray popup menu test and changelog

Closes #365

## Validation
- ruff check .
- ruff format --check .
- pytest -v tests/test_system_tray.py
- pytest -n auto -v (environment has unrelated dependency gaps: openai and wx.lib.scrolledpanel; suite ended with 2 failed, 2195 passed, 3 errors)
