### PR TITLE
fix(updates): default nightly builds to nightly update channel

### DIFF
--- a/src/accessiweather/config/config_manager.py
+++ b/src/accessiweather/config/config_manager.py
@@ -80,6 +80,11 @@ class ConfigManager:
             return package.logger  # type: ignore[return-value]
         return logger
 
+    def _default_update_channel_for_current_build(self) -> str:
+        """Return default update channel based on current build tag."""
+        build_tag = (getattr(self.app, "build_tag", None) or "").lower()
+        return "nightly" if build_tag.startswith("nightly-") else "stable"
+
     def load_config(self) -> AppConfig:
         """Load configuration from file or create default."""
         if self._config is not None:
@@ -104,6 +109,17 @@ class ConfigManager:
                 deserialize_elapsed = time.perf_counter() - deserialize_start
                 logger.debug(f"AppConfig deserialization took {deserialize_elapsed:.4f}s")
 
+                # If update_channel is missing, apply build-aware default.
+                settings_data = data.get("settings") if isinstance(data, dict) else None
+                if isinstance(settings_data, dict) and "update_channel" not in settings_data:
+                    default_channel = self._default_update_channel_for_current_build()
+                    self._config.settings.update_channel = default_channel
+                    logger.info(
+                        "Applying build-aware default update channel for legacy config: %s",
+                        default_channel,
+                    )
+                    self.save_config()
+
                 # Time secure keys loading from SecureStorage
                 secure_keys_start = time.perf_counter()
                 self._load_secure_keys()
@@ -120,6 +136,9 @@ class ConfigManager:
             else:
                 logger.info("No config file found, creating default configuration")
                 self._config = AppConfig.default()
+                self._config.settings.update_channel = (
+                    self._default_update_channel_for_current_build()
+                )
                 self.save_config()  # Save default config
 
         except Exception as e:

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -28,6 +28,7 @@ class TestConfigManager:
         app = MagicMock()
         app.paths = MagicMock()
         app.paths.config = config_dir
+        app.build_tag = None
         return app
 
     @pytest.fixture
@@ -188,3 +189,28 @@ class TestConfigManager:
         # Verify the config file exists (not a temp file)
         assert manager.config_file.exists()
         assert not manager.config_file.with_suffix(".json.tmp").exists()
+
+    def test_default_update_channel_is_nightly_for_nightly_build(self, mock_app, config_dir):
+        """Nightly builds should default to nightly channel on new config."""
+        mock_app.build_tag = "nightly-20260226"
+        manager = ConfigManager(mock_app, config_dir=config_dir)
+
+        config = manager.load_config()
+
+        assert config.settings.update_channel == "nightly"
+
+    def test_missing_update_channel_in_legacy_config_uses_build_default(self, mock_app, config_dir):
+        """Legacy config without update_channel should get build-aware default."""
+        mock_app.build_tag = "nightly-20260226"
+        manager = ConfigManager(mock_app, config_dir=config_dir)
+
+        # Write legacy config payload missing update_channel in settings.
+        manager.config_file.parent.mkdir(parents=True, exist_ok=True)
+        manager.config_file.write_text(
+            '{"settings": {"temperature_unit": "both"}, "locations": [], "current_location": null}',
+            encoding="utf-8",
+        )
+
+        config = manager.load_config()
+
+        assert config.settings.update_channel == "nightly"


### PR DESCRIPTION
## Summary
Default the update channel to **nightly** when running a nightly build.

## What changed
- Added build-aware default channel logic in `ConfigManager`:
  - New config on nightly builds defaults `settings.update_channel` to `nightly`.
  - Legacy configs missing `update_channel` now get a build-aware default and are persisted.
- Stable/non-nightly builds continue defaulting to `stable`.

## Tests
- `ruff check src/accessiweather/config/config_manager.py tests/test_config_manager.py`
- `pytest -q tests/test_config_manager.py`
