### PR TITLE
fix(updater): clean up wx before applying update and skip lock prompt on restart

### DIFF
--- a/src/accessiweather/__main__.py
+++ b/src/accessiweather/__main__.py
@@ -43,6 +43,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Force the onboarding wizard to run even if it has already been shown",
     )
+    parser.add_argument(
+        "--updated",
+        action="store_true",
+        help="Skip lock-file prompt (set automatically after an update restart)",
+    )
     return parser.parse_args()
 
 
@@ -62,6 +67,7 @@ def main() -> None:
         fake_version=args.fake_version,
         fake_nightly=args.fake_nightly,
         force_wizard=args.wizard,
+        updated=args.updated,
     )
 
 

--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -449,6 +449,7 @@ class AccessiWeatherApp(wx.App):
         portable_mode: bool = False,
         debug: bool = False,
         force_wizard: bool = False,
+        updated: bool = False,
     ):
         """
         Initialize the AccessiWeather application.
@@ -458,8 +459,10 @@ class AccessiWeatherApp(wx.App):
             portable_mode: If True, use portable mode (config in app directory)
             debug: If True, enable debug mode (enables debug logging and extra UI tools)
             force_wizard: If True, force the onboarding wizard even if already shown
+            updated: If True, skip lock-file prompt (app was restarted after an update)
 
         """
+        self._updated = updated
         self._config_dir = config_dir
 
         # Auto-detect portable mode for frozen builds unless explicitly overridden
@@ -558,9 +561,15 @@ class AccessiWeatherApp(wx.App):
             # Check for single instance
             self.single_instance_manager = SingleInstanceManager(self)
             if not self.single_instance_manager.try_acquire_lock():
-                logger.info("Another instance is already running, showing force start dialog")
-                if not self._show_force_start_dialog():
-                    return False
+                if self._updated:
+                    # After an update restart the old lock file is stale; force-acquire it
+                    logger.info("Post-update restart: forcing lock acquisition")
+                    self.single_instance_manager.force_remove_lock()
+                    self.single_instance_manager.try_acquire_lock()
+                else:
+                    logger.info("Another instance is already running, showing force start dialog")
+                    if not self._show_force_start_dialog():
+                        return False
 
             # Start async event loop in background thread
             self._start_async_loop()
@@ -1426,6 +1435,11 @@ class AccessiWeatherApp(wx.App):
                     )
                     if result == wx.YES:
                         portable = is_portable_mode()
+                        # Destroy all wx windows so file handles are released before exit
+                        for win in wx.GetTopLevelWindows():
+                            with contextlib.suppress(Exception):
+                                win.Destroy()
+                        wx.SafeYield()
                         apply_update(update_path, portable=portable)
 
                 wx.CallAfter(confirm_apply)
@@ -1628,6 +1642,7 @@ def main(
     fake_version: str | None = None,
     fake_nightly: str | None = None,
     force_wizard: bool = False,
+    updated: bool = False,
 ):
     """
     Run AccessiWeather application.
@@ -1639,6 +1654,7 @@ def main(
         fake_version: Fake version for testing updates (e.g., '0.1.0').
         fake_nightly: Fake nightly tag for testing updates (e.g., 'nightly-20250101').
         force_wizard: Force the onboarding wizard even if already shown.
+        updated: Skip lock-file prompt (app was restarted after an update).
 
     """
     if config_dir is None:
@@ -1657,6 +1673,7 @@ def main(
         portable_mode=portable_mode,
         debug=debug,
         force_wizard=force_wizard,
+        updated=updated,
     )
 
     # Override version/build_tag for update testing

--- a/src/accessiweather/main.py
+++ b/src/accessiweather/main.py
@@ -50,6 +50,11 @@ def main() -> None:
         action="store_true",
         help="Force the onboarding wizard to run even if it has already been shown",
     )
+    parser.add_argument(
+        "--updated",
+        action="store_true",
+        help="Skip lock-file prompt (set automatically after an update restart)",
+    )
     args = parser.parse_args()
 
     setup_logging(debug=args.debug)
@@ -63,6 +68,7 @@ def main() -> None:
         fake_version=args.fake_version,
         fake_nightly=args.fake_nightly,
         force_wizard=args.wizard,
+        updated=args.updated,
     )
 
 

--- a/src/accessiweather/services/simple_update.py
+++ b/src/accessiweather/services/simple_update.py
@@ -378,7 +378,7 @@ def build_macos_update_script(
             cp -R /Volumes/*/*.app "{app_dir}/"
             hdiutil detach /Volumes/* -quiet
         fi
-        open "{app_path}"
+        open "{app_path}" --args --updated
         rm -f "$0" "{update_path}"
         """
     ).strip()
@@ -420,7 +420,7 @@ def build_portable_update_script(
         rd /s /q "%EXTRACT_DIR%"
         del "%ZIP_PATH%"
         timeout /t 2 /nobreak >NUL
-        start "" "%EXE_PATH%"
+        start "" "%EXE_PATH%" --updated
         (goto) 2>nul & del "%~f0"
         """
     ).strip()


### PR DESCRIPTION
Fixes two auto-updater bugs:

- Destroy all top-level wx windows and call SafeYield before applying update, so file handles are released before the installer/extract script runs
- Add `--updated` CLI flag to skip the stuck lock file prompt on a clean update restart