### PR TITLE
fix: use Path.relative_to() for cross-platform zip slip detection

### DIFF
--- a/src/accessiweather/notifications/sound_pack_installer.py
+++ b/src/accessiweather/notifications/sound_pack_installer.py
@@ -19,10 +19,12 @@ def safe_extractall(zip_file: zipfile.ZipFile, target_dir: Path) -> None:
     target_dir = target_dir.resolve()
     for member in zip_file.namelist():
         member_path = (target_dir / member).resolve()
-        if not str(member_path).startswith(str(target_dir) + "/") and member_path != target_dir:
+        try:
+            member_path.relative_to(target_dir)
+        except ValueError as e:
             raise ValueError(
                 f"Zip Slip detected: member '{member}' would extract outside target directory"
-            )
+            ) from e
     zip_file.extractall(target_dir)
 
 


### PR DESCRIPTION
## Problem

The `safe_extractall` function used a string-based check with a hardcoded `"/"` separator:

```python
if not str(member_path).startswith(str(target_dir) + "/") and member_path != target_dir:
```

On Windows, `Path.resolve()` returns backslash-separated paths (e.g. `C:\Users\...\tmpXXX`), so appending `"/"` never matches any member path. Every zip member gets falsely flagged as a zip slip attempt — including totally normal files like `pack.json`.

## Fix

Replace string comparison with `Path.relative_to()` which is OS-agnostic:

```python
try:
    member_path.relative_to(target_dir)
except ValueError as e:
    raise ValueError(...) from e
```

All 4 existing zip slip tests still pass. Security is intact — real traversal attacks (`../../etc/passwd`, absolute paths) are still rejected.