### PR TITLE
fix(settings): persist show_nationwide_location across restart

### DIFF
--- a/src/accessiweather/models/config.py
+++ b/src/accessiweather/models/config.py
@@ -34,6 +34,7 @@ NON_CRITICAL_SETTINGS: set[str] = {
     # Sound settings
     "sound_enabled",
     "sound_pack",
+    "show_nationwide_location",
     # Event notifications
     "notify_discussion_update",
     "notify_severe_risk_change",
@@ -366,6 +367,7 @@ class AppSettings:
             "update_check_interval_hours": self.update_check_interval_hours,
             "sound_enabled": self.sound_enabled,
             "sound_pack": self.sound_pack,
+            "show_nationwide_location": self.show_nationwide_location,
             "notify_discussion_update": self.notify_discussion_update,
             "notify_severe_risk_change": self.notify_severe_risk_change,
             "github_backend_url": self.github_backend_url,
@@ -436,6 +438,7 @@ class AppSettings:
             update_check_interval_hours=data.get("update_check_interval_hours", 24),
             sound_enabled=cls._as_bool(data.get("sound_enabled"), True),
             sound_pack=data.get("sound_pack", "default"),
+            show_nationwide_location=cls._as_bool(data.get("show_nationwide_location"), True),
             notify_discussion_update=cls._as_bool(data.get("notify_discussion_update"), False),
             notify_severe_risk_change=cls._as_bool(data.get("notify_severe_risk_change"), False),
             github_backend_url=data.get("github_backend_url", ""),

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -60,6 +60,17 @@ class TestConfigManager:
         loaded = manager2.load_config()
         assert loaded.settings.update_interval_minutes == 30
 
+    def test_show_nationwide_location_persists_roundtrip(self, manager):
+        """show_nationwide_location should persist across save/load."""
+        config = manager.load_config()
+        config.settings.show_nationwide_location = False
+        manager.save_config()
+
+        manager2 = ConfigManager(manager.app, config_dir=manager.config_dir)
+        loaded = manager2.load_config()
+
+        assert loaded.settings.show_nationwide_location is False
+
     def test_add_location(self, manager):
         """Test adding a location."""
         result = manager.add_location(


### PR DESCRIPTION
## Summary
- persist `show_nationwide_location` in `AppSettings.to_dict()`
- restore `show_nationwide_location` in `AppSettings.from_dict()`
- include `show_nationwide_location` in non-critical boolean validation set
- add a config-manager round-trip test that verifies unchecked state survives save/load

## Root cause
`show_nationwide_location` existed on `AppSettings` and was written from the settings dialog, but it was missing from both settings serialization and deserialization in `models/config.py`. On restart, it defaulted back to `True`, so an unchecked checkbox appeared to not persist.

## Testing
- `pytest -q tests/test_config_manager.py::TestConfigManager::test_show_nationwide_location_persists_roundtrip tests/test_models.py::TestAppConfig::test_serialization_roundtrip`
- `pytest -q tests/test_config_manager.py tests/test_models.py -q`
