### PR TITLE
fix(audio): add user-level per-event sound muting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file.
 - Standardized classification of PMD/SWO discussions using WMO header codes.
 
 ### Fixed
+- Added per-event sound toggles in Settings > Audio, so you can mute sounds like weather refreshes without editing the active sound pack. Weather refresh sounds now stay off by default until you turn them back on.
+- Muted and zero-volume sounds now stop before fallback playback, so backends like `playsound3` no longer leak audio when an event should be silent.
 - Fixed PyInstaller bundling for `prismatoid`/`prism` in nightly builds.
 - Enabled "Show Nationwide location" checkbox and correctly handled Nationwide location in `set_current_location()`.
 - Corrected CPC URLs to point to the actual discussion page (`fxus06.html`).

--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -1491,7 +1491,8 @@ class AccessiWeatherApp(wx.App):
                 from .notifications.sound_player import play_startup_sound
 
                 sound_pack = getattr(settings, "sound_pack", "default")
-                play_startup_sound(sound_pack)
+                muted_events = getattr(settings, "muted_sound_events", ["data_updated"])
+                play_startup_sound(sound_pack, muted_events=muted_events)
         except Exception as e:
             logger.debug(f"Could not play startup sound: {e}")
 
@@ -1517,6 +1518,7 @@ class AccessiWeatherApp(wx.App):
                 )
 
                 sound_pack = getattr(settings, "sound_pack", "default")
+                muted_events = getattr(settings, "muted_sound_events", ["data_updated"])
                 frozen = bool(getattr(sys, "frozen", False))
                 logger.debug(
                     "[packaging-diag] exit sound: frozen=%s sound_pack=%s sound_lib=%s playsound3=%s",
@@ -1526,7 +1528,7 @@ class AccessiWeatherApp(wx.App):
                     PLAYSOUND_AVAILABLE,
                 )
 
-                play_exit_sound(sound_pack)
+                play_exit_sound(sound_pack, muted_events=muted_events)
         except Exception:
             pass
 
@@ -1567,6 +1569,9 @@ class AccessiWeatherApp(wx.App):
             if self._notifier:
                 self._notifier.sound_enabled = bool(getattr(settings, "sound_enabled", True))
                 self._notifier.soundpack = getattr(settings, "sound_pack", "default")
+                self._notifier.muted_sound_events = list(
+                    getattr(settings, "muted_sound_events", ["data_updated"])
+                )
 
             if self.alert_notification_system:
                 self.alert_notification_system.settings = settings

--- a/src/accessiweather/app_initialization.py
+++ b/src/accessiweather/app_initialization.py
@@ -93,6 +93,7 @@ def initialize_components(app: AccessiWeatherApp) -> None:
     app._notifier = SafeDesktopNotifier(
         sound_enabled=bool(getattr(config.settings, "sound_enabled", True)),
         soundpack=getattr(config.settings, "sound_pack", "default"),
+        muted_sound_events=getattr(config.settings, "muted_sound_events", ["data_updated"]),
     )
 
     # Initialize AI explanation cache (lazy import)

