### PR TITLE
refactor: use Open-Meteo for extended forecasts instead of NWS+OM stitching (#481)

### DIFF
--- a/src/accessiweather/weather_client_base.py
+++ b/src/accessiweather/weather_client_base.py
@@ -287,6 +287,17 @@ class WeatherClient:
             self._get_openmeteo_hourly_forecast(location),
         )
 
+    def _should_use_openmeteo_for_extended_forecast(
+        self, location: Location, source: str | None = None
+    ) -> bool:
+        """Use Open-Meteo for full-range forecasts when NWS-style sources exceed 7 days."""
+        normalized_source = (source or self.data_source).strip().lower()
+        if normalized_source not in {"nws", "pw", "auto"}:
+            return False
+        if not self._is_us_location(location):
+            return False
+        return self._get_forecast_days_for_source(location, "openmeteo") > 7
+
     async def close(self) -> None:
         """Close the HTTP client and release resources."""
         if self._http_client is not None and not self._http_client.is_closed:
@@ -590,14 +601,31 @@ class WeatherClient:
         else:
             # Use NWS API only (user explicitly selected this source)
             try:
-                (
-                    current,
-                    forecast,
-                    discussion,
-                    discussion_issuance_time,
-                    alerts,
-                    hourly_forecast,
-                ) = await self._fetch_nws_data(location)
+                use_openmeteo_forecast = self._should_use_openmeteo_for_extended_forecast(
+                    location, source="nws"
+                )
+
+                if use_openmeteo_forecast:
+                    current_task = asyncio.create_task(self._get_nws_current_conditions(location))
+                    forecast_task = asyncio.create_task(self._get_openmeteo_forecast(location))
+                    discussion_task = asyncio.create_task(self._get_nws_discussion_only(location))
+                    alerts_task = asyncio.create_task(self._get_nws_alerts(location))
+                    hourly_task = asyncio.create_task(self._get_nws_hourly_forecast(location))
+
+                    current = await current_task
+                    forecast = await forecast_task
+                    discussion, discussion_issuance_time = await discussion_task
+                    alerts = await alerts_task
+                    hourly_forecast = await hourly_task
+                else:
+                    (
+                        current,
+                        forecast,
+                        discussion,
+                        discussion_issuance_time,
+                        alerts,
+                        hourly_forecast,
+                    ) = await self._fetch_nws_data(location)
 
                 weather_data.current = current
                 weather_data.forecast = forecast
@@ -618,7 +646,13 @@ class WeatherClient:
 
                 # Set source attribution for single-source mode
                 weather_data.source_attribution = SourceAttribution(
-                    contributing_sources={"nws"},
+                    field_sources={
+                        "forecast_source": "openmeteo" if use_openmeteo_forecast else "nws",
+                        "hourly_source": "nws",
+                    },
+                    contributing_sources={"nws", "openmeteo"}
+                    if use_openmeteo_forecast
+                    else {"nws"},
                 )
 
                 if (current is None or not current.has_data()) and forecast is None:
@@ -778,9 +812,17 @@ class WeatherClient:
 
         # Build source attribution
         attribution = SourceAttribution(
-            field_sources=current_attribution.field_sources,
+            field_sources={
+                **current_attribution.field_sources,
+                **forecast_attribution,
+                **hourly_attribution,
+            },
             conflicts=current_attribution.conflicts,
-            contributing_sources=current_attribution.contributing_sources,
+            contributing_sources=(
+                current_attribution.contributing_sources
+                | set(forecast_attribution.values())
+                | set(hourly_attribution.values())
+            ),
             failed_sources=current_attribution.failed_sources,
         )
 

--- a/src/accessiweather/weather_client_fusion.py
+++ b/src/accessiweather/weather_client_fusion.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import fields, replace
-from datetime import date
+from dataclasses import fields
 from typing import Any
 
 from accessiweather.config.source_priority import SourcePriorityConfig
@@ -200,37 +199,6 @@ class DataFusionEngine:
                         f"selected {selected_source}={selected_value}"
                     )
 
-    def _max_forecast_date(self, forecast: Forecast) -> date | None:
-        dated = [p.start_time.date() for p in forecast.periods if p.start_time is not None]
-        return max(dated) if dated else None
-
-    def _append_openmeteo_tail_for_us(
-        self, nws_forecast: Forecast, openmeteo_forecast: Forecast
-    ) -> Forecast:
-        """Append Open-Meteo daily periods strictly after NWS horizon for US auto mode."""
-        nws_max_date = self._max_forecast_date(nws_forecast)
-        if nws_max_date is None:
-            return nws_forecast
-
-        tail_periods = [
-            p
-            for p in openmeteo_forecast.periods
-            if p.start_time is not None and p.start_time.date() > nws_max_date
-        ]
-        if not tail_periods:
-            return nws_forecast
-
-        # Label the first appended period so users can hear where extended data starts.
-        first_tail = tail_periods[0]
-        marker = "Extended outlook (Open-Meteo): "
-        if not (first_tail.name or "").startswith(marker):
-            tail_periods[0] = replace(first_tail, name=f"{marker}{first_tail.name or 'Day 8+'}")
-
-        return Forecast(
-            periods=[*nws_forecast.periods, *tail_periods],
-            generated_at=nws_forecast.generated_at or openmeteo_forecast.generated_at,
-        )
-
     def merge_forecasts(
         self,
         sources: list[SourceData],
@@ -265,10 +233,14 @@ class DataFusionEngine:
             return None, field_sources
 
         # Select single source based on location (no merging to avoid duplicates)
-        # US: prefer NWS > Open-Meteo > Visual Crossing
+        # US: prefer NWS for 7-day forecasts, Open-Meteo for extended ranges
         # International: prefer Open-Meteo > Visual Crossing
         if is_us:
-            preferred_order = ["nws", "openmeteo", "visualcrossing"]
+            preferred_order = (
+                ["openmeteo", "nws", "visualcrossing"]
+                if requested_days > 7
+                else ["nws", "openmeteo", "visualcrossing"]
+            )
         else:
             preferred_order = ["openmeteo", "visualcrossing"]
 
@@ -286,19 +258,9 @@ class DataFusionEngine:
         if not selected_source:
             selected_source = valid_sources[0]
 
-        # Use the selected source's forecast directly (no merging)
+        # Use the selected source's forecast directly (no merging / stitching).
         forecast = selected_source.forecast
         source_name = selected_source.source
-
-        # In US auto mode, allow Open-Meteo to fill forecast tail beyond NWS horizon.
-        # This enables >7 day outlooks while preserving NWS for near-term periods.
-        if is_us and source_name == "nws" and requested_days > 7 and forecast is not None:
-            openmeteo_source = next((s for s in valid_sources if s.source == "openmeteo"), None)
-            if openmeteo_source and openmeteo_source.forecast is not None:
-                extended = self._append_openmeteo_tail_for_us(forecast, openmeteo_source.forecast)
-                if len(extended.periods) > len(forecast.periods):
-                    forecast = extended
-                    source_name = "nws+openmeteo-tail"
 
         # Track attribution
         field_sources["forecast_source"] = source_name

--- a/tests/test_weather_client.py
+++ b/tests/test_weather_client.py
@@ -347,6 +347,55 @@ class TestWeatherClientHelpers:
         assert client._get_forecast_days_for_source(us_location, "openmeteo") == 15
         assert client._get_forecast_days_for_source(us_location, "visualcrossing") == 15
 
+    def test_extended_nws_forecasts_switch_to_openmeteo_for_us(self):
+        """US NWS-style requests over 7 days should use Open-Meteo forecasts."""
+        client = WeatherClient(settings=AppSettings(forecast_duration_days=15))
+        us_location = Location(name="NYC", latitude=40.7128, longitude=-74.0060, country_code="US")
+        intl_location = Location(
+            name="London", latitude=51.5074, longitude=-0.1278, country_code="GB"
+        )
+
+        assert client._should_use_openmeteo_for_extended_forecast(us_location, "nws") is True
+        assert client._should_use_openmeteo_for_extended_forecast(us_location, "pw") is True
+        assert client._should_use_openmeteo_for_extended_forecast(us_location, "auto") is True
+        assert client._should_use_openmeteo_for_extended_forecast(intl_location, "nws") is False
+        assert client._should_use_openmeteo_for_extended_forecast(us_location, "openmeteo") is False
+
+
+class TestWeatherClientExtendedForecastRouting:
+    """Tests for extended forecast provider routing."""
+
+    @pytest.mark.asyncio
+    async def test_explicit_nws_uses_openmeteo_for_extended_forecast(self):
+        settings = AppSettings(forecast_duration_days=15)
+        client = WeatherClient(data_source="nws", settings=settings)
+        location = Location(name="NYC", latitude=40.7128, longitude=-74.0060, country_code="US")
+        current = CurrentConditions(temperature_f=72.0, condition="Sunny")
+        forecast = Forecast(
+            periods=[ForecastPeriod(name=f"Day {i}", temperature=70 + i) for i in range(1, 16)]
+        )
+        hourly_forecast = MagicMock()
+        alerts = WeatherAlerts(alerts=[])
+        client._get_nws_current_conditions = AsyncMock(return_value=current)
+        client._get_openmeteo_forecast = AsyncMock(return_value=forecast)
+        client._get_nws_discussion_only = AsyncMock(return_value=("NWS discussion", None))
+        client._get_nws_alerts = AsyncMock(return_value=alerts)
+        client._get_nws_hourly_forecast = AsyncMock(return_value=hourly_forecast)
+        client._fetch_nws_data = AsyncMock()
+        client._fetch_nws_cancel_references = AsyncMock(return_value=set())
+        client._launch_enrichment_tasks = MagicMock(return_value={})
+        client._await_enrichments = AsyncMock()
+
+        data = await client.get_weather_data(location)
+
+        assert data.forecast is forecast
+        assert data.current is current
+        assert data.source_attribution is not None
+        assert data.source_attribution.field_sources["forecast_source"] == "openmeteo"
+        assert data.source_attribution.contributing_sources == {"nws", "openmeteo"}
+        client._get_openmeteo_forecast.assert_awaited_once_with(location)
+        client._fetch_nws_data.assert_not_called()
+
 
 class TestWeatherClientContextManager:
     """Tests for async context manager."""

--- a/tests/test_weather_client_fusion.py
+++ b/tests/test_weather_client_fusion.py
@@ -367,16 +367,14 @@ class TestMergeForecasts:
         result, field_sources = engine.merge_forecasts(sources, us_location)
         assert field_sources["forecast_source"] == "openmeteo"
 
-    def test_us_auto_appends_openmeteo_tail_when_requested_days_exceed_seven(
-        self, engine, us_location
-    ):
+    def test_us_extended_forecast_prefers_openmeteo_full_range(self, engine, us_location):
         start = datetime(2026, 2, 1, tzinfo=UTC)
         nws_periods = [
             ForecastPeriod(name=f"NWS {i}", start_time=start + timedelta(hours=12 * i))
             for i in range(14)
         ]
         om_periods = [
-            ForecastPeriod(name=f"OM {i}", start_time=start + timedelta(days=i)) for i in range(16)
+            ForecastPeriod(name=f"OM {i}", start_time=start + timedelta(days=i)) for i in range(15)
         ]
         sources = [
             _make_source("nws", forecast=Forecast(periods=nws_periods)),
@@ -386,11 +384,8 @@ class TestMergeForecasts:
         result, field_sources = engine.merge_forecasts(sources, us_location, requested_days=15)
 
         assert result is not None
-        assert len(result.periods) > len(nws_periods)
-        assert field_sources["forecast_source"] == "nws+openmeteo-tail"
-        assert any(
-            (p.name or "").startswith("Extended outlook (Open-Meteo):") for p in result.periods
-        )
+        assert result.periods == om_periods
+        assert field_sources["forecast_source"] == "openmeteo"
 
 
 # --- merge_hourly_forecasts ---


### PR DESCRIPTION
## Summary

Replaces the NWS 7-day + Open-Meteo tail stitching hack with a cleaner approach: when extended forecasts are requested (>7 days), use Open-Meteo directly for the full range.

## Changes
- When `forecast_days > 7` and source is NWS or PW (which max at 7 days), delegate to Open-Meteo for the full period
- Removed the NWS+Open-Meteo stitching logic from the fusion engine
- Open-Meteo supports up to 16 days with no API key
- Updated tests to reflect the cleaner behavior

Closes #481