### PR TITLE
fix: keep public release notes user-facing

### DIFF
--- a/.github/scripts/extract_release_notes.py
+++ b/.github/scripts/extract_release_notes.py
@@ -1,0 +1,179 @@
+"""Extract curated public release notes from CHANGELOG.md."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+INTERNAL_BULLET_PATTERN = re.compile(
+    r"(?i)\b("
+    r"ci|coverage|test(?:s|ing)?|workflow|cron|refactor|internal|developer-facing|"
+    r"docs?|documentation|antfarm|release note|changelog"
+    r")\b"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Extract a user-facing release note section from CHANGELOG.md."
+    )
+    parser.add_argument(
+        "--changelog",
+        type=Path,
+        default=Path("CHANGELOG.md"),
+        help="Path to the changelog file.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("nightly", "stable"),
+        required=True,
+        help="Section to extract: nightly uses 'Unreleased', stable uses a version heading.",
+    )
+    parser.add_argument(
+        "--version",
+        help="Stable version to extract (required when --mode=stable).",
+    )
+    parser.add_argument(
+        "--default-message",
+        required=True,
+        help="Fallback text when the requested section is missing or empty.",
+    )
+    return parser.parse_args()
+
+
+def _extract_section(lines: list[str], heading_pattern: re.Pattern[str]) -> str | None:
+    start_index: int | None = None
+    for index, line in enumerate(lines):
+        if heading_pattern.match(line):
+            start_index = index + 1
+            break
+
+    if start_index is None:
+        return None
+
+    section_lines: list[str] = []
+    for line in lines[start_index:]:
+        if line.startswith("## "):
+            break
+        section_lines.append(line)
+
+    return "\n".join(section_lines).strip()
+
+
+def _is_internal_bullet(line: str) -> bool:
+    stripped = line.lstrip()
+    if not stripped.startswith("- "):
+        return False
+    return bool(INTERNAL_BULLET_PATTERN.search(stripped[2:]))
+
+
+def sanitize_release_notes(section: str) -> str:
+    if not section.strip():
+        return ""
+
+    output_lines: list[str] = []
+    pending_heading: str | None = None
+    pending_block: list[str] = []
+    skip_nested_bullets = False
+
+    def flush_heading() -> None:
+        nonlocal pending_heading, pending_block
+        if pending_heading and pending_block:
+            if output_lines and output_lines[-1] != "":
+                output_lines.append("")
+            output_lines.append(pending_heading)
+            output_lines.extend(pending_block)
+        pending_heading = None
+        pending_block = []
+
+    for line in section.splitlines():
+        stripped = line.strip()
+
+        if line.startswith("### "):
+            flush_heading()
+            pending_heading = line
+            skip_nested_bullets = False
+            continue
+
+        if not stripped:
+            if pending_heading:
+                if pending_block and pending_block[-1] != "":
+                    pending_block.append("")
+            elif output_lines and output_lines[-1] != "":
+                output_lines.append("")
+            skip_nested_bullets = False
+            continue
+
+        if stripped == "---":
+            skip_nested_bullets = False
+            continue
+
+        if _is_internal_bullet(line):
+            skip_nested_bullets = True
+            continue
+
+        if skip_nested_bullets and line.startswith(("  - ", "    - ", "\t- ")):
+            continue
+
+        skip_nested_bullets = False
+        if pending_heading:
+            pending_block.append(line)
+        else:
+            output_lines.append(line)
+
+    flush_heading()
+    return "\n".join(output_lines).strip()
+
+
+def extract_release_notes(
+    changelog_text: str,
+    *,
+    mode: str,
+    version: str | None = None,
+) -> str | None:
+    lines = changelog_text.splitlines()
+
+    if mode == "nightly":
+        pattern = re.compile(r"^##\s+Unreleased\s*$")
+        section = _extract_section(lines, pattern)
+        return sanitize_release_notes(section or "")
+
+    if not version:
+        raise ValueError("Stable mode requires a version.")
+
+    normalized_version = version.removeprefix("v")
+    pattern = re.compile(
+        rf"^##\s+\[{re.escape(normalized_version)}\](?:\s+-\s+.+)?\s*$"
+    )
+    section = _extract_section(lines, pattern)
+    return sanitize_release_notes(section or "")
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        changelog_text = args.changelog.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"Failed to read changelog: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        notes = extract_release_notes(
+            changelog_text,
+            mode=args.mode,
+            version=args.version,
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    output = notes.strip() if notes else args.default_message.strip()
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,7 +28,8 @@ This directory contains the GitHub Actions workflows for AccessiWeather. Below i
 
 **What it does**:
 - Builds Windows installer + portable ZIP and macOS DMG
-- Creates nightly or stable GitHub releases
+- Creates nightly or stable GitHub releases using curated `CHANGELOG.md`
+  sections for the public release notes
 - Triggers GitHub Pages refresh after a successful release
 
 ---

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,23 +213,19 @@ jobs:
           # Generate checksums
           cd assets && sha256sum * > checksums.txt 2>/dev/null || true
 
-          # Generate release notes via git-cliff (nightly and stable)
+          # Public release notes come from curated CHANGELOG.md sections.
           cd ..
           if [ "$IS_NIGHTLY" = "true" ]; then
-            LAST_TAG=$(git tag --list "nightly-*" --sort=-version:refname | head -1)
-            if [ -n "$LAST_TAG" ]; then
-              npx git-cliff@latest "$LAST_TAG"..HEAD --strip all > notes.md.tmp || true
-              awk '!seen[$0]++' notes.md.tmp > notes.md && rm -f notes.md.tmp
-              [ -s notes.md ] || echo "- No user-facing changes" > notes.md
-            else
-              echo "Initial nightly build" > notes.md
-            fi
+            python3 .github/scripts/extract_release_notes.py \
+              --mode nightly \
+              --changelog CHANGELOG.md \
+              --default-message "- No user-facing changes." > notes.md
           else
-            npx git-cliff@latest --latest --ignore-tags "nightly-.*" --strip all > notes.md.tmp || true
-            awk '!seen[$0]++' notes.md.tmp > notes.md && rm -f notes.md.tmp
-            if [ ! -s notes.md ]; then
-              echo "See [CHANGELOG.md](https://github.com/Orinks/AccessiWeather/blob/main/CHANGELOG.md) for full release notes." > notes.md
-            fi
+            python3 .github/scripts/extract_release_notes.py \
+              --mode stable \
+              --version "$VERSION" \
+              --changelog CHANGELOG.md \
+              --default-message "See [CHANGELOG.md](https://github.com/Orinks/AccessiWeather/blob/main/CHANGELOG.md) for full release notes." > notes.md
           fi
 
       - name: Create release

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,4 +1,6 @@
 # git-cliff configuration for AccessiWeather
+# Internal note: public nightly/stable GitHub release notes come from curated
+# CHANGELOG.md sections. This config is only for changelog maintenance workflows.
 # https://git-cliff.org/docs/configuration
 # Format: Keep a Changelog (https://keepachangelog.com/en/1.0.0/)
 

--- a/tests/test_extract_release_notes.py
+++ b/tests/test_extract_release_notes.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_module():
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / ".github"
+        / "scripts"
+        / "extract_release_notes.py"
+    )
+    spec = importlib.util.spec_from_file_location("extract_release_notes", script_path)
+    module = importlib.util.module_from_spec(spec)
+    try:
+        assert spec and spec.loader
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(spec.name, None)
+    return module
+
+
+SAMPLE_CHANGELOG = """# AccessiWeather Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### Added
+- Added clearer update summaries
+- Added a new update download flow
+
+### Fixed
+- Fixed installer wording shown to users
+- Improved CI coverage gate behavior
+- Added missing tests for release note extraction
+
+## [0.4.4] - 2026-03-13
+
+### Fixed
+- Fixed alert wording in the update dialog
+- Updated workflow docs
+
+## [0.4.3] - 2026-02-11
+
+### Added
+- Older stable notes
+"""
+
+
+def test_extract_nightly_uses_unreleased_section():
+    module = load_module()
+
+    notes = module.extract_release_notes(SAMPLE_CHANGELOG, mode="nightly")
+
+    assert notes == (
+        "### Added\n"
+        "- Added clearer update summaries\n"
+        "- Added a new update download flow\n\n"
+        "### Fixed\n"
+        "- Fixed installer wording shown to users"
+    )
+
+
+def test_extract_stable_uses_matching_version_section():
+    module = load_module()
+
+    notes = module.extract_release_notes(SAMPLE_CHANGELOG, mode="stable", version="0.4.4")
+
+    assert notes == "### Fixed\n- Fixed alert wording in the update dialog"
+
+
+def test_extract_stable_accepts_v_prefix():
+    module = load_module()
+
+    notes = module.extract_release_notes(SAMPLE_CHANGELOG, mode="stable", version="v0.4.3")
+
+    assert notes == "### Added\n- Older stable notes"
+
+
+def test_extract_stable_requires_version():
+    module = load_module()
+
+    try:
+        module.extract_release_notes(SAMPLE_CHANGELOG, mode="stable")
+    except ValueError as exc:
+        assert str(exc) == "Stable mode requires a version."
+    else:
+        raise AssertionError("Expected ValueError when stable mode has no version")
+
+
+def test_extract_returns_none_when_section_missing():
+    module = load_module()
+
+    notes = module.extract_release_notes(SAMPLE_CHANGELOG, mode="stable", version="9.9.9")
+
+    assert notes == ""


### PR DESCRIPTION
## Summary
- stop generating public GitHub release notes from raw commit subjects
- extract nightly notes from CHANGELOG.md's Unreleased section and stable notes from the matching version section
- apply a lightweight filter so obvious CI/test/internal bullets do not reach nightly or stable public notes

## Testing
- pytest -q tests/test_extract_release_notes.py tests/test_wordpress_release_page.py
