### PR TITLE
fix(portable): comprehensive API key portability overhaul

### DIFF
--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -747,63 +747,6 @@ class AccessiWeatherApp(wx.App):
         self._startup_update_check_deferred = False
         self._check_for_updates_on_startup()
 
-    def _has_any_saved_api_keys(self) -> bool:
-        """Return True when at least one API key exists in secure storage."""
-        from .config.secure_storage import SecureStorage
-
-        key_names = ("openrouter_api_key", "visual_crossing_api_key")
-        return any(bool((SecureStorage.get_password(name) or "").strip()) for name in key_names)
-
-    def _maybe_offer_portable_key_export(self) -> None:
-        """During portable onboarding, offer to export keyring keys as an encrypted bundle."""
-        if not self.main_window or not self.config_manager:
-            return
-        if not self._has_any_saved_api_keys():
-            return
-
-        offer_dlg = wx.MessageDialog(
-            self.main_window,
-            "API keys were found in your system keyring.\n\n"
-            "Would you like to export them as an encrypted bundle into your portable folder now?\n"
-            "This lets you carry your keys with the portable install.",
-            "Export API keys to portable folder",
-            wx.YES_NO | wx.ICON_QUESTION,
-        )
-        offer_dlg.SetYesNoLabels("Export now", "Skip")
-        choice = offer_dlg.ShowModal()
-        offer_dlg.Destroy()
-
-        if choice != wx.ID_YES:
-            return
-
-        passphrase = self._prompt_optional_secret(
-            "Export passphrase",
-            "Enter a passphrase to encrypt the exported API key bundle.\n"
-            "You will need this passphrase to import the keys on another machine.",
-        )
-        if not passphrase:
-            wx.MessageBox(
-                "Key export cancelled — no passphrase was entered.",
-                "Export skipped",
-                wx.OK | wx.ICON_WARNING,
-            )
-            return
-
-        export_path = self.config_manager.config_dir / "api-keys.keys"
-        success = self.config_manager.export_encrypted_api_keys(export_path, passphrase)
-        if success:
-            wx.MessageBox(
-                f"API keys exported successfully to:\n{export_path}",
-                "Export successful",
-                wx.OK | wx.ICON_INFORMATION,
-            )
-        else:
-            wx.MessageBox(
-                "Failed to export API keys. Check the log for details.",
-                "Export failed",
-                wx.OK | wx.ICON_ERROR,
-            )
-
     def _maybe_show_portable_missing_keys_hint(self) -> None:
         """Show a one-time hint when portable mode has no bundle and no keys entered."""
         if not self.main_window or not self.config_manager or not self._portable_mode:
@@ -952,9 +895,11 @@ class AccessiWeatherApp(wx.App):
             self._run_deferred_startup_update_check()
             return
 
+        total_steps = 4 if self._portable_mode else 3
+
         step1 = wx.MessageDialog(
             self.main_window,
-            "Welcome to AccessiWeather.\n\nStep 1 of 4: Add your first location now?",
+            f"Welcome to AccessiWeather.\n\nStep 1 of {total_steps}: Add your first location now?",
             "Getting started",
             wx.YES_NO | wx.ICON_INFORMATION,
         )
@@ -967,7 +912,7 @@ class AccessiWeatherApp(wx.App):
 
         from .config.secure_storage import is_keyring_available
 
-        if not is_keyring_available():
+        if not self._portable_mode and not is_keyring_available():
             _warn_dlg = wx.MessageDialog(
                 self.main_window,
                 "Your system keyring is not available.\n\n"
@@ -988,7 +933,7 @@ class AccessiWeatherApp(wx.App):
 
         openrouter_key = self._prompt_optional_secret_with_link(
             "OpenRouter API key (optional)",
-            "Step 2 of 4: Enter your OpenRouter API key now, or leave blank to skip.",
+            f"Step 2 of {total_steps}: Enter your OpenRouter API key now, or leave blank to skip.",
             "https://openrouter.ai/keys",
             "Get OpenRouter API key",
         )
@@ -1001,7 +946,7 @@ class AccessiWeatherApp(wx.App):
 
         visual_crossing_key = self._prompt_optional_secret_with_link(
             "Visual Crossing weather provider key (optional)",
-            "Step 3 of 4: Enter your Visual Crossing weather provider key now, or leave blank to skip.",
+            f"Step 3 of {total_steps}: Enter your Visual Crossing weather provider key now, or leave blank to skip.",
             "https://www.visualcrossing.com/sign-up",
             "Get Visual Crossing weather provider key",
         )
@@ -1021,28 +966,31 @@ class AccessiWeatherApp(wx.App):
                 "Leave blank to skip (keys will not be saved).",
             )
             if passphrase:
-                bundle_path = self.config_manager.get_portable_api_key_bundle_path()
-                import json
-
-                from .config.portable_secrets import encrypt_secret_bundle
-
                 try:
-                    envelope = encrypt_secret_bundle(_wizard_keys, passphrase)
-                    with open(bundle_path, "w", encoding="utf-8") as fh:
-                        json.dump(envelope, fh, indent=2)
-                    # Load keys into session memory via in-memory update (no keyring).
+                    # Set keys in-memory first so export_encrypted_api_keys can read them.
                     for k, v in _wizard_keys.items():
                         setattr(self.config_manager.get_config().settings, k, v)
-                    self._portable_keys_imported_this_session = True
-                    # Cache passphrase so next launch is silent.
-                    from .config.secure_storage import SecureStorage
+                    bundle_path = self.config_manager.get_portable_api_key_bundle_path()
+                    success = self.config_manager.export_encrypted_api_keys(bundle_path, passphrase)
+                    if success:
+                        self._portable_keys_imported_this_session = True
+                        # Cache passphrase so next launch is silent.
+                        from .config.secure_storage import SecureStorage
 
-                    SecureStorage.set_password(self._PORTABLE_PASSPHRASE_KEYRING_KEY, passphrase)
-                    wx.MessageBox(
-                        "API keys saved to encrypted bundle. They are now active.",
-                        "Keys saved",
-                        wx.OK | wx.ICON_INFORMATION,
-                    )
+                        SecureStorage.set_password(
+                            self._PORTABLE_PASSPHRASE_KEYRING_KEY, passphrase
+                        )
+                        wx.MessageBox(
+                            "API keys saved to encrypted bundle. They are now active.",
+                            "Keys saved",
+                            wx.OK | wx.ICON_INFORMATION,
+                        )
+                    else:
+                        wx.MessageBox(
+                            "Failed to save the key bundle. Keys will not persist after this session.",
+                            "Bundle write failed",
+                            wx.OK | wx.ICON_WARNING,
+                        )
                 except Exception as exc:
                     logger.error("Failed to write portable bundle: %s", exc)
                     wx.MessageBox(

--- a/src/accessiweather/config/config_manager.py
+++ b/src/accessiweather/config/config_manager.py
@@ -68,8 +68,6 @@ class ConfigManager:
         self._settings = SettingsOperations(self)
         self._github = GitHubConfigOperations(self)
         self._import_export = ImportExportOperations(self)
-        self._portable_bundle_passphrase: str | None = None
-
         # Ensure config directory exists
         self.config_file.parent.mkdir(parents=True, exist_ok=True)
         logger.info(f"Config file path: {self.config_file}")
@@ -322,41 +320,6 @@ class ConfigManager:
     def get_portable_api_key_bundle_path(self) -> Path:
         """Return the default portable encrypted API key bundle path."""
         return self.config_dir / "api-keys.keys"
-
-    def set_portable_bundle_passphrase(self, passphrase: str | None) -> None:
-        """Set in-memory passphrase for this app session (never persisted to disk)."""
-        self._portable_bundle_passphrase = (passphrase or "").strip() or None
-
-    def has_portable_bundle_passphrase(self) -> bool:
-        """Return whether an in-memory portable bundle passphrase is currently available."""
-        return bool(self._portable_bundle_passphrase)
-
-    def refresh_portable_api_key_bundle(self) -> bool:
-        """Refresh portable encrypted API key bundle when opt-in is enabled."""
-        config = self.get_config()
-        if not getattr(self.app, "_portable_mode", False):
-            return False
-        if not getattr(config.settings, "portable_auto_bundle_enabled", False):
-            return False
-        if not self._portable_bundle_passphrase:
-            logger.info("Portable auto-bundle skipped: no session passphrase available")
-            return False
-
-        return self.export_encrypted_api_keys(
-            self.get_portable_api_key_bundle_path(), self._portable_bundle_passphrase
-        )
-
-    def disable_portable_api_key_bundle(self) -> bool:
-        """Disable portable auto-bundle and remove generated portable bundle file."""
-        self.set_portable_bundle_passphrase(None)
-        bundle_path = self.get_portable_api_key_bundle_path()
-        try:
-            if bundle_path.exists():
-                bundle_path.unlink()
-            return True
-        except Exception as exc:
-            logger.error("Failed to remove portable bundle file %s: %s", bundle_path, exc)
-            return False
 
     def _get_startup_manager(self):
         """Get startup manager, initializing lazily on first access."""

--- a/src/accessiweather/config/import_export.py
+++ b/src/accessiweather/config/import_export.py
@@ -200,11 +200,27 @@ class ImportExportOperations:
             return False
 
     def export_encrypted_api_keys(self, export_path: Path, passphrase: str) -> bool:
-        """Export API keys from keyring to an encrypted portable bundle file."""
+        """
+        Export API keys to an encrypted portable bundle file.
+
+        Checks in-memory settings first (covers portable mode where keys are
+        not in keyring), then falls back to keyring (covers installed mode).
+        LazySecureStorage values are resolved via ``str()``.
+        """
         try:
             secrets: dict[str, str] = {}
             for key_name in PORTABLE_API_SECRET_KEYS:
-                value = SecureStorage.get_password(key_name)
+                value: str | None = None
+                # 1. Try in-memory settings (covers portable mode)
+                if self._manager._config is not None:
+                    raw = getattr(self._manager._config.settings, key_name, None)
+                    if raw is not None:
+                        resolved = str(raw)  # resolves LazySecureStorage
+                        if resolved:
+                            value = resolved
+                # 2. Fall back to keyring (covers installed mode)
+                if not value:
+                    value = SecureStorage.get_password(key_name)
                 if value:
                     secrets[key_name] = value
 
@@ -238,25 +254,39 @@ class ImportExportOperations:
             secrets = decrypt_secret_bundle(envelope, passphrase)
 
             imported = 0
+            failed = []
             for key_name in PORTABLE_API_SECRET_KEYS:
                 value = secrets.get(key_name)
                 if not value:
                     continue
                 if not SecureStorage.set_password(key_name, value):
                     self.logger.error(f"Failed to import API key into secure storage: {key_name}")
-                    return False
-                imported += 1
+                    failed.append(key_name)
+                else:
+                    imported += 1
 
-            if imported == 0:
+            if imported == 0 and not failed:
                 self.logger.warning("Encrypted API key bundle did not contain supported keys")
                 return False
 
             self.logger.info("Imported %d API keys into secure storage", imported)
 
-            # Refresh in-memory config so keys are active without a restart
-            self._manager._load_secure_keys()
+            # In portable mode, set keys directly on in-memory settings so they
+            # are active immediately (keyring may not be available).
+            is_portable = getattr(self._manager, "app", None) and getattr(
+                self._manager.app, "_portable_mode", False
+            )
+            if is_portable and self._manager._config is not None:
+                for key_name in PORTABLE_API_SECRET_KEYS:
+                    value = secrets.get(key_name)
+                    if value:
+                        setattr(self._manager._config.settings, key_name, value)
+                        self.logger.debug(f"Set in-memory key for portable mode: {key_name}")
+            else:
+                # Refresh in-memory config so keys are active without a restart
+                self._manager._load_secure_keys()
 
-            return True
+            return not failed
         except PortableSecretsError as exc:
             self.logger.error(f"Failed to import encrypted API keys: {exc}")
             return False

--- a/src/accessiweather/config/settings.py
+++ b/src/accessiweather/config/settings.py
@@ -194,40 +194,19 @@ class SettingsOperations:
         # These keys should be redacted in logs
         redacted_keys = {"github_app_private_key", "visual_crossing_api_key", "openrouter_api_key"}
 
-        api_key_changed = False
-        portable_auto_bundle_updated = False
-        portable_auto_bundle_enabled = getattr(
-            config.settings, "portable_auto_bundle_enabled", False
-        )
-
         for key, value in kwargs.items():
             if hasattr(config.settings, key):
                 setattr(config.settings, key, value)
 
                 if key in secure_keys and not SecureStorage.set_password(key, value):
                     self.logger.error(f"Failed to save {key} to secure storage")
-                if key in {"visual_crossing_api_key", "openrouter_api_key"}:
-                    api_key_changed = True
-                if key == "portable_auto_bundle_enabled":
-                    portable_auto_bundle_updated = True
-                    portable_auto_bundle_enabled = bool(value)
 
                 log_value = "***redacted***" if key in redacted_keys else value
                 self.logger.info(f"Updated setting {key} = {log_value}")
             else:
                 self.logger.warning(f"Unknown setting: {key}")
 
-        save_ok = self._manager.save_config()
-        if not save_ok:
-            return False
-
-        if portable_auto_bundle_updated and not portable_auto_bundle_enabled:
-            self._manager.disable_portable_api_key_bundle()
-
-        if api_key_changed and portable_auto_bundle_enabled:
-            self._manager.refresh_portable_api_key_bundle()
-
-        return True
+        return self._manager.save_config()
 
     def get_settings(self) -> AppSettings:
         """Return the current AppSettings instance."""

--- a/src/accessiweather/models/config.py
+++ b/src/accessiweather/models/config.py
@@ -84,7 +84,6 @@ NON_CRITICAL_SETTINGS: set[str] = {
     "source_priority_us",
     "source_priority_international",
     "openmeteo_weather_model",
-    "portable_auto_bundle_enabled",
 }
 
 
@@ -182,7 +181,6 @@ class AppSettings:
     # Startup UX guidance flags
     onboarding_wizard_shown: bool = False
     portable_missing_api_keys_hint_shown: bool = False
-    portable_auto_bundle_enabled: bool = False
 
     @staticmethod
     def _as_bool(value, default: bool) -> bool:
@@ -425,7 +423,6 @@ class AppSettings:
             "severe_weather_override": self.severe_weather_override,
             "onboarding_wizard_shown": self.onboarding_wizard_shown,
             "portable_missing_api_keys_hint_shown": self.portable_missing_api_keys_hint_shown,
-            "portable_auto_bundle_enabled": self.portable_auto_bundle_enabled,
         }
 
     @classmethod
