### PR TITLE
feat(startup): auto-import encrypted API key bundle on portable startup

### DIFF
--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -612,8 +612,94 @@ class AccessiWeatherApp(wx.App):
 
     def _schedule_startup_guidance_prompts(self) -> None:
         """Schedule lightweight first-run and portable hints after startup."""
+        wx.CallLater(400, self._maybe_auto_import_keys_file)
         wx.CallLater(800, self._maybe_show_first_start_onboarding)
         wx.CallLater(1400, self._maybe_show_portable_missing_keys_hint)
+
+    def _maybe_auto_import_keys_file(self) -> None:
+        """
+        Auto-import an encrypted API key bundle on startup (portable mode only).
+
+        Looks for ``api-keys.keys`` (or legacy ``api-keys.awkeys``) in the
+        portable config directory.  When found and at least one API key is
+        missing from the local keyring, the user is prompted once for the
+        passphrase.  On success the keys are live immediately — no restart
+        needed.
+        """
+        if not self.main_window or not self.config_manager:
+            return
+        if not self._portable_mode:
+            return
+
+        # Only run when at least one key is absent.
+        if self._has_any_saved_api_keys():
+            # Check whether *all* keys are present, not just any.
+            from .config.import_export import PORTABLE_API_SECRET_KEYS
+            from .config.secure_storage import SecureStorage
+
+            missing = [
+                k
+                for k in PORTABLE_API_SECRET_KEYS
+                if not (SecureStorage.get_password(k) or "").strip()
+            ]
+            if not missing:
+                return
+
+        config_dir = self.config_manager.config_dir
+        candidate_names = ["api-keys.keys", "api-keys.awkeys"]
+        keys_path = None
+        for name in candidate_names:
+            p = config_dir / name
+            if p.exists():
+                keys_path = p
+                break
+
+        if keys_path is None:
+            return
+
+        # Prompt for passphrase with retry loop.
+        while True:
+            with wx.TextEntryDialog(
+                self.main_window,
+                "An encrypted API key bundle was found. Enter your passphrase to import your keys.",
+                "Import API keys",
+                style=wx.OK | wx.CANCEL | wx.TE_PASSWORD,
+            ) as dlg:
+                result = dlg.ShowModal()
+                if result != wx.ID_OK:
+                    return
+                passphrase = dlg.GetValue().strip()
+
+            if not passphrase:
+                return
+
+            try:
+                success = self.config_manager.import_encrypted_api_keys(keys_path, passphrase)
+            except Exception as exc:
+                logger.warning("Auto-import of API keys failed: %s", exc)
+                success = False
+
+            if success:
+                wx.MessageBox(
+                    "API keys imported successfully. They are now active.",
+                    "Keys imported",
+                    wx.OK | wx.ICON_INFORMATION,
+                )
+                return
+
+            # Wrong passphrase or other failure — offer retry or skip.
+            retry_dlg = wx.MessageDialog(
+                self.main_window,
+                "The passphrase was incorrect or the key bundle could not be read.\n\n"
+                "Would you like to try again?",
+                "Import failed",
+                wx.YES_NO | wx.ICON_WARNING,
+            )
+            retry_dlg.SetYesNoLabels("Try again", "Skip")
+            retry_result = retry_dlg.ShowModal()
+            retry_dlg.Destroy()
+            if retry_result != wx.ID_YES:
+                return
 
     def _should_show_first_start_onboarding(self) -> bool:
         """Return True when first-start onboarding should be shown."""

--- a/tests/test_startup_guidance_prompts.py
+++ b/tests/test_startup_guidance_prompts.py
@@ -108,10 +108,12 @@ def test_schedule_startup_guidance_prompts_uses_call_later(monkeypatch):
 
     app._schedule_startup_guidance_prompts()
 
-    assert calls[0][0] == 800
-    assert calls[0][1] == app._maybe_show_first_start_onboarding
-    assert calls[1][0] == 1400
-    assert calls[1][1] == app._maybe_show_portable_missing_keys_hint
+    assert calls[0][0] == 400
+    assert calls[0][1] == app._maybe_auto_import_keys_file
+    assert calls[1][0] == 800
+    assert calls[1][1] == app._maybe_show_first_start_onboarding
+    assert calls[2][0] == 1400
+    assert calls[2][1] == app._maybe_show_portable_missing_keys_hint
 
 
 def test_has_any_saved_api_keys_checks_both_keys(monkeypatch):
@@ -512,3 +514,253 @@ def test_portable_key_export_shows_error_on_failure(monkeypatch, tmp_path):
 
     assert messagebox_calls, "An error MessageBox should have been shown"
     assert "fail" in messagebox_calls[0][0].lower() or "fail" in messagebox_calls[0][1].lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests for _maybe_auto_import_keys_file
