### PR TITLE
fix(settings): wire tray weather text controls in General tab

### DIFF
--- a/src/accessiweather/ui/dialogs/settings_dialog.py
+++ b/src/accessiweather/ui/dialogs/settings_dialog.py
@@ -93,6 +93,34 @@ class SettingsDialogSimple(wx.Dialog):
         )
         sizer.Add(self._controls["show_nationwide"], 0, wx.ALL, 5)
 
+        sizer.Add(wx.StaticLine(panel), 0, wx.EXPAND | wx.ALL, 5)
+        sizer.Add(wx.StaticText(panel, label="Taskbar icon text:"), 0, wx.LEFT | wx.TOP, 5)
+
+        self._controls["taskbar_icon_text_enabled"] = wx.CheckBox(
+            panel, label="Show weather text on tray icon"
+        )
+        self._controls["taskbar_icon_text_enabled"].Bind(
+            wx.EVT_CHECKBOX,
+            self._on_taskbar_icon_text_enabled_changed,
+        )
+        sizer.Add(self._controls["taskbar_icon_text_enabled"], 0, wx.ALL, 5)
+
+        self._controls["taskbar_icon_dynamic_enabled"] = wx.CheckBox(
+            panel, label="Update tray text dynamically"
+        )
+        sizer.Add(self._controls["taskbar_icon_dynamic_enabled"], 0, wx.LEFT | wx.BOTTOM, 15)
+
+        row_taskbar_format = wx.BoxSizer(wx.HORIZONTAL)
+        row_taskbar_format.Add(
+            wx.StaticText(panel, label="Tray text format:"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        self._controls["taskbar_icon_text_format"] = wx.TextCtrl(panel, size=(280, -1))
+        row_taskbar_format.Add(self._controls["taskbar_icon_text_format"], 1)
+        sizer.Add(row_taskbar_format, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 15)
+
         panel.SetSizer(sizer)
         self.notebook.AddPage(panel, "General")
 
@@ -1125,6 +1153,17 @@ class SettingsDialogSimple(wx.Dialog):
             )
             # Link settings: disable minimize_on_startup if minimize_to_tray is disabled
             self._update_minimize_on_startup_state(minimize_to_tray)
+
+            # General tab - taskbar icon text options
+            taskbar_text_enabled = getattr(settings, "taskbar_icon_text_enabled", False)
+            self._controls["taskbar_icon_text_enabled"].SetValue(taskbar_text_enabled)
+            self._controls["taskbar_icon_dynamic_enabled"].SetValue(
+                getattr(settings, "taskbar_icon_dynamic_enabled", True)
+            )
+            self._controls["taskbar_icon_text_format"].SetValue(
+                getattr(settings, "taskbar_icon_text_format", "{temp} {condition}")
+            )
+            self._update_taskbar_text_controls_state(taskbar_text_enabled)
             self._controls["startup"].SetValue(getattr(settings, "startup_enabled", False))
             self._controls["weather_history"].SetValue(
                 getattr(settings, "weather_history_enabled", True)
@@ -1165,6 +1204,11 @@ class SettingsDialogSimple(wx.Dialog):
                 # General
                 "update_interval_minutes": self._controls["update_interval"].GetValue(),
                 "show_nationwide_location": show_nationwide,
+                "taskbar_icon_text_enabled": self._controls["taskbar_icon_text_enabled"].GetValue(),
+                "taskbar_icon_dynamic_enabled": self._controls[
+                    "taskbar_icon_dynamic_enabled"
+                ].GetValue(),
+                "taskbar_icon_text_format": self._controls["taskbar_icon_text_format"].GetValue(),
                 # Display
                 "temperature_unit": temp_values[self._controls["temp_unit"].GetSelection()],
                 "show_dewpoint": self._controls["show_dewpoint"].GetValue(),
@@ -2072,6 +2116,12 @@ class SettingsDialogSimple(wx.Dialog):
         self._update_minimize_on_startup_state(minimize_to_tray_enabled)
         event.Skip()
 
+    def _on_taskbar_icon_text_enabled_changed(self, event):
+        """Enable/disable taskbar text controls when main toggle changes."""
+        taskbar_text_enabled = self._controls["taskbar_icon_text_enabled"].GetValue()
+        self._update_taskbar_text_controls_state(taskbar_text_enabled)
+        event.Skip()
+
     def _update_minimize_on_startup_state(self, minimize_to_tray_enabled: bool):
         """
         Update the enabled state of minimize_on_startup based on minimize_to_tray.
@@ -2084,6 +2134,11 @@ class SettingsDialogSimple(wx.Dialog):
         if not minimize_to_tray_enabled:
             # If minimize to tray is disabled, also uncheck minimize on startup
             self._controls["minimize_on_startup"].SetValue(False)
+
+    def _update_taskbar_text_controls_state(self, taskbar_text_enabled: bool):
+        """Enable/disable dependent taskbar text controls."""
+        self._controls["taskbar_icon_dynamic_enabled"].Enable(taskbar_text_enabled)
+        self._controls["taskbar_icon_text_format"].Enable(taskbar_text_enabled)
 
     def _on_open_soundpacks_dir(self, event):
         """Open sound packs directory."""

--- a/tests/test_settings_dialog_tray_text.py
+++ b/tests/test_settings_dialog_tray_text.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _load_settings_dialog_class():
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "accessiweather"
+        / "ui"
+        / "dialogs"
+        / "settings_dialog.py"
+    )
+    spec = importlib.util.spec_from_file_location("test_settings_dialog_module", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.SettingsDialogSimple
+
+
+SettingsDialogSimple = _load_settings_dialog_class()
+
+
+class _DummyControl:
+    def __init__(self) -> None:
+        self._selection = 0
+        self._value = False
+        self.enabled = True
+
+    def SetSelection(self, value: int) -> None:
+        self._selection = value
+
+    def GetSelection(self) -> int:
+        return self._selection
+
+    def SetValue(self, value):
+        self._value = value
+
+    def GetValue(self):
+        return self._value
+
+    def Enable(self, value: bool) -> None:
+        self.enabled = value
+
+    def Append(self, _value: str) -> None:
+        return None
+
+    def __getattr__(self, _name: str):
+        return lambda *args, **kwargs: None
+
+
+class _Controls(dict):
+    def __missing__(self, key: str) -> _DummyControl:
+        value = _DummyControl()
+        self[key] = value
+        return value
+
+
+def _make_dialog_for_settings(settings: SimpleNamespace) -> SettingsDialogSimple:
+    dialog = SettingsDialogSimple.__new__(SettingsDialogSimple)
+    dialog._controls = _Controls()
+    dialog._sound_pack_ids = ["default"]
+    dialog._selected_specific_model = None
+    dialog.config_manager = MagicMock()
+    dialog.config_manager.get_settings.return_value = settings
+    return dialog
+
+
+def test_load_settings_populates_tray_text_controls_and_disables_dependents_when_off():
+    settings = SimpleNamespace(
+        taskbar_icon_text_enabled=False,
+        taskbar_icon_dynamic_enabled=True,
+        taskbar_icon_text_format="{temp}",
+    )
+    dialog = _make_dialog_for_settings(settings)
+
+    dialog._load_settings()
+
+    assert dialog._controls["taskbar_icon_text_enabled"].GetValue() is False
+    assert dialog._controls["taskbar_icon_dynamic_enabled"].GetValue() is True
+    assert dialog._controls["taskbar_icon_text_format"].GetValue() == "{temp}"
+    assert dialog._controls["taskbar_icon_dynamic_enabled"].enabled is False
+    assert dialog._controls["taskbar_icon_text_format"].enabled is False
+
+
+def test_load_settings_enables_dependents_when_tray_text_on():
+    settings = SimpleNamespace(
+        taskbar_icon_text_enabled=True,
+        taskbar_icon_dynamic_enabled=False,
+        taskbar_icon_text_format="{temp} {condition}",
+    )
+    dialog = _make_dialog_for_settings(settings)
+
+    dialog._load_settings()
+
+    assert dialog._controls["taskbar_icon_dynamic_enabled"].enabled is True
+    assert dialog._controls["taskbar_icon_text_format"].enabled is True
+
+
+def test_save_settings_persists_tray_text_fields():
+    dialog = _make_dialog_for_settings(SimpleNamespace())
+    dialog._get_ai_model_preference = lambda: "openrouter/free"
+    dialog.config_manager.update_settings.return_value = True
+
+    dialog._controls["taskbar_icon_text_enabled"].SetValue(True)
+    dialog._controls["taskbar_icon_dynamic_enabled"].SetValue(False)
+    dialog._controls["taskbar_icon_text_format"].SetValue("{temp}")
+
+    success = dialog._save_settings()
+
+    assert success is True
+    kwargs = dialog.config_manager.update_settings.call_args.kwargs
+    assert kwargs["taskbar_icon_text_enabled"] is True
+    assert kwargs["taskbar_icon_dynamic_enabled"] is False
+    assert kwargs["taskbar_icon_text_format"] == "{temp}"


### PR DESCRIPTION
## Summary
- add General tab controls for tray weather text settings:
  - Show weather text on tray icon
  - Update tray text dynamically
  - Tray text format
- wire load/save mapping for:
  - `taskbar_icon_text_enabled`
  - `taskbar_icon_dynamic_enabled`
  - `taskbar_icon_text_format`
- add enable/disable behavior so dynamic + format controls are only enabled when the main tray text toggle is on

## Runtime behavior
- verified existing `refresh_runtime_settings` flow already consumes these keys and updates `taskbar_icon_updater` at runtime

## Tests
- add `tests/test_settings_dialog_tray_text.py` covering:
  - load mapping for tray text settings
  - dependent control enable/disable behavior
  - save mapping persistence
- ran:
  - `pytest -q tests/test_settings_dialog_source_priority.py tests/test_settings_dialog_tray_text.py tests/test_app_auto_update_checks.py`

## Notes
- UX copy kept concise and aligned with existing settings language.
