### PR TITLE
feat(alerts): conditional GET caching and hardcoded 60s poll interval

### DIFF
--- a/src/accessiweather/api/nws/alerts_discussions.py
+++ b/src/accessiweather/api/nws/alerts_discussions.py
@@ -5,8 +5,12 @@ This module handles weather alerts, forecast discussions, and national
 weather products from various centers.
 """
 
+from __future__ import annotations
+
 import logging
 from typing import Any, cast
+
+import httpx
 
 from accessiweather.api_client import ApiClientError, NoaaApiError
 from accessiweather.weather_gov_api_client.api.default import alerts_active, alerts_active_zone
@@ -27,6 +31,53 @@ class NwsAlertsDiscussions:
 
         """
         self.wrapper = wrapper_instance
+        # Conditional GET state for alert polling
+        self._alert_etag: str | None = None
+        self._alert_last_modified: str | None = None
+        self._cached_alert_response: dict[str, Any] | None = None
+
+    def reset_conditional_cache(self) -> None:
+        """Reset conditional GET cache state (e.g. when location changes)."""
+        self._alert_etag = None
+        self._alert_last_modified = None
+        self._cached_alert_response = None
+
+    def _fetch_alerts_conditional(self, url: str) -> dict[str, Any]:
+        """
+        Fetch alerts using HTTP conditional GET (ETag / Last-Modified).
+
+        On 304 Not Modified, returns the previously cached response.
+        On 200, stores new ETag/Last-Modified headers and caches the response.
+        Gracefully degrades when the server omits caching headers.
+        """
+        self.wrapper._rate_limit()
+
+        headers = {"User-Agent": f"{self.wrapper.user_agent} ({self.wrapper.contact_info})"}
+        if self._alert_etag:
+            headers["If-None-Match"] = self._alert_etag
+        if self._alert_last_modified:
+            headers["If-Modified-Since"] = self._alert_last_modified
+
+        with httpx.Client(timeout=httpx.Timeout(10.0), follow_redirects=True) as client:
+            response = client.get(url, headers=headers)
+
+            if response.status_code == 304 and self._cached_alert_response is not None:
+                logger.debug("Alerts not modified (304), returning cached data")
+                return self._cached_alert_response
+
+            response.raise_for_status()
+
+            # Store conditional GET headers for next request
+            etag = response.headers.get("ETag")
+            last_modified = response.headers.get("Last-Modified")
+            if etag:
+                self._alert_etag = etag
+            if last_modified:
+                self._alert_last_modified = last_modified
+
+            data = response.json()
+            self._cached_alert_response = data
+            return data
 
     def get_alerts(
         self,
@@ -69,10 +120,9 @@ class NwsAlertsDiscussions:
                 )
 
                 def fetch_data() -> dict[str, Any]:
-                    self.wrapper._rate_limit()
                     try:
                         url = f"{self.wrapper.core_client.BASE_URL}/alerts/active?point={lat},{lon}"
-                        response = self.wrapper._fetch_url(url)
+                        response = self._fetch_alerts_conditional(url)
                         return self._transform_alerts_data(response)
                     except Exception as e:
                         logger.error(f"Error getting alerts for point ({lat}, {lon}): {str(e)}")
@@ -129,12 +179,11 @@ class NwsAlertsDiscussions:
                 cache_key = self.wrapper._generate_cache_key("alerts_state", {"state": location_id})
 
                 def fetch_data() -> dict[str, Any]:
-                    self.wrapper._rate_limit()
                     try:
                         url = (
                             f"{self.wrapper.core_client.BASE_URL}/alerts/active?area={location_id}"
                         )
-                        response = self.wrapper._fetch_url(url)
+                        response = self._fetch_alerts_conditional(url)
                         return self._transform_alerts_data(response)
                     except Exception as e:
                         logger.error(f"Error getting alerts for state {location_id}: {str(e)}")
@@ -158,10 +207,9 @@ class NwsAlertsDiscussions:
                 )
 
                 def fetch_data() -> dict[str, Any]:
-                    self.wrapper._rate_limit()
                     try:
                         url = f"{self.wrapper.core_client.BASE_URL}/alerts/active?point={lat},{lon}&radius={radius}"
-                        response = self.wrapper._fetch_url(url)
+                        response = self._fetch_alerts_conditional(url)
                         return self._transform_alerts_data(response)
                     except Exception as e:
                         logger.error(f"Error getting alerts for point ({lat}, {lon}): {str(e)}")

--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -1491,12 +1491,13 @@ class AccessiWeatherApp(wx.App):
     def _start_background_updates(self) -> None:
         """Start split background timers for full refreshes and lightweight event checks."""
         try:
+            from .constants import ALERT_POLL_INTERVAL_SECONDS
+
             self._stop_background_updates()
             settings = self.config_manager.get_settings()
             interval_minutes = getattr(settings, "update_interval_minutes", 10)
-            event_interval_minutes = getattr(settings, "event_check_interval_minutes", 2)
             interval_ms = interval_minutes * 60 * 1000
-            event_interval_ms = event_interval_minutes * 60 * 1000
+            event_interval_ms = ALERT_POLL_INTERVAL_SECONDS * 1000
 
             self._update_timer = wx.Timer()
             self._update_timer.Bind(wx.EVT_TIMER, self._on_background_update)
@@ -1507,9 +1508,9 @@ class AccessiWeatherApp(wx.App):
             self._event_check_timer.Start(event_interval_ms)
 
             logger.info(
-                "Background updates started (weather every %s minutes, events every %s minutes)",
+                "Background updates started (weather every %s minutes, events every %ss)",
                 interval_minutes,
-                event_interval_minutes,
+                ALERT_POLL_INTERVAL_SECONDS,
             )
         except Exception as e:
             logger.error(f"Failed to start background updates: {e}")

--- a/src/accessiweather/constants.py
+++ b/src/accessiweather/constants.py
@@ -64,6 +64,7 @@ WINDOWS_APP_USER_MODEL_ID = "Orinks.AccessiWeather"
 
 # Default values for intervals
 UPDATE_INTERVAL = 15  # Default update interval in minutes
+ALERT_POLL_INTERVAL_SECONDS = 60  # Fixed alert polling interval (not user-configurable)
 
 # Validation limits
 MIN_UPDATE_INTERVAL = 1