+# ---------------------------------------------------------------------------
+
+
+def _make_app_for_auto_import(tmp_path, all_keys_missing: bool = True):
+    """Build a minimal AccessiWeatherApp stub for auto-import tests."""
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    app._portable_mode = True
+    app.main_window = SimpleNamespace()
+    app.config_manager = SimpleNamespace(
+        config_dir=tmp_path,
+        import_encrypted_api_keys=MagicMock(return_value=True),
+    )
+
+    # Mimic _has_any_saved_api_keys — if all_keys_missing, return False
+    app._has_any_saved_api_keys = MagicMock(return_value=not all_keys_missing)
+
+    _ensure_wx_dialog_constants()
+    return app
+
+
+def test_auto_import_noops_in_non_portable_mode(tmp_path):
+    """_maybe_auto_import_keys_file is a no-op when not in portable mode."""
+    app = _make_app_for_auto_import(tmp_path)
+    app._portable_mode = False
+
+    # Create a .keys file — should still be ignored.
+    (tmp_path / "api-keys.keys").write_bytes(b"dummy")
+
+    app._maybe_auto_import_keys_file()
+
+    app.config_manager.import_encrypted_api_keys.assert_not_called()
+
+
+def test_auto_import_noops_when_all_keys_present(monkeypatch, tmp_path):
+    """If all API keys are present, auto-import is skipped."""
+    app = _make_app_for_auto_import(tmp_path, all_keys_missing=False)
+    (tmp_path / "api-keys.keys").write_bytes(b"dummy")
+
+    # Patch PORTABLE_API_SECRET_KEYS and SecureStorage so "all keys present"
+    monkeypatch.setattr(
+        "accessiweather.config.import_export.PORTABLE_API_SECRET_KEYS",
+        ("openrouter_api_key", "visual_crossing_api_key"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "accessiweather.config.secure_storage.SecureStorage.get_password",
+        lambda name: "some-key",
+        raising=False,
+    )
+
+    app._maybe_auto_import_keys_file()
+
+    app.config_manager.import_encrypted_api_keys.assert_not_called()
+
+
+def test_auto_import_noops_when_no_keys_file(tmp_path):
+    """If neither .keys nor .awkeys file exists, nothing happens."""
+    app = _make_app_for_auto_import(tmp_path)
+
+    app._maybe_auto_import_keys_file()
+
+    app.config_manager.import_encrypted_api_keys.assert_not_called()
+
+
+def test_auto_import_happy_path_keys_file(monkeypatch, tmp_path):
+    """User enters correct passphrase → import succeeds, confirmation shown."""
+    app = _make_app_for_auto_import(tmp_path)
+    keys_file = tmp_path / "api-keys.keys"
+    keys_file.write_bytes(b"encrypted-blob")
+
+    monkeypatch.setattr(
+        "accessiweather.app.wx.TextEntryDialog",
+        lambda *a, **kw: _FakeTextEntryDialog(["correct-pass"]),
+        raising=False,
+    )
+    messagebox_calls = []
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageBox",
+        lambda *a, **kw: messagebox_calls.append(a),
+        raising=False,
+    )
+
+    app._maybe_auto_import_keys_file()
+
+    app.config_manager.import_encrypted_api_keys.assert_called_once_with(keys_file, "correct-pass")
+    assert messagebox_calls, "A success message should appear"
+    assert "imported" in messagebox_calls[0][0].lower()
+
+
+def test_auto_import_happy_path_legacy_awkeys(monkeypatch, tmp_path):
+    """Legacy api-keys.awkeys file is also detected."""
+    app = _make_app_for_auto_import(tmp_path)
+    legacy_file = tmp_path / "api-keys.awkeys"
+    legacy_file.write_bytes(b"encrypted-blob")
+
+    monkeypatch.setattr(
+        "accessiweather.app.wx.TextEntryDialog",
+        lambda *a, **kw: _FakeTextEntryDialog(["pass"]),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageBox",
+        lambda *a, **kw: None,
+        raising=False,
+    )
+
+    app._maybe_auto_import_keys_file()
+
+    app.config_manager.import_encrypted_api_keys.assert_called_once_with(legacy_file, "pass")
+
+
+def test_auto_import_prefers_keys_over_awkeys(monkeypatch, tmp_path):
+    """When both exist, api-keys.keys takes precedence over the legacy name."""
+    app = _make_app_for_auto_import(tmp_path)
+    (tmp_path / "api-keys.keys").write_bytes(b"preferred")
+    (tmp_path / "api-keys.awkeys").write_bytes(b"legacy")
+
+    monkeypatch.setattr(
+        "accessiweather.app.wx.TextEntryDialog",
+        lambda *a, **kw: _FakeTextEntryDialog(["pass"]),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageBox",
+        lambda *a, **kw: None,
+        raising=False,
+    )
+
+    app._maybe_auto_import_keys_file()
+
+    called_path = app.config_manager.import_encrypted_api_keys.call_args[0][0]
+    assert called_path.name == "api-keys.keys"
+
+
+def test_auto_import_wrong_passphrase_then_skip(monkeypatch, tmp_path):
+    """Wrong passphrase → error dialog → user picks Skip → no import."""
+    app = _make_app_for_auto_import(tmp_path)
+    (tmp_path / "api-keys.keys").write_bytes(b"blob")
+    app.config_manager.import_encrypted_api_keys = MagicMock(return_value=False)
+
+    monkeypatch.setattr(
+        "accessiweather.app.wx.TextEntryDialog",
+        lambda *a, **kw: _FakeTextEntryDialog(["bad-pass"]),
+        raising=False,
+    )
+    # Retry dialog → user picks "Skip" (ID_NO)
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageDialog",
+        lambda *a, **kw: _FakeDialog([getattr(wx, "ID_NO", 0)]),
+        raising=False,
+    )
+
+    app._maybe_auto_import_keys_file()
+
+    app.config_manager.import_encrypted_api_keys.assert_called_once()
+
+
+def test_auto_import_wrong_passphrase_then_retry_success(monkeypatch, tmp_path):
+    """Wrong passphrase first → user retries → second attempt succeeds."""
+    app = _make_app_for_auto_import(tmp_path)
+    (tmp_path / "api-keys.keys").write_bytes(b"blob")
+
+    call_count = {"n": 0}
+
+    def _import_side_effect(path, passphrase):
+        call_count["n"] += 1
+        return call_count["n"] > 1  # fails first, succeeds after
+
+    app.config_manager.import_encrypted_api_keys = MagicMock(side_effect=_import_side_effect)
+
+    text_iter = iter(["bad-pass", "good-pass"])
+    monkeypatch.setattr(
+        "accessiweather.app.wx.TextEntryDialog",
+        lambda *a, **kw: _FakeTextEntryDialog([next(text_iter)]),
+        raising=False,
+    )
+    # First retry dialog → "Try again" (ID_YES)
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageDialog",
+        lambda *a, **kw: _FakeDialog([getattr(wx, "ID_YES", 1)]),
+        raising=False,
+    )
+    messagebox_calls = []
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageBox",
+        lambda *a, **kw: messagebox_calls.append(a),
+        raising=False,
+    )
+
+    app._maybe_auto_import_keys_file()
+
+    assert app.config_manager.import_encrypted_api_keys.call_count == 2
+    assert messagebox_calls, "Success confirmation should appear"
+
+
+def test_auto_import_cancel_passphrase_dialog_exits_silently(monkeypatch, tmp_path):
+    """User cancels passphrase dialog → no import, no error."""
+    app = _make_app_for_auto_import(tmp_path)
+    (tmp_path / "api-keys.keys").write_bytes(b"blob")
+
+    class _CancelDialog:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+        def ShowModal(self):
+            return getattr(wx, "ID_CANCEL", 2)
+
+        def GetValue(self):
+            return ""
+
+    monkeypatch.setattr(
+        "accessiweather.app.wx.TextEntryDialog",
+        _CancelDialog,
+        raising=False,
+    )
+
+    app._maybe_auto_import_keys_file()
+
+    app.config_manager.import_encrypted_api_keys.assert_not_called()
+
+
+def test_schedule_startup_guidance_prompts_includes_auto_import(monkeypatch):
+    """_schedule_startup_guidance_prompts schedules the auto-import step first."""
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+
+    calls: list[tuple[int, object]] = []
+    monkeypatch.setattr(
+        "accessiweather.app.wx.CallLater",
+        lambda delay, fn: calls.append((delay, fn)),
+        raising=False,
+    )
+
+    app._schedule_startup_guidance_prompts()
+
+    fns = [fn for _, fn in calls]
+    assert app._maybe_auto_import_keys_file in fns
+    # auto-import must fire before onboarding
+    auto_idx = fns.index(app._maybe_auto_import_keys_file)
+    onboard_idx = fns.index(app._maybe_show_first_start_onboarding)
+    assert auto_idx < onboard_idx


### PR DESCRIPTION
## Summary

Adds auto-detection and import of `.keys` file at startup when running in portable mode.

### What changed

- **New method `_maybe_auto_import_keys_file()`** in `app.py` — runs at startup (400ms delay, before onboarding)
- Only active in portable mode
- Checks if any API keys are missing from the local keyring
- Looks for `api-keys.keys` in the portable config dir (also checks legacy `api-keys.awkeys`)
- If found, prompts user once for their passphrase with a password field
- On success: keys are live immediately (no restart needed, in-memory reload from PR #388)
- Wrong passphrase: offers retry or skip
- No file found: silent no-op (wizard handles first-run offer)

### Tests

9 new tests added to `tests/test_startup_guidance_prompts.py` covering:
- Non-portable mode no-op
- All keys present no-op
- No .keys file no-op
- Happy path (.keys and legacy .awkeys)
- Precedence (.keys wins over .awkeys)
- Wrong passphrase → skip
- Wrong passphrase → retry → success
- Cancel dialog exits silently
- Schedule order assertion

Closes #389