--- a/src/accessiweather/models/config.py
+++ b/src/accessiweather/models/config.py
@@ -34,6 +34,7 @@ NON_CRITICAL_SETTINGS: set[str] = {
     # Sound settings
     "sound_enabled",
     "sound_pack",
+    "muted_sound_events",
     "show_nationwide_location",
     # Event notifications
     "notify_discussion_update",
@@ -106,6 +107,7 @@ class AppSettings:
     update_check_interval_hours: int = 24
     sound_enabled: bool = True
     sound_pack: str = "default"
+    muted_sound_events: list[str] = field(default_factory=lambda: ["data_updated"])
     # Nationwide location visibility
     show_nationwide_location: bool = True
     # Event-based notifications (opt-in, disabled by default)
@@ -253,6 +255,22 @@ class AppSettings:
             if not isinstance(value, str) or not value.strip():
                 setattr(self, setting_name, "default")
 
+        elif setting_name == "muted_sound_events":
+            if not isinstance(value, list):
+                setattr(self, setting_name, ["data_updated"])
+            else:
+                normalized: list[str] = []
+                seen: set[str] = set()
+                for item in value:
+                    if not isinstance(item, str):
+                        continue
+                    event = item.strip()
+                    if not event or event in seen:
+                        continue
+                    seen.add(event)
+                    normalized.append(event)
+                setattr(self, setting_name, normalized)
+
         elif setting_name == "taskbar_icon_text_format":
             # Ensure format string is valid
             if not isinstance(value, str) or not value.strip():
@@ -383,6 +401,7 @@ class AppSettings:
             "update_check_interval_hours": self.update_check_interval_hours,
             "sound_enabled": self.sound_enabled,
             "sound_pack": self.sound_pack,
+            "muted_sound_events": self.muted_sound_events,
             "show_nationwide_location": self.show_nationwide_location,
             "notify_discussion_update": self.notify_discussion_update,
             "notify_severe_risk_change": self.notify_severe_risk_change,
@@ -457,6 +476,7 @@ class AppSettings:
             update_check_interval_hours=data.get("update_check_interval_hours", 24),
             sound_enabled=cls._as_bool(data.get("sound_enabled"), True),
             sound_pack=data.get("sound_pack", "default"),
+            muted_sound_events=data.get("muted_sound_events", ["data_updated"]),
             show_nationwide_location=cls._as_bool(data.get("show_nationwide_location"), True),
             notify_discussion_update=cls._as_bool(data.get("notify_discussion_update"), True),
             notify_severe_risk_change=cls._as_bool(data.get("notify_severe_risk_change"), False),

--- a/src/accessiweather/notifications/sound_player.py
+++ b/src/accessiweather/notifications/sound_player.py
@@ -2,6 +2,7 @@ import json
 import logging
 import platform
 import sys
+from collections.abc import Collection
 from pathlib import Path
 from typing import Any
 
@@ -36,6 +37,38 @@ logger = logging.getLogger(__name__)
 SOUNDPACKS_DIR = get_soundpacks_dir()
 DEFAULT_PACK = "default"
 DEFAULT_EVENT = "alert"
+DEFAULT_MUTED_SOUND_EVENTS: tuple[str, ...] = ("data_updated",)
+USER_MUTABLE_SOUND_EVENTS: tuple[tuple[str, str], ...] = (
+    ("data_updated", "Play a sound after weather refresh"),
+    ("fetch_error", "Play a sound when weather refresh fails"),
+    ("discussion_update", "Play a sound for forecast discussion updates"),
+    ("severe_risk", "Play a sound for severe risk changes"),
+    ("startup", "Play a startup sound when the app opens"),
+    ("exit", "Play an exit sound when the app closes"),
+)
+
+
+def normalize_muted_sound_events(events: Collection[str] | None) -> list[str]:
+    """Normalize muted event names while preserving order."""
+    if not events:
+        return []
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in events:
+        event = str(item).strip()
+        if not event or event in seen:
+            continue
+        seen.add(event)
+        normalized.append(event)
+    return normalized
+
+
+def is_sound_event_muted(event: str, muted_events: Collection[str] | None = None) -> bool:
+    """Return True when a user-level mute disables the event."""
+    if not event:
+        return False
+    return event in set(normalize_muted_sound_events(muted_events))
 
 
 def _log_packaging_sound_diagnostics() -> None:
@@ -188,6 +221,9 @@ def _play_sound_file(sound_file: Path, block: bool = False, volume: float = 1.0)
     """
     # Clamp volume to valid range
     volume = max(0.0, min(1.0, volume))
+    if volume <= 0.0:
+        logger.debug(f"Skipping silent sound playback: {sound_file}")
+        return True
 
     # Always prefer sound_lib when available (supports volume, stop, better reliability)
     if SOUND_LIB_AVAILABLE:
@@ -390,7 +426,12 @@ def is_playsound_available() -> bool:
 is_sound_lib_available = is_playsound_available
 
 
-def play_notification_sound(event: str, pack_dir: str) -> None:
+def play_notification_sound(
+    event: str,
+    pack_dir: str,
+    *,
+    muted_events: Collection[str] | None = None,
+) -> None:
     """
     Play a notification sound for the given event and pack.
 
@@ -399,8 +440,13 @@ def play_notification_sound(event: str, pack_dir: str) -> None:
     Args:
         event: The sound event name (e.g., "alert", "critical_alert")
         pack_dir: The sound pack directory name
+        muted_events: Optional user-level muted events that override the sound pack
 
     """
+    if is_sound_event_muted(event, muted_events):
+        logger.debug(f"Skipping muted sound event: {event}")
+        return
+
     sound_file, volume = get_sound_entry(event, pack_dir)
     if not sound_file:
         logger.warning("Sound file not found.")
@@ -415,18 +461,26 @@ def play_sample_sound(pack_dir: str) -> None:
     play_notification_sound(DEFAULT_EVENT, pack_dir)
 
 
-def play_startup_sound(pack_dir: str = DEFAULT_PACK) -> None:
+def play_startup_sound(
+    pack_dir: str = DEFAULT_PACK, *, muted_events: Collection[str] | None = None
+) -> None:
     """Play the application startup sound."""
     try:
-        play_notification_sound("startup", pack_dir)
+        play_notification_sound("startup", pack_dir, muted_events=muted_events)
         logger.debug(f"Played startup sound from pack: {pack_dir}")
     except Exception as e:
         logger.debug(f"Failed to play startup sound: {e}")
 
 
-def play_exit_sound(pack_dir: str = DEFAULT_PACK) -> None:
+def play_exit_sound(
+    pack_dir: str = DEFAULT_PACK, *, muted_events: Collection[str] | None = None
+) -> None:
     """Play the application exit sound."""
     try:
+        if is_sound_event_muted("exit", muted_events):
+            logger.debug("Skipping muted sound event: exit")
+            return
+
         sound_file, volume = get_sound_entry("exit", pack_dir)
         logger.debug(
             "[packaging-diag] exit sound async: pack=%s file=%s exists=%s volume=%s sound_lib=%s playsound3=%s",
@@ -446,9 +500,15 @@ def play_exit_sound(pack_dir: str = DEFAULT_PACK) -> None:
         logger.debug(f"Failed to play exit sound: {e}")
 
 
-def play_exit_sound_blocking(pack_dir: str = DEFAULT_PACK) -> None:
+def play_exit_sound_blocking(
+    pack_dir: str = DEFAULT_PACK, *, muted_events: Collection[str] | None = None
+) -> None:
     """Play the application exit sound and wait for it to finish."""
     try:
+        if is_sound_event_muted("exit", muted_events):
+            logger.debug("Skipping muted sound event: exit")
+            return
+
         sound_file, volume = get_sound_entry("exit", pack_dir)
         logger.debug(
             "[packaging-diag] exit sound blocking: pack=%s file=%s exists=%s volume=%s sound_lib=%s playsound3=%s",
@@ -469,37 +529,45 @@ def play_exit_sound_blocking(pack_dir: str = DEFAULT_PACK) -> None:
         logger.debug(f"Failed to play exit sound: {e}")
 
 
-def play_error_sound(pack_dir: str = DEFAULT_PACK) -> None:
+def play_error_sound(
+    pack_dir: str = DEFAULT_PACK, *, muted_events: Collection[str] | None = None
+) -> None:
     """Play an error sound."""
     try:
-        play_notification_sound("error", pack_dir)
+        play_notification_sound("error", pack_dir, muted_events=muted_events)
         logger.debug(f"Played error sound from pack: {pack_dir}")
     except Exception as e:
         logger.debug(f"Failed to play error sound: {e}")
 
 
-def play_success_sound(pack_dir: str = DEFAULT_PACK) -> None:
+def play_success_sound(
+    pack_dir: str = DEFAULT_PACK, *, muted_events: Collection[str] | None = None
+) -> None:
     """Play a success sound."""
     try:
-        play_notification_sound("success", pack_dir)
+        play_notification_sound("success", pack_dir, muted_events=muted_events)
         logger.debug(f"Played success sound from pack: {pack_dir}")
     except Exception as e:
         logger.debug(f"Failed to play success sound: {e}")
 
 
-def play_data_updated_sound(pack_dir: str = DEFAULT_PACK) -> None:
+def play_data_updated_sound(
+    pack_dir: str = DEFAULT_PACK, *, muted_events: Collection[str] | None = None
+) -> None:
     """Play a sound when weather data is successfully refreshed."""
     try:
-        play_notification_sound("data_updated", pack_dir)
+        play_notification_sound("data_updated", pack_dir, muted_events=muted_events)
         logger.debug(f"Played data_updated sound from pack: {pack_dir}")
     except Exception as e:
         logger.debug(f"Failed to play data_updated sound: {e}")
 
 
-def play_fetch_error_sound(pack_dir: str = DEFAULT_PACK) -> None:
+def play_fetch_error_sound(
+    pack_dir: str = DEFAULT_PACK, *, muted_events: Collection[str] | None = None
+) -> None:
     """Play a sound when a weather data fetch fails."""
     try:
-        play_notification_sound("fetch_error", pack_dir)
+        play_notification_sound("fetch_error", pack_dir, muted_events=muted_events)
         logger.debug(f"Played fetch_error sound from pack: {pack_dir}")
     except Exception as e:
         logger.debug(f"Failed to play fetch_error sound: {e}")
@@ -663,7 +731,13 @@ def get_sound_file_for_candidates(candidates: list[str], pack_dir: str) -> Path 
     return sound_file
 
 
-def play_notification_sound_candidates(candidates: list[str], pack_dir: str) -> None:
+def play_notification_sound_candidates(
+    candidates: list[str],
+    pack_dir: str,
+    *,
+    logical_event: str | None = None,
+    muted_events: Collection[str] | None = None,
+) -> None:
     """
     Play the first available sound from a list of candidate event keys.
 
@@ -672,9 +746,23 @@ def play_notification_sound_candidates(candidates: list[str], pack_dir: str) -> 
     Args:
         candidates: List of event names to try in order
         pack_dir: The sound pack directory name
+        logical_event: Optional high-level event key used for mute checks before fallback
+        muted_events: Optional user-level muted events that override the sound pack
 
     """
-    sound_file, volume = get_sound_entry_for_candidates(candidates, pack_dir)
+    effective_event = logical_event or (candidates[0] if candidates else None)
+    if effective_event and is_sound_event_muted(effective_event, muted_events):
+        logger.debug(f"Skipping muted sound event: {effective_event}")
+        return
+
+    filtered_candidates = [
+        candidate for candidate in candidates if not is_sound_event_muted(candidate, muted_events)
+    ]
+    if not filtered_candidates:
+        logger.debug("All candidate sound events are muted; skipping playback")
+        return
+
+    sound_file, volume = get_sound_entry_for_candidates(filtered_candidates, pack_dir)
     if not sound_file:
         logger.warning("No candidate sound file found.")
         return

--- a/src/accessiweather/notifications/toast_notifier.py
+++ b/src/accessiweather/notifications/toast_notifier.py
@@ -17,7 +17,12 @@ import sys
 import threading
 
 from ..constants import WINDOWS_APP_USER_MODEL_ID
-from .sound_player import play_notification_sound, play_notification_sound_candidates
+from .sound_player import (
+    DEFAULT_MUTED_SOUND_EVENTS,
+    normalize_muted_sound_events,
+    play_notification_sound,
+    play_notification_sound_candidates,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +94,7 @@ class ToastedWindowsNotifier:
         app_name: str = "AccessiWeather",
         sound_enabled: bool = True,
         soundpack: str | None = None,
+        muted_sound_events: list[str] | None = None,
     ):
         """Initialize the Windows toasted notification backend."""
         self.app_name = app_name
@@ -97,6 +103,10 @@ class ToastedWindowsNotifier:
         # Sound configuration
         self.sound_enabled: bool = bool(sound_enabled)
         self.soundpack: str = soundpack or "default"
+        initial_muted_events = (
+            DEFAULT_MUTED_SOUND_EVENTS if muted_sound_events is None else muted_sound_events
+        )
+        self.muted_sound_events: list[str] = normalize_muted_sound_events(initial_muted_events)
 
         # Optional fallback callable (same contract as SafeDesktopNotifier)
         self.balloon_fn = None  # Optional[Callable[[str, str], None]]
@@ -299,10 +309,20 @@ class ToastedWindowsNotifier:
     def _play_sound(self, sound_event: str | None, sound_candidates: list[str] | None) -> None:
         """Play a notification sound."""
         try:
+            effective_event = sound_event or (sound_candidates[0] if sound_candidates else None)
             if sound_candidates:
-                play_notification_sound_candidates(sound_candidates, self.soundpack)
+                play_notification_sound_candidates(
+                    sound_candidates,
+                    self.soundpack,
+                    logical_event=effective_event,
+                    muted_events=self.muted_sound_events,
+                )
             else:
-                play_notification_sound(sound_event or "alert", self.soundpack)
+                play_notification_sound(
+                    sound_event or "alert",
+                    self.soundpack,
+                    muted_events=self.muted_sound_events,
+                )
         except Exception as e:
             logger.debug("Sound playback failed: %s", e)
 
@@ -327,6 +347,7 @@ class _DesktopNotifierBackend:
         app_name: str = "AccessiWeather",
         sound_enabled: bool = True,
         soundpack: str | None = None,
+        muted_sound_events: list[str] | None = None,
     ):
         self.app_name = app_name
         _log_packaging_notifier_diagnostics()
@@ -334,6 +355,10 @@ class _DesktopNotifierBackend:
         # Sound configuration
         self.sound_enabled: bool = bool(sound_enabled)
         self.soundpack: str = soundpack or "default"
+        initial_muted_events = (
+            DEFAULT_MUTED_SOUND_EVENTS if muted_sound_events is None else muted_sound_events
+        )
+        self.muted_sound_events: list[str] = normalize_muted_sound_events(initial_muted_events)
 
         # Optional fallback callable: balloon_fn(title, message) is called when the
         # WinRT/desktop-notifier toast fails (e.g. window hidden in system tray).
@@ -542,10 +567,20 @@ class _DesktopNotifierBackend:
     def _play_sound(self, sound_event: str | None, sound_candidates: list[str] | None) -> None:
         """Play a notification sound."""
         try:
+            effective_event = sound_event or (sound_candidates[0] if sound_candidates else None)
             if sound_candidates:
-                play_notification_sound_candidates(sound_candidates, self.soundpack)
+                play_notification_sound_candidates(
+                    sound_candidates,
+                    self.soundpack,
+                    logical_event=effective_event,
+                    muted_events=self.muted_sound_events,
+                )
             else:
-                play_notification_sound(sound_event or "alert", self.soundpack)
+                play_notification_sound(
+                    sound_event or "alert",
+                    self.soundpack,
+                    muted_events=self.muted_sound_events,
+                )
         except Exception as e:
             logger.debug("Sound playback failed: %s", e)
 
@@ -574,16 +609,26 @@ class SafeToastNotifier:
     best available backend (toasted on Windows, desktop-notifier elsewhere).
     """
 
-    def __init__(self, sound_enabled: bool = True, soundpack: str | None = None):
+    def __init__(
+        self,
+        sound_enabled: bool = True,
+        soundpack: str | None = None,
+        muted_sound_events: list[str] | None = None,
+    ):
         """Initialize the notification wrapper."""
         self.sound_enabled: bool = bool(sound_enabled)
         self.soundpack: str = soundpack if soundpack is not None else "default"
+        initial_muted_events = (
+            DEFAULT_MUTED_SOUND_EVENTS if muted_sound_events is None else muted_sound_events
+        )
+        self.muted_sound_events: list[str] = normalize_muted_sound_events(initial_muted_events)
         # Initialize underlying notifier with sound preferences
         if NOTIFIER_AVAILABLE:
             self._desktop_notifier = SafeDesktopNotifier(
                 app_name="AccessiWeather",
                 sound_enabled=self.sound_enabled,
                 soundpack=self.soundpack,
+                muted_sound_events=self.muted_sound_events,
             )
         else:
             self._desktop_notifier = None
@@ -624,7 +669,11 @@ class SafeToastNotifier:
                     sound_event = (
                         "alert" if str(alert_type).lower() in ("urgent", "alert") else "notify"
                     )
-                    play_notification_sound(sound_event, self.soundpack)
+                    play_notification_sound(
+                        sound_event,
+                        self.soundpack,
+                        muted_events=self.muted_sound_events,
+                    )
                 except Exception as e:
                     logger.error("Failed to play notification sound: %s", e)
 

--- a/src/accessiweather/ui/dialogs/settings_dialog.py
+++ b/src/accessiweather/ui/dialogs/settings_dialog.py
@@ -664,6 +664,28 @@ class SettingsDialogSimple(wx.Dialog):
         manage_btn.Bind(wx.EVT_BUTTON, self._on_manage_soundpacks)
         sizer.Add(manage_btn, 0, wx.LEFT | wx.TOP, 10)
 
+        sizer.Add(wx.StaticLine(panel), 0, wx.EXPAND | wx.ALL, 10)
+        sizer.Add(wx.StaticText(panel, label="Per-event sounds:"), 0, wx.LEFT | wx.BOTTOM, 5)
+        sizer.Add(
+            wx.StaticText(
+                panel,
+                label="These toggles override the selected sound pack. Weather refresh is off by default, and you can re-enable it here at any time.",
+            ),
+            0,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
+            10,
+        )
+
+        from ...notifications.sound_player import USER_MUTABLE_SOUND_EVENTS
+
+        self._event_sound_controls = {}
+        for event_key, label in USER_MUTABLE_SOUND_EVENTS:
+            control_key = f"sound_event_{event_key}"
+            checkbox = wx.CheckBox(panel, label=label)
+            self._controls[control_key] = checkbox
+            self._event_sound_controls[event_key] = checkbox
+            sizer.Add(checkbox, 0, wx.LEFT | wx.BOTTOM, 10)
+
         panel.SetSizer(sizer)
         self.notebook.AddPage(panel, "Audio")
 
@@ -1172,6 +1194,10 @@ class SettingsDialogSimple(wx.Dialog):
             except (ValueError, AttributeError):
                 self._controls["sound_pack"].SetSelection(0)
 
+            muted_sound_events = set(getattr(settings, "muted_sound_events", ["data_updated"]))
+            for event_key, control in getattr(self, "_event_sound_controls", {}).items():
+                control.SetValue(event_key not in muted_sound_events)
+
             # Updates tab
             self._controls["auto_update"].SetValue(getattr(settings, "auto_update_enabled", True))
             channel = getattr(settings, "update_channel", "stable")
@@ -1343,6 +1369,11 @@ class SettingsDialogSimple(wx.Dialog):
                 if hasattr(self, "_sound_pack_ids")
                 and self._controls["sound_pack"].GetSelection() < len(self._sound_pack_ids)
                 else "default",
+                "muted_sound_events": [
+                    event_key
+                    for event_key, control in getattr(self, "_event_sound_controls", {}).items()
+                    if not control.GetValue()
+                ],
                 # Updates
                 "auto_update_enabled": self._controls["auto_update"].GetValue(),
                 "update_channel": "stable"
@@ -1461,6 +1492,11 @@ class SettingsDialogSimple(wx.Dialog):
             "startup": "Launch automatically at startup",
             "weather_history": "Enable weather history comparisons",
         }
