### PR TITLE
feat(portable): offer keyring key export during onboarding wizard

### DIFF
--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -647,6 +647,56 @@ class AccessiWeatherApp(wx.App):
         key_names = ("openrouter_api_key", "visual_crossing_api_key")
         return any(bool((SecureStorage.get_password(name) or "").strip()) for name in key_names)
 
+    def _maybe_offer_portable_key_export(self) -> None:
+        """During portable onboarding, offer to export keyring keys as an encrypted bundle."""
+        if not self.main_window or not self.config_manager:
+            return
+        if not self._has_any_saved_api_keys():
+            return
+
+        offer_dlg = wx.MessageDialog(
+            self.main_window,
+            "API keys were found in your system keyring.\n\n"
+            "Would you like to export them as an encrypted bundle into your portable folder now?\n"
+            "This lets you carry your keys with the portable install.",
+            "Export API keys to portable folder",
+            wx.YES_NO | wx.ICON_QUESTION,
+        )
+        offer_dlg.SetYesNoLabels("Export now", "Skip")
+        choice = offer_dlg.ShowModal()
+        offer_dlg.Destroy()
+
+        if choice != wx.ID_YES:
+            return
+
+        passphrase = self._prompt_optional_secret(
+            "Export passphrase",
+            "Enter a passphrase to encrypt the exported API key bundle.\n"
+            "You will need this passphrase to import the keys on another machine.",
+        )
+        if not passphrase:
+            wx.MessageBox(
+                "Key export cancelled — no passphrase was entered.",
+                "Export skipped",
+                wx.OK | wx.ICON_WARNING,
+            )
+            return
+
+        export_path = self.config_manager.config_dir / "api-keys.keys"
+        success = self.config_manager.export_encrypted_api_keys(export_path, passphrase)
+        if success:
+            wx.MessageBox(
+                f"API keys exported successfully to:\n{export_path}",
+                "Export successful",
+                wx.OK | wx.ICON_INFORMATION,
+            )
+        else:
+            wx.MessageBox(
+                "Failed to export API keys. Check the log for details.",
+                "Export failed",
+                wx.OK | wx.ICON_ERROR,
+            )
+
     def _maybe_show_portable_missing_keys_hint(self) -> None:
         """Show a one-time hint when portable mode starts with empty local keyring keys."""
         if not self.main_window or not self.config_manager or not self._portable_mode:

--- a/tests/test_startup_guidance_prompts.py
+++ b/tests/test_startup_guidance_prompts.py
@@ -14,6 +14,8 @@ def _ensure_wx_dialog_constants() -> None:
         "CANCEL": 0,
         "ICON_INFORMATION": 0,
         "ICON_WARNING": 0,
+        "ICON_QUESTION": 0,
+        "ICON_ERROR": 0,
         "OK": 0,
         "ID_OK": 1,
         "TE_PASSWORD": 0,
