### PR TITLE
fix(changelog): keep squash-merge commits in nightly release notes

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -76,25 +76,8 @@ commit_parsers = [
     { message = "^style", skip = true },
     { message = "^test", skip = true },
 
-    # Skip noise - dev/CI keywords in any commit message
-    { message = "(?i)git-cliff", skip = true },
-    { message = "(?i)github.pages", skip = true },
-    { message = "(?i)github.actions", skip = true },
-    { message = "(?i)workflow", skip = true },
-    { message = "(?i)pyinstaller", skip = true },
-    { message = "(?i)ci/cd", skip = true },
-    { message = "(?i)linting", skip = true },
-    { message = "(?i)pre-commit", skip = true },
-    { message = "(?i)dependabot", skip = true },
-    { message = "(?i)codecov", skip = true },
-    { message = "(?i)coverage", skip = true },
-    { message = "(?i)[.]github", skip = true },
-    { message = "(?i)release.notes", skip = true },
-    { message = "(?i)changelog", skip = true },
-    { message = "(?i)update-pages", skip = true },
-    { message = "(?i)nightly", skip = true },
-    { message = "(?i)build_tag", skip = true },
-    { message = "(?i)app\\.version", skip = true },
+    # NOTE: avoid broad keyword-based skip rules here.
+    # They can hide valid squash commits when those words appear in PR body text.
 
     # Added - new features
     { message = "^feat", group = "Added" },


### PR DESCRIPTION
## Summary
- remove broad keyword-based skip rules from cliff config
- keep type-based filtering (chore/ci/build/test/merge/revert) for noise
- prevent valid feat/fix squash commits from being dropped when PR bodies mention changelog/nightly terms

## Why
Nightly notes were under-reporting user-facing changes due to over-broad keyword matching.

## Verification
- git-cliff range for nightly-20260226..nightly-20260227 now includes the expected user-facing fixes/features.