+
+        from ...notifications.sound_player import USER_MUTABLE_SOUND_EVENTS
+
+        for event_key, label in USER_MUTABLE_SOUND_EVENTS:
+            control_names[f"sound_event_{event_key}"] = label
 
         for key, name in control_names.items():
             self._controls[key].SetName(name)

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -636,6 +636,7 @@ class MainWindow(SizedFrame):
             app_name="AccessiWeather",
             sound_enabled=bool(getattr(settings, "sound_enabled", True)),
             soundpack=getattr(settings, "sound_pack", "default"),
+            muted_sound_events=getattr(settings, "muted_sound_events", ["data_updated"]),
         )
         sent = notifier.send_notification(
             title="NWS Discussion Updated",
@@ -1073,7 +1074,8 @@ class MainWindow(SizedFrame):
                     from accessiweather.notifications.sound_player import play_data_updated_sound
 
                     sound_pack = getattr(settings, "sound_pack", "default")
-                    play_data_updated_sound(sound_pack)
+                    muted_events = getattr(settings, "muted_sound_events", ["data_updated"])
+                    play_data_updated_sound(sound_pack, muted_events=muted_events)
             except Exception as sound_exc:
                 logger.debug(f"Failed to play data_updated sound: {sound_exc}")
 
@@ -1098,7 +1100,8 @@ class MainWindow(SizedFrame):
                 from accessiweather.notifications.sound_player import play_fetch_error_sound
 
                 sound_pack = getattr(settings, "sound_pack", "default")
-                play_fetch_error_sound(sound_pack)
+                muted_events = getattr(settings, "muted_sound_events", ["data_updated"])
+                play_fetch_error_sound(sound_pack, muted_events=muted_events)
         except Exception as sound_exc:
             logger.debug(f"Failed to play fetch_error sound: {sound_exc}")
 

--- a/tests/test_main_window_sounds.py
+++ b/tests/test_main_window_sounds.py
@@ -22,7 +22,7 @@ class TestMainWindowDataUpdatedSound:
         from accessiweather.models.config import AppSettings
 
         app = MagicMock()
-        settings = AppSettings(sound_enabled=True, sound_pack="default")
+        settings = AppSettings(sound_enabled=True, sound_pack="default", muted_sound_events=[])
         app.config_manager.get_settings.return_value = settings
         app.config_manager.get_current_location.return_value = MagicMock(name="Test Location")
         app.is_updating = True
@@ -35,7 +35,7 @@ class TestMainWindowDataUpdatedSound:
         from accessiweather.models.config import AppSettings
 
         app = MagicMock()
-        settings = AppSettings(sound_enabled=False, sound_pack="default")
+        settings = AppSettings(sound_enabled=False, sound_pack="default", muted_sound_events=[])
         app.config_manager.get_settings.return_value = settings
         app.config_manager.get_current_location.return_value = MagicMock(name="Test Location")
         app.is_updating = True
@@ -79,7 +79,7 @@ class TestMainWindowDataUpdatedSound:
         ) as mock_play:
             win._on_weather_data_received(weather_data)
 