@@ -358,3 +360,155 @@ def test_onboarding_completion_triggers_deferred_startup_update_check(monkeypatc
     app._maybe_show_first_start_onboarding()
 
     app._run_deferred_startup_update_check.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests for _maybe_offer_portable_key_export
+# ---------------------------------------------------------------------------
+
+
+def _make_app_for_key_export(monkeypatch, has_keys: bool, config_dir=None):
+    """Build a minimal AccessiWeatherApp stub for key-export tests."""
+    from pathlib import Path
+
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    app._portable_mode = True
+    app.main_window = SimpleNamespace()
+
+    cfg_dir = Path(config_dir) if config_dir else Path("/tmp/portable-config")
+    app.config_manager = SimpleNamespace(
+        config_dir=cfg_dir,
+        export_encrypted_api_keys=MagicMock(return_value=True),
+    )
+
+    # Patch _has_any_saved_api_keys directly on the instance
+    app._has_any_saved_api_keys = MagicMock(return_value=has_keys)
+
+    _ensure_wx_dialog_constants()
+    return app
+
+
+def test_portable_key_export_skips_when_no_keyring_keys(monkeypatch):
+    """If no keyring keys exist, _maybe_offer_portable_key_export is a no-op."""
+    app = _make_app_for_key_export(monkeypatch, has_keys=False)
+
+    dialog_calls = []
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageDialog",
+        lambda *a, **kw: dialog_calls.append(a) or _FakeDialog([]),
+        raising=False,
+    )
+
+    app._maybe_offer_portable_key_export()
+
+    assert dialog_calls == [], "No dialog should appear when no keyring keys exist"
+    app.config_manager.export_encrypted_api_keys.assert_not_called()
+
+
+def test_portable_key_export_skips_when_user_declines(monkeypatch):
+    """User says 'Skip' → no export attempted."""
+    app = _make_app_for_key_export(monkeypatch, has_keys=True)
+
+    responses = [getattr(wx, "ID_NO", 0)]
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageDialog",
+        lambda *a, **kw: _FakeDialog(responses),
+        raising=False,
+    )
+
+    app._maybe_offer_portable_key_export()
+
+    app.config_manager.export_encrypted_api_keys.assert_not_called()
+
+
+def test_portable_key_export_skips_when_no_passphrase(monkeypatch):
+    """User says yes but enters no passphrase → show warning, no export."""
+    app = _make_app_for_key_export(monkeypatch, has_keys=True)
+
+    dialog_responses = [getattr(wx, "ID_YES", 1)]
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageDialog",
+        lambda *a, **kw: _FakeDialog(dialog_responses),
+        raising=False,
+    )
+    # Empty passphrase from TextEntryDialog
+    monkeypatch.setattr(
+        "accessiweather.app.wx.TextEntryDialog",
+        lambda *a, **kw: _FakeTextEntryDialog([""]),
+        raising=False,
+    )
+    messagebox_calls = []
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageBox",
+        lambda *a, **kw: messagebox_calls.append(a),
+        raising=False,
+    )
+
+    app._maybe_offer_portable_key_export()
+
+    app.config_manager.export_encrypted_api_keys.assert_not_called()
+    assert messagebox_calls, "A warning MessageBox should have been shown"
+
+
+def test_portable_key_export_happy_path(monkeypatch, tmp_path):
+    """User accepts export, provides passphrase → export called, success dialog shown."""
+    app = _make_app_for_key_export(monkeypatch, has_keys=True, config_dir=str(tmp_path))
+
+    dialog_responses = [getattr(wx, "ID_YES", 1)]
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageDialog",
+        lambda *a, **kw: _FakeDialog(dialog_responses),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "accessiweather.app.wx.TextEntryDialog",
+        lambda *a, **kw: _FakeTextEntryDialog(["my-secret-pass"]),
+        raising=False,
+    )
+    messagebox_calls = []
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageBox",
+        lambda *a, **kw: messagebox_calls.append(a),
+        raising=False,
+    )
+
+    app._maybe_offer_portable_key_export()
+
+    expected_path = tmp_path / "api-keys.keys"
+    app.config_manager.export_encrypted_api_keys.assert_called_once_with(
+        expected_path, "my-secret-pass"
+    )
+    assert messagebox_calls, "A success MessageBox should have been shown"
+    assert (
+        "successful" in messagebox_calls[0][1].lower()
+        or "successful" in messagebox_calls[0][0].lower()
+    )
+
+
+def test_portable_key_export_shows_error_on_failure(monkeypatch, tmp_path):
+    """When export_encrypted_api_keys returns False, an error dialog is shown."""
+    app = _make_app_for_key_export(monkeypatch, has_keys=True, config_dir=str(tmp_path))
+    app.config_manager.export_encrypted_api_keys = MagicMock(return_value=False)
+
+    dialog_responses = [getattr(wx, "ID_YES", 1)]
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageDialog",
+        lambda *a, **kw: _FakeDialog(dialog_responses),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "accessiweather.app.wx.TextEntryDialog",
+        lambda *a, **kw: _FakeTextEntryDialog(["pass"]),
+        raising=False,
+    )
+    messagebox_calls = []
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageBox",
+        lambda *a, **kw: messagebox_calls.append(a),
+        raising=False,
+    )
+
+    app._maybe_offer_portable_key_export()
+
+    assert messagebox_calls, "An error MessageBox should have been shown"
+    assert "fail" in messagebox_calls[0][0].lower() or "fail" in messagebox_calls[0][1].lower()


### PR DESCRIPTION
## Summary

During portable mode onboarding, after the existing bundle-passphrase step, the wizard now checks whether any API keys exist in the system keyring. If found, the user is offered a chance to export them as an encrypted `api-keys.keys` bundle directly into the portable config folder.

## Changes

- **`src/accessiweather/app.py`**
  - Added `_maybe_offer_portable_key_export()` method
  - Called from `_maybe_show_first_start_onboarding()` at end of the portable-mode branch

## Behaviour

1. No keyring keys → silently skipped
2. Keys found → dialog offers export
3. User says Yes → prompted for passphrase → export to `config_dir / 'api-keys.keys'`
4. Success/failure feedback via `wx.MessageBox`
5. User declines or enters no passphrase → skipped with appropriate warning

## Tests

Five new tests added to `tests/test_startup_guidance_prompts.py`:
- Skip when no keyring keys
- Skip when user declines
- Warning when no passphrase entered
- Happy path: export called, success dialog shown
- Failure path: error dialog shown

Closes #389