### PR TITLE
fix(alerts): skip stale-new notifications on first load and suppress false cancel+reissue pairs

### DIFF
--- a/src/accessiweather/alert_lifecycle.py
+++ b/src/accessiweather/alert_lifecycle.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 
 from accessiweather.constants import SEVERITY_PRIORITY_MAP
@@ -148,6 +148,22 @@ def _build_summary(
     return ", ".join(parts) if parts else "No changes"
 
 
+def _alert_is_recently_issued(alert: WeatherAlert | None, max_age_minutes: int = 10) -> bool:
+    """Return True only if the alert was issued within *max_age_minutes*."""
+    if alert is None:
+        return True  # no alert object → assume new to be safe
+    effective_dt = alert.effective or alert.onset
+    if effective_dt is None:
+        return True  # no timestamp → assume new
+    try:
+        now = datetime.now(UTC)
+        if effective_dt.tzinfo is None:
+            effective_dt = effective_dt.replace(tzinfo=UTC)
+        return (now - effective_dt) <= timedelta(minutes=max_age_minutes)
+    except Exception:
+        return True  # parse error → assume new to be safe
+
+
 def diff_alerts(
     previous: WeatherAlerts | None,
     current: WeatherAlerts | None,
@@ -249,6 +265,34 @@ def diff_alerts(
                     title=alert.title or "",
                 )
             )
+
+    # Bug fix 1: On first load (previous is None), suppress "New" notifications
+    # for alerts that have been active for more than 10 minutes. They silently
+    # enter the known-set without firing notifications.
+    if previous is None:
+        new_changes = [c for c in new_changes if _alert_is_recently_issued(c.alert)]
+
+    # Bug fix 2: Suppress false "cancelled" notifications when NWS cancels and
+    # reissues an alert with a new ID. If a cancelled alert and a new alert share
+    # the same event type AND have overlapping areas, treat it as an in-place
+    # reissue — suppress the cancel notification, keep the new alert.
+    suppressed_cancel_ids: set[str] = set()
+    for cancelled in cancelled_changes:
+        cancelled_alert = prev_map.get(cancelled.alert_id)
+        if not cancelled_alert:
+            continue
+        for new_change in new_changes:
+            new_alert = new_change.alert
+            if new_alert is None:
+                continue
+            if (
+                (cancelled_alert.event or "").lower() == (new_alert.event or "").lower()
+                and cancelled_alert.event is not None
+                and set(cancelled_alert.areas or []) & set(new_alert.areas or [])
+            ):
+                suppressed_cancel_ids.add(cancelled.alert_id)
+                break
+    cancelled_changes = [c for c in cancelled_changes if c.alert_id not in suppressed_cancel_ids]
 
     summary = _build_summary(
         new_changes, updated_changes, escalated_changes, extended_changes, cancelled_changes

--- a/tests/test_alert_lifecycle.py
+++ b/tests/test_alert_lifecycle.py
@@ -8,6 +8,7 @@ from accessiweather.alert_lifecycle import (
     AlertChange,
     AlertChangeKind,
     AlertLifecycleDiff,
+    _alert_is_recently_issued,
     compute_lifecycle_labels,
     diff_alerts,
 )
@@ -449,3 +450,230 @@ class TestComputeLifecycleLabels:
         }
         assert "nws-c" not in labels
         assert "vc-1" not in labels
+
+
+# ---------------------------------------------------------------------------
+# Bug fix: first-load stale alerts should not fire "New" notifications
+# ---------------------------------------------------------------------------
+
+
+class TestDiffAlertsFirstLoadStaleFilter:
+    def test_first_load_old_alerts_not_new(self):
+        """Alerts active for hours should not appear as NEW on first load."""
+        old_alert = WeatherAlert(
+            title="Heat Advisory",
+            description="Excessive heat.",
+            severity="Moderate",
+            urgency="Expected",
+            id="ha1",
+            effective=datetime.now(UTC) - timedelta(hours=2),
+        )
+        diff = diff_alerts(None, alerts(old_alert))
+        assert len(diff.new_alerts) == 0
+
+    def test_first_load_recent_alerts_are_new(self):
+        """Alerts issued within 10 minutes should appear as NEW on first load."""
+        recent_alert = WeatherAlert(
+            title="Tornado Warning",
+            description="Take shelter.",
+            severity="Extreme",
+            urgency="Immediate",
+            id="tw1",
+            effective=datetime.now(UTC) - timedelta(minutes=3),
+        )
+        diff = diff_alerts(None, alerts(recent_alert))
+        assert len(diff.new_alerts) == 1
+        assert diff.new_alerts[0].alert_id == "tw1"
+
+    def test_first_load_no_effective_assumes_new(self):
+        """Alert without effective/onset timestamps should be treated as new."""
+        alert = make_alert("Unknown Alert", alert_id="ua1")
+        diff = diff_alerts(None, alerts(alert))
+        assert len(diff.new_alerts) == 1
+
+    def test_second_load_old_alert_still_detected(self):
+        """With a real previous snapshot (empty), old alerts should be detected as NEW."""
+        old_alert = WeatherAlert(
+            title="Heat Advisory",
+            description="Excessive heat.",
+            severity="Moderate",
+            urgency="Expected",
+            id="ha1",
+            effective=datetime.now(UTC) - timedelta(hours=2),
+        )
+        # previous is an empty WeatherAlerts, NOT None — the filter doesn't apply
+        diff = diff_alerts(alerts(), alerts(old_alert))
+        assert len(diff.new_alerts) == 1
+
+    def test_first_load_mixed_old_and_new(self):
+        """Only recent alerts fire notifications; old ones silently enter known-set."""
+        old_alert = WeatherAlert(
+            title="Heat Advisory",
+            description="Excessive heat.",
+            severity="Moderate",
+            urgency="Expected",
+            id="ha1",
+            effective=datetime.now(UTC) - timedelta(hours=5),
+        )
+        recent_alert = WeatherAlert(
+            title="Tornado Warning",
+            description="Take shelter.",
+            severity="Extreme",
+            urgency="Immediate",
+            id="tw1",
+            effective=datetime.now(UTC) - timedelta(minutes=2),
+        )
+        diff = diff_alerts(None, alerts(old_alert, recent_alert))
+        assert len(diff.new_alerts) == 1
+        assert diff.new_alerts[0].alert_id == "tw1"
+
+
+# ---------------------------------------------------------------------------
+# Bug fix: cancel+reissue suppression
+# ---------------------------------------------------------------------------
+
+
+class TestDiffAlertsCancelReissueSuppression:
+    def test_cancel_reissue_same_event_overlapping_areas_suppresses_cancel(self):
+        """Cancel+reissue with same event and overlapping areas suppresses cancel."""
+        old_alert = WeatherAlert(
+            title="Flood Warning",
+            description="Flooding expected.",
+            severity="Severe",
+            urgency="Immediate",
+            id="old-flood-1",
+            event="Flood Warning",
+            areas=["County A", "County B"],
+        )
+        new_alert = WeatherAlert(
+            title="Flood Warning",
+            description="Updated flooding info.",
+            severity="Severe",
+            urgency="Immediate",
+            id="new-flood-2",
+            event="Flood Warning",
+            areas=["County B", "County C"],
+        )
+        diff = diff_alerts(alerts(old_alert), alerts(new_alert))
+        # Cancel should be suppressed, new alert should remain
+        assert len(diff.cancelled_alerts) == 0
+        assert len(diff.new_alerts) == 1
+        assert diff.new_alerts[0].alert_id == "new-flood-2"
+
+    def test_cancel_different_event_not_suppressed(self):
+        """Cancel for a different event type should NOT be suppressed."""
+        old_alert = WeatherAlert(
+            title="Flood Warning",
+            description="Flooding expected.",
+            severity="Severe",
+            urgency="Immediate",
+            id="old-flood-1",
+            event="Flood Warning",
+            areas=["County A"],
+        )
+        new_alert = WeatherAlert(
+            title="Tornado Warning",
+            description="Tornado spotted.",
+            severity="Extreme",
+            urgency="Immediate",
+            id="new-tornado-1",
+            event="Tornado Warning",
+            areas=["County A"],
+        )
+        diff = diff_alerts(alerts(old_alert), alerts(new_alert))
+        assert len(diff.cancelled_alerts) == 1
+        assert len(diff.new_alerts) == 1
+
+    def test_cancel_no_overlapping_areas_not_suppressed(self):
+        """Cancel with same event but no overlapping areas should NOT be suppressed."""
+        old_alert = WeatherAlert(
+            title="Flood Warning",
+            description="Flooding expected.",
+            severity="Severe",
+            urgency="Immediate",
+            id="old-flood-1",
+            event="Flood Warning",
+            areas=["County A"],
+        )
+        new_alert = WeatherAlert(
+            title="Flood Warning",
+            description="Different area flooding.",
+            severity="Severe",
+            urgency="Immediate",
+            id="new-flood-2",
+            event="Flood Warning",
+            areas=["County X"],
+        )
+        diff = diff_alerts(alerts(old_alert), alerts(new_alert))
+        assert len(diff.cancelled_alerts) == 1
+        assert len(diff.new_alerts) == 1
+
+    def test_cancel_reissue_with_none_event_not_suppressed(self):
+        """Alerts with None event should not match for suppression."""
+        old_alert = WeatherAlert(
+            title="Some Alert",
+            description="Something.",
+            severity="Moderate",
+            urgency="Expected",
+            id="old-1",
+            event=None,
+            areas=["County A"],
+        )
+        new_alert = WeatherAlert(
+            title="Some Alert",
+            description="Something new.",
+            severity="Moderate",
+            urgency="Expected",
+            id="new-1",
+            event=None,
+            areas=["County A"],
+        )
+        diff = diff_alerts(alerts(old_alert), alerts(new_alert))
+        # Both have event=None → should NOT be suppressed (guard clause)
+        assert len(diff.cancelled_alerts) == 1
+
+
+# ---------------------------------------------------------------------------
+# _alert_is_recently_issued helper
+# ---------------------------------------------------------------------------
+
+
+class TestAlertIsRecentlyIssued:
+    def test_recent_alert_returns_true(self):
+        alert = WeatherAlert(
+            title="Test",
+            description="Test",
+            effective=datetime.now(UTC) - timedelta(minutes=5),
+        )
+        assert _alert_is_recently_issued(alert) is True
+
+    def test_old_alert_returns_false(self):
+        alert = WeatherAlert(
+            title="Test",
+            description="Test",
+            effective=datetime.now(UTC) - timedelta(hours=1),
+        )
+        assert _alert_is_recently_issued(alert) is False
+
+    def test_no_timestamps_returns_true(self):
+        alert = WeatherAlert(title="Test", description="Test")
+        assert _alert_is_recently_issued(alert) is True
+
+    def test_none_alert_returns_true(self):
+        assert _alert_is_recently_issued(None) is True
+
+    def test_onset_used_when_no_effective(self):
+        alert = WeatherAlert(
+            title="Test",
+            description="Test",
+            onset=datetime.now(UTC) - timedelta(hours=2),
+        )
+        assert _alert_is_recently_issued(alert) is False
+
+    def test_naive_datetime_treated_as_utc(self):
+        alert = WeatherAlert(
+            title="Test",
+            description="Test",
+            effective=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2),
+        )
+        assert _alert_is_recently_issued(alert) is False


### PR DESCRIPTION
Fixes two alert notification bugs:

- On first load or location switch (previous=None), alerts older than 10 minutes are not marked as New — suppresses spurious notifications for hours-old alerts
- When NWS cancels and reissues an alert with a new ID (same event + overlapping areas), the cancel notification is suppressed and the new alert is kept as-is