@@ -517,9 +514,6 @@ class AppSettings:
             onboarding_wizard_shown=cls._as_bool(data.get("onboarding_wizard_shown"), False),
             portable_missing_api_keys_hint_shown=cls._as_bool(
                 data.get("portable_missing_api_keys_hint_shown"), False
-            ),
-            portable_auto_bundle_enabled=cls._as_bool(
-                data.get("portable_auto_bundle_enabled"), False
             ),
         )
 

--- a/src/accessiweather/ui/dialogs/settings_dialog.py
+++ b/src/accessiweather/ui/dialogs/settings_dialog.py
@@ -967,30 +967,6 @@ class SettingsDialogSimple(wx.Dialog):
         import_api_keys_btn.Bind(wx.EVT_BUTTON, self._on_import_encrypted_api_keys)
         sizer.Add(import_api_keys_btn, 0, wx.LEFT | wx.TOP, 10)
 
-        if self._is_runtime_portable_mode():
-            self._controls["portable_auto_bundle_enabled"] = wx.CheckBox(
-                panel,
-                label="Keep encrypted API key bundle with this portable folder",
-            )
-            sizer.Add(self._controls["portable_auto_bundle_enabled"], 0, wx.LEFT | wx.TOP, 10)
-
-            set_passphrase_btn = wx.Button(panel, label="Set bundle passphrase for this session")
-            set_passphrase_btn.Bind(wx.EVT_BUTTON, self._on_set_portable_bundle_passphrase)
-            sizer.Add(set_passphrase_btn, 0, wx.LEFT | wx.TOP, 10)
-
-            sizer.Add(
-                wx.StaticText(
-                    panel,
-                    label=(
-                        "Passphrase is kept in memory for this app session only and never written "
-                        "to disk. Auto-bundle refresh requires setting it each launch."
-                    ),
-                ),
-                0,
-                wx.LEFT | wx.TOP,
-                10,
-            )
-
         # Sound Pack Files
         sizer.Add(
             wx.StaticText(panel, label="Sound Pack Files"),
@@ -1225,10 +1201,6 @@ class SettingsDialogSimple(wx.Dialog):
             self._controls["weather_history"].SetValue(
                 getattr(settings, "weather_history_enabled", True)
             )
-            if "portable_auto_bundle_enabled" in self._controls:
-                self._controls["portable_auto_bundle_enabled"].SetValue(
-                    getattr(settings, "portable_auto_bundle_enabled", False)
-                )
         except Exception as e:
             logger.error(f"Failed to load settings: {e}")
 
@@ -1349,11 +1321,6 @@ class SettingsDialogSimple(wx.Dialog):
                 "startup_enabled": self._controls["startup"].GetValue(),
                 "weather_history_enabled": self._controls["weather_history"].GetValue(),
             }