-        mock_play.assert_called_once_with("default")
+        mock_play.assert_called_once_with("default", muted_events=[])
 
     def test_data_updated_sound_not_called_when_sound_disabled(self, mock_app_sound_disabled):
         """play_data_updated_sound is NOT called when sound_enabled=False."""
@@ -94,6 +94,20 @@ class TestMainWindowDataUpdatedSound:
 
         mock_play.assert_not_called()
 
+    def test_data_updated_sound_not_called_when_event_muted(self, mock_app):
+        """play_data_updated_sound is skipped when the event is muted."""
+        mock_app.config_manager.get_settings.return_value.muted_sound_events = ["data_updated"]
+        win = self._make_window(mock_app)
+        weather_data = MagicMock()
+        weather_data.alert_lifecycle_diff = None
+
+        with patch(
+            "accessiweather.notifications.sound_player.play_data_updated_sound"
+        ) as mock_play:
+            win._on_weather_data_received(weather_data)
+
+        mock_play.assert_called_once_with("default", muted_events=["data_updated"])
+
 
 class TestMainWindowFetchErrorSound:
     """Tests for fetch_error sound playback in _on_weather_error."""
@@ -104,7 +118,7 @@ class TestMainWindowFetchErrorSound:
         from accessiweather.models.config import AppSettings
 
         app = MagicMock()
