### PR TITLE
fix: include locations in settings export and refresh API keys after import

### DIFF
--- a/src/accessiweather/config/import_export.py
+++ b/src/accessiweather/config/import_export.py
@@ -175,6 +175,17 @@ class ImportExportOperations:
             # SECURITY: Only export non-sensitive settings (API keys stay in keyring)
             settings_data = {
                 "settings": config.settings.to_dict(),
+                "locations": [
+                    {
+                        "name": location.name,
+                        "latitude": location.latitude,
+                        "longitude": location.longitude,
+                        **(
+                            {"country_code": location.country_code} if location.country_code else {}
+                        ),
+                    }
+                    for location in config.locations
+                ],
                 "exported_at": str(datetime.now()),
             }
 
@@ -241,6 +252,10 @@ class ImportExportOperations:
                 return False
 
             self.logger.info("Imported %d API keys into secure storage", imported)
+
+            # Refresh in-memory config so keys are active without a restart
+            self._manager._load_secure_keys()
+
             return True
         except PortableSecretsError as exc:
             self.logger.error(f"Failed to import encrypted API keys: {exc}")
@@ -477,9 +492,41 @@ class ImportExportOperations:
                 self.logger.error(f"Failed to deserialize settings: {exc}")
                 return False
 
-            # SECURITY: Merge settings while preserving locations (settings-only import)
+            # SECURITY: Merge settings while preserving existing locations
             config = self._manager.get_config()
             config.settings = imported_settings
+
+            # Import locations if present in export file (skip duplicates by name)
+            locations_imported = 0
+            for entry in data.get("locations", []):
+                if not isinstance(entry, dict):
+                    continue
+                name = entry.get("name")
+                latitude = entry.get("latitude")
+                longitude = entry.get("longitude")
+                if not name or latitude is None or longitude is None:
+                    continue
+                try:
+                    latitude_value = float(latitude)
+                    longitude_value = float(longitude)
+                except (TypeError, ValueError):
+                    continue
+                if any(loc.name == name for loc in config.locations):
+                    self.logger.info(f"Skipped existing location: {name}")
+                    continue
+                config.locations.append(
+                    Location(
+                        name=name,
+                        latitude=latitude_value,
+                        longitude=longitude_value,
+                        country_code=entry.get("country_code"),
+                    )
+                )
+                locations_imported += 1
+                self.logger.info(f"Imported location: {name}")
+
+            if locations_imported:
+                self.logger.info("Imported %d locations from settings file", locations_imported)
 
             # Save the updated configuration
             if not self._manager.save_config():

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -175,6 +175,9 @@ class TestExportSettings:
         assert "exported_at" in exported_data
         assert exported_data["settings"]["temperature_unit"] == "celsius"
         assert exported_data["settings"]["data_source"] == "openmeteo"
+        # Locations should be included in settings export
+        assert "locations" in exported_data
+        assert isinstance(exported_data["locations"], list)
 
     def test_export_settings_write_error(self, operations, tmp_path):
         """Test export settings with write error."""
@@ -581,6 +584,51 @@ class TestImportSettings:
 
         # Verify locations were preserved
         assert config.locations is original_locations
+
+    def test_import_settings_imports_locations(self, operations, mock_manager, tmp_path):
+        """Test that import_settings imports locations from export file."""
+        import_file = tmp_path / "import.json"
+        import_data = {
+            "settings": {
+                "temperature_unit": "fahrenheit",
+            },
+            "locations": [
+                {"name": "New City", "latitude": 51.5, "longitude": -0.1},
+                {"name": "Another City", "latitude": 48.8, "longitude": 2.3, "country_code": "FR"},
+            ],
+        }
+        import_file.write_text(json.dumps(import_data))
+
+        config = mock_manager.get_config.return_value
+        config.locations = []
+
+        operations.import_settings(import_file)
+
+        names = [loc.name for loc in config.locations]
+        assert "New City" in names
+        assert "Another City" in names
+        fr_loc = next(loc for loc in config.locations if loc.name == "Another City")
+        assert fr_loc.country_code == "FR"
+
+    def test_import_settings_skips_duplicate_locations(self, operations, mock_manager, tmp_path):
+        """Test that import_settings skips locations already present by name."""
+        import_file = tmp_path / "import.json"
+        import_data = {
+            "settings": {"temperature_unit": "celsius"},
+            "locations": [
+                {"name": "Existing", "latitude": 10.0, "longitude": 20.0},
+            ],
+        }
+        import_file.write_text(json.dumps(import_data))
+
+        existing = Location(name="Existing", latitude=10.0, longitude=20.0)
+        config = mock_manager.get_config.return_value
+        config.locations = [existing]
+
+        operations.import_settings(import_file)
+
+        # Should still be just one location (no duplicate)
+        assert len(config.locations) == 1
 
     def test_import_settings_logs_missing_fields(self, operations, tmp_path):
         """Test that missing fields are logged appropriately."""

--- a/tests/test_portable_secrets.py
+++ b/tests/test_portable_secrets.py
@@ -80,6 +80,8 @@ class TestPortableSecretsImportExportWiring:
 
         assert imported_store["openrouter_api_key"] == "sk-exported"
         assert imported_store["visual_crossing_api_key"] == "vc-exported"
+        # After import, in-memory config should be refreshed so keys are active immediately
+        manager._load_secure_keys.assert_called_once()
 
     def test_export_encrypted_api_keys_returns_false_when_no_keys(self, tmp_path):
         manager = MagicMock()


### PR DESCRIPTION
## Fixes

### Bug 1: Locations not included in settings export
`export_settings()` now includes a `locations` key containing all saved locations (name, latitude, longitude, country_code). `import_settings()` reads this key and adds new locations, skipping duplicates by name — consistent with existing `import_locations()` logic.

### Bug 2: API keys not active after import (require restart)
`import_encrypted_api_keys()` now calls `_load_secure_keys()` after a successful keyring write. This replaces any stale `LazySecureStorage` instances with fresh ones, so imported API keys are active immediately without a restart.

## Tests
- Updated `test_export_settings_success` to assert `locations` key is present
- Added `test_import_settings_imports_locations` and `test_import_settings_skips_duplicate_locations`
- Updated `test_export_import_encrypted_api_keys_uses_secure_storage` to assert `_load_secure_keys` is called after import