-            if "portable_auto_bundle_enabled" in self._controls:
-                settings_dict["portable_auto_bundle_enabled"] = self._controls[
-                    "portable_auto_bundle_enabled"
-                ].GetValue()
-
             # Source priority
             us_idx = self._controls["us_priority"].GetSelection()
             us_priorities = [
@@ -1371,18 +1338,6 @@ class SettingsDialogSimple(wx.Dialog):
             settings_dict["source_priority_international"] = intl_priorities[
                 intl_idx if intl_idx >= 0 else 0
             ]
-
-            if (
-                settings_dict.get("portable_auto_bundle_enabled")
-                and not self.config_manager.has_portable_bundle_passphrase()
-            ):
-                wx.MessageBox(
-                    "Portable auto-bundle requires a session passphrase. "
-                    "Click 'Set bundle passphrase for this session' first.",
-                    "Passphrase required",
-                    wx.OK | wx.ICON_WARNING,
-                )
-                return False
 
             success = self.config_manager.update_settings(**settings_dict)
             if success:
@@ -1852,9 +1807,8 @@ class SettingsDialogSimple(wx.Dialog):
         After saving settings in portable mode, keep the bundle in sync.
 
         If any API key was changed:
-        - Bundle exists + passphrase cached → silently re-encrypt bundle
-        - Bundle exists + no cached passphrase → prompt for passphrase
-        - No bundle → offer to create one, or warn keys won't persist
+        - Passphrase cached → silently re-encrypt bundle via export_encrypted_api_keys
+        - No cached passphrase → prompt for passphrase, then export
         """
         changed_keys = {
             k: v for k, v in settings_dict.items() if k in self._PORTABLE_KEY_SETTINGS and v
@@ -1904,31 +1858,21 @@ class SettingsDialogSimple(wx.Dialog):
             # Cache for future use.
             SecureStorage.set_password(_PASSPHRASE_KEY, passphrase)
 
-        # Write/update the bundle.
+        # Write/update the bundle — export_encrypted_api_keys reads all keys
+        # from in-memory settings + keyring, so no manual merge needed.
         if bundle_path is None:
             bundle_path = config_dir / "api-keys.keys"
 
-        import json
-
-        from ...config.portable_secrets import encrypt_secret_bundle
-
-        # Merge existing bundle contents with updated keys so we don't drop other keys.
-        existing: dict[str, str] = {}
-        if bundle_path.exists():
-            try:
-                from ...config.portable_secrets import decrypt_secret_bundle
-
-                with open(bundle_path, encoding="utf-8") as fh:
-                    existing = decrypt_secret_bundle(json.load(fh), passphrase)
-            except Exception:
-                existing = {}
-
-        merged = {**existing, **changed_keys}
         try:
-            envelope = encrypt_secret_bundle(merged, passphrase)
-            with open(bundle_path, "w", encoding="utf-8") as fh:
-                json.dump(envelope, fh, indent=2)
-            logger.info("Portable key bundle updated after settings save.")
+            ok = self.config_manager.export_encrypted_api_keys(bundle_path, passphrase)
+            if ok:
+                logger.info("Portable key bundle updated after settings save.")
+            else:
+                wx.MessageBox(
+                    "No API keys found to export. Keys are active this session but won't persist.",
+                    "Bundle update skipped",
+                    wx.OK | wx.ICON_WARNING,
+                )
         except Exception as exc:
             logger.error("Failed to update portable key bundle: %s", exc)
             wx.MessageBox(
@@ -2187,16 +2131,82 @@ class SettingsDialogSimple(wx.Dialog):
                 "Copied settings summary:\n"
                 f"{summary_block}\n\n"
                 f"From:\n{installed_config_dir}\n\n"
-                f"To:\n{portable_config_dir}\n\n"
-                f"Important: {API_KEYS_TRANSFER_NOTE}",
+                f"To:\n{portable_config_dir}",
                 "Copy complete",
                 wx.OK | wx.ICON_INFORMATION,
             )
+
+            # Offer to export API keys from keyring to encrypted bundle.
+            self._offer_api_key_export_after_copy(portable_config_dir)
         except Exception as e:
             logger.error(f"Failed to copy installed config to portable: {e}")
             wx.MessageBox(
                 f"Failed to copy config: {e}",
                 "Copy failed",
+                wx.OK | wx.ICON_ERROR,
+            )
+
+    def _offer_api_key_export_after_copy(self, portable_config_dir: Path) -> None:
+        """After copying installed config to portable, offer to export API keys."""
+        result = wx.MessageBox(
+            "Config copied. Your API keys are stored in the system keyring and were not "
+            "copied.\n\n"
+            "Would you like to export them to an encrypted bundle now so they work in "
+            "portable mode?",
+            "Export API keys?",
+            wx.YES_NO | wx.ICON_QUESTION,
+        )
+        if result != wx.YES:
+            wx.MessageBox(
+                "You can export API keys later from Settings > Advanced > "
+                "Export API keys (encrypted).",
+                "API keys not exported",
+                wx.OK | wx.ICON_INFORMATION,
+            )
+            return
+
+        passphrase = self._prompt_passphrase(
+            "Export API keys (encrypted)",
+            "Enter a passphrase to encrypt your API keys.",
+        )
+        if passphrase is None:
+            return
+
+        confirm = self._prompt_passphrase(
+            "Confirm passphrase",
+            "Re-enter the passphrase to confirm.",
+        )
+        if confirm is None:
+            return
+        if passphrase != confirm:
+            wx.MessageBox(
+                "Passphrases do not match. API keys were not exported.",
+                "Export cancelled",
+                wx.OK | wx.ICON_WARNING,
+            )
+            return
+
+        bundle_path = portable_config_dir / "api-keys.keys"
+        try:
+            ok = self.config_manager.export_encrypted_api_keys(bundle_path, passphrase)
+            if ok:
+                wx.MessageBox(
+                    f"API keys exported to:\n{bundle_path}",
+                    "Export complete",
+                    wx.OK | wx.ICON_INFORMATION,
+                )
+            else:
+                wx.MessageBox(
+                    "No API keys found to export. You can add keys in Settings > Data Sources "
+                    "and export later.",
+                    "No keys to export",
+                    wx.OK | wx.ICON_WARNING,
+                )
+        except Exception as exc:
+            logger.error("Failed to export API keys after config copy: %s", exc)
+            wx.MessageBox(
+                f"Failed to export API keys: {exc}",
+                "Export failed",
                 wx.OK | wx.ICON_ERROR,
             )
 
@@ -2209,34 +2219,6 @@ class SettingsDialogSimple(wx.Dialog):
                 return None
             value = dlg.GetValue().strip()
             return value or None
-
-    def _on_set_portable_bundle_passphrase(self, event):
-        """Set in-memory passphrase used for portable auto-bundle refresh."""
-        passphrase = self._prompt_passphrase(
-            "Portable bundle passphrase",
-            "Enter passphrase for automatic portable API key bundle refresh.",
-        )
-        if passphrase is None:
-            return
-
-        confirm = self._prompt_passphrase(
-            "Confirm passphrase",
-            "Re-enter passphrase to confirm.",
-        )
-        if confirm is None:
-            return
-        if passphrase != confirm:
-            wx.MessageBox(
-                "Passphrases do not match.", "Passphrase not set", wx.OK | wx.ICON_WARNING
-            )
-            return
-
-        self.config_manager.set_portable_bundle_passphrase(passphrase)
-        wx.MessageBox(
-            "Passphrase saved for this session only.",
-            "Portable bundle passphrase",
-            wx.OK | wx.ICON_INFORMATION,
-        )
 
     def _on_export_encrypted_api_keys(self, event):
         """Export API keys from keyring to encrypted bundle file."""

--- a/tests/test_keyring_warning.py
+++ b/tests/test_keyring_warning.py
@@ -49,7 +49,6 @@ def _make_app_stub(*, portable=False):
     app.config_manager = MagicMock()
     settings = SimpleNamespace(
         onboarding_wizard_shown=False,
-        portable_auto_bundle_enabled=False,
     )
     config = SimpleNamespace(settings=settings, locations={})
     app.config_manager.get_config.return_value = config
@@ -158,7 +157,6 @@ class TestWizardKeyringWarning:
             patch.object(app, "_run_deferred_startup_update_check"),
             patch.object(app, "_show_onboarding_readiness_summary"),
             patch.object(app, "_has_saved_api_key", return_value=False),
-            patch.object(app, "_maybe_offer_portable_key_export"),
         ):
             app._maybe_show_first_start_onboarding()
 
@@ -185,11 +183,37 @@ class TestWizardKeyringWarning:
             patch.object(app, "_run_deferred_startup_update_check"),
             patch.object(app, "_show_onboarding_readiness_summary"),
             patch.object(app, "_has_saved_api_key", return_value=False),
-            patch.object(app, "_maybe_offer_portable_key_export"),
         ):
             app._maybe_show_first_start_onboarding()
 
         assert not any("Secure storage unavailable" in t for t in shown_titles)
+
+    def test_no_warning_in_portable_mode(self):
+        """Keyring warning is suppressed in portable mode even when keyring unavailable."""
+        import accessiweather.config.secure_storage as ss
+
+        ss._keyring_available = False
+
+        app = _make_app_stub(portable=True)
+        shown_titles = []
+
+        def fake_msg_dialog(parent, msg, title, style=0):
+            shown_titles.append(title)
+            return _make_wx_dialog()
+
+        with (
+            patch("accessiweather.app.wx.MessageDialog", side_effect=fake_msg_dialog),
+            patch.object(app, "_prompt_optional_secret_with_link", return_value=""),
+            patch.object(app, "_should_show_first_start_onboarding", return_value=True),
+            patch.object(app, "_run_deferred_startup_update_check"),
+            patch.object(app, "_show_onboarding_readiness_summary"),
+            patch.object(app, "_has_saved_api_key", return_value=False),
+        ):
+            app._maybe_show_first_start_onboarding()
+
+        assert not any("Secure storage unavailable" in t for t in shown_titles), (
+            f"Keyring warning should not appear in portable mode, got titles: {shown_titles}"
+        )
 
     def test_wizard_continues_after_warning(self):
         import accessiweather.config.secure_storage as ss
@@ -212,7 +236,6 @@ class TestWizardKeyringWarning:
             patch.object(app, "_run_deferred_startup_update_check"),
             patch.object(app, "_show_onboarding_readiness_summary"),
             patch.object(app, "_has_saved_api_key", return_value=False),
-            patch.object(app, "_maybe_offer_portable_key_export"),
         ):
             app._maybe_show_first_start_onboarding()
 
@@ -229,9 +252,8 @@ class TestPortableSessionFlag:
         app = _make_app_stub(portable=True)
         app._portable_keys_imported_this_session = True
 
-        with patch.object(app, "_has_any_saved_api_keys") as mock_check:
-            app._maybe_auto_import_keys_file()
-            mock_check.assert_not_called()
+        app._maybe_auto_import_keys_file()
+        app.config_manager.import_encrypted_api_keys.assert_not_called()
 
     def test_session_flag_false_by_default(self):
         app = _make_app_stub(portable=True)

--- a/tests/test_portable_secrets.py
+++ b/tests/test_portable_secrets.py
@@ -12,7 +12,10 @@ from accessiweather.config.portable_secrets import (
 
 
 def test_encrypt_decrypt_secret_bundle_round_trip():
-    secrets = {"openrouter_api_key": "sk-test", "visual_crossing_api_key": "vc-test"}
+    secrets = {
+        "openrouter_api_key": "FAKE_SK_TEST_ONLY",
+        "visual_crossing_api_key": "FAKE_VC_TEST_ONLY",
+    }
 
     envelope = encrypt_secret_bundle(secrets, "correct horse battery staple")
     restored = decrypt_secret_bundle(envelope, "correct horse battery staple")
@@ -23,21 +26,25 @@ def test_encrypt_decrypt_secret_bundle_round_trip():
 
 
 def test_decrypt_secret_bundle_wrong_passphrase_fails():
-    envelope = encrypt_secret_bundle({"openrouter_api_key": "sk-test"}, "right-passphrase")
+    envelope = encrypt_secret_bundle(
+        {"openrouter_api_key": "FAKE_SK_TEST_ONLY"}, "FAKE_RIGHT_PASSPHRASE"
+    )
 
     try:
-        decrypt_secret_bundle(envelope, "wrong-passphrase")
+        decrypt_secret_bundle(envelope, "FAKE_WRONG_PASSPHRASE")
         raise AssertionError("Expected decryption failure")
     except PortableSecretsError as exc:
         assert "Invalid passphrase" in str(exc)
 
 
 def test_decrypt_secret_bundle_unknown_version_fails():
-    envelope = encrypt_secret_bundle({"openrouter_api_key": "sk-test"}, "passphrase")
+    envelope = encrypt_secret_bundle(
+        {"openrouter_api_key": "FAKE_SK_TEST_ONLY"}, "FAKE_TEST_PASSPHRASE"
+    )
     envelope["version"] = 999
 
     try:
-        decrypt_secret_bundle(envelope, "passphrase")
+        decrypt_secret_bundle(envelope, "FAKE_TEST_PASSPHRASE")
         raise AssertionError("Expected version validation failure")
     except PortableSecretsError as exc:
         assert "Unsupported encrypted bundle version" in str(exc)
@@ -45,8 +52,11 @@ def test_decrypt_secret_bundle_unknown_version_fails():
 
 class TestPortableSecretsImportExportWiring:
     def test_export_import_encrypted_api_keys_uses_secure_storage(self, tmp_path):
+        """Installed-mode round-trip: export from keyring, import writes both keys."""
         manager = MagicMock()
         manager._get_logger.return_value = MagicMock()
+        manager._config = None  # no in-memory config; export falls through to keyring
+        manager.app = None  # not portable; import calls _load_secure_keys
         operations = ImportExportOperations(manager)
 
         export_file = tmp_path / "keys.keys"
@@ -54,8 +64,8 @@ class TestPortableSecretsImportExportWiring:
 
         def _fake_get_password(key_name: str) -> str | None:
             return {
-                "openrouter_api_key": "sk-exported",
-                "visual_crossing_api_key": "vc-exported",
+                "openrouter_api_key": "FAKE_OR_EXPORTED_TEST",
+                "visual_crossing_api_key": "FAKE_VC_EXPORTED_TEST",
             }.get(key_name)
 
         def _fake_set_password(key_name: str, value: str) -> bool:
@@ -70,22 +80,27 @@ class TestPortableSecretsImportExportWiring:
                 "accessiweather.config.import_export.SecureStorage.set_password", _fake_set_password
             ),
         ):
-            assert operations.export_encrypted_api_keys(export_file, "bundle-pass") is True
+            assert (
+                operations.export_encrypted_api_keys(export_file, "FAKE_BUNDLE_PASSPHRASE") is True
+            )
             assert export_file.exists()
 
             saved = json.loads(export_file.read_text(encoding="utf-8"))
             assert saved["version"] == 1
 
-            assert operations.import_encrypted_api_keys(export_file, "bundle-pass") is True
+            assert (
+                operations.import_encrypted_api_keys(export_file, "FAKE_BUNDLE_PASSPHRASE") is True
+            )
 
-        assert imported_store["openrouter_api_key"] == "sk-exported"
-        assert imported_store["visual_crossing_api_key"] == "vc-exported"
+        assert imported_store["openrouter_api_key"] == "FAKE_OR_EXPORTED_TEST"
+        assert imported_store["visual_crossing_api_key"] == "FAKE_VC_EXPORTED_TEST"
         # After import, in-memory config should be refreshed so keys are active immediately
         manager._load_secure_keys.assert_called_once()
 
     def test_export_encrypted_api_keys_returns_false_when_no_keys(self, tmp_path):
         manager = MagicMock()
         manager._get_logger.return_value = MagicMock()
+        manager._config = None  # no in-memory config
         operations = ImportExportOperations(manager)
 
         export_file = tmp_path / "keys.keys"
@@ -94,7 +109,128 @@ class TestPortableSecretsImportExportWiring:
             "accessiweather.config.import_export.SecureStorage.get_password",
             lambda _key_name: None,
         ):
-            assert operations.export_encrypted_api_keys(export_file, "bundle-pass") is False
+            assert (
+                operations.export_encrypted_api_keys(export_file, "FAKE_BUNDLE_PASSPHRASE") is False
+            )
+
+    def test_export_reads_in_memory_keys_for_portable_mode(self, tmp_path):
+        """Portable-mode export: reads keys from settings, not keyring."""
+        manager = MagicMock()
+        manager._get_logger.return_value = MagicMock()
+        # Simulate in-memory settings with API keys (portable mode)
+        config = MagicMock()
+        config.settings.visual_crossing_api_key = "FAKE_VC_KEY_TEST"
+        config.settings.openrouter_api_key = "FAKE_OR_KEY_TEST"
+        manager._config = config
+        operations = ImportExportOperations(manager)
+
+        export_file = tmp_path / "keys.keys"
+
+        # Keyring returns nothing — keys are only in-memory
+        with patch(
+            "accessiweather.config.import_export.SecureStorage.get_password",
+            lambda _key_name: None,
+        ):
+            assert operations.export_encrypted_api_keys(export_file, "FAKE_PASSPHRASE_123") is True
+
+        # Decrypt and verify both keys were exported
+        saved = json.loads(export_file.read_text(encoding="utf-8"))
+        restored = decrypt_secret_bundle(saved, "FAKE_PASSPHRASE_123")
+        assert restored["visual_crossing_api_key"] == "FAKE_VC_KEY_TEST"
+        assert restored["openrouter_api_key"] == "FAKE_OR_KEY_TEST"
+
+    def test_export_resolves_lazy_secure_storage_values(self, tmp_path):
+        """Export resolves LazySecureStorage objects via str()."""
+        from accessiweather.config.secure_storage import LazySecureStorage
+
+        manager = MagicMock()
+        manager._get_logger.return_value = MagicMock()
+        config = MagicMock()
+        # Simulate a LazySecureStorage value on one key
+        lazy = LazySecureStorage("visual_crossing_api_key")
+        lazy._value = "FAKE_VC_LAZY_TEST"
+        lazy._loaded = True
+        config.settings.visual_crossing_api_key = lazy
+        config.settings.openrouter_api_key = "FAKE_OR_PLAIN_TEST"
+        manager._config = config
+        operations = ImportExportOperations(manager)
+
+        export_file = tmp_path / "keys.keys"
+
+        with patch(
+            "accessiweather.config.import_export.SecureStorage.get_password",
+            lambda _key_name: None,
+        ):
+            assert operations.export_encrypted_api_keys(export_file, "FAKE_PASSPHRASE_123") is True
+
+        saved = json.loads(export_file.read_text(encoding="utf-8"))
+        restored = decrypt_secret_bundle(saved, "FAKE_PASSPHRASE_123")
+        assert restored["visual_crossing_api_key"] == "FAKE_VC_LAZY_TEST"
+        assert restored["openrouter_api_key"] == "FAKE_OR_PLAIN_TEST"
+
+    def test_import_writes_all_keys_even_if_first_fails(self, tmp_path):
+        """Import continues writing remaining keys after a failure."""
+        manager = MagicMock()
+        manager._get_logger.return_value = MagicMock()
+        manager.app = None
+        operations = ImportExportOperations(manager)
+
+        secrets = {
+            "visual_crossing_api_key": "FAKE_VC_VAL_TEST",
+            "openrouter_api_key": "FAKE_OR_VAL_TEST",
+        }
+        envelope = encrypt_secret_bundle(secrets, "FAKE_TEST_PASSPHRASE")
+        export_file = tmp_path / "keys.keys"
+        export_file.write_text(json.dumps(envelope), encoding="utf-8")
+
+        written: dict[str, str] = {}
+
+        def _set_pw(key_name: str, value: str) -> bool:
+            if key_name == "visual_crossing_api_key":
+                return False  # first key fails
+            written[key_name] = value
+            return True
+
+        with patch("accessiweather.config.import_export.SecureStorage.set_password", _set_pw):
+            result = operations.import_encrypted_api_keys(export_file, "FAKE_TEST_PASSPHRASE")
+
+        # Returns False because one key failed
+        assert result is False
+        # But the second key was still written
+        assert written["openrouter_api_key"] == "FAKE_OR_VAL_TEST"
+
+    def test_import_sets_in_memory_keys_in_portable_mode(self, tmp_path):
+        """In portable mode, import sets keys on settings directly."""
+        from accessiweather.models import AppConfig
+
+        manager = MagicMock()
+        manager._get_logger.return_value = MagicMock()
+        app_mock = MagicMock()
+        app_mock._portable_mode = True
+        manager.app = app_mock
+        config = AppConfig.default()
+        manager._config = config
+        operations = ImportExportOperations(manager)
+
+        secrets = {
+            "visual_crossing_api_key": "FAKE_VC_PORTABLE_TEST",
+            "openrouter_api_key": "FAKE_OR_PORTABLE_TEST",
+        }
+        envelope = encrypt_secret_bundle(secrets, "FAKE_TEST_PASSPHRASE")
+        export_file = tmp_path / "keys.keys"
+        export_file.write_text(json.dumps(envelope), encoding="utf-8")
+
+        with patch(
+            "accessiweather.config.import_export.SecureStorage.set_password",
+            lambda _k, _v: True,
+        ):
+            result = operations.import_encrypted_api_keys(export_file, "FAKE_TEST_PASSPHRASE")
+
+        assert result is True
+        assert config.settings.visual_crossing_api_key == "FAKE_VC_PORTABLE_TEST"
+        assert config.settings.openrouter_api_key == "FAKE_OR_PORTABLE_TEST"
+        # Should NOT call _load_secure_keys in portable mode
+        manager._load_secure_keys.assert_not_called()
 
     def test_import_encrypted_api_keys_rejects_non_dict_bundle(self, tmp_path):
         manager = MagicMock()
@@ -105,7 +241,9 @@ class TestPortableSecretsImportExportWiring:
         export_file.write_text("[]", encoding="utf-8")
 
         with patch("accessiweather.config.import_export.SecureStorage.set_password") as mock_set:
-            assert operations.import_encrypted_api_keys(export_file, "bundle-pass") is False
+            assert (
+                operations.import_encrypted_api_keys(export_file, "FAKE_BUNDLE_PASSPHRASE") is False
+            )
             mock_set.assert_not_called()
 
     def test_import_encrypted_api_keys_returns_false_when_no_supported_keys(self, tmp_path):
@@ -114,11 +252,13 @@ class TestPortableSecretsImportExportWiring:
         operations = ImportExportOperations(manager)
 
         export_file = tmp_path / "keys.keys"
-        envelope = encrypt_secret_bundle({"other": "value"}, "right-pass")
+        envelope = encrypt_secret_bundle({"other": "value"}, "FAKE_RIGHT_PASS_TEST")
         export_file.write_text(json.dumps(envelope), encoding="utf-8")
 
         with patch("accessiweather.config.import_export.SecureStorage.set_password") as mock_set:
-            assert operations.import_encrypted_api_keys(export_file, "right-pass") is False
+            assert (
+                operations.import_encrypted_api_keys(export_file, "FAKE_RIGHT_PASS_TEST") is False
+            )
             mock_set.assert_not_called()
 
     def test_import_encrypted_api_keys_wrong_passphrase_returns_false(self, tmp_path):
@@ -127,9 +267,13 @@ class TestPortableSecretsImportExportWiring:
         operations = ImportExportOperations(manager)
 
         export_file = tmp_path / "keys.keys"
-        envelope = encrypt_secret_bundle({"openrouter_api_key": "sk-exported"}, "right-pass")
+        envelope = encrypt_secret_bundle(
+            {"openrouter_api_key": "FAKE_OR_EXPORTED_TEST"}, "FAKE_RIGHT_PASS_TEST"
+        )
         export_file.write_text(json.dumps(envelope), encoding="utf-8")
 
         with patch("accessiweather.config.import_export.SecureStorage.set_password") as mock_set:
-            assert operations.import_encrypted_api_keys(export_file, "wrong-pass") is False
+            assert (
+                operations.import_encrypted_api_keys(export_file, "FAKE_WRONG_PASS_TEST") is False
+            )
             mock_set.assert_not_called()

--- a/tests/test_settings_dialog_portable_copy.py
+++ b/tests/test_settings_dialog_portable_copy.py
@@ -29,12 +29,16 @@ SettingsDialogSimple = module.SettingsDialogSimple
 def _ensure_wx_constants() -> None:
     for name, value in {
         "YES": 1,
+        "NO": 0,
         "OK": 0,
         "YES_NO": 0,
+        "CANCEL": 0,
+        "ID_OK": 1,
         "ICON_QUESTION": 0,
         "ICON_INFORMATION": 0,
         "ICON_WARNING": 0,
         "ICON_ERROR": 0,
+        "TE_PASSWORD": 0,
     }.items():
         if not hasattr(module.wx, name):
             setattr(module.wx, name, value)
@@ -75,7 +79,7 @@ def test_validate_portable_copy_detects_missing_locations(tmp_path):
     assert any("Location count mismatch" in e for e in errors)
 
 
-def test_copy_installed_config_to_portable_success_reloads_and_mentions_keyring(
+def test_copy_installed_config_to_portable_success_reloads_and_offers_key_export(
     tmp_path, monkeypatch
 ):
     installed = tmp_path / "installed"
@@ -89,12 +93,17 @@ def test_copy_installed_config_to_portable_success_reloads_and_mentions_keyring(
     dialog._get_installed_config_dir = lambda: installed
 
     _ensure_wx_constants()
+    if not hasattr(module.wx, "YES_NO"):
+        module.wx.YES_NO = 0
     calls: list[tuple] = []
 
     def _fake_message_box(message, title, style):
         calls.append((message, title, style))
         if title == "Copy installed config to portable":
             return module.wx.YES
+        # Decline the API key export offer
+        if title == "Export API keys?":
+            return getattr(module.wx, "NO", 0)
         return module.wx.OK
 
     monkeypatch.setattr(module.wx, "MessageBox", _fake_message_box, raising=False)
@@ -109,19 +118,21 @@ def test_copy_installed_config_to_portable_success_reloads_and_mentions_keyring(
     assert not (portable / "cache.db").exists()
     assert not (portable / "weather_cache").exists()
 
-    final_message = calls[-1][0]
-    assert calls[-1][1] == "Copy complete"
-    assert "• accessiweather.json" in final_message
-    assert "Copied settings summary:" in final_message
-    assert "• locations: 1" in final_message
-    assert "• data source: auto" in final_message
-    assert "• AI model preference: openrouter/auto" in final_message
-    assert "• temperature unit: f" in final_message
-    assert "• custom prompt: no" in final_message
-    assert "cache.db" not in final_message
-    assert "API keys stay in this machine's secure keyring by default" in final_message
-    assert "Export API keys (encrypted)" in final_message
-    assert "Import API keys (encrypted)" in final_message
+    # Check "Copy complete" message
+    copy_complete = next((msg, t, s) for msg, t, s in calls if t == "Copy complete")
+    assert "• accessiweather.json" in copy_complete[0]
+    assert "Copied settings summary:" in copy_complete[0]
+    assert "• locations: 1" in copy_complete[0]
+    assert "• data source: auto" in copy_complete[0]
+    assert "• AI model preference: openrouter/auto" in copy_complete[0]
+    assert "• temperature unit: f" in copy_complete[0]
+    assert "• custom prompt: no" in copy_complete[0]
+    assert "cache.db" not in copy_complete[0]
+
+    # Check API key export was offered
+    assert any(t == "Export API keys?" for _, t, _ in calls)
+    # Declined → reminder message shown
+    assert any(t == "API keys not exported" for _, t, _ in calls)
 
 
 def test_copy_installed_config_to_portable_validation_failure_reports_incomplete(
@@ -360,4 +371,261 @@ def test_copy_installed_config_to_portable_no_locations_warns_and_stops(tmp_path
     assert any(title == "Nothing to copy" for _, title, _ in calls)
     assert any("no saved locations" in message.lower() for message, _, _ in calls)
     assert not any(title == "Copy installed config to portable" for _, title, _ in calls)
-    dialog.config_manager.save_config.assert_not_called()
+
+
+def test_offer_api_key_export_after_copy_yes_exports_bundle(tmp_path, monkeypatch):
+    """When user accepts the key export offer, export_encrypted_api_keys is called."""
+    portable = tmp_path / "portable"
+    portable.mkdir(parents=True, exist_ok=True)
+
+    dialog = _make_dialog(portable)
+    dialog.config_manager.export_encrypted_api_keys = MagicMock(return_value=True)
+
+    _ensure_wx_constants()
+    if not hasattr(module.wx, "YES_NO"):
+        module.wx.YES_NO = 0
+    if not hasattr(module.wx, "NO"):
+        module.wx.NO = 0
+    if not hasattr(module.wx, "ID_OK"):
+        module.wx.ID_OK = 1
+
+    calls: list[tuple] = []
+
+    def _fake_message_box(message, title, style):
+        calls.append((message, title, style))
+        if title == "Export API keys?":
+            return module.wx.YES
+        return module.wx.OK
+
+    passphrase_responses = iter(["FAKE_MY_PASS", "FAKE_MY_PASS"])
+
+    class _FakeTextEntryDialog:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def ShowModal(self):
+            return module.wx.ID_OK
+
+        def GetValue(self):
+            return next(passphrase_responses)
+
+    monkeypatch.setattr(module.wx, "MessageBox", _fake_message_box, raising=False)
+    monkeypatch.setattr(module.wx, "TextEntryDialog", _FakeTextEntryDialog, raising=False)
+
+    dialog._offer_api_key_export_after_copy(portable)
+
+    dialog.config_manager.export_encrypted_api_keys.assert_called_once_with(
+        portable / "api-keys.keys", "FAKE_MY_PASS"
+    )
+    assert any(t == "Export complete" for _, t, _ in calls)
+
+
+def test_offer_api_key_export_after_copy_no_shows_reminder(tmp_path, monkeypatch):
+    """When user declines the key export offer, a reminder is shown."""
+    portable = tmp_path / "portable"
+    portable.mkdir(parents=True, exist_ok=True)
+
+    dialog = _make_dialog(portable)
+
+    _ensure_wx_constants()
+    if not hasattr(module.wx, "YES_NO"):
+        module.wx.YES_NO = 0
+    if not hasattr(module.wx, "NO"):
+        module.wx.NO = 0
+
+    calls: list[tuple] = []
+
+    def _fake_message_box(message, title, style):
+        calls.append((message, title, style))
+        if title == "Export API keys?":
+            return getattr(module.wx, "NO", 0)
+        return module.wx.OK
+
+    monkeypatch.setattr(module.wx, "MessageBox", _fake_message_box, raising=False)
+
+    dialog._offer_api_key_export_after_copy(portable)
+
+    assert any(t == "API keys not exported" for _, t, _ in calls)
+    reminder = next(msg for msg, t, _ in calls if t == "API keys not exported")
+    assert "Export API keys (encrypted)" in reminder
+
+
+def test_offer_api_key_export_after_copy_mismatch_cancels(tmp_path, monkeypatch):
+    """When passphrases don't match, export is cancelled."""
+    portable = tmp_path / "portable"
+    portable.mkdir(parents=True, exist_ok=True)
+
+    dialog = _make_dialog(portable)
+    dialog.config_manager.export_encrypted_api_keys = MagicMock()
+
+    _ensure_wx_constants()
+    if not hasattr(module.wx, "YES_NO"):
+        module.wx.YES_NO = 0
+    if not hasattr(module.wx, "ID_OK"):
+        module.wx.ID_OK = 1
+
+    calls: list[tuple] = []
+
+    def _fake_message_box(message, title, style):
+        calls.append((message, title, style))
+        if title == "Export API keys?":
+            return module.wx.YES
+        return module.wx.OK
+
+    passphrase_responses = iter(["FAKE_PASS_ONE", "FAKE_PASS_TWO"])
+
+    class _FakeTextEntryDialog:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def ShowModal(self):
+            return module.wx.ID_OK
+
+        def GetValue(self):
+            return next(passphrase_responses)
+
+    monkeypatch.setattr(module.wx, "MessageBox", _fake_message_box, raising=False)
+    monkeypatch.setattr(module.wx, "TextEntryDialog", _FakeTextEntryDialog, raising=False)
+
+    dialog._offer_api_key_export_after_copy(portable)
+
+    dialog.config_manager.export_encrypted_api_keys.assert_not_called()
+    assert any(t == "Export cancelled" for _, t, _ in calls)
+
+
+def _make_mock_secure_storage(get_password_fn=None, set_password_fn=None):
+    """Create a mock SecureStorage class for injection into the settings_dialog module."""
+    mock_cls = MagicMock()
+    mock_cls.get_password = staticmethod(get_password_fn or (lambda key: None))
+    mock_cls.set_password = staticmethod(set_password_fn or (lambda key, val: True))
+    return mock_cls
+
+
+def _get_real_settings_dialog_class():
+    """Import SettingsDialogSimple through proper package paths (handles wx stubs)."""
+    import sys
+
+    # Ensure wx.lib.scrolledpanel exists (may be missing in test env)
+    if "wx.lib.scrolledpanel" not in sys.modules:
+        from types import ModuleType
+
+        fake_scrolled = ModuleType("wx.lib.scrolledpanel")
+        fake_scrolled.ScrolledPanel = type("ScrolledPanel", (), {})
+        sys.modules["wx.lib.scrolledpanel"] = fake_scrolled
+
+    from accessiweather.ui.dialogs.settings_dialog import SettingsDialogSimple
+
+    return SettingsDialogSimple
+
+
+def test_maybe_update_portable_bundle_uses_export_encrypted_api_keys(tmp_path, monkeypatch):
+    """_maybe_update_portable_bundle_after_save delegates to export_encrypted_api_keys."""
+    from accessiweather.config.secure_storage import SecureStorage
+
+    RealClass = _get_real_settings_dialog_class()
+
+    portable = tmp_path / "portable"
+    portable.mkdir(parents=True, exist_ok=True)
+
+    dialog = RealClass.__new__(RealClass)
+    dialog.config_manager = MagicMock()
+    dialog.config_manager.config_dir = portable
+    dialog.config_manager.export_encrypted_api_keys = MagicMock(return_value=True)
+    dialog.app = MagicMock()
+    dialog.app._PORTABLE_PASSPHRASE_KEYRING_KEY = "portable_bundle_passphrase"
+
+    # Simulate cached passphrase via SecureStorage.get_password
+    monkeypatch.setattr(
+        SecureStorage,
+        "get_password",
+        staticmethod(
+            lambda key: "FAKE_CACHED_PASS" if key == "portable_bundle_passphrase" else None
+        ),
+    )
+
+    dialog._maybe_update_portable_bundle_after_save(
+        {"visual_crossing_api_key": "FAKE_VC_KEY_123", "other_setting": "ignored"}
+    )
+
+    dialog.config_manager.export_encrypted_api_keys.assert_called_once_with(
+        portable / "api-keys.keys", "FAKE_CACHED_PASS"
+    )
+
+
+def test_maybe_update_portable_bundle_prompts_when_no_cached_passphrase(tmp_path, monkeypatch):
+    """When no cached passphrase, user is prompted; export runs on success."""
+    import wx
+
+    from accessiweather.config.secure_storage import SecureStorage
+
+    RealClass = _get_real_settings_dialog_class()
+
+    portable = tmp_path / "portable"
+    portable.mkdir(parents=True, exist_ok=True)
+
+    dialog = RealClass.__new__(RealClass)
+    dialog.config_manager = MagicMock()
+    dialog.config_manager.config_dir = portable
+    dialog.config_manager.export_encrypted_api_keys = MagicMock(return_value=True)
+    dialog.app = MagicMock()
+    dialog.app._PORTABLE_PASSPHRASE_KEYRING_KEY = "portable_bundle_passphrase"
+
+    # No cached passphrase
+    monkeypatch.setattr(SecureStorage, "get_password", staticmethod(lambda key: None))
+    set_pw_calls: list[tuple] = []
+    monkeypatch.setattr(
+        SecureStorage,
+        "set_password",
+        staticmethod(lambda key, val: set_pw_calls.append((key, val)) or True),
+    )
+
+    class _FakeTextEntryDialog:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def ShowModal(self):
+            return wx.ID_OK
+
+        def GetValue(self):
+            return "FAKE_NEW_PASSPHRASE"
+
+    monkeypatch.setattr(wx, "TextEntryDialog", _FakeTextEntryDialog, raising=False)
+
+    dialog._maybe_update_portable_bundle_after_save({"openrouter_api_key": "FAKE_OR_KEY_456"})
+
+    dialog.config_manager.export_encrypted_api_keys.assert_called_once_with(
+        portable / "api-keys.keys", "FAKE_NEW_PASSPHRASE"
+    )
+    # Passphrase was cached for future use
+    assert ("portable_bundle_passphrase", "FAKE_NEW_PASSPHRASE") in set_pw_calls
+
+
+def test_maybe_update_portable_bundle_skips_when_no_key_changes(tmp_path, monkeypatch):
+    """When no API keys are in settings_dict, bundle update is skipped entirely."""
+    portable = tmp_path / "portable"
+    portable.mkdir(parents=True, exist_ok=True)
+
+    dialog = _make_dialog(portable)
+    dialog.config_manager.export_encrypted_api_keys = MagicMock()
+
+    dialog._maybe_update_portable_bundle_after_save({"temperature_unit": "c", "data_source": "nws"})
+
+    dialog.config_manager.export_encrypted_api_keys.assert_not_called()

--- a/tests/test_startup_guidance_prompts.py
+++ b/tests/test_startup_guidance_prompts.py
@@ -123,18 +123,6 @@ def test_schedule_startup_guidance_prompts_uses_call_later(monkeypatch):
     assert calls[2][1] == app._maybe_show_portable_missing_keys_hint
 
 
-def test_has_any_saved_api_keys_checks_both_keys(monkeypatch):
-    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
-
-    monkeypatch.setattr(
-        "accessiweather.config.secure_storage.SecureStorage.get_password",
-        lambda name: "  " if name == "openrouter_api_key" else "vc-key",
-        raising=False,
-    )
-
-    assert app._has_any_saved_api_keys() is True
-
-
 def test_portable_missing_api_keys_hint_noops_when_not_portable():
     app = AccessiWeatherApp.__new__(AccessiWeatherApp)
     app._portable_mode = False
@@ -200,10 +188,12 @@ def test_onboarding_wizard_portable_happy_path_sets_keys_and_bundle(monkeypatch,
     settings = SimpleNamespace(onboarding_wizard_shown=False)
     config = SimpleNamespace(locations=[], settings=settings)
     bundle_path = tmp_path / "api-keys.keys"
+    export_mock = MagicMock(return_value=True)
     app.config_manager = SimpleNamespace(
         get_config=lambda: config,
         update_settings=MagicMock(),
         get_portable_api_key_bundle_path=lambda: bundle_path,
+        export_encrypted_api_keys=export_mock,
     )
 
     _ensure_wx_dialog_constants()
@@ -220,7 +210,7 @@ def test_onboarding_wizard_portable_happy_path_sets_keys_and_bundle(monkeypatch,
         raising=False,
     )
     # TextEntryDialog: OR key, VC key, bundle passphrase
-    text_responses = ["sk-or", "vc-key", "bundle-pass"]
+    text_responses = ["FAKE_OR_KEY_TEST", "FAKE_VC_KEY_TEST", "FAKE_BUNDLE_PASSPHRASE"]
     monkeypatch.setattr(
         "accessiweather.app.wx.TextEntryDialog",
         lambda *args, **kwargs: _FakeTextEntryDialog(text_responses),
@@ -244,11 +234,11 @@ def test_onboarding_wizard_portable_happy_path_sets_keys_and_bundle(monkeypatch,
 
     app._maybe_show_first_start_onboarding()
 
-    # Bundle file should have been written with the entered keys
-    assert bundle_path.exists(), "Bundle file should have been created"
-    # Keys should be live in session memory
-    assert settings.openrouter_api_key == "sk-or"
-    assert settings.visual_crossing_api_key == "vc-key"
+    # Wizard should delegate to export_encrypted_api_keys (not raw encrypt_secret_bundle)
+    export_mock.assert_called_once_with(bundle_path, "FAKE_BUNDLE_PASSPHRASE")
+    # Keys should be live in session memory (set before export call)
+    assert settings.openrouter_api_key == "FAKE_OR_KEY_TEST"
+    assert settings.visual_crossing_api_key == "FAKE_VC_KEY_TEST"
     assert app._portable_keys_imported_this_session is True
     # wizard_shown should be marked
     last_call = app.config_manager.update_settings.call_args_list[-1]
@@ -281,7 +271,7 @@ def test_onboarding_wizard_api_key_link_actions_open_browser(monkeypatch):
         lambda *args, **kwargs: _FakeDialog(responses),
         raising=False,
     )
-    text_responses = ["sk-or"]
+    text_responses = ["FAKE_OR_KEY_TEST"]
     monkeypatch.setattr(
         "accessiweather.app.wx.TextEntryDialog",
         lambda *args, **kwargs: _FakeTextEntryDialog(text_responses),
@@ -302,7 +292,7 @@ def test_onboarding_wizard_api_key_link_actions_open_browser(monkeypatch):
         "https://www.visualcrossing.com/sign-up",
     ]
     calls = app.config_manager.update_settings.call_args_list
-    assert calls[0].kwargs == {"openrouter_api_key": "sk-or"}
+    assert calls[0].kwargs == {"openrouter_api_key": "FAKE_OR_KEY_TEST"}
     assert calls[1].kwargs == {"onboarding_wizard_shown": True}
 
 
@@ -311,7 +301,7 @@ def test_onboarding_summary_includes_readiness_status(monkeypatch):
     app._portable_mode = False
     app._force_wizard = False
     app.main_window = SimpleNamespace(on_add_location=MagicMock(), open_settings=MagicMock())
-    settings = SimpleNamespace(onboarding_wizard_shown=False, portable_auto_bundle_enabled=False)
+    settings = SimpleNamespace(onboarding_wizard_shown=False)
     configs = iter(
         [
             SimpleNamespace(locations=[], settings=settings),
@@ -397,157 +387,144 @@ def test_onboarding_completion_triggers_deferred_startup_update_check(monkeypatc
 
 
 # ---------------------------------------------------------------------------
-# Tests for _maybe_offer_portable_key_export
+# Tests for wizard step numbering (non-portable = 3 steps, portable = 4)
 # ---------------------------------------------------------------------------
 
 
-def _make_app_for_key_export(monkeypatch, has_keys: bool, config_dir=None):
-    """Build a minimal AccessiWeatherApp stub for key-export tests."""
-    from pathlib import Path
+def _capture_wizard_step_messages(monkeypatch, *, portable: bool):
+    """Run the wizard and capture all dialog messages to verify step numbering."""
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    app._portable_mode = portable
+    app._force_wizard = False
+    app._portable_keys_imported_this_session = False
+    app.main_window = SimpleNamespace(on_add_location=MagicMock(), open_settings=MagicMock())
+    settings = SimpleNamespace(onboarding_wizard_shown=False)
+    app.config_manager = SimpleNamespace(
+        get_config=lambda: SimpleNamespace(locations=[], settings=settings),
+        update_settings=MagicMock(),
+    )
 
+    _ensure_wx_dialog_constants()
+    captured_messages: list[str] = []
+
+    class _CapturingDialog(_FakeDialog):
+        def __init__(self, message: str, responses: list[int]):
+            super().__init__(responses)
+            captured_messages.append(message)
+
+    # Skip location, skip OR key, skip VC key, OK summary
+    responses = [
+        getattr(wx, "ID_NO", 0),
+        getattr(wx, "ID_CANCEL", 2),
+        getattr(wx, "ID_CANCEL", 2),
+        getattr(wx, "ID_OK", 1),
+    ]
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageDialog",
+        lambda _parent, message, *_args, **_kwargs: _CapturingDialog(message, responses),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "accessiweather.app.wx.TextEntryDialog",
+        lambda *args, **kwargs: _FakeTextEntryDialog([]),
+        raising=False,
+    )
+    monkeypatch.setattr(app, "_has_saved_api_key", lambda key_name: False)
+
+    app._maybe_show_first_start_onboarding()
+    return captured_messages
+
+
+def test_wizard_step_numbering_non_portable(monkeypatch):
+    """Non-portable wizard uses 'of 3' in step labels."""
+    messages = _capture_wizard_step_messages(monkeypatch, portable=False)
+    step1 = messages[0]
+    assert "Step 1 of 3" in step1, f"Expected 'Step 1 of 3' in: {step1}"
+
+
+def test_wizard_step_numbering_portable(monkeypatch):
+    """Portable wizard uses 'of 4' in step labels."""
+    messages = _capture_wizard_step_messages(monkeypatch, portable=True)
+    step1 = messages[0]
+    assert "Step 1 of 4" in step1, f"Expected 'Step 1 of 4' in: {step1}"
+
+
+def test_wizard_step2_step3_numbering_non_portable(monkeypatch):
+    """Non-portable wizard passes 'of 3' to _prompt_optional_secret_with_link calls."""
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    app._portable_mode = False
+    app._force_wizard = False
+    app._portable_keys_imported_this_session = False
+    app.main_window = SimpleNamespace(on_add_location=MagicMock(), open_settings=MagicMock())
+    settings = SimpleNamespace(onboarding_wizard_shown=False)
+    app.config_manager = SimpleNamespace(
+        get_config=lambda: SimpleNamespace(locations=[], settings=settings),
+        update_settings=MagicMock(),
+    )
+
+    _ensure_wx_dialog_constants()
+    prompt_messages: list[str] = []
+
+    def fake_prompt(title, message, url, label):
+        prompt_messages.append(message)
+        return ""
+
+    responses = [
+        getattr(wx, "ID_NO", 0),  # step 1 skip
+        getattr(wx, "ID_OK", 1),  # summary
+    ]
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageDialog",
+        lambda *args, **kwargs: _FakeDialog(responses),
+        raising=False,
+    )
+    monkeypatch.setattr(app, "_prompt_optional_secret_with_link", fake_prompt)
+    monkeypatch.setattr(app, "_has_saved_api_key", lambda key_name: False)
+
+    app._maybe_show_first_start_onboarding()
+
+    assert len(prompt_messages) == 2
+    assert "Step 2 of 3" in prompt_messages[0], f"Expected 'Step 2 of 3' in: {prompt_messages[0]}"
+    assert "Step 3 of 3" in prompt_messages[1], f"Expected 'Step 3 of 3' in: {prompt_messages[1]}"
+
+
+def test_wizard_step2_step3_numbering_portable(monkeypatch):
+    """Portable wizard passes 'of 4' to _prompt_optional_secret_with_link calls."""
     app = AccessiWeatherApp.__new__(AccessiWeatherApp)
     app._portable_mode = True
     app._force_wizard = False
-    app.main_window = SimpleNamespace()
-
-    cfg_dir = Path(config_dir) if config_dir else Path("/tmp/portable-config")
+    app._portable_keys_imported_this_session = False
+    app.main_window = SimpleNamespace(on_add_location=MagicMock(), open_settings=MagicMock())
+    settings = SimpleNamespace(onboarding_wizard_shown=False)
     app.config_manager = SimpleNamespace(
-        config_dir=cfg_dir,
-        export_encrypted_api_keys=MagicMock(return_value=True),
+        get_config=lambda: SimpleNamespace(locations=[], settings=settings),
+        update_settings=MagicMock(),
     )
-
-    # Patch _has_any_saved_api_keys directly on the instance
-    app._has_any_saved_api_keys = MagicMock(return_value=has_keys)
-    app._force_wizard = False
 
     _ensure_wx_dialog_constants()
-    return app
+    prompt_messages: list[str] = []
 
+    def fake_prompt(title, message, url, label):
+        prompt_messages.append(message)
+        return ""
 
-def test_portable_key_export_skips_when_no_keyring_keys(monkeypatch):
-    """If no keyring keys exist, _maybe_offer_portable_key_export is a no-op."""
-    app = _make_app_for_key_export(monkeypatch, has_keys=False)
-
-    dialog_calls = []
+    responses = [
+        getattr(wx, "ID_NO", 0),  # step 1 skip
+        getattr(wx, "ID_OK", 1),  # summary
+    ]
     monkeypatch.setattr(
         "accessiweather.app.wx.MessageDialog",
-        lambda *a, **kw: dialog_calls.append(a) or _FakeDialog([]),
+        lambda *args, **kwargs: _FakeDialog(responses),
         raising=False,
     )
+    monkeypatch.setattr(app, "_prompt_optional_secret_with_link", fake_prompt)
+    monkeypatch.setattr(app, "_has_saved_api_key", lambda key_name: False)
 
-    app._maybe_offer_portable_key_export()
+    app._maybe_show_first_start_onboarding()
 
-    assert dialog_calls == [], "No dialog should appear when no keyring keys exist"
-    app.config_manager.export_encrypted_api_keys.assert_not_called()
-
-
-def test_portable_key_export_skips_when_user_declines(monkeypatch):
-    """User says 'Skip' → no export attempted."""
-    app = _make_app_for_key_export(monkeypatch, has_keys=True)
-
-    responses = [getattr(wx, "ID_NO", 0)]
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageDialog",
-        lambda *a, **kw: _FakeDialog(responses),
-        raising=False,
-    )
-
-    app._maybe_offer_portable_key_export()
-
-    app.config_manager.export_encrypted_api_keys.assert_not_called()
-
-
-def test_portable_key_export_skips_when_no_passphrase(monkeypatch):
-    """User says yes but enters no passphrase → show warning, no export."""
-    app = _make_app_for_key_export(monkeypatch, has_keys=True)
-
-    dialog_responses = [getattr(wx, "ID_YES", 1)]
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageDialog",
-        lambda *a, **kw: _FakeDialog(dialog_responses),
-        raising=False,
-    )
-    # Empty passphrase from TextEntryDialog
-    monkeypatch.setattr(
-        "accessiweather.app.wx.TextEntryDialog",
-        lambda *a, **kw: _FakeTextEntryDialog([""]),
-        raising=False,
-    )
-    messagebox_calls = []
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageBox",
-        lambda *a, **kw: messagebox_calls.append(a),
-        raising=False,
-    )
-
-    app._maybe_offer_portable_key_export()
-
-    app.config_manager.export_encrypted_api_keys.assert_not_called()
-    assert messagebox_calls, "A warning MessageBox should have been shown"
-
-
-def test_portable_key_export_happy_path(monkeypatch, tmp_path):
-    """User accepts export, provides passphrase → export called, success dialog shown."""
-    app = _make_app_for_key_export(monkeypatch, has_keys=True, config_dir=str(tmp_path))
-
-    dialog_responses = [getattr(wx, "ID_YES", 1)]
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageDialog",
-        lambda *a, **kw: _FakeDialog(dialog_responses),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        "accessiweather.app.wx.TextEntryDialog",
-        lambda *a, **kw: _FakeTextEntryDialog(["my-secret-pass"]),
-        raising=False,
-    )
-    messagebox_calls = []
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageBox",
-        lambda *a, **kw: messagebox_calls.append(a),
-        raising=False,
-    )
-
-    app._maybe_offer_portable_key_export()
-
-    expected_path = tmp_path / "api-keys.keys"
-    app.config_manager.export_encrypted_api_keys.assert_called_once_with(
-        expected_path, "my-secret-pass"
-    )
-    assert messagebox_calls, "A success MessageBox should have been shown"
-    assert (
-        "successful" in messagebox_calls[0][1].lower()
-        or "successful" in messagebox_calls[0][0].lower()
-    )
-
-
-def test_portable_key_export_shows_error_on_failure(monkeypatch, tmp_path):
-    """When export_encrypted_api_keys returns False, an error dialog is shown."""
-    app = _make_app_for_key_export(monkeypatch, has_keys=True, config_dir=str(tmp_path))
-    app.config_manager.export_encrypted_api_keys = MagicMock(return_value=False)
-
-    dialog_responses = [getattr(wx, "ID_YES", 1)]
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageDialog",
-        lambda *a, **kw: _FakeDialog(dialog_responses),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        "accessiweather.app.wx.TextEntryDialog",
-        lambda *a, **kw: _FakeTextEntryDialog(["pass"]),
-        raising=False,
-    )
-    messagebox_calls = []
-    monkeypatch.setattr(
-        "accessiweather.app.wx.MessageBox",
-        lambda *a, **kw: messagebox_calls.append(a),
-        raising=False,
-    )
-
-    app._maybe_offer_portable_key_export()
-
-    assert messagebox_calls, "An error MessageBox should have been shown"
-    assert "fail" in messagebox_calls[0][0].lower() or "fail" in messagebox_calls[0][1].lower()
+    assert len(prompt_messages) == 2
+    assert "Step 2 of 4" in prompt_messages[0], f"Expected 'Step 2 of 4' in: {prompt_messages[0]}"
+    assert "Step 3 of 4" in prompt_messages[1], f"Expected 'Step 3 of 4' in: {prompt_messages[1]}"
 
 
 # ---------------------------------------------------------------------------