-        settings = AppSettings(sound_enabled=True, sound_pack="default")
+        settings = AppSettings(sound_enabled=True, sound_pack="default", muted_sound_events=[])
         app.config_manager.get_settings.return_value = settings
         app.is_updating = True
         return app
@@ -115,7 +129,7 @@ class TestMainWindowFetchErrorSound:
         from accessiweather.models.config import AppSettings
 
         app = MagicMock()
-        settings = AppSettings(sound_enabled=False, sound_pack="default")
+        settings = AppSettings(sound_enabled=False, sound_pack="default", muted_sound_events=[])
         app.config_manager.get_settings.return_value = settings
         app.is_updating = True
         return app
@@ -139,7 +153,7 @@ class TestMainWindowFetchErrorSound:
         with patch("accessiweather.notifications.sound_player.play_fetch_error_sound") as mock_play:
             win._on_weather_error("Connection timed out")
 
-        mock_play.assert_called_once_with("default")
+        mock_play.assert_called_once_with("default", muted_events=[])
 
     def test_fetch_error_sound_not_called_when_sound_disabled(self, mock_app_sound_disabled):
         """play_fetch_error_sound is NOT called when sound_enabled=False."""
@@ -149,6 +163,16 @@ class TestMainWindowFetchErrorSound:
             win._on_weather_error("Connection timed out")
 
         mock_play.assert_not_called()
+
+    def test_fetch_error_sound_called_with_muted_events(self, mock_app):
+        """play_fetch_error_sound receives muted event overrides."""
+        mock_app.config_manager.get_settings.return_value.muted_sound_events = ["data_updated"]
+        win = self._make_window(mock_app)
+
+        with patch("accessiweather.notifications.sound_player.play_fetch_error_sound") as mock_play:
+            win._on_weather_error("Connection timed out")
+
+        mock_play.assert_called_once_with("default", muted_events=["data_updated"])
 
     def test_data_updated_sound_exception_is_swallowed(self, mock_app):
         """Exceptions from play_data_updated_sound must not propagate."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -343,6 +343,12 @@ class TestAppSettings:
         assert settings.forecast_duration_days == 7
         assert settings.forecast_time_reference == "location"
 
+    def test_default_muted_sound_events(self):
+        """Weather refresh sound is muted by default."""
+        settings = AppSettings()
+
+        assert settings.muted_sound_events == ["data_updated"]
+
     def test_custom_settings(self):
         """Test custom settings."""
         settings = AppSettings(
@@ -369,6 +375,23 @@ class TestAppSettings:
 
         assert settings.validate_on_access("forecast_duration_days") is True
         assert settings.forecast_duration_days == 7
+
+    def test_muted_sound_events_round_trip(self):
+        """Muted sound events should serialize and load cleanly."""
+        settings = AppSettings(muted_sound_events=["data_updated", "startup"])
+
+        restored = AppSettings.from_dict(settings.to_dict())
+        restored.validate_on_access("muted_sound_events")
+
+        assert restored.muted_sound_events == ["data_updated", "startup"]
+
+    def test_muted_sound_events_validation_filters_invalid_values(self):
+        """Muted sound events validation should normalize the stored list."""
+        settings = AppSettings(muted_sound_events=["data_updated"])
+        settings.muted_sound_events = ["data_updated", "", "data_updated", 123]  # type: ignore[list-item]
+
+        assert settings.validate_on_access("muted_sound_events") is True
+        assert settings.muted_sound_events == ["data_updated"]
 
 
 class TestAppConfig:

--- a/tests/test_settings_dialog_audio_events.py
+++ b/tests/test_settings_dialog_audio_events.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _load_settings_dialog_class():
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "accessiweather"
+        / "ui"
+        / "dialogs"
+        / "settings_dialog.py"
+    )
+    spec = importlib.util.spec_from_file_location("test_settings_dialog_audio_module", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.SettingsDialogSimple
+
+
+SettingsDialogSimple = _load_settings_dialog_class()
+
+
+class _DummyControl:
+    def __init__(self) -> None:
+        self._selection = 0
+        self._value = False
+
+    def SetSelection(self, value: int) -> None:
+        self._selection = value
+
+    def GetSelection(self) -> int:
+        return self._selection
+
+    def SetValue(self, value):
+        self._value = value
+
+    def GetValue(self):
+        return self._value
+
+    def SetName(self, _value: str) -> None:
+        return None
+
+    def __getattr__(self, _name: str):
+        return lambda *args, **kwargs: None
+
+
+class _Controls(dict):
+    def __missing__(self, key: str) -> _DummyControl:
+        value = _DummyControl()
+        self[key] = value
+        return value
+
+
+def _make_dialog(settings: SimpleNamespace) -> SettingsDialogSimple:
+    dialog = SettingsDialogSimple.__new__(SettingsDialogSimple)
+    dialog._controls = _Controls()
+    dialog._sound_pack_ids = ["default"]
+    dialog._selected_specific_model = None
+    dialog.config_manager = MagicMock()
+    dialog.config_manager.get_settings.return_value = settings
+    dialog.config_manager.update_settings.return_value = True
+    dialog._get_ai_model_preference = lambda: "openrouter/free"
+    dialog._event_sound_controls = {
+        "data_updated": dialog._controls["sound_event_data_updated"],
+        "fetch_error": dialog._controls["sound_event_fetch_error"],
+    }
+    return dialog
+
+
+def test_load_settings_marks_muted_events_as_unchecked():
+    dialog = _make_dialog(
+        SimpleNamespace(
+            sound_enabled=True,
+            sound_pack="default",
+            muted_sound_events=["data_updated"],
+        )
+    )
+
+    dialog._load_settings()
+
+    assert dialog._controls["sound_event_data_updated"].GetValue() is False
+    assert dialog._controls["sound_event_fetch_error"].GetValue() is True
+
+
+def test_save_settings_collects_unchecked_audio_events():
+    dialog = _make_dialog(SimpleNamespace())
+    dialog._controls["sound_enabled"].SetValue(True)
+    dialog._controls["sound_pack"].SetSelection(0)
+    dialog._controls["sound_event_data_updated"].SetValue(False)
+    dialog._controls["sound_event_fetch_error"].SetValue(True)
+
+    success = dialog._save_settings()
+
+    assert success is True
+    kwargs = dialog.config_manager.update_settings.call_args.kwargs
+    assert kwargs["muted_sound_events"] == ["data_updated"]

--- a/tests/test_sound_player.py
+++ b/tests/test_sound_player.py
@@ -794,3 +794,54 @@ class TestPlaySoundFileWithVolume:
             assert isinstance(result, bool)
         finally:
             temp_path.unlink(missing_ok=True)
+
+
+class TestUserLevelMute:
+    """Test user-level event muting in the sound player."""
+
+    def test_play_notification_sound_skips_muted_event(self):
+        """Muted events should never reach the playback backend."""
+        from accessiweather.notifications.sound_player import play_notification_sound
+
+        with patch("accessiweather.notifications.sound_player._play_sound_file") as mock_play:
+            play_notification_sound("data_updated", "default", muted_events=["data_updated"])
+
+        mock_play.assert_not_called()
+
+    def test_play_notification_sound_candidates_skips_muted_logical_event(self):
+        """Candidate playback should skip entirely when the logical event is muted."""
+        from accessiweather.notifications.sound_player import play_notification_sound_candidates
+
+        with patch("accessiweather.notifications.sound_player._play_sound_file") as mock_play:
+            play_notification_sound_candidates(
+                ["discussion_update", "notify"],
+                "default",
+                logical_event="discussion_update",
+                muted_events=["discussion_update"],
+            )
+
+        mock_play.assert_not_called()
+
+
+class TestSilentPlaybackBypassesFallback:
+    """Test that silent events do not leak through fallback backends."""
+
+    def test_volume_zero_returns_without_playsound(self):
+        """Volume zero should be treated as a silent no-op."""
+        from accessiweather.notifications.sound_player import _play_sound_file
+
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            temp_path = Path(f.name)
+
+        try:
+            with (
+                patch("accessiweather.notifications.sound_player.SOUND_LIB_AVAILABLE", False),
+                patch("accessiweather.notifications.sound_player.PLAYSOUND_AVAILABLE", True),
+                patch("accessiweather.notifications.sound_player.playsound") as mock_playsound,
+            ):
+                result = _play_sound_file(temp_path, volume=0.0)
+
+            assert result is True
+            mock_playsound.assert_not_called()
+        finally:
+            temp_path.unlink(missing_ok=True)

--- a/tests/test_toasted_windows_notifier.py
+++ b/tests/test_toasted_windows_notifier.py
@@ -94,7 +94,7 @@ class TestToastedWindowsNotifierSend:
         ):
             notifier = toast_notifier.ToastedWindowsNotifier(sound_enabled=True)
             notifier.send_notification("Title", "Body", play_sound=True)
-            mock_sound.assert_called_once_with("alert", "default")
+            mock_sound.assert_called_once_with("alert", "default", muted_events=["data_updated"])
 
     def test_send_skips_sound_when_play_sound_false(self):
         """When play_sound=False, no sound is played."""
@@ -114,7 +114,12 @@ class TestToastedWindowsNotifierSend:
         ):
             notifier = toast_notifier.ToastedWindowsNotifier(sound_enabled=True)
             notifier.send_notification("Title", "Body", sound_candidates=["alert", "notify"])
-            mock_candidates.assert_called_once_with(["alert", "notify"], "default")
+            mock_candidates.assert_called_once_with(
+                ["alert", "notify"],
+                "default",
+                logical_event="alert",
+                muted_events=["data_updated"],
+            )
 
     def test_balloon_fallback_called_on_failure(self):
         """When _send_in_worker fails, balloon_fn fallback is tried."""

--- a/tests/test_windows_app_user_model_id.py
+++ b/tests/test_windows_app_user_model_id.py
@@ -405,7 +405,9 @@ def test_request_exit_does_not_use_blocking_sound_in_frozen_build(monkeypatch):
     app = AccessiWeatherApp.__new__(AccessiWeatherApp)
     app._update_timer = None
     app.config_manager = SimpleNamespace(
-        get_settings=lambda: SimpleNamespace(sound_enabled=True, sound_pack="default")
+        get_settings=lambda: SimpleNamespace(
+            sound_enabled=True, sound_pack="default", muted_sound_events=[]
+        )
     )
     app.tray_icon = None
     app.single_instance_manager = None
@@ -428,6 +430,6 @@ def test_request_exit_does_not_use_blocking_sound_in_frozen_build(monkeypatch):
 
     app.request_exit()
 
-    mock_play_exit_sound.assert_called_once_with("default")
+    mock_play_exit_sound.assert_called_once_with("default", muted_events=[])
     mock_play_exit_sound_blocking.assert_not_called()
     app.ExitMainLoop.assert_called_once()


### PR DESCRIPTION
## Summary
- add a user-level `muted_sound_events` setting so event mutes apply regardless of the selected sound pack
- expose per-event sound toggles in `Settings > Audio`, with weather refresh sounds off by default but easy to re-enable
- stop muted and zero-volume events before backend fallback so `playsound3` never leaks audio for silent events
- thread muted-event overrides through startup, exit, refresh, fetch-error, and desktop notifier playback paths
- add focused model, settings dialog, sound player, notifier, main-window, and exit-sound tests

## Verification
- `ruff check src/accessiweather/models/config.py src/accessiweather/notifications/sound_player.py src/accessiweather/notifications/toast_notifier.py src/accessiweather/ui/dialogs/settings_dialog.py src/accessiweather/ui/main_window.py src/accessiweather/app.py src/accessiweather/app_initialization.py tests/test_sound_player.py tests/test_main_window_sounds.py tests/test_models.py tests/test_settings_dialog_audio_events.py tests/test_toasted_windows_notifier.py tests/test_windows_app_user_model_id.py`
- `TMPDIR=/tmp PYTHONDONTWRITEBYTECODE=1 pytest -q -s -p no:cacheprovider -n0 tests/test_sound_player.py tests/test_main_window_sounds.py tests/test_models.py tests/test_settings_dialog_audio_events.py tests/test_toasted_windows_notifier.py tests/test_windows_app_user_model_id.py`

## Notes
- Focused pytest still emits the existing `RuntimeWarning` from `ToastedWindowsNotifier._send_in_worker` in `tests/test_windows_app_user_model_id.py`; the suite otherwise passes cleanly.