### PR TITLE
fix(portable): seamless cross-machine key portability via api-keys.pass

### DIFF
--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -620,19 +620,13 @@ class AccessiWeatherApp(wx.App):
         wx.CallLater(800, self._maybe_show_first_start_onboarding)
         wx.CallLater(1400, self._maybe_show_portable_missing_keys_hint)
 
-    # Keyring key used to cache the portable bundle passphrase for convenience.
-    # Only the passphrase is stored here — API keys always live in the bundle.
-    _PORTABLE_PASSPHRASE_KEYRING_KEY: str = "portable_bundle_passphrase"
-
     def _maybe_auto_import_keys_file(self) -> None:
         """
         Auto-import an encrypted API key bundle on startup (portable mode only).
 
-        API keys always live in the bundle — keyring is not used for key storage.
-        The bundle passphrase is cached in keyring purely for convenience so the
-        user is not prompted on every launch.  On first launch (or new machine)
-        the user is prompted once; on success the passphrase is stored in keyring
-        for silent auto-import on subsequent launches.
+        Passphrase is read from api-keys.pass in the config dir — completely
+        silent, no prompts.  If the pass file is missing but a bundle exists,
+        we do a one-time migration prompt, then save the passphrase to file.
         """
         if not self.main_window or not self.config_manager:
             return
@@ -655,55 +649,63 @@ class AccessiWeatherApp(wx.App):
         if keys_path is None:
             return
 
-        from .config.secure_storage import SecureStorage
+        from .config.import_export import (
+            load_portable_passphrase,
+            save_portable_passphrase,
+        )
 
-        # Try cached passphrase for silent auto-import.
-        stored = (SecureStorage.get_password(self._PORTABLE_PASSPHRASE_KEYRING_KEY) or "").strip()
-        if stored:
+        pass_path = self.config_manager.get_portable_passphrase_path()
+        passphrase = load_portable_passphrase(pass_path)
+
+        if passphrase:
+            # Silent import — passphrase file exists.
             try:
-                if self.config_manager.import_encrypted_api_keys(keys_path, stored):
+                if self.config_manager.import_encrypted_api_keys(keys_path, passphrase):
                     self._portable_keys_imported_this_session = True
-                    logger.info("Portable API keys auto-imported silently.")
+                    self.config_manager.set_portable_bundle_passphrase(passphrase)
+                    logger.info("Portable API keys auto-imported silently from pass file.")
                     return
             except Exception as exc:
-                logger.warning("Silent auto-import failed: %s", exc)
-            # Cached passphrase is stale — clear and fall through to prompt.
-            SecureStorage.delete_password(self._PORTABLE_PASSPHRASE_KEYRING_KEY)
+                logger.warning("Silent auto-import with pass file failed: %s", exc)
 
-        # Prompt for passphrase with retry loop.
+        # One-time migration: bundle exists but no pass file.
+        # Prompt once so we can write the pass file for future launches.
         while True:
             with wx.TextEntryDialog(
                 self.main_window,
-                "An encrypted API key bundle was found. Enter your passphrase to import your keys.",
-                "Import API keys",
+                "An encrypted API key bundle was found but no passphrase file.\n"
+                "Enter your passphrase once to migrate to the new seamless flow.",
+                "One-time key migration",
                 style=wx.OK | wx.CANCEL | wx.TE_PASSWORD,
             ) as dlg:
                 result = dlg.ShowModal()
                 if result != wx.ID_OK:
                     return
-                passphrase = dlg.GetValue().strip()
+                entered = dlg.GetValue().strip()
 
-            if not passphrase:
+            if not entered:
                 return
 
             try:
-                success = self.config_manager.import_encrypted_api_keys(keys_path, passphrase)
+                success = self.config_manager.import_encrypted_api_keys(keys_path, entered)
             except Exception as exc:
-                logger.warning("Auto-import of API keys failed: %s", exc)
+                logger.warning("Migration import failed: %s", exc)
                 success = False
 
             if success:
                 self._portable_keys_imported_this_session = True
-                # Cache passphrase in keyring so next launch is silent.
-                SecureStorage.set_password(self._PORTABLE_PASSPHRASE_KEYRING_KEY, passphrase)
+                self.config_manager.set_portable_bundle_passphrase(entered)
+                # Save passphrase to file so future launches are silent.
+                save_portable_passphrase(pass_path, entered)
                 wx.MessageBox(
-                    "API keys imported successfully. They are now active.",
-                    "Keys imported",
+                    "API keys imported. A passphrase file has been created so future "
+                    "launches will be completely silent.",
+                    "Migration complete",
                     wx.OK | wx.ICON_INFORMATION,
                 )
                 return
 
-            # Wrong passphrase or other failure — offer retry or skip.
+            # Wrong passphrase — offer retry or skip.
             retry_dlg = wx.MessageDialog(
                 self.main_window,
                 "The passphrase was incorrect or the key bundle could not be read.\n\n"
@@ -755,54 +757,31 @@ class AccessiWeatherApp(wx.App):
         return any(bool((SecureStorage.get_password(name) or "").strip()) for name in key_names)
 
     def _maybe_offer_portable_key_export(self) -> None:
-        """During portable onboarding, offer to export keyring keys as an encrypted bundle."""
+        """During portable onboarding, silently export keyring keys as an encrypted bundle."""
         if not self.main_window or not self.config_manager:
             return
         if not self._has_any_saved_api_keys():
             return
 
-        offer_dlg = wx.MessageDialog(
-            self.main_window,
-            "API keys were found in your system keyring.\n\n"
-            "Would you like to export them as an encrypted bundle into your portable folder now?\n"
-            "This lets you carry your keys with the portable install.",
-            "Export API keys to portable folder",
-            wx.YES_NO | wx.ICON_QUESTION,
+        from .config.import_export import (
+            generate_portable_passphrase,
+            load_portable_passphrase,
+            save_portable_passphrase,
         )
-        offer_dlg.SetYesNoLabels("Export now", "Skip")
-        choice = offer_dlg.ShowModal()
-        offer_dlg.Destroy()
 
-        if choice != wx.ID_YES:
-            return
-
-        passphrase = self._prompt_optional_secret(
-            "Export passphrase",
-            "Enter a passphrase to encrypt the exported API key bundle.\n"
-            "You will need this passphrase to import the keys on another machine.",
-        )
+        pass_path = self.config_manager.get_portable_passphrase_path()
+        passphrase = load_portable_passphrase(pass_path)
         if not passphrase:
-            wx.MessageBox(
-                "Key export cancelled — no passphrase was entered.",
-                "Export skipped",
-                wx.OK | wx.ICON_WARNING,
-            )
-            return
+            passphrase = generate_portable_passphrase()
+            save_portable_passphrase(pass_path, passphrase)
 
         export_path = self.config_manager.config_dir / "api-keys.keys"
         success = self.config_manager.export_encrypted_api_keys(export_path, passphrase)
         if success:
-            wx.MessageBox(
-                f"API keys exported successfully to:\n{export_path}",
-                "Export successful",
-                wx.OK | wx.ICON_INFORMATION,
-            )
+            self.config_manager.set_portable_bundle_passphrase(passphrase)
+            logger.info("Portable key bundle exported silently to %s", export_path)
         else:
-            wx.MessageBox(
-                "Failed to export API keys. Check the log for details.",
-                "Export failed",
-                wx.OK | wx.ICON_ERROR,
-            )
+            logger.warning("Failed to export portable key bundle.")
 
     def _maybe_show_portable_missing_keys_hint(self) -> None:
         """Show a one-time hint when portable mode has no bundle and no keys entered."""
@@ -1013,50 +992,32 @@ class AccessiWeatherApp(wx.App):
                 _wizard_keys["visual_crossing_api_key"] = visual_crossing_key
 
         if self._portable_mode and _wizard_keys:
-            # Keys were entered — prompt for passphrase and write bundle directly.
-            passphrase = self._prompt_optional_secret(
-                "Step 4 of 4: Secure your API keys",
-                "Enter a passphrase to encrypt your API keys into a portable bundle.\n"
-                "This bundle travels with the app so your keys work on any machine.\n\n"
-                "Leave blank to skip (keys will not be saved).",
+            # Silently generate a random passphrase, save it, and write the bundle.
+            import json
+
+            from .config.import_export import (
+                generate_portable_passphrase,
+                save_portable_passphrase,
             )
-            if passphrase:
-                bundle_path = self.config_manager.get_portable_api_key_bundle_path()
-                import json
+            from .config.portable_secrets import encrypt_secret_bundle
 
-                from .config.portable_secrets import encrypt_secret_bundle
+            passphrase = generate_portable_passphrase()
+            pass_path = self.config_manager.get_portable_passphrase_path()
+            bundle_path = self.config_manager.get_portable_api_key_bundle_path()
 
-                try:
-                    envelope = encrypt_secret_bundle(_wizard_keys, passphrase)
-                    with open(bundle_path, "w", encoding="utf-8") as fh:
-                        json.dump(envelope, fh, indent=2)
-                    # Load keys into session memory via in-memory update (no keyring).
-                    for k, v in _wizard_keys.items():
-                        setattr(self.config_manager.get_config().settings, k, v)
-                    self._portable_keys_imported_this_session = True
-                    # Cache passphrase so next launch is silent.
-                    from .config.secure_storage import SecureStorage
-
-                    SecureStorage.set_password(self._PORTABLE_PASSPHRASE_KEYRING_KEY, passphrase)
-                    wx.MessageBox(
-                        "API keys saved to encrypted bundle. They are now active.",
-                        "Keys saved",
-                        wx.OK | wx.ICON_INFORMATION,
-                    )
-                except Exception as exc:
-                    logger.error("Failed to write portable bundle: %s", exc)
-                    wx.MessageBox(
-                        "Failed to save the key bundle. Keys will not persist after this session.",
-                        "Bundle write failed",
-                        wx.OK | wx.ICON_WARNING,
-                    )
-            else:
-                wx.MessageBox(
-                    "No passphrase entered — API keys will not be saved.",
-                    "Keys not saved",
-                    wx.OK | wx.ICON_WARNING,
-                )
-        # No keys entered — skip step 4 entirely, nothing to bundle.
+            try:
+                save_portable_passphrase(pass_path, passphrase)
+                envelope = encrypt_secret_bundle(_wizard_keys, passphrase)
+                with open(bundle_path, "w", encoding="utf-8") as fh:
+                    json.dump(envelope, fh, indent=2)
+                # Load keys into session memory (no keyring).
+                for k, v in _wizard_keys.items():
+                    setattr(self.config_manager.get_config().settings, k, v)
+                self._portable_keys_imported_this_session = True
+                self.config_manager.set_portable_bundle_passphrase(passphrase)
+            except Exception as exc:
+                logger.error("Failed to write portable bundle: %s", exc)
+        # No keys entered — skip bundle entirely, nothing to save.
 
         self._show_onboarding_readiness_summary()
         self.config_manager.update_settings(onboarding_wizard_shown=True)

--- a/src/accessiweather/config/config_manager.py
+++ b/src/accessiweather/config/config_manager.py
@@ -323,6 +323,10 @@ class ConfigManager:
         """Return the default portable encrypted API key bundle path."""
         return self.config_dir / "api-keys.keys"
 
+    def get_portable_passphrase_path(self) -> Path:
+        """Return the path to the portable passphrase file (api-keys.pass)."""
+        return self.config_dir / "api-keys.pass"
+
     def set_portable_bundle_passphrase(self, passphrase: str | None) -> None:
         """Set in-memory passphrase for this app session (never persisted to disk)."""
         self._portable_bundle_passphrase = (passphrase or "").strip() or None
@@ -338,8 +342,17 @@ class ConfigManager:
             return False
         if not getattr(config.settings, "portable_auto_bundle_enabled", False):
             return False
+
+        # Load passphrase from file if not already in memory.
         if not self._portable_bundle_passphrase:
-            logger.info("Portable auto-bundle skipped: no session passphrase available")
+            from .import_export import load_portable_passphrase
+
+            self._portable_bundle_passphrase = load_portable_passphrase(
+                self.get_portable_passphrase_path()
+            )
+
+        if not self._portable_bundle_passphrase:
+            logger.info("Portable auto-bundle skipped: no passphrase file found")
             return False
 
         return self.export_encrypted_api_keys(
@@ -347,15 +360,18 @@ class ConfigManager:
         )
 
     def disable_portable_api_key_bundle(self) -> bool:
-        """Disable portable auto-bundle and remove generated portable bundle file."""
+        """Disable portable auto-bundle and remove generated bundle + passphrase files."""
         self.set_portable_bundle_passphrase(None)
         bundle_path = self.get_portable_api_key_bundle_path()
+        pass_path = self.get_portable_passphrase_path()
         try:
             if bundle_path.exists():
                 bundle_path.unlink()
+            if pass_path.exists():
+                pass_path.unlink()
             return True
         except Exception as exc:
-            logger.error("Failed to remove portable bundle file %s: %s", bundle_path, exc)
+            logger.error("Failed to remove portable bundle/pass file: %s", exc)
             return False
 
     def _get_startup_manager(self):

--- a/src/accessiweather/config/import_export.py
+++ b/src/accessiweather/config/import_export.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import secrets
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -26,6 +27,37 @@ PORTABLE_API_SECRET_KEYS: Final[tuple[str, ...]] = (
     "visual_crossing_api_key",
     "openrouter_api_key",
 )
+
+
+def load_portable_passphrase(path: Path) -> str | None:
+    """Read the passphrase from an api-keys.pass file. Returns None if missing."""
+    try:
+        if path.exists():
+            value = path.read_text(encoding="utf-8").strip()
+            return value or None
+    except Exception as exc:
+        logger.warning("Failed to read portable passphrase file %s: %s", path, exc)
+    return None
+
+
+def save_portable_passphrase(path: Path, passphrase: str) -> bool:
+    """Write a passphrase to the api-keys.pass file."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(passphrase, encoding="utf-8")
+        from .file_permissions import set_secure_file_permissions
+
+        set_secure_file_permissions(path)
+        logger.info("Portable passphrase saved to %s", path)
+        return True
+    except Exception as exc:
+        logger.error("Failed to save portable passphrase to %s: %s", path, exc)
+        return False
+
+
+def generate_portable_passphrase() -> str:
+    """Generate a cryptographically random passphrase for portable bundles."""
+    return secrets.token_urlsafe(32)
 
 
 class ImportExportOperations:

--- a/src/accessiweather/ui/dialogs/settings_dialog.py
+++ b/src/accessiweather/ui/dialogs/settings_dialog.py
@@ -974,16 +974,11 @@ class SettingsDialogSimple(wx.Dialog):
             )
             sizer.Add(self._controls["portable_auto_bundle_enabled"], 0, wx.LEFT | wx.TOP, 10)
 
-            set_passphrase_btn = wx.Button(panel, label="Set bundle passphrase for this session")
-            set_passphrase_btn.Bind(wx.EVT_BUTTON, self._on_set_portable_bundle_passphrase)
-            sizer.Add(set_passphrase_btn, 0, wx.LEFT | wx.TOP, 10)
-
             sizer.Add(
                 wx.StaticText(
                     panel,
                     label=(
-                        "Passphrase is kept in memory for this app session only and never written "
-                        "to disk. Auto-bundle refresh requires setting it each launch."
+                        "Passphrase is managed automatically via api-keys.pass in the config folder."
                     ),
                 ),
                 0,
@@ -1371,18 +1366,6 @@ class SettingsDialogSimple(wx.Dialog):
             settings_dict["source_priority_international"] = intl_priorities[
                 intl_idx if intl_idx >= 0 else 0
             ]
-
-            if (
-                settings_dict.get("portable_auto_bundle_enabled")
-                and not self.config_manager.has_portable_bundle_passphrase()
-            ):
-                wx.MessageBox(
-                    "Portable auto-bundle requires a session passphrase. "
-                    "Click 'Set bundle passphrase for this session' first.",
-                    "Passphrase required",
-                    wx.OK | wx.ICON_WARNING,
-                )
-                return False
 
             success = self.config_manager.update_settings(**settings_dict)
             if success:
@@ -1851,10 +1834,8 @@ class SettingsDialogSimple(wx.Dialog):
         """
         After saving settings in portable mode, keep the bundle in sync.
 
-        If any API key was changed:
-        - Bundle exists + passphrase cached → silently re-encrypt bundle
-        - Bundle exists + no cached passphrase → prompt for passphrase
-        - No bundle → offer to create one, or warn keys won't persist
+        Reads passphrase from api-keys.pass (generates + saves if missing).
+        Completely silent — no prompts.
         """
         changed_keys = {
             k: v for k, v in settings_dict.items() if k in self._PORTABLE_KEY_SETTINGS and v
@@ -1862,49 +1843,27 @@ class SettingsDialogSimple(wx.Dialog):
         if not changed_keys:
             return
 
-        from ...config.secure_storage import SecureStorage
-
-        app = self.app
-        _PASSPHRASE_KEY = getattr(
-            app, "_PORTABLE_PASSPHRASE_KEYRING_KEY", "portable_bundle_passphrase"
+        from ...config.import_export import (
+            generate_portable_passphrase,
+            load_portable_passphrase,
+            save_portable_passphrase,
         )
+
         config_dir = self.config_manager.config_dir
+        pass_path = self.config_manager.get_portable_passphrase_path()
+        passphrase = load_portable_passphrase(pass_path)
+
+        if not passphrase:
+            passphrase = generate_portable_passphrase()
+            save_portable_passphrase(pass_path, passphrase)
+
+        self.config_manager.set_portable_bundle_passphrase(passphrase)
+
+        # Write/update the bundle.
         bundle_names = ("api-keys.keys", "api-keys.awkeys")
         bundle_path = next(
             (config_dir / n for n in bundle_names if (config_dir / n).exists()), None
         )
-
-        # Get or prompt for passphrase.
-        passphrase = (SecureStorage.get_password(_PASSPHRASE_KEY) or "").strip()
-
-        if not passphrase:
-            if bundle_path:
-                msg = (
-                    "Your API keys have been updated.\n\n"
-                    "Enter your bundle passphrase to re-encrypt the portable key bundle, "
-                    "or Cancel to leave the bundle unchanged (keys are active this session only)."
-                )
-            else:
-                msg = (
-                    "Your API keys have been updated.\n\n"
-                    "Enter a passphrase to create an encrypted key bundle so your keys "
-                    "persist across launches, or Cancel to skip (keys active this session only)."
-                )
-            with wx.TextEntryDialog(
-                self,
-                msg,
-                "Portable key bundle",
-                style=wx.OK | wx.CANCEL | wx.TE_PASSWORD,
-            ) as dlg:
-                if dlg.ShowModal() != wx.ID_OK:
-                    return
-                passphrase = dlg.GetValue().strip()
-            if not passphrase:
-                return
-            # Cache for future use.
-            SecureStorage.set_password(_PASSPHRASE_KEY, passphrase)
-
-        # Write/update the bundle.
         if bundle_path is None:
             bundle_path = config_dir / "api-keys.keys"
 
@@ -2210,33 +2169,7 @@ class SettingsDialogSimple(wx.Dialog):
             value = dlg.GetValue().strip()
             return value or None
 
-    def _on_set_portable_bundle_passphrase(self, event):
-        """Set in-memory passphrase used for portable auto-bundle refresh."""
-        passphrase = self._prompt_passphrase(
-            "Portable bundle passphrase",
-            "Enter passphrase for automatic portable API key bundle refresh.",
-        )
-        if passphrase is None:
-            return
-
-        confirm = self._prompt_passphrase(
-            "Confirm passphrase",
-            "Re-enter passphrase to confirm.",
-        )
-        if confirm is None:
-            return
-        if passphrase != confirm:
-            wx.MessageBox(
-                "Passphrases do not match.", "Passphrase not set", wx.OK | wx.ICON_WARNING
-            )
-            return
-
-        self.config_manager.set_portable_bundle_passphrase(passphrase)
-        wx.MessageBox(
-            "Passphrase saved for this session only.",
-            "Portable bundle passphrase",
-            wx.OK | wx.ICON_INFORMATION,
-        )
+    # _on_set_portable_bundle_passphrase removed — passphrase is now file-managed.
 
     def _on_export_encrypted_api_keys(self, event):
         """Export API keys from keyring to encrypted bundle file."""

--- a/tests/test_portable_passphrase_file.py
+++ b/tests/test_portable_passphrase_file.py
@@ -1,0 +1,54 @@
+"""Tests for file-based portable passphrase helpers."""
+
+from __future__ import annotations
+
+from accessiweather.config.import_export import (
+    generate_portable_passphrase,
+    load_portable_passphrase,
+    save_portable_passphrase,
+)
+
+
+def test_generate_portable_passphrase_is_random():
+    p1 = generate_portable_passphrase()
+    p2 = generate_portable_passphrase()
+    assert p1 != p2
+    assert len(p1) > 20
+
+
+def test_save_and_load_round_trip(tmp_path):
+    path = tmp_path / "api-keys.pass"
+    passphrase = "test-secret-value"
+    assert save_portable_passphrase(path, passphrase) is True
+    assert path.exists()
+    loaded = load_portable_passphrase(path)
+    assert loaded == passphrase
+
+
+def test_load_returns_none_when_missing(tmp_path):
+    path = tmp_path / "nonexistent.pass"
+    assert load_portable_passphrase(path) is None
+
+
+def test_load_returns_none_for_empty_file(tmp_path):
+    path = tmp_path / "empty.pass"
+    path.write_text("   ", encoding="utf-8")
+    assert load_portable_passphrase(path) is None
+
+
+def test_save_creates_parent_dirs(tmp_path):
+    path = tmp_path / "nested" / "dir" / "api-keys.pass"
+    assert save_portable_passphrase(path, "secret") is True
+    assert path.exists()
+    assert path.read_text(encoding="utf-8") == "secret"
+
+
+def test_get_portable_passphrase_path():
+    """ConfigManager.get_portable_passphrase_path returns correct path."""
+    from pathlib import Path
+
+    from accessiweather.config.config_manager import ConfigManager
+
+    cm = ConfigManager.__new__(ConfigManager)
+    cm.config_dir = Path("/fake/config")
+    assert cm.get_portable_passphrase_path() == Path("/fake/config/api-keys.pass")

--- a/tests/test_startup_guidance_prompts.py
+++ b/tests/test_startup_guidance_prompts.py
@@ -200,10 +200,13 @@ def test_onboarding_wizard_portable_happy_path_sets_keys_and_bundle(monkeypatch,
     settings = SimpleNamespace(onboarding_wizard_shown=False)
     config = SimpleNamespace(locations=[], settings=settings)
     bundle_path = tmp_path / "api-keys.keys"
+    pass_path = tmp_path / "api-keys.pass"
     app.config_manager = SimpleNamespace(
         get_config=lambda: config,
         update_settings=MagicMock(),
         get_portable_api_key_bundle_path=lambda: bundle_path,
+        get_portable_passphrase_path=lambda: pass_path,
+        set_portable_bundle_passphrase=MagicMock(),
     )
 
     _ensure_wx_dialog_constants()
@@ -219,8 +222,8 @@ def test_onboarding_wizard_portable_happy_path_sets_keys_and_bundle(monkeypatch,
         lambda *args, **kwargs: _FakeDialog(responses),
         raising=False,
     )
-    # TextEntryDialog: OR key, VC key, bundle passphrase
-    text_responses = ["sk-or", "vc-key", "bundle-pass"]
+    # TextEntryDialog: OR key, VC key — NO passphrase prompt (auto-generated)
+    text_responses = ["sk-or", "vc-key"]
     monkeypatch.setattr(
         "accessiweather.app.wx.TextEntryDialog",
         lambda *args, **kwargs: _FakeTextEntryDialog(text_responses),
@@ -231,21 +234,14 @@ def test_onboarding_wizard_portable_happy_path_sets_keys_and_bundle(monkeypatch,
         lambda *a, **kw: None,
         raising=False,
     )
-    monkeypatch.setattr(
-        "accessiweather.config.secure_storage.SecureStorage.set_password",
-        lambda *a: True,
-        raising=False,
-    )
-    monkeypatch.setattr(
-        "accessiweather.config.secure_storage.SecureStorage.get_password",
-        lambda *a: None,
-        raising=False,
-    )
 
     app._maybe_show_first_start_onboarding()
 
     # Bundle file should have been written with the entered keys
     assert bundle_path.exists(), "Bundle file should have been created"
+    # Passphrase file should have been created
+    assert pass_path.exists(), "Passphrase file should have been created"
+    assert len(pass_path.read_text(encoding="utf-8")) > 20, "Should be a long random passphrase"
     # Keys should be live in session memory
     assert settings.openrouter_api_key == "sk-or"
     assert settings.visual_crossing_api_key == "vc-key"
@@ -401,153 +397,70 @@ def test_onboarding_completion_triggers_deferred_startup_update_check(monkeypatc
 # ---------------------------------------------------------------------------
 
 
-def _make_app_for_key_export(monkeypatch, has_keys: bool, config_dir=None):
+def _make_app_for_key_export(tmp_path, has_keys: bool):
     """Build a minimal AccessiWeatherApp stub for key-export tests."""
-    from pathlib import Path
-
     app = AccessiWeatherApp.__new__(AccessiWeatherApp)
     app._portable_mode = True
     app._force_wizard = False
     app.main_window = SimpleNamespace()
 
-    cfg_dir = Path(config_dir) if config_dir else Path("/tmp/portable-config")
     app.config_manager = SimpleNamespace(
-        config_dir=cfg_dir,
+        config_dir=tmp_path,
         export_encrypted_api_keys=MagicMock(return_value=True),
+        get_portable_passphrase_path=lambda: tmp_path / "api-keys.pass",
+        set_portable_bundle_passphrase=MagicMock(),
     )
 
     # Patch _has_any_saved_api_keys directly on the instance
     app._has_any_saved_api_keys = MagicMock(return_value=has_keys)
-    app._force_wizard = False
 
     _ensure_wx_dialog_constants()
     return app
 
 
-def test_portable_key_export_skips_when_no_keyring_keys(monkeypatch):
+def test_portable_key_export_skips_when_no_keyring_keys(tmp_path):
     """If no keyring keys exist, _maybe_offer_portable_key_export is a no-op."""
-    app = _make_app_for_key_export(monkeypatch, has_keys=False)
-
-    dialog_calls = []
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageDialog",
-        lambda *a, **kw: dialog_calls.append(a) or _FakeDialog([]),
-        raising=False,
-    )
-
-    app._maybe_offer_portable_key_export()
-
-    assert dialog_calls == [], "No dialog should appear when no keyring keys exist"
-    app.config_manager.export_encrypted_api_keys.assert_not_called()
-
-
-def test_portable_key_export_skips_when_user_declines(monkeypatch):
-    """User says 'Skip' → no export attempted."""
-    app = _make_app_for_key_export(monkeypatch, has_keys=True)
-
-    responses = [getattr(wx, "ID_NO", 0)]
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageDialog",
-        lambda *a, **kw: _FakeDialog(responses),
-        raising=False,
-    )
+    app = _make_app_for_key_export(tmp_path, has_keys=False)
 
     app._maybe_offer_portable_key_export()
 
     app.config_manager.export_encrypted_api_keys.assert_not_called()
 
 
-def test_portable_key_export_skips_when_no_passphrase(monkeypatch):
-    """User says yes but enters no passphrase → show warning, no export."""
-    app = _make_app_for_key_export(monkeypatch, has_keys=True)
-
-    dialog_responses = [getattr(wx, "ID_YES", 1)]
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageDialog",
-        lambda *a, **kw: _FakeDialog(dialog_responses),
-        raising=False,
-    )
-    # Empty passphrase from TextEntryDialog
-    monkeypatch.setattr(
-        "accessiweather.app.wx.TextEntryDialog",
-        lambda *a, **kw: _FakeTextEntryDialog([""]),
-        raising=False,
-    )
-    messagebox_calls = []
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageBox",
-        lambda *a, **kw: messagebox_calls.append(a),
-        raising=False,
-    )
-
-    app._maybe_offer_portable_key_export()
-
-    app.config_manager.export_encrypted_api_keys.assert_not_called()
-    assert messagebox_calls, "A warning MessageBox should have been shown"
-
-
-def test_portable_key_export_happy_path(monkeypatch, tmp_path):
-    """User accepts export, provides passphrase → export called, success dialog shown."""
-    app = _make_app_for_key_export(monkeypatch, has_keys=True, config_dir=str(tmp_path))
-
-    dialog_responses = [getattr(wx, "ID_YES", 1)]
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageDialog",
-        lambda *a, **kw: _FakeDialog(dialog_responses),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        "accessiweather.app.wx.TextEntryDialog",
-        lambda *a, **kw: _FakeTextEntryDialog(["my-secret-pass"]),
-        raising=False,
-    )
-    messagebox_calls = []
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageBox",
-        lambda *a, **kw: messagebox_calls.append(a),
-        raising=False,
-    )
+def test_portable_key_export_happy_path_silent(tmp_path):
+    """With keys in keyring, export happens silently — no dialogs."""
+    app = _make_app_for_key_export(tmp_path, has_keys=True)
 
     app._maybe_offer_portable_key_export()
 
     expected_path = tmp_path / "api-keys.keys"
-    app.config_manager.export_encrypted_api_keys.assert_called_once_with(
-        expected_path, "my-secret-pass"
-    )
-    assert messagebox_calls, "A success MessageBox should have been shown"
-    assert (
-        "successful" in messagebox_calls[0][1].lower()
-        or "successful" in messagebox_calls[0][0].lower()
-    )
+    app.config_manager.export_encrypted_api_keys.assert_called_once()
+    call_args = app.config_manager.export_encrypted_api_keys.call_args[0]
+    assert call_args[0] == expected_path
+    # Passphrase should be a non-empty auto-generated string.
+    assert len(call_args[1]) > 20
+    # Passphrase file should have been created.
+    assert (tmp_path / "api-keys.pass").exists()
 
 
-def test_portable_key_export_shows_error_on_failure(monkeypatch, tmp_path):
-    """When export_encrypted_api_keys returns False, an error dialog is shown."""
-    app = _make_app_for_key_export(monkeypatch, has_keys=True, config_dir=str(tmp_path))
-    app.config_manager.export_encrypted_api_keys = MagicMock(return_value=False)
-
-    dialog_responses = [getattr(wx, "ID_YES", 1)]
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageDialog",
-        lambda *a, **kw: _FakeDialog(dialog_responses),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        "accessiweather.app.wx.TextEntryDialog",
-        lambda *a, **kw: _FakeTextEntryDialog(["pass"]),
-        raising=False,
-    )
-    messagebox_calls = []
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageBox",
-        lambda *a, **kw: messagebox_calls.append(a),
-        raising=False,
-    )
+def test_portable_key_export_reuses_existing_pass_file(tmp_path):
+    """If api-keys.pass already exists, it's reused instead of generating a new one."""
+    app = _make_app_for_key_export(tmp_path, has_keys=True)
+    (tmp_path / "api-keys.pass").write_text("existing-pass", encoding="utf-8")
 
     app._maybe_offer_portable_key_export()
 
-    assert messagebox_calls, "An error MessageBox should have been shown"
-    assert "fail" in messagebox_calls[0][0].lower() or "fail" in messagebox_calls[0][1].lower()
+    call_args = app.config_manager.export_encrypted_api_keys.call_args[0]
+    assert call_args[1] == "existing-pass"
+
+
+def test_portable_key_export_failure_does_not_crash(tmp_path):
+    """When export_encrypted_api_keys returns False, it logs but doesn't crash."""
+    app = _make_app_for_key_export(tmp_path, has_keys=True)
+    app.config_manager.export_encrypted_api_keys = MagicMock(return_value=False)
+
+    # Should not raise
+    app._maybe_offer_portable_key_export()
 
 
 # ---------------------------------------------------------------------------
@@ -565,11 +478,9 @@ def _make_app_for_auto_import(tmp_path, all_keys_missing: bool = True):
     app.config_manager = SimpleNamespace(
         config_dir=tmp_path,
         import_encrypted_api_keys=MagicMock(return_value=True),
+        get_portable_passphrase_path=lambda: tmp_path / "api-keys.pass",
+        set_portable_bundle_passphrase=MagicMock(),
     )
-
-    app._force_wizard = False
-    # all_keys_missing controls whether SecureStorage returns keys or not;
-    # callers that need "all present" should patch SecureStorage.get_password.
 
     _ensure_wx_dialog_constants()
     return app
@@ -589,45 +500,27 @@ def test_auto_import_noops_in_non_portable_mode(tmp_path):
     app.config_manager.import_encrypted_api_keys.assert_not_called()
 
 
-def test_auto_import_silent_when_passphrase_cached(monkeypatch, tmp_path):
-    """If passphrase is cached in keyring, bundle is imported silently."""
+def test_auto_import_silent_when_pass_file_exists(monkeypatch, tmp_path):
+    """If api-keys.pass exists, bundle is imported silently — no prompts."""
     app = _make_app_for_auto_import(tmp_path)
     (tmp_path / "api-keys.keys").write_bytes(b"dummy")
+    (tmp_path / "api-keys.pass").write_text("file-pass", encoding="utf-8")
     app.config_manager.import_encrypted_api_keys = MagicMock(return_value=True)
-
-    monkeypatch.setattr(
-        "accessiweather.config.secure_storage.SecureStorage.get_password",
-        lambda name: "cached-pass" if name == app._PORTABLE_PASSPHRASE_KEYRING_KEY else None,
-        raising=False,
-    )
-    monkeypatch.setattr(
-        "accessiweather.config.secure_storage.SecureStorage.set_password",
-        lambda *a: True,
-        raising=False,
-    )
 
     app._maybe_auto_import_keys_file()
 
-    app.config_manager.import_encrypted_api_keys.assert_called_once()
+    app.config_manager.import_encrypted_api_keys.assert_called_once_with(
+        tmp_path / "api-keys.keys", "file-pass"
+    )
     assert app._portable_keys_imported_this_session is True
 
 
-def test_auto_import_prompts_when_no_cached_passphrase(monkeypatch, tmp_path):
-    """Without cached passphrase, user is prompted."""
+def test_auto_import_migration_prompt_when_no_pass_file(monkeypatch, tmp_path):
+    """Without pass file, user is prompted once for migration; pass file is saved."""
     app = _make_app_for_auto_import(tmp_path)
     (tmp_path / "api-keys.keys").write_bytes(b"dummy")
     app.config_manager.import_encrypted_api_keys = MagicMock(return_value=True)
 
-    monkeypatch.setattr(
-        "accessiweather.config.secure_storage.SecureStorage.get_password",
-        lambda name: None,
-        raising=False,
-    )
-    monkeypatch.setattr(
-        "accessiweather.config.secure_storage.SecureStorage.set_password",
-        lambda *a: True,
-        raising=False,
-    )
     monkeypatch.setattr(
         "accessiweather.app.wx.TextEntryDialog",
         lambda *a, **kw: _FakeTextEntryDialog(["my-passphrase"]),
@@ -643,6 +536,9 @@ def test_auto_import_prompts_when_no_cached_passphrase(monkeypatch, tmp_path):
 
     app.config_manager.import_encrypted_api_keys.assert_called_once()
     assert app._portable_keys_imported_this_session is True
+    # Pass file should have been saved for future silent imports.
+    assert (tmp_path / "api-keys.pass").exists()
+    assert (tmp_path / "api-keys.pass").read_text(encoding="utf-8") == "my-passphrase"
 
 
 def test_auto_import_noops_when_no_keys_file(tmp_path):
@@ -654,69 +550,37 @@ def test_auto_import_noops_when_no_keys_file(tmp_path):
     app.config_manager.import_encrypted_api_keys.assert_not_called()
 
 
-def test_auto_import_happy_path_keys_file(monkeypatch, tmp_path):
-    """User enters correct passphrase → import succeeds, confirmation shown."""
+def test_auto_import_happy_path_keys_file_with_pass(tmp_path):
+    """Both bundle and pass file exist → silent import, no prompts."""
     app = _make_app_for_auto_import(tmp_path)
     keys_file = tmp_path / "api-keys.keys"
     keys_file.write_bytes(b"encrypted-blob")
-
-    monkeypatch.setattr(
-        "accessiweather.app.wx.TextEntryDialog",
-        lambda *a, **kw: _FakeTextEntryDialog(["correct-pass"]),
-        raising=False,
-    )
-    messagebox_calls = []
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageBox",
-        lambda *a, **kw: messagebox_calls.append(a),
-        raising=False,
-    )
+    (tmp_path / "api-keys.pass").write_text("correct-pass", encoding="utf-8")
 
     app._maybe_auto_import_keys_file()
 
     app.config_manager.import_encrypted_api_keys.assert_called_once_with(keys_file, "correct-pass")
-    assert messagebox_calls, "A success message should appear"
-    assert "imported" in messagebox_calls[0][0].lower()
+    assert app._portable_keys_imported_this_session is True
 
 
 def test_auto_import_happy_path_legacy_awkeys(monkeypatch, tmp_path):
-    """Legacy api-keys.awkeys file is also detected."""
+    """Legacy api-keys.awkeys file is also detected with pass file."""
     app = _make_app_for_auto_import(tmp_path)
     legacy_file = tmp_path / "api-keys.awkeys"
     legacy_file.write_bytes(b"encrypted-blob")
-
-    monkeypatch.setattr(
-        "accessiweather.app.wx.TextEntryDialog",
-        lambda *a, **kw: _FakeTextEntryDialog(["pass"]),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageBox",
-        lambda *a, **kw: None,
-        raising=False,
-    )
+    (tmp_path / "api-keys.pass").write_text("pass", encoding="utf-8")
 
     app._maybe_auto_import_keys_file()
 
     app.config_manager.import_encrypted_api_keys.assert_called_once_with(legacy_file, "pass")
 
 
-def test_auto_import_prefers_keys_over_awkeys(monkeypatch, tmp_path):
+def test_auto_import_prefers_keys_over_awkeys(tmp_path):
     """When both exist, api-keys.keys takes precedence over the legacy name."""
     app = _make_app_for_auto_import(tmp_path)
     (tmp_path / "api-keys.keys").write_bytes(b"preferred")
     (tmp_path / "api-keys.awkeys").write_bytes(b"legacy")
-
-    monkeypatch.setattr(
-        "accessiweather.app.wx.TextEntryDialog",
-        lambda *a, **kw: _FakeTextEntryDialog(["pass"]),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageBox",
-        lambda *a, **kw: None,
-        raising=False,
-    )
+    (tmp_path / "api-keys.pass").write_text("pass", encoding="utf-8")
 
     app._maybe_auto_import_keys_file()
 
@@ -725,9 +589,10 @@ def test_auto_import_prefers_keys_over_awkeys(monkeypatch, tmp_path):
 
 
 def test_auto_import_wrong_passphrase_then_skip(monkeypatch, tmp_path):
-    """Wrong passphrase → error dialog → user picks Skip → no import."""
+    """Migration: wrong passphrase → error dialog → user picks Skip → no import."""
     app = _make_app_for_auto_import(tmp_path)
     (tmp_path / "api-keys.keys").write_bytes(b"blob")
+    # No pass file — triggers migration prompt.
     app.config_manager.import_encrypted_api_keys = MagicMock(return_value=False)
 
     monkeypatch.setattr(
@@ -748,7 +613,7 @@ def test_auto_import_wrong_passphrase_then_skip(monkeypatch, tmp_path):
 
 
 def test_auto_import_wrong_passphrase_then_retry_success(monkeypatch, tmp_path):
-    """Wrong passphrase first → user retries → second attempt succeeds."""
+    """Migration: wrong passphrase first → user retries → second attempt succeeds."""
     app = _make_app_for_auto_import(tmp_path)
     (tmp_path / "api-keys.keys").write_bytes(b"blob")
 
@@ -783,10 +648,12 @@ def test_auto_import_wrong_passphrase_then_retry_success(monkeypatch, tmp_path):
 
     assert app.config_manager.import_encrypted_api_keys.call_count == 2
     assert messagebox_calls, "Success confirmation should appear"
+    # Pass file should have been saved after successful migration.
+    assert (tmp_path / "api-keys.pass").exists()
 
 
-def test_auto_import_cancel_passphrase_dialog_exits_silently(monkeypatch, tmp_path):
-    """User cancels passphrase dialog → no import, no error."""
+def test_auto_import_cancel_migration_dialog_exits_silently(monkeypatch, tmp_path):
+    """User cancels migration passphrase dialog → no import, no error."""
     app = _make_app_for_auto_import(tmp_path)
     (tmp_path / "api-keys.keys").write_bytes(b"blob")
 


### PR DESCRIPTION
## Summary

- Stores the bundle passphrase in `api-keys.pass` alongside the encrypted bundle so it travels with the portable config folder — no prompts on new machines, ever
- Replaces keyring-based passphrase caching (`_PORTABLE_PASSPHRASE_KEYRING_KEY`) with file-based storage
- Wizard, settings dialog save, and key export all silently generate a random passphrase and write it to the pass file when one doesn't exist

## Changes

### `src/accessiweather/config/import_export.py`
- Added `load_portable_passphrase()`, `save_portable_passphrase()`, `generate_portable_passphrase()` helpers

### `src/accessiweather/config/config_manager.py`
- Added `get_portable_passphrase_path()` → `config_dir / "api-keys.pass"`
- `refresh_portable_api_key_bundle()` now loads passphrase from file if not in memory

### `src/accessiweather/app.py`
- `_maybe_auto_import_keys_file`: reads passphrase from file for silent import; one-time migration prompt when bundle exists but no pass file
- `_maybe_offer_portable_key_export`: fully silent — generates passphrase, saves file, exports bundle
- Wizard key-writing: generates random passphrase, saves file, writes bundle — no dialog
- Removed `_PORTABLE_PASSPHRASE_KEYRING_KEY` and all keyring passphrase caching

### `src/accessiweather/ui/dialogs/settings_dialog.py`
- `_sync_portable_key_bundle_after_save`: reads passphrase from file (generates if missing), no prompts
- Removed "Set bundle passphrase" button and `_on_set_portable_bundle_passphrase` method

### Tests
- Updated 24 tests in `test_startup_guidance_prompts.py` for new file-based flow
- Added `test_portable_passphrase_file.py` with 6 unit tests for passphrase helpers

## Test plan
- [x] All 30 portable key tests pass (24 existing + 6 new)
- [x] Full test suite passes (2273 tests, 0 new failures)
- [x] Lint clean (ruff check + format)
- [ ] Manual: fresh portable install auto-generates pass file on wizard key entry
- [ ] Manual: moving portable folder to new machine imports keys silently
- [ ] Manual: settings dialog key changes re-encrypt bundle silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)