### PR TITLE
fix: include default soundpack in portable zip

### DIFF
--- a/installer/build.py
+++ b/installer/build.py
@@ -32,6 +32,7 @@ SRC_DIR = ROOT / "src"
 DIST_DIR = ROOT / "dist"
 BUILD_DIR = ROOT / "build"
 RESOURCES_DIR = SRC_DIR / "accessiweather" / "resources"
+SOUNDPACKS_DIR = ROOT / "soundpacks"
 
 # Platform detection
 IS_WINDOWS = platform.system() == "Windows"
@@ -338,8 +339,22 @@ def create_portable_zip() -> bool:
             exe_path = DIST_DIR / "AccessiWeather.exe"
             if exe_path.exists():
                 source_dir = DIST_DIR / "AccessiWeather_portable"
+                if source_dir.exists():
+                    shutil.rmtree(source_dir)
                 source_dir.mkdir(exist_ok=True)
                 shutil.copy2(exe_path, source_dir / "AccessiWeather.exe")
+
+                # Portable frozen builds resolve bundled soundpacks from data/soundpacks
+                # next to the executable, not from PyInstaller's temp extraction dir.
+                default_soundpack_dir = SOUNDPACKS_DIR / "default"
+                if default_soundpack_dir.exists():
+                    portable_soundpacks_dir = source_dir / "data" / "soundpacks"
+                    portable_soundpacks_dir.mkdir(parents=True, exist_ok=True)
+                    shutil.copytree(
+                        default_soundpack_dir,
+                        portable_soundpacks_dir / "default",
+                        dirs_exist_ok=True,
+                    )
             else:
                 print("Error: No build output found")
                 return False

--- a/tests/test_installer_build.py
+++ b/tests/test_installer_build.py
@@ -1,0 +1,41 @@
+"""Tests for portable ZIP staging in installer.build."""
+
+from __future__ import annotations
+
+import zipfile
+
+from installer import build
+
+
+def test_create_portable_zip_from_single_exe_includes_default_soundpack(
+    tmp_path, monkeypatch
+) -> None:
+    """Portable ZIPs staged from a single exe must include the default soundpack."""
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    (dist_dir / "AccessiWeather.exe").write_bytes(b"fake-exe")
+
+    soundpacks_dir = tmp_path / "soundpacks"
+    default_soundpack_dir = soundpacks_dir / "default"
+    default_soundpack_dir.mkdir(parents=True)
+    (default_soundpack_dir / "pack.json").write_text('{"name":"Default"}', encoding="utf-8")
+    (default_soundpack_dir / "startup.wav").write_bytes(b"fake-wav")
+
+    monkeypatch.setattr(build, "IS_WINDOWS", True)
+    monkeypatch.setattr(build, "IS_MACOS", False)
+    monkeypatch.setattr(build, "IS_LINUX", False)
+    monkeypatch.setattr(build, "DIST_DIR", dist_dir)
+    monkeypatch.setattr(build, "SOUNDPACKS_DIR", soundpacks_dir)
+    monkeypatch.setattr(build, "get_version", lambda: "9.9.9")
+
+    assert build.create_portable_zip() is True
+
+    zip_path = dist_dir / "AccessiWeather_Portable_v9.9.9.zip"
+    assert zip_path.exists()
+
+    with zipfile.ZipFile(zip_path) as archive:
+        names = set(archive.namelist())
+
+    assert "AccessiWeather_portable/AccessiWeather.exe" in names
+    assert "AccessiWeather_portable/data/soundpacks/default/pack.json" in names
+    assert "AccessiWeather_portable/data/soundpacks/default/startup.wav" in names


### PR DESCRIPTION
## Summary
- copy the default soundpack into the Windows portable zip staging directory at `data/soundpacks/default`
- add a regression test that verifies the portable zip contains the default soundpack files
- keep the portable soundpack path relative to the extracted app folder, not any absolute machine path

## Testing
- pytest -q tests/test_installer_build.py tests/test_soundpack_paths.py

## Notes
Portable soundpack staging uses `source_dir / "data" / "soundpacks"`, so users can unzip the portable build anywhere and the default pack still resolves correctly.