### PR TITLE
fix(installer): harden install scope to prevent duplicate ARP entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - Fixed packaged Windows launches dropping discussion/alert toasts by no longer overriding the installer's AppUserModelID at runtime.
 - Added a forecast time reference setting so hourly forecasts can show either the location's timezone (default) or your local system timezone.
 - Forecast length now follows your configured duration, with automatic source caps (Open-Meteo up to 16, Visual Crossing up to 15, and US/NWS locations capped at 7).
+- Hardened Windows Inno installer scope handling to reduce duplicate Add/Remove Programs entries from mixed per-user/per-machine installs while preserving AppId-based upgrades.
 
 ---
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -99,6 +99,12 @@ The `accessiweather.iss` script creates:
 - Proper uninstaller
 - Per-user installation (no admin required)
 
+Installer scope policy (ARP hardening):
+- Default scope is per-user (`PrivilegesRequired=lowest`).
+- Upgrades reuse the previous install privilege mode (`UsePreviousPrivileges=yes`) so users stay on one logical install identity.
+- Interactive privilege switching is disabled to reduce accidental HKCU/HKLM split installs.
+- When running as admin, setup removes stale per-user uninstall keys for AccessiWeather to prevent duplicate Add/Remove Programs entries.
+
 To modify installer behavior, edit `accessiweather.iss`.
 
 ## Troubleshooting
@@ -140,3 +146,26 @@ installer/
 ├── accessiweather.iss     # Inno Setup script
 ├── app.ico                # Generated Windows icon
 ```
+
+## Installer Validation (Windows ARP dedupe)
+
+Use these deterministic smoke checks after generating a setup EXE:
+
+1. Install current build in per-user mode.
+2. (Optional) Install an older build in elevated/per-machine mode to simulate mixed scope history.
+3. Install the new setup and confirm only one AccessiWeather entry remains in Add/Remove Programs for the active scope.
+
+PowerShell registry checks:
+
+```powershell
+$hkcu = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall'
+$hklm = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall'
+
+Get-ChildItem $hkcu, $hklm |
+  Where-Object { $_.PSChildName -match 'B8F4D7A2-9E3C-4B5A-8D1F-6C2E7A9B0D3E' } |
+  Select-Object PSPath
+```
+
+Expected:
+- Fresh installs: one uninstall key for AccessiWeather.
+- Admin upgrades from mixed history: HKCU stale key removed by installer cleanup.

--- a/installer/accessiweather.iss
+++ b/installer/accessiweather.iss
@@ -50,9 +50,14 @@ SolidCompression=yes
 LZMAUseSeparateProcess=yes
 LZMANumBlockThreads=4
 
-; Privileges (no admin required for per-user install)
+; Privileges and install scope
+; - Default to per-user installs (safest for accessibility/non-admin users)
+; - Keep using previous privilege mode for upgrades so install scope stays stable
+; - Disable interactive override dialog to avoid accidental scope switching and
+;   duplicate ARP entries from mixed HKCU/HKLM installs
 PrivilegesRequired=lowest
-PrivilegesRequiredOverridesAllowed=dialog
+UsePreviousPrivileges=yes
+PrivilegesRequiredOverridesAllowed=commandline
 
 ; Modern installer appearance
 WizardStyle=modern
@@ -100,7 +105,36 @@ Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChang
 Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\App Paths\{#MyAppExeName}"; ValueType: string; ValueName: ""; ValueData: "{app}\{#MyAppExeName}"; Flags: uninsdeletekey
 
 [Code]
-// Custom code for accessibility announcements and checks
+// Installer scope hardening:
+// If setup is running in admin install mode, remove a stale per-user uninstall
+// entry for this AppId to avoid duplicate Add/Remove Programs rows.
+// (Per-user mode intentionally does not touch HKLM for safety/permissions.)
+const
+  UninstallKeyWithBraces = 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{B8F4D7A2-9E3C-4B5A-8D1F-6C2E7A9B0D3E}_is1';
+  UninstallKeyWithoutBraces = 'Software\Microsoft\Windows\CurrentVersion\Uninstall\B8F4D7A2-9E3C-4B5A-8D1F-6C2E7A9B0D3E_is1';
+
+procedure RemoveStalePerUserArpEntriesForAdminInstall();
+begin
+  if not IsAdminInstallMode then
+    exit;
+
+  if RegKeyExists(HKCU, UninstallKeyWithBraces) then
+  begin
+    if RegDeleteKeyIncludingSubkeys(HKCU, UninstallKeyWithBraces) then
+      Log('Removed stale HKCU uninstall key: ' + UninstallKeyWithBraces)
+    else
+      Log('Failed to remove HKCU uninstall key: ' + UninstallKeyWithBraces);
+  end;
+
+  // Older/legacy builds may have emitted a key without braces around the GUID.
+  if RegKeyExists(HKCU, UninstallKeyWithoutBraces) then
+  begin
+    if RegDeleteKeyIncludingSubkeys(HKCU, UninstallKeyWithoutBraces) then
+      Log('Removed stale HKCU uninstall key: ' + UninstallKeyWithoutBraces)
+    else
+      Log('Failed to remove HKCU uninstall key: ' + UninstallKeyWithoutBraces);
+  end;
+end;
 
 function InitializeSetup(): Boolean;
 begin
@@ -110,6 +144,9 @@ end;
 
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
+  if CurStep = ssInstall then
+    RemoveStalePerUserArpEntriesForAdminInstall();
+
   if CurStep = ssPostInstall then
   begin
     // Post-installation tasks


### PR DESCRIPTION
## Summary
- harden Inno Setup install scope behavior to reduce duplicate Add/Remove Programs entries caused by mixed per-user/per-machine installs
- keep `AppId` unchanged to preserve upgrade identity
- add guarded cleanup of stale HKCU uninstall key when running in admin install mode
- document installer scope policy and deterministic registry smoke checks

## Root cause
The installer allowed interactive privilege-mode switching (`PrivilegesRequiredOverridesAllowed=dialog`) while using a single `AppId`. Users could install once per-user (HKCU uninstall entry) and later per-machine (HKLM uninstall entry), leading to duplicate ARP rows for the same app identity.

## What changed
- `installer/accessiweather.iss`
  - kept existing `AppId` stable
  - set `UsePreviousPrivileges=yes` explicitly so upgrades stay in prior scope
  - changed `PrivilegesRequiredOverridesAllowed` from `dialog` to `commandline` to prevent accidental GUI scope flips
  - added safe `[Code]` cleanup: in `IsAdminInstallMode`, delete stale HKCU uninstall keys for this AppId (`{GUID}_is1` and legacy `GUID_is1` variants)
- `installer/README.md`
  - documented scope policy and ARP dedupe behavior
  - added deterministic PowerShell registry smoke checks
- `CHANGELOG.md`
  - added unreleased note for installer hardening

## Registry behavior
Before:
- per-user install: `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{B8F4D7A2-9E3C-4B5A-8D1F-6C2E7A9B0D3E}_is1`
- per-machine install: `HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{B8F4D7A2-9E3C-4B5A-8D1F-6C2E7A9B0D3E}_is1`
- mixed history could leave both visible in ARP

After:
- fresh installs default per-user and no GUI scope toggle
- upgrades prefer previous privilege mode (`UsePreviousPrivileges=yes`)
- admin-mode runs remove stale HKCU uninstall key for this AppId, reducing duplicates after mixed-scope history

## Migration / edge cases
- existing per-user users: continue per-user upgrade path unchanged
- existing per-machine users: continue per-machine upgrade path via previous-privilege reuse
- existing mixed-scope systems:
  - running installer in admin mode now removes stale HKCU key
  - non-admin mode intentionally does not modify HKLM (safety/permissions)

## Validation
- `python -m py_compile installer/build.py`
- added deterministic manual smoke steps in `installer/README.md`:
  - install/migrate scenarios
  - PowerShell query for HKCU/HKLM uninstall keys by AppId GUID