@@ -597,7 +574,7 @@ def test_auto_import_silent_when_passphrase_cached(monkeypatch, tmp_path):
 
     monkeypatch.setattr(
         "accessiweather.config.secure_storage.SecureStorage.get_password",
-        lambda name: "cached-pass" if name == app._PORTABLE_PASSPHRASE_KEYRING_KEY else None,
+        lambda name: "FAKE_CACHED_PASS" if name == app._PORTABLE_PASSPHRASE_KEYRING_KEY else None,
         raising=False,
     )
     monkeypatch.setattr(
@@ -630,7 +607,7 @@ def test_auto_import_prompts_when_no_cached_passphrase(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         "accessiweather.app.wx.TextEntryDialog",
-        lambda *a, **kw: _FakeTextEntryDialog(["my-passphrase"]),
+        lambda *a, **kw: _FakeTextEntryDialog(["FAKE_MY_PASSPHRASE"]),
         raising=False,
     )
     monkeypatch.setattr(
@@ -662,7 +639,7 @@ def test_auto_import_happy_path_keys_file(monkeypatch, tmp_path):
 
     monkeypatch.setattr(
         "accessiweather.app.wx.TextEntryDialog",
-        lambda *a, **kw: _FakeTextEntryDialog(["correct-pass"]),
+        lambda *a, **kw: _FakeTextEntryDialog(["FAKE_CORRECT_PASSPHRASE"]),
         raising=False,
     )
     messagebox_calls = []
@@ -674,7 +651,9 @@ def test_auto_import_happy_path_keys_file(monkeypatch, tmp_path):
 
     app._maybe_auto_import_keys_file()
 
-    app.config_manager.import_encrypted_api_keys.assert_called_once_with(keys_file, "correct-pass")
+    app.config_manager.import_encrypted_api_keys.assert_called_once_with(
+        keys_file, "FAKE_CORRECT_PASSPHRASE"
+    )
     assert messagebox_calls, "A success message should appear"
     assert "imported" in messagebox_calls[0][0].lower()
 
@@ -687,7 +666,7 @@ def test_auto_import_happy_path_legacy_awkeys(monkeypatch, tmp_path):
 
     monkeypatch.setattr(
         "accessiweather.app.wx.TextEntryDialog",
-        lambda *a, **kw: _FakeTextEntryDialog(["pass"]),
+        lambda *a, **kw: _FakeTextEntryDialog(["FAKE_TEST_PASSPHRASE"]),
         raising=False,
     )
     monkeypatch.setattr(
@@ -698,7 +677,9 @@ def test_auto_import_happy_path_legacy_awkeys(monkeypatch, tmp_path):
 
     app._maybe_auto_import_keys_file()
 
-    app.config_manager.import_encrypted_api_keys.assert_called_once_with(legacy_file, "pass")
+    app.config_manager.import_encrypted_api_keys.assert_called_once_with(
+        legacy_file, "FAKE_TEST_PASSPHRASE"
+    )
 
 
 def test_auto_import_prefers_keys_over_awkeys(monkeypatch, tmp_path):
@@ -709,7 +690,7 @@ def test_auto_import_prefers_keys_over_awkeys(monkeypatch, tmp_path):
 
     monkeypatch.setattr(
         "accessiweather.app.wx.TextEntryDialog",
-        lambda *a, **kw: _FakeTextEntryDialog(["pass"]),
+        lambda *a, **kw: _FakeTextEntryDialog(["FAKE_TEST_PASSPHRASE"]),
         raising=False,
     )
     monkeypatch.setattr(
@@ -732,7 +713,7 @@ def test_auto_import_wrong_passphrase_then_skip(monkeypatch, tmp_path):
 
     monkeypatch.setattr(
         "accessiweather.app.wx.TextEntryDialog",
-        lambda *a, **kw: _FakeTextEntryDialog(["bad-pass"]),
+        lambda *a, **kw: _FakeTextEntryDialog(["FAKE_BAD_PASSPHRASE"]),
         raising=False,
     )
     # Retry dialog → user picks "Skip" (ID_NO)
@@ -760,7 +741,7 @@ def test_auto_import_wrong_passphrase_then_retry_success(monkeypatch, tmp_path):
 
     app.config_manager.import_encrypted_api_keys = MagicMock(side_effect=_import_side_effect)
 
-    text_iter = iter(["bad-pass", "good-pass"])
+    text_iter = iter(["FAKE_BAD_PASSPHRASE", "FAKE_GOOD_PASSPHRASE"])
     monkeypatch.setattr(
         "accessiweather.app.wx.TextEntryDialog",
         lambda *a, **kw: _FakeTextEntryDialog([next(text_iter)]),
@@ -836,3 +817,73 @@ def test_schedule_startup_guidance_prompts_includes_auto_import(monkeypatch):
     auto_idx = fns.index(app._maybe_auto_import_keys_file)
     onboard_idx = fns.index(app._maybe_show_first_start_onboarding)
     assert auto_idx < onboard_idx
+
+
+# ---------------------------------------------------------------------------
+# Tests for wizard using export_encrypted_api_keys (not raw encrypt_secret_bundle)
+# ---------------------------------------------------------------------------
+
+
+def test_wizard_portable_export_failure_shows_warning(monkeypatch, tmp_path):
+    """When export_encrypted_api_keys returns False, wizard shows bundle write failure."""
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    app._portable_mode = True
+    app._force_wizard = False
+    app._portable_keys_imported_this_session = False
+    app.main_window = SimpleNamespace(on_add_location=MagicMock(), open_settings=MagicMock())
+    settings = SimpleNamespace(onboarding_wizard_shown=False)
+    config = SimpleNamespace(locations=[], settings=settings)
+    bundle_path = tmp_path / "api-keys.keys"
+    export_mock = MagicMock(return_value=False)
+    app.config_manager = SimpleNamespace(
+        get_config=lambda: config,
+        update_settings=MagicMock(),
+        get_portable_api_key_bundle_path=lambda: bundle_path,
+        export_encrypted_api_keys=export_mock,
+    )
+
+    _ensure_wx_dialog_constants()
+    responses = [
+        getattr(wx, "ID_NO", 0),  # step 1: skip location
+        getattr(wx, "ID_YES", 1),  # step 2: OR key — choose "Enter key"
+        getattr(wx, "ID_CANCEL", 2),  # step 3: VC key — skip
+        getattr(wx, "ID_OK", 1),  # onboarding summary
+    ]
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageDialog",
+        lambda *args, **kwargs: _FakeDialog(responses),
+        raising=False,
+    )
+    text_responses = ["FAKE_OR_KEY_TEST", "FAKE_BUNDLE_PASSPHRASE"]
+    monkeypatch.setattr(
+        "accessiweather.app.wx.TextEntryDialog",
+        lambda *args, **kwargs: _FakeTextEntryDialog(text_responses),
+        raising=False,
+    )
+    messagebox_calls = []
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageBox",
+        lambda *a, **kw: messagebox_calls.append(a),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "accessiweather.config.secure_storage.SecureStorage.set_password",
+        lambda *a: True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "accessiweather.config.secure_storage.SecureStorage.get_password",
+        lambda *a: None,
+        raising=False,
+    )
+
+    app._maybe_show_first_start_onboarding()
+
+    export_mock.assert_called_once()
+    # Should NOT mark as imported when export fails
+    assert app._portable_keys_imported_this_session is False
+    # A failure warning should have been shown
+    assert any(
+        "failed" in str(call).lower() or "not persist" in str(call).lower()
+        for call in messagebox_calls
+    )


### PR DESCRIPTION
## Summary

Fixes the entire portable and installed API key flow end-to-end for a seamless user experience.

## Problems Fixed

### Bug fixes
- **Only one key transferred**: `import_encrypted_api_keys` bailed immediately on first `set_password` failure, silently dropping the second key. Now collects all failures and writes all keys before returning.
- **Portable export read keyring only**: `export_encrypted_api_keys` called `SecureStorage.get_password` only — in portable mode keys live in-memory, not keyring. Now checks in-memory settings first, falls back to keyring. Covers portable→portable, installed→portable, and installed→installed transfer.
- **Wizard bypassed export logic**: The onboarding wizard wrote the encrypted bundle raw inline using `encrypt_secret_bundle` directly, missing the dual-source fix. Now sets keys in-memory then calls `export_encrypted_api_keys`.
- **Settings dialog also wrote bundle raw**: `_maybe_update_portable_bundle_after_save` had the same raw bundle-write pattern. Refactored to use `export_encrypted_api_keys`.
- **Installed → portable migration left users with no API keys**: `Copy installed config to portable` only copied `accessiweather.json`. API keys live in keyring and weren't transferred. Now offers to export keys to an encrypted bundle immediately after the copy.
- **Import sets keys in-memory for portable mode**: After importing a bundle in portable mode, keys are now set directly on `config.settings` so they're active immediately without a restart.

### UX cleanup
- **Removed session passphrase UX**: The "Keep encrypted API key bundle" checkbox and "Set bundle passphrase for this session" button required two manual steps per session and reset on every launch. Removed entirely — the keyring-cached passphrase flow handles bundle sync automatically.
- **Keyring warning suppressed in portable mode**: The keyring unavailability warning in the onboarding wizard no longer fires in portable mode (keys go to the bundle, not keyring).
- **Wizard step numbering fixed**: Non-portable users saw "Step 2 of 4" / "Step 3 of 4" but never saw a step 4. Now correctly shows "Step X of 3" for non-portable and "Step X of 4" for portable.
- **Dead code removed**: `_maybe_offer_portable_key_export` and `_has_any_saved_api_keys` were defined but never called. Removed.

### Model/config cleanup
- Removed `portable_auto_bundle_enabled` from `AppSettings` dataclass, `to_dict`, `from_dict`, and `NON_CRITICAL_SETTINGS`
- Removed `set_portable_bundle_passphrase`, `has_portable_bundle_passphrase`, `refresh_portable_api_key_bundle`, `disable_portable_api_key_bundle`, and `_portable_bundle_passphrase` from `ConfigManager`
- Removed `portable_auto_bundle` tracking logic from `SettingsOperations.update_settings`

## Result
- Fresh portable install: wizard collects keys → bundle created silently with keyring-cached passphrase
- Same machine, subsequent launches: silent auto-import
- New machine (copy folder): one passphrase prompt, cached in keyring, silent thereafter
- Settings key changes in portable mode: bundle re-encrypted automatically
- Installed → portable migration: config copy + immediate offer to transfer keys
- Both keys (OpenRouter + Visual Crossing) always transfer correctly

## Tests
- 2331 passing
- Net positive: new tests for dual-source export, no-bail import, wizard routing, bundle sync, migration key export, step numbering, keyring warning suppression