### PR TITLE
fix(portable): remove writable-dir heuristic from is_portable_mode

### DIFF
--- a/src/accessiweather/config_utils.py
+++ b/src/accessiweather/config_utils.py
@@ -19,8 +19,9 @@ def is_portable_mode() -> bool:
     """
     Determine if the application is running in portable mode.
 
-    Portable mode is detected by checking if the executable is running from a
-    non-standard location (not Program Files) and if the directory is writable.
+    Portable mode is detected via explicit markers: a `.portable` file next to
+    the executable, a `config/` directory next to the executable (legacy), or
+    the presence of an Inno Setup uninstaller (which confirms installed mode).
 
     For testing purposes, portable mode can be forced by setting the
     ACCESSIWEATHER_FORCE_PORTABLE environment variable to "1" or "true".
@@ -101,18 +102,9 @@ def is_portable_mode() -> bool:
                 )
                 return False
 
-        # Check if the directory is writable (portable installations should be)
-        try:
-            test_file = os.path.join(app_dir, ".write_test")
-            with open(test_file, "w") as f:
-                f.write("test")
-            os.remove(test_file)
-            logger.debug(f"Portable mode detected: directory {app_dir} is writable")
-            return True
-        except (OSError, PermissionError) as e:
-            # If we can't write to the directory, assume it's not portable
-            logger.debug(f"Not in portable mode: directory {app_dir} is not writable ({e})")
-            return False
+        # No portable markers found and not in Program Files — assume installed.
+        logger.debug("Not in portable mode: no portable markers found, assuming installed build")
+        return False
 
     logger.debug("Not in portable mode: default fallback")
     return False

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -99,8 +99,13 @@ class TestIsPortableMode:
         ):
             assert is_portable_mode() is False
 
-    def test_frozen_writable_directory_is_portable(self, tmp_path):
-        """Frozen app in writable non-Program Files dir should be portable."""
+    def test_frozen_no_markers_not_portable(self, tmp_path):
+        """
+        Frozen app with no markers and not in Program Files should NOT be portable.
+
+        The old writable-directory heuristic incorrectly returned True here,
+        causing installed builds in custom directories to lose keyring API keys.
+        """
         exe_path = str(tmp_path / "app.exe")
 
         with (
@@ -112,7 +117,7 @@ class TestIsPortableMode:
             ),
             mock.patch("os.listdir", return_value=[]),
         ):
-            assert is_portable_mode() is True
+            assert is_portable_mode() is False
 
     def test_frozen_portable_marker_file_is_portable(self, tmp_path):
         """A .portable marker should force portable mode."""
@@ -144,9 +149,9 @@ class TestIsPortableMode:
         ):
             assert is_portable_mode() is True
 
-    def test_frozen_non_writable_directory_not_portable(self, tmp_path):
-        """Frozen app in non-writable dir should not be portable."""
-        exe_path = str(tmp_path / "app.exe")
+    def test_frozen_custom_install_path_not_portable(self, tmp_path):
+        """Frozen app installed to a custom path (not Program Files) should not be portable."""
+        exe_path = str(tmp_path / "MyApps" / "AccessiWeather" / "app.exe")
 
         with (
             mock.patch.object(sys, "frozen", True, create=True),
@@ -156,7 +161,6 @@ class TestIsPortableMode:
                 {"ACCESSIWEATHER_FORCE_PORTABLE": "", "PROGRAMFILES": "", "PROGRAMFILES(X86)": ""},
             ),
             mock.patch("os.listdir", return_value=[]),
-            mock.patch("builtins.open", side_effect=PermissionError("no write")),
         ):
             assert is_portable_mode() is False
 


### PR DESCRIPTION
## Problem

Installed builds in custom directories (e.g. `D:\MyApps\AccessiWeather`) were being detected as portable mode after the recent portable key storage overhaul. This caused the app to skip loading API keys from the keyring on startup, leaving users with blank keys and broken weather data.

The culprit: a writable-directory heuristic at the bottom of `is_portable_mode()` that returned `True` if the app directory was writable — which is true for any custom install path.

## Fix

Removed the writable-directory fallback entirely. Portable mode is now only detected via explicit signals:
- `ACCESSIWEATHER_FORCE_PORTABLE` env var (testing only)
- `.portable` marker file next to the executable
- `config/` directory next to the executable (legacy)
- Inno Setup uninstaller present → confirmed installed, return `False`

If none match, we return `False` (assume installed). This is the safe default.

## Tests

Updated `test_frozen_writable_directory_is_portable` → now asserts `False` (the old behaviour was wrong). Renamed for clarity. Added a second case for custom install paths.