--- a/src/accessiweather/models/config.py
+++ b/src/accessiweather/models/config.py
@@ -40,7 +40,6 @@ NON_CRITICAL_SETTINGS: set[str] = {
     # Event notifications
     "notify_discussion_update",
     "notify_severe_risk_change",
-    "event_check_interval_minutes",
     # GitHub settings
     "github_backend_url",
     "github_app_id",
@@ -115,7 +114,6 @@ class AppSettings:
     # Event-based notifications
     notify_discussion_update: bool = True
     notify_severe_risk_change: bool = False
-    event_check_interval_minutes: int = 2
     github_backend_url: str = ""
     github_app_id: str = ""
     github_app_private_key: str = ""
@@ -399,7 +397,6 @@ class AppSettings:
             "show_nationwide_location": self.show_nationwide_location,
             "notify_discussion_update": self.notify_discussion_update,
             "notify_severe_risk_change": self.notify_severe_risk_change,
-            "event_check_interval_minutes": self.event_check_interval_minutes,
             "github_backend_url": self.github_backend_url,
             "alert_radius_type": self.alert_radius_type,
             "alert_notifications_enabled": self.alert_notifications_enabled,
@@ -475,7 +472,6 @@ class AppSettings:
             show_nationwide_location=cls._as_bool(data.get("show_nationwide_location"), True),
             notify_discussion_update=cls._as_bool(data.get("notify_discussion_update"), True),
             notify_severe_risk_change=cls._as_bool(data.get("notify_severe_risk_change"), False),
-            event_check_interval_minutes=data.get("event_check_interval_minutes", 2),
             github_backend_url=data.get("github_backend_url", ""),
             alert_radius_type=data.get("alert_radius_type", "county"),
             alert_notifications_enabled=cls._as_bool(data.get("alert_notifications_enabled"), True),

--- a/src/accessiweather/ui/dialogs/settings_dialog.py
+++ b/src/accessiweather/ui/dialogs/settings_dialog.py
@@ -473,18 +473,6 @@ class SettingsDialogSimple(wx.Dialog):
         self._controls["alert_notif"] = wx.CheckBox(panel, label="Enable alert notifications")
         sizer.Add(self._controls["alert_notif"], 0, wx.LEFT | wx.BOTTOM, 5)
 
-        # Alert check interval
-        row_check_interval = wx.BoxSizer(wx.HORIZONTAL)
-        row_check_interval.Add(
-            wx.StaticText(panel, label="Alert Check Interval (minutes):"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-        self._controls["event_check_interval"] = wx.SpinCtrl(panel, min=1, max=60, initial=2)
-        row_check_interval.Add(self._controls["event_check_interval"], 0)
-        sizer.Add(row_check_interval, 0, wx.ALL, 5)
-
         # Alert area setting
         row_area = wx.BoxSizer(wx.HORIZONTAL)
         row_area.Add(
@@ -1246,9 +1234,6 @@ class SettingsDialogSimple(wx.Dialog):
             self._controls["update_interval"].SetValue(
                 getattr(settings, "update_interval_minutes", 10)
             )
-            self._controls["event_check_interval"].SetValue(
-                getattr(settings, "event_check_interval_minutes", 2)
-            )
             self._controls["show_nationwide"].SetValue(
                 getattr(self.config_manager.get_settings(), "show_nationwide_location", True)
             )
@@ -1513,7 +1498,6 @@ class SettingsDialogSimple(wx.Dialog):
             settings_dict = {
                 # General
                 "update_interval_minutes": self._controls["update_interval"].GetValue(),
-                "event_check_interval_minutes": self._controls["event_check_interval"].GetValue(),
                 "show_nationwide_location": show_nationwide,
                 "taskbar_icon_text_enabled": self._controls["taskbar_icon_text_enabled"].GetValue(),
                 "taskbar_icon_dynamic_enabled": self._controls[
@@ -1651,7 +1635,6 @@ class SettingsDialogSimple(wx.Dialog):
         """Set up accessibility labels for controls."""
         control_names = {
             "update_interval": "Update Interval (minutes)",
-            "event_check_interval": "Alert Check Interval (minutes)",
             "show_nationwide": "Show Nationwide location (requires Auto or NWS data source)",
             "taskbar_icon_text_enabled": "Show weather text on tray icon",
             "taskbar_icon_dynamic_enabled": "Update tray text dynamically",

--- a/tests/test_alerts_conditional_get.py
+++ b/tests/test_alerts_conditional_get.py
@@ -1,0 +1,187 @@
+"""Tests for conditional GET (ETag / Last-Modified) in NWS alert polling."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from accessiweather.api.nws.alerts_discussions import NwsAlertsDiscussions
+
+
+@pytest.fixture()
+def discussions():
+    """Create a NwsAlertsDiscussions instance with a mocked wrapper."""
+    wrapper = MagicMock()
+    wrapper.user_agent = "TestAgent"
+    wrapper.contact_info = "test@example.com"
+    wrapper.core_client.BASE_URL = "https://api.weather.gov"
+    return NwsAlertsDiscussions(wrapper)
+
+
+def _mock_response(status_code=200, json_data=None, headers=None):
+    """Build a mock httpx.Response."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.headers = httpx.Headers(headers or {})
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+class TestConditionalGet:
+    """Tests for _fetch_alerts_conditional."""
+
+    def test_first_request_stores_etag_and_last_modified(self, discussions):
+        resp = _mock_response(
+            200,
+            json_data={"features": []},
+            headers={"ETag": '"abc123"', "Last-Modified": "Wed, 11 Mar 2026 12:00:00 GMT"},
+        )
+        with patch("accessiweather.api.nws.alerts_discussions.httpx.Client") as mock_client_cls:
+            mock_client_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock(get=MagicMock(return_value=resp))
+            )
+            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = discussions._fetch_alerts_conditional(
+                "https://api.weather.gov/alerts/active?point=40,-90"
+            )
+
+        assert result == {"features": []}
+        assert discussions._alert_etag == '"abc123"'
+        assert discussions._alert_last_modified == "Wed, 11 Mar 2026 12:00:00 GMT"
+        assert discussions._cached_alert_response == {"features": []}
+
+    def test_304_returns_cached_data(self, discussions):
+        # Pre-populate cached state
+        discussions._alert_etag = '"abc123"'
+        discussions._alert_last_modified = "Wed, 11 Mar 2026 12:00:00 GMT"
+        discussions._cached_alert_response = {"features": [{"id": "cached"}]}
+
+        resp = _mock_response(304)
+        with patch("accessiweather.api.nws.alerts_discussions.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.get.return_value = resp
+            mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = discussions._fetch_alerts_conditional(
+                "https://api.weather.gov/alerts/active?point=40,-90"
+            )
+
+        assert result == {"features": [{"id": "cached"}]}
+        # Verify conditional headers were sent
+        call_args = mock_client.get.call_args
+        headers = call_args[1].get("headers", call_args[0][1] if len(call_args[0]) > 1 else {})
+        if isinstance(headers, dict):
+            assert headers.get("If-None-Match") == '"abc123"'
+            assert headers.get("If-Modified-Since") == "Wed, 11 Mar 2026 12:00:00 GMT"
+
+    def test_subsequent_request_sends_conditional_headers(self, discussions):
+        # Pre-populate cached state
+        discussions._alert_etag = '"etag-value"'
+        discussions._alert_last_modified = "Mon, 09 Mar 2026 08:00:00 GMT"
+        discussions._cached_alert_response = {"features": []}
+
+        resp = _mock_response(
+            200,
+            json_data={"features": [{"id": "new"}]},
+            headers={"ETag": '"etag-new"', "Last-Modified": "Wed, 11 Mar 2026 14:00:00 GMT"},
+        )
+        with patch("accessiweather.api.nws.alerts_discussions.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.get.return_value = resp
+            mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = discussions._fetch_alerts_conditional(
+                "https://api.weather.gov/alerts/active?point=40,-90"
+            )
+
+        # Verify conditional headers sent
+        call_kwargs = mock_client.get.call_args[1]
+        sent_headers = call_kwargs["headers"]
+        assert sent_headers["If-None-Match"] == '"etag-value"'
+        assert sent_headers["If-Modified-Since"] == "Mon, 09 Mar 2026 08:00:00 GMT"
+
+        # Verify new data is returned and cached
+        assert result == {"features": [{"id": "new"}]}
+        assert discussions._alert_etag == '"etag-new"'
+        assert discussions._alert_last_modified == "Wed, 11 Mar 2026 14:00:00 GMT"
+        assert discussions._cached_alert_response == {"features": [{"id": "new"}]}
+
+    def test_graceful_degradation_no_caching_headers(self, discussions):
+        """When server returns 200 without ETag/Last-Modified, conditional GET state is not set."""
+        resp = _mock_response(200, json_data={"features": [{"id": "fresh"}]}, headers={})
+        with patch("accessiweather.api.nws.alerts_discussions.httpx.Client") as mock_client_cls:
+            mock_client_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock(get=MagicMock(return_value=resp))
+            )
+            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = discussions._fetch_alerts_conditional(
+                "https://api.weather.gov/alerts/active?point=40,-90"
+            )
+
+        assert result == {"features": [{"id": "fresh"}]}
+        assert discussions._alert_etag is None
+        assert discussions._alert_last_modified is None
+        # Response is still cached for potential future 304
+        assert discussions._cached_alert_response == {"features": [{"id": "fresh"}]}
+
+    def test_first_request_no_conditional_headers_sent(self, discussions):
+        """First request should not include If-None-Match or If-Modified-Since."""
+        resp = _mock_response(200, json_data={"features": []}, headers={})
+        with patch("accessiweather.api.nws.alerts_discussions.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.get.return_value = resp
+            mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            discussions._fetch_alerts_conditional(
+                "https://api.weather.gov/alerts/active?point=40,-90"
+            )
+
+        call_kwargs = mock_client.get.call_args[1]
+        sent_headers = call_kwargs["headers"]
+        assert "If-None-Match" not in sent_headers
+        assert "If-Modified-Since" not in sent_headers
+
+    def test_reset_conditional_cache(self, discussions):
+        """reset_conditional_cache clears all conditional GET state."""
+        discussions._alert_etag = '"abc"'
+        discussions._alert_last_modified = "some date"
+        discussions._cached_alert_response = {"features": []}
+
+        discussions.reset_conditional_cache()
+
+        assert discussions._alert_etag is None
+        assert discussions._alert_last_modified is None
+        assert discussions._cached_alert_response is None
+
+
+class TestHardcodedAlertPollInterval:
+    """Test that alert poll interval uses the constant."""
+
+    def test_constant_value(self):
+        from accessiweather.constants import ALERT_POLL_INTERVAL_SECONDS
+
+        assert ALERT_POLL_INTERVAL_SECONDS == 60
+
+    def test_event_check_interval_removed_from_settings(self):
+        """event_check_interval_minutes should not be on AppSettings."""
+        from accessiweather.models.config import AppSettings
+
+        assert not hasattr(AppSettings(), "event_check_interval_minutes")
+
+    def test_old_config_with_event_check_interval_loads_without_error(self):
+        """Configs with the removed key should load silently."""
+        from accessiweather.models.config import AppSettings
+
+        old_config = {"event_check_interval_minutes": 5, "update_interval_minutes": 10}
+        settings = AppSettings.from_dict(old_config)
+        assert settings.update_interval_minutes == 10
+        # The old key is silently ignored
+        assert not hasattr(settings, "event_check_interval_minutes")

--- a/tests/test_split_update_timers.py
+++ b/tests/test_split_update_timers.py
@@ -16,7 +16,6 @@ def test_start_background_updates_uses_split_intervals(monkeypatch):
     app.config_manager = MagicMock()
     app.config_manager.get_settings.return_value = SimpleNamespace(
         update_interval_minutes=60,
-        event_check_interval_minutes=2,
     )
 
     weather_timer = MagicMock()
@@ -30,7 +29,10 @@ def test_start_background_updates_uses_split_intervals(monkeypatch):
     weather_timer.Bind.assert_called_once_with(wx.EVT_TIMER, app._on_background_update)
     weather_timer.Start.assert_called_once_with(60 * 60 * 1000)
     event_timer.Bind.assert_called_once_with(wx.EVT_TIMER, app._on_event_check_update)
-    event_timer.Start.assert_called_once_with(2 * 60 * 1000)
+    # Alert poll interval is hardcoded to 60 seconds
+    from accessiweather.constants import ALERT_POLL_INTERVAL_SECONDS
+
+    event_timer.Start.assert_called_once_with(ALERT_POLL_INTERVAL_SECONDS * 1000)
 
 
 def test_request_exit_stops_weather_and_event_timers():


### PR DESCRIPTION
## Summary
- Implements HTTP conditional GET for NWS alert polling using ETag/Last-Modified headers
- Handles 304 Not Modified by returning cached alert data
- Hardcodes alert poll interval to 60 seconds (removes user-configurable setting)
- Graceful degradation when server does not return caching headers

## Changes
- NWS alert client: cache ETag/Last-Modified, send If-None-Match/If-Modified-Since on subsequent requests
- 304 handling: skip parsing, return cached alerts
- ALERT_POLL_INTERVAL_SECONDS = 60 constant replaces config-driven interval
- Settings dialog: removed alert interval UI control
- Config: removed alert interval key from defaults; existing configs with old key load without error

## Tests
- Test 304 response handling
- Test conditional GET headers sent on subsequent requests
- Test graceful degradation (no caching headers from server)
- Updated/removed tests for removed setting