### PR TITLE
chore(portable): remove portable_auto_bundle_enabled and related dead code

### DIFF
--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -6,7 +6,7 @@ Tests configuration loading, saving, and location management.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -242,51 +242,3 @@ class TestConfigManager:
         config = manager.load_config()
 
         assert config.settings.update_channel == "nightly"
-
-
-class TestPortableAutoBundleConfigManager:
-    @pytest.fixture
-    def config_dir(self, tmp_path):
-        return tmp_path / "config"
-
-    @pytest.fixture
-    def mock_app(self, config_dir):
-        app = MagicMock()
-        app.paths = MagicMock()
-        app.paths.config = config_dir
-        app.build_tag = None
-        return app
-
-    @pytest.fixture
-    def manager(self, mock_app, config_dir):
-        return ConfigManager(mock_app, config_dir=config_dir)
-
-    def test_refresh_requires_session_passphrase(self, manager):
-        manager.load_config()
-        manager._config.settings.portable_auto_bundle_enabled = True
-        manager.app._portable_mode = True
-
-        with patch.object(manager, "export_encrypted_api_keys", return_value=True) as export_mock:
-            assert manager.refresh_portable_api_key_bundle() is False
-            export_mock.assert_not_called()
-
-    def test_refresh_exports_to_default_keys_path_when_enabled(self, manager):
-        manager.load_config()
-        manager._config.settings.portable_auto_bundle_enabled = True
-        manager.app._portable_mode = True
-        manager.set_portable_bundle_passphrase("session-pass")
-
-        with patch.object(manager, "export_encrypted_api_keys", return_value=True) as export_mock:
-            assert manager.refresh_portable_api_key_bundle() is True
-            export_mock.assert_called_once_with(
-                manager.config_dir / "api-keys.keys", "session-pass"
-            )
-
-    def test_disable_portable_auto_bundle_deletes_bundle_file(self, manager):
-        bundle_path = manager.get_portable_api_key_bundle_path()
-        bundle_path.parent.mkdir(parents=True, exist_ok=True)
-        bundle_path.write_text("{}", encoding="utf-8")
-        assert bundle_path.exists()
-
-        assert manager.disable_portable_api_key_bundle() is True
-        assert not bundle_path.exists()

--- a/tests/test_settings_operations.py
+++ b/tests/test_settings_operations.py
@@ -114,39 +114,6 @@ class TestValidateAndFixConfig:
         mock_manager.save_config.assert_not_called()
 
 
-class TestPortableAutoBundleSettings:
-    @pytest.fixture
-    def mock_manager(self):
-        manager = MagicMock()
-        manager._get_logger.return_value = MagicMock()
-        manager.save_config.return_value = True
-        manager._config = AppConfig.default()
-        manager.get_config.return_value = manager._config
-        manager.refresh_portable_api_key_bundle.return_value = True
-        manager.disable_portable_api_key_bundle.return_value = True
-        return manager
-
-    @pytest.fixture
-    def operations(self, mock_manager):
-        return SettingsOperations(mock_manager)
-
-    def test_api_key_update_refreshes_portable_bundle_when_enabled(self, operations):
-        operations._manager._config.settings.portable_auto_bundle_enabled = True
-
-        with patch("accessiweather.config.settings.SecureStorage.set_password", return_value=True):
-            ok = operations.update_settings(openrouter_api_key="sk-updated")
-
-        assert ok is True
-        operations._manager.refresh_portable_api_key_bundle.assert_called_once()
-
-    def test_disable_portable_auto_bundle_removes_bundle(self, operations):
-        with patch("accessiweather.config.settings.SecureStorage.set_password", return_value=True):
-            ok = operations.update_settings(portable_auto_bundle_enabled=False)
-
-        assert ok is True
-        operations._manager.disable_portable_api_key_bundle.assert_called_once()
-
-
 class TestValidateNonCritical:
     """Tests for validate_non_critical method."""
 


### PR DESCRIPTION
Cleans up everything made obsolete by the portable bundle redesign in #400.

Removed:
- `portable_auto_bundle_enabled` field from `AppSettings` model and serialisation
- `set_portable_bundle_passphrase`, `has_portable_bundle_passphrase`, `refresh_portable_api_key_bundle`, `disable_portable_api_key_bundle` from `ConfigManager`
- `_portable_bundle_passphrase` instance variable
- Auto-bundle tracking logic (`portable_auto_bundle_updated` etc.) from `update_settings`
- Checkbox, passphrase button, and `_on_set_portable_bundle_passphrase` handler from settings dialog
- `_maybe_offer_portable_key_export` dead method from `app.py`
- `TestPortableAutoBundleConfigManager` and `TestPortableAutoBundleSettings` test classes