### PR TITLE
fix(ci): allow manual WordPress sync dispatch

### DIFF
--- a/.github/workflows/update-wordpress.yml
+++ b/.github/workflows/update-wordpress.yml
@@ -3,6 +3,7 @@ name: Update WordPress on release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   push-to-wordpress:


### PR DESCRIPTION
Adds workflow_dispatch to update-wordpress.yml so we can manually trigger WordPress release sync when needed.