### PR TITLE
feat: add Pirate Weather API key to onboarding wizard and portable setup (#482)

### DIFF
--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -410,7 +410,7 @@ class AccessiWeatherApp(wx.App):
         dialog = wx.MessageDialog(
             self.main_window,
             "This portable copy has no API keys yet.\n\n"
-            "Visual Crossing weather provider keys can be entered in Settings > Data Sources. "
+            "Visual Crossing and Pirate Weather provider keys can be entered in Settings > Data Sources. "
             "OpenRouter AI keys can be entered in Settings > AI.\n\n"
             "You can also create an encrypted key bundle to carry your keys with the portable install.",
             "Portable setup hint",
@@ -506,6 +506,7 @@ class AccessiWeatherApp(wx.App):
             f"- Location configured: {self._onboarding_status_text(bool(config.locations))}",
             f"- OpenRouter key set: {self._onboarding_status_text(self._has_saved_api_key('openrouter_api_key'))}",
             f"- Visual Crossing weather provider key set: {self._onboarding_status_text(self._has_saved_api_key('visual_crossing_api_key'))}",
+            f"- Pirate Weather provider key set: {self._onboarding_status_text(self._has_saved_api_key('pirate_weather_api_key'))}",
             *(
                 [
                     f"- Portable key bundle created: {self._onboarding_status_text(self._portable_keys_imported_this_session)}"
@@ -530,7 +531,7 @@ class AccessiWeatherApp(wx.App):
             self._run_deferred_startup_update_check()
             return
 
-        total_steps = 4 if self._portable_mode else 3
+        total_steps = 5 if self._portable_mode else 4
 
         step1 = wx.MessageDialog(
             self.main_window,
@@ -592,10 +593,23 @@ class AccessiWeatherApp(wx.App):
             else:
                 _wizard_keys["visual_crossing_api_key"] = visual_crossing_key
 
+        pirate_weather_key = self._prompt_optional_secret_with_link(
+            "Pirate Weather provider key (optional)",
+            f"Step 4 of {total_steps}: Enter your Pirate Weather provider key now, or leave blank to skip.",
+            "https://pirateweather.net/",
+            "Get Pirate Weather provider key",
+        )
+        if pirate_weather_key is not None and pirate_weather_key:
+            if not self._portable_mode:
+                self.config_manager.update_settings(pirate_weather_api_key=pirate_weather_key)
+                self._maybe_offer_test_key_now("Pirate Weather provider key")
+            else:
+                _wizard_keys["pirate_weather_api_key"] = pirate_weather_key
+
         if self._portable_mode and _wizard_keys:
             # Keys were entered — prompt for passphrase and write bundle directly.
             passphrase = self._prompt_optional_secret(
-                "Step 4 of 4: Secure your API keys",
+                "Step 5 of 5: Secure your API keys",
                 "Enter a passphrase to encrypt your API keys into a portable bundle.\n"
                 "This bundle travels with the app so your keys work on any machine.\n\n"
                 "Leave blank to skip (keys will not be saved).",

--- a/src/accessiweather/config/config_manager.py
+++ b/src/accessiweather/config/config_manager.py
@@ -173,10 +173,15 @@ class ConfigManager:
         # In portable mode, API keys live in the bundle — not in keyring.
         # Only load non-API-key secrets (e.g. GitHub app credentials) from keyring.
         is_portable = getattr(self.app, "_portable_mode", False)
-        portable_api_keys = {"visual_crossing_api_key", "openrouter_api_key"}
+        portable_api_keys = {
+            "visual_crossing_api_key",
+            "pirate_weather_api_key",
+            "openrouter_api_key",
+        }
 
         secure_keys = [
             "visual_crossing_api_key",
+            "pirate_weather_api_key",
             "openrouter_api_key",
             "github_app_id",
             "github_app_private_key",

--- a/src/accessiweather/config/import_export.py
+++ b/src/accessiweather/config/import_export.py
@@ -24,6 +24,7 @@ logger = logging.getLogger("accessiweather.config")
 
 PORTABLE_API_SECRET_KEYS: Final[tuple[str, ...]] = (
     "visual_crossing_api_key",
+    "pirate_weather_api_key",
     "openrouter_api_key",
 )
 

--- a/src/accessiweather/config/settings.py
+++ b/src/accessiweather/config/settings.py
@@ -179,11 +179,16 @@ class SettingsOperations:
         config = self._manager.get_config()
         # In portable mode, API keys live in the bundle — skip keyring writes for them.
         is_portable = getattr(self._manager.app, "_portable_mode", False)
-        portable_api_keys = {"visual_crossing_api_key", "openrouter_api_key"}
+        portable_api_keys = {
+            "visual_crossing_api_key",
+            "pirate_weather_api_key",
+            "openrouter_api_key",
+        }
 
         # These keys should be stored in SecureStorage (non-portable, or non-API-key secrets)
         secure_keys = {
             "visual_crossing_api_key",
+            "pirate_weather_api_key",
             "openrouter_api_key",
             "github_app_id",
             "github_app_private_key",
@@ -192,7 +197,12 @@ class SettingsOperations:
         if is_portable:
             secure_keys -= portable_api_keys
         # These keys should be redacted in logs
-        redacted_keys = {"github_app_private_key", "visual_crossing_api_key", "openrouter_api_key"}
+        redacted_keys = {
+            "github_app_private_key",
+            "visual_crossing_api_key",
+            "pirate_weather_api_key",
+            "openrouter_api_key",
+        }
 
         for key, value in kwargs.items():
             if hasattr(config.settings, key):

--- a/src/accessiweather/models/config.py
+++ b/src/accessiweather/models/config.py
@@ -53,6 +53,7 @@ NON_CRITICAL_SETTINGS: set[str] = {
     "custom_system_prompt",
     "custom_instructions",
     # API key settings (loaded lazily via keyring)
+    "pirate_weather_api_key",
     "visual_crossing_api_key",
     # Display preferences
     "round_values",
@@ -104,6 +105,7 @@ class AppSettings:
     startup_enabled: bool = False
     data_source: str = "auto"
     visual_crossing_api_key: str = ""
+    pirate_weather_api_key: str = ""
     auto_update_enabled: bool = True
     update_channel: str = "stable"
     update_check_interval_hours: int = 24
@@ -390,7 +392,7 @@ class AppSettings:
             "minimize_on_startup": self.minimize_on_startup,
             "startup_enabled": self.startup_enabled,
             "data_source": self.data_source,
-            # visual_crossing_api_key and github_app_* are stored in secure keyring, not JSON
+            # weather provider API keys and github_app_* are stored in secure keyring, not JSON
             "auto_update_enabled": self.auto_update_enabled,
             "update_channel": self.update_channel,
             "update_check_interval_hours": self.update_check_interval_hours,
@@ -467,6 +469,7 @@ class AppSettings:
             startup_enabled=cls._as_bool(data.get("startup_enabled"), False),
             data_source=data.get("data_source", "auto"),
             visual_crossing_api_key=data.get("visual_crossing_api_key", ""),
+            pirate_weather_api_key=data.get("pirate_weather_api_key", ""),
             auto_update_enabled=cls._as_bool(data.get("auto_update_enabled"), True),
             update_channel=data.get("update_channel", "stable"),
             update_check_interval_hours=data.get("update_check_interval_hours", 24),

--- a/src/accessiweather/ui/dialogs/settings_dialog.py
+++ b/src/accessiweather/ui/dialogs/settings_dialog.py
@@ -357,6 +357,32 @@ class SettingsDialogSimple(wx.Dialog):
         btn_row.Add(validate_btn, 0)
         sizer.Add(btn_row, 0, wx.LEFT | wx.TOP | wx.BOTTOM, 10)
 
+        sizer.Add(
+            wx.StaticText(panel, label="Pirate Weather API Configuration:"),
+            0,
+            wx.ALL,
+            5,
+        )
+
+        row_pw_key = wx.BoxSizer(wx.HORIZONTAL)
+        row_pw_key.Add(
+            wx.StaticText(panel, label="API Key:"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        self._controls["pirate_weather_key"] = wx.TextCtrl(
+            panel, style=wx.TE_PASSWORD, size=(250, -1)
+        )
+        row_pw_key.Add(self._controls["pirate_weather_key"], 1)
+        sizer.Add(row_pw_key, 0, wx.LEFT | wx.EXPAND, 10)
+
+        pirate_btn_row = wx.BoxSizer(wx.HORIZONTAL)
+        get_pirate_key_btn = wx.Button(panel, label="Get Free API Key")
+        get_pirate_key_btn.Bind(wx.EVT_BUTTON, self._on_get_pirate_weather_api_key)
+        pirate_btn_row.Add(get_pirate_key_btn, 0)
+        sizer.Add(pirate_btn_row, 0, wx.LEFT | wx.TOP | wx.BOTTOM, 10)
+
         # Source Priority (Auto Mode)
         sizer.Add(
             wx.StaticText(panel, label="Source Priority (Auto Mode):"),
@@ -1314,6 +1340,9 @@ class SettingsDialogSimple(wx.Dialog):
             vc_key = getattr(settings, "visual_crossing_api_key", "") or ""
             self._controls["vc_key"].SetValue(str(vc_key))
             self._original_vc_key = str(vc_key)
+            pirate_weather_key = getattr(settings, "pirate_weather_api_key", "") or ""
+            self._controls["pirate_weather_key"].SetValue(str(pirate_weather_key))
+            self._original_pirate_weather_key = str(pirate_weather_key)
 
             # Source priority
             us_priority = getattr(
@@ -1546,6 +1575,7 @@ class SettingsDialogSimple(wx.Dialog):
                 # Data sources
                 "data_source": source_values[self._controls["data_source"].GetSelection()],
                 "visual_crossing_api_key": self._controls["vc_key"].GetValue(),
+                "pirate_weather_api_key": self._controls["pirate_weather_key"].GetValue(),
                 "source_priority_us": [
                     ["nws", "openmeteo", "visualcrossing"],
                     ["nws", "visualcrossing", "openmeteo"],
@@ -1627,6 +1657,7 @@ class SettingsDialogSimple(wx.Dialog):
             # keyring load failed transiently — keep the existing keyring value.
             for key, orig_attr in (
                 ("visual_crossing_api_key", "_original_vc_key"),
+                ("pirate_weather_api_key", "_original_pirate_weather_key"),
                 ("openrouter_api_key", "_original_openrouter_key"),
             ):
                 if not settings_dict.get(key) and getattr(self, orig_attr, ""):
@@ -1671,6 +1702,7 @@ class SettingsDialogSimple(wx.Dialog):
             "severe_weather_override": "Automatically prioritize severe weather info",
             "data_source": "Weather Data Source",
             "vc_key": "API Key",
+            "pirate_weather_key": "Pirate Weather API Key",
             "us_priority": "US Locations Priority",
             "intl_priority": "International Locations Priority",
             "openmeteo_model": "Open-Meteo Weather Model",
@@ -1735,6 +1767,10 @@ class SettingsDialogSimple(wx.Dialog):
     def _on_get_vc_api_key(self, event):
         """Open Visual Crossing signup page."""
         webbrowser.open("https://www.visualcrossing.com/sign-up")
+
+    def _on_get_pirate_weather_api_key(self, event):
+        """Open Pirate Weather API key page."""
+        webbrowser.open("https://pirateweather.net/")
 
     def _on_validate_vc_api_key(self, event):
         """Validate Visual Crossing API key."""
@@ -2152,7 +2188,11 @@ class SettingsDialogSimple(wx.Dialog):
                 wx.OK | wx.ICON_ERROR,
             )
 
-    _PORTABLE_KEY_SETTINGS = ("visual_crossing_api_key", "openrouter_api_key")
+    _PORTABLE_KEY_SETTINGS = (
+        "visual_crossing_api_key",
+        "pirate_weather_api_key",
+        "openrouter_api_key",
+    )
 
     def _maybe_update_portable_bundle_after_save(self, settings_dict: dict) -> None:
         """
@@ -2550,7 +2590,7 @@ class SettingsDialogSimple(wx.Dialog):
             else:
                 wx.MessageBox(
                     "No API keys found to export. You can add keys in Settings > Data Sources "
-                    "and export later.",
+                    "or Settings > AI and export later.",
                     "No keys to export",
                     wx.OK | wx.ICON_WARNING,
                 )

--- a/tests/test_portable_secrets.py
+++ b/tests/test_portable_secrets.py
@@ -15,6 +15,7 @@ def test_encrypt_decrypt_secret_bundle_round_trip():
     secrets = {
         "openrouter_api_key": "FAKE_SK_TEST_ONLY",
         "visual_crossing_api_key": "FAKE_VC_TEST_ONLY",
+        "pirate_weather_api_key": "FAKE_PW_TEST_ONLY",
     }
 
     envelope = encrypt_secret_bundle(secrets, "correct horse battery staple")
@@ -66,6 +67,7 @@ class TestPortableSecretsImportExportWiring:
             return {
                 "openrouter_api_key": "FAKE_OR_EXPORTED_TEST",
                 "visual_crossing_api_key": "FAKE_VC_EXPORTED_TEST",
+                "pirate_weather_api_key": "FAKE_PW_EXPORTED_TEST",
             }.get(key_name)
 
         def _fake_set_password(key_name: str, value: str) -> bool:
@@ -94,6 +96,7 @@ class TestPortableSecretsImportExportWiring:
 
         assert imported_store["openrouter_api_key"] == "FAKE_OR_EXPORTED_TEST"
         assert imported_store["visual_crossing_api_key"] == "FAKE_VC_EXPORTED_TEST"
+        assert imported_store["pirate_weather_api_key"] == "FAKE_PW_EXPORTED_TEST"
         # After import, in-memory config should be refreshed so keys are active immediately
         manager._load_secure_keys.assert_called_once()
 
@@ -120,6 +123,7 @@ class TestPortableSecretsImportExportWiring:
         # Simulate in-memory settings with API keys (portable mode)
         config = MagicMock()
         config.settings.visual_crossing_api_key = "FAKE_VC_KEY_TEST"
+        config.settings.pirate_weather_api_key = "FAKE_PW_KEY_TEST"
         config.settings.openrouter_api_key = "FAKE_OR_KEY_TEST"
         manager._config = config
         operations = ImportExportOperations(manager)
@@ -137,6 +141,7 @@ class TestPortableSecretsImportExportWiring:
         saved = json.loads(export_file.read_text(encoding="utf-8"))
         restored = decrypt_secret_bundle(saved, "FAKE_PASSPHRASE_123")
         assert restored["visual_crossing_api_key"] == "FAKE_VC_KEY_TEST"
+        assert restored["pirate_weather_api_key"] == "FAKE_PW_KEY_TEST"
         assert restored["openrouter_api_key"] == "FAKE_OR_KEY_TEST"
 
     def test_export_resolves_lazy_secure_storage_values(self, tmp_path):
@@ -151,6 +156,7 @@ class TestPortableSecretsImportExportWiring:
         lazy._value = "FAKE_VC_LAZY_TEST"
         lazy._loaded = True
         config.settings.visual_crossing_api_key = lazy
+        config.settings.pirate_weather_api_key = "FAKE_PW_PLAIN_TEST"
         config.settings.openrouter_api_key = "FAKE_OR_PLAIN_TEST"
         manager._config = config
         operations = ImportExportOperations(manager)
@@ -166,6 +172,7 @@ class TestPortableSecretsImportExportWiring:
         saved = json.loads(export_file.read_text(encoding="utf-8"))
         restored = decrypt_secret_bundle(saved, "FAKE_PASSPHRASE_123")
         assert restored["visual_crossing_api_key"] == "FAKE_VC_LAZY_TEST"
+        assert restored["pirate_weather_api_key"] == "FAKE_PW_PLAIN_TEST"
         assert restored["openrouter_api_key"] == "FAKE_OR_PLAIN_TEST"
 
     def test_import_writes_all_keys_even_if_first_fails(self, tmp_path):
@@ -177,6 +184,7 @@ class TestPortableSecretsImportExportWiring:
 
         secrets = {
             "visual_crossing_api_key": "FAKE_VC_VAL_TEST",
+            "pirate_weather_api_key": "FAKE_PW_VAL_TEST",
             "openrouter_api_key": "FAKE_OR_VAL_TEST",
         }
         envelope = encrypt_secret_bundle(secrets, "FAKE_TEST_PASSPHRASE")
@@ -197,6 +205,7 @@ class TestPortableSecretsImportExportWiring:
         # Returns False because one key failed
         assert result is False
         # But the second key was still written
+        assert written["pirate_weather_api_key"] == "FAKE_PW_VAL_TEST"
         assert written["openrouter_api_key"] == "FAKE_OR_VAL_TEST"
 
     def test_import_sets_in_memory_keys_in_portable_mode(self, tmp_path):
@@ -214,6 +223,7 @@ class TestPortableSecretsImportExportWiring:
 
         secrets = {
             "visual_crossing_api_key": "FAKE_VC_PORTABLE_TEST",
+            "pirate_weather_api_key": "FAKE_PW_PORTABLE_TEST",
             "openrouter_api_key": "FAKE_OR_PORTABLE_TEST",
         }
         envelope = encrypt_secret_bundle(secrets, "FAKE_TEST_PASSPHRASE")
@@ -228,6 +238,7 @@ class TestPortableSecretsImportExportWiring:
 
         assert result is True
         assert config.settings.visual_crossing_api_key == "FAKE_VC_PORTABLE_TEST"
+        assert config.settings.pirate_weather_api_key == "FAKE_PW_PORTABLE_TEST"
         assert config.settings.openrouter_api_key == "FAKE_OR_PORTABLE_TEST"
         # Should NOT call _load_secure_keys in portable mode
         manager._load_secure_keys.assert_not_called()

--- a/tests/test_settings_dialog_api_key_guard.py
+++ b/tests/test_settings_dialog_api_key_guard.py
@@ -14,7 +14,14 @@ but the original was non-empty, skip the key in settings_dict entirely.
 from __future__ import annotations
 
 
-def _make_dialog(vc_key="", openrouter_key="", original_vc="", original_or=""):
+def _make_dialog(
+    vc_key="",
+    pirate_key="",
+    openrouter_key="",
+    original_vc="",
+    original_pirate="",
+    original_or="",
+):
     """Create a minimal SettingsDialogSimple stand-in with the guard logic."""
     import importlib.util
     from pathlib import Path
@@ -33,10 +40,12 @@ def _make_dialog(vc_key="", openrouter_key="", original_vc="", original_or=""):
 
     dlg = mod.SettingsDialogSimple.__new__(mod.SettingsDialogSimple)
     dlg._original_vc_key = original_vc
+    dlg._original_pirate_weather_key = original_pirate
     dlg._original_openrouter_key = original_or
 
     settings_dict = {
         "visual_crossing_api_key": vc_key,
+        "pirate_weather_api_key": pirate_key,
         "openrouter_api_key": openrouter_key,
         "update_interval_minutes": 30,
     }
@@ -45,6 +54,7 @@ def _make_dialog(vc_key="", openrouter_key="", original_vc="", original_or=""):
 
     for key, orig_attr in (
         ("visual_crossing_api_key", "_original_vc_key"),
+        ("pirate_weather_api_key", "_original_pirate_weather_key"),
         ("openrouter_api_key", "_original_openrouter_key"),
     ):
         if not settings_dict.get(key) and getattr(dlg, orig_attr, ""):
@@ -75,13 +85,21 @@ class TestApiKeyGuard:
         result = _make_dialog(openrouter_key="", original_or="sk-abc123")
         assert "openrouter_api_key" not in result
 
+    def test_pirate_weather_key_guard(self):
+        """Same guard applies to Pirate Weather key."""
+        result = _make_dialog(pirate_key="", original_pirate="pw-abc123")
+        assert "pirate_weather_api_key" not in result
+
     def test_both_keys_guarded_independently(self):
         """Each key is guarded independently."""
         result = _make_dialog(
             vc_key="",
+            pirate_key="still-set-pw",
             openrouter_key="still-set",
             original_vc="was-set",
+            original_pirate="still-set-pw",
             original_or="still-set",
         )
         assert "visual_crossing_api_key" not in result
+        assert result["pirate_weather_api_key"] == "still-set-pw"
         assert result["openrouter_api_key"] == "still-set"

--- a/tests/test_settings_dialog_portable_copy.py
+++ b/tests/test_settings_dialog_portable_copy.py
@@ -682,7 +682,11 @@ def test_maybe_update_portable_bundle_uses_export_encrypted_api_keys(tmp_path, m
     )
 
     dialog._maybe_update_portable_bundle_after_save(
-        {"visual_crossing_api_key": "FAKE_VC_KEY_123", "other_setting": "ignored"}
+        {
+            "visual_crossing_api_key": "FAKE_VC_KEY_123",
+            "pirate_weather_api_key": "FAKE_PW_KEY_123",
+            "other_setting": "ignored",
+        }
     )
 
     dialog.config_manager.export_encrypted_api_keys.assert_called_once_with(
@@ -735,7 +739,7 @@ def test_maybe_update_portable_bundle_prompts_when_no_cached_passphrase(tmp_path
 
     monkeypatch.setattr(wx, "TextEntryDialog", _FakeTextEntryDialog, raising=False)
 
-    dialog._maybe_update_portable_bundle_after_save({"openrouter_api_key": "FAKE_OR_KEY_456"})
+    dialog._maybe_update_portable_bundle_after_save({"pirate_weather_api_key": "FAKE_PW_KEY_456"})
 
     dialog.config_manager.export_encrypted_api_keys.assert_called_once_with(
         portable / "api-keys.keys", "FAKE_NEW_PASSPHRASE"

--- a/tests/test_settings_operations.py
+++ b/tests/test_settings_operations.py
@@ -314,11 +314,11 @@ class TestUpdateSettings:
         """Test updating a secure setting."""
         mock_set_password.return_value = True
 
-        result = operations.update_settings(visual_crossing_api_key="test_key")
+        result = operations.update_settings(pirate_weather_api_key="test_key")
 
         config = mock_manager.get_config.return_value
-        assert config.settings.visual_crossing_api_key == "test_key"
-        mock_set_password.assert_called_once_with("visual_crossing_api_key", "test_key")
+        assert config.settings.pirate_weather_api_key == "test_key"
+        mock_set_password.assert_called_once_with("pirate_weather_api_key", "test_key")
         assert result is True
 
     @patch("accessiweather.config.settings.SecureStorage.set_password")
@@ -326,11 +326,11 @@ class TestUpdateSettings:
         """Test updating a secure setting when secure storage fails."""
         mock_set_password.return_value = False
 
-        result = operations.update_settings(visual_crossing_api_key="test_key")
+        result = operations.update_settings(pirate_weather_api_key="test_key")
 
         # Should still update the setting and save config
         config = mock_manager.get_config.return_value
-        assert config.settings.visual_crossing_api_key == "test_key"
+        assert config.settings.pirate_weather_api_key == "test_key"
         assert result is True
 
     def test_update_multiple_settings(self, operations, mock_manager):
@@ -363,11 +363,11 @@ class TestUpdateSettings:
 
     def test_redacted_logging(self, operations, mock_manager):
         """Test that sensitive values are redacted in logs."""
-        operations.update_settings(github_app_private_key="secret_key")
+        operations.update_settings(pirate_weather_api_key="secret_key")
 
         logger = mock_manager._get_logger.return_value
         # Check that logger.info was called with redacted value
-        logger.info.assert_called_with("Updated setting github_app_private_key = ***redacted***")
+        logger.info.assert_called_with("Updated setting pirate_weather_api_key = ***redacted***")
 
 
 class TestGetSettings:

--- a/tests/test_startup_guidance_prompts.py
+++ b/tests/test_startup_guidance_prompts.py
@@ -152,7 +152,7 @@ def test_onboarding_wizard_shown_once_with_skip_path(monkeypatch):
     _ensure_wx_dialog_constants()
     skip_id = getattr(wx, "ID_NO", 0)
     cancel_id = getattr(wx, "ID_CANCEL", 2)
-    responses = [skip_id, cancel_id, cancel_id, getattr(wx, "ID_OK", 1)]
+    responses = [skip_id, cancel_id, cancel_id, cancel_id, getattr(wx, "ID_OK", 1)]
     monkeypatch.setattr(
         "accessiweather.app.wx.MessageDialog",
         lambda *args, **kwargs: _FakeDialog(responses),
@@ -197,11 +197,12 @@ def test_onboarding_wizard_portable_happy_path_sets_keys_and_bundle(monkeypatch,
     )
 
     _ensure_wx_dialog_constants()
-    # Step 1: skip location; step 2: OR key prompt+link dialogs; step 3: VC key; summary OK
+    # Step 1: skip location; step 2: OR key; step 3: VC key; step 4: Pirate key; summary OK
     responses = [
         getattr(wx, "ID_NO", 0),  # step 1: skip location
         getattr(wx, "ID_YES", 1),  # step 2: OR key — choose "Enter key"
         getattr(wx, "ID_YES", 1),  # step 3: VC key — choose "Enter key"
+        getattr(wx, "ID_YES", 1),  # step 4: Pirate key — choose "Enter key"
         getattr(wx, "ID_OK", 1),  # onboarding summary
     ]
     monkeypatch.setattr(
@@ -209,8 +210,13 @@ def test_onboarding_wizard_portable_happy_path_sets_keys_and_bundle(monkeypatch,
         lambda *args, **kwargs: _FakeDialog(responses),
         raising=False,
     )
-    # TextEntryDialog: OR key, VC key, bundle passphrase
-    text_responses = ["FAKE_OR_KEY_TEST", "FAKE_VC_KEY_TEST", "FAKE_BUNDLE_PASSPHRASE"]
+    # TextEntryDialog: OR key, VC key, Pirate key, bundle passphrase
+    text_responses = [
+        "FAKE_OR_KEY_TEST",
+        "FAKE_VC_KEY_TEST",
+        "FAKE_PW_KEY_TEST",
+        "FAKE_BUNDLE_PASSPHRASE",
+    ]
     monkeypatch.setattr(
         "accessiweather.app.wx.TextEntryDialog",
         lambda *args, **kwargs: _FakeTextEntryDialog(text_responses),
@@ -239,6 +245,7 @@ def test_onboarding_wizard_portable_happy_path_sets_keys_and_bundle(monkeypatch,
     # Keys should be live in session memory (set before export call)
     assert settings.openrouter_api_key == "FAKE_OR_KEY_TEST"
     assert settings.visual_crossing_api_key == "FAKE_VC_KEY_TEST"
+    assert settings.pirate_weather_api_key == "FAKE_PW_KEY_TEST"
     assert app._portable_keys_imported_this_session is True
     # wizard_shown should be marked
     last_call = app.config_manager.update_settings.call_args_list[-1]
@@ -262,6 +269,8 @@ def test_onboarding_wizard_api_key_link_actions_open_browser(monkeypatch):
         getattr(wx, "ID_NO", 0),
         getattr(wx, "ID_YES", 1),
         getattr(wx, "ID_NO", 0),
+        getattr(wx, "ID_NO", 0),
+        getattr(wx, "ID_CANCEL", 2),
         getattr(wx, "ID_NO", 0),
         getattr(wx, "ID_CANCEL", 2),
         getattr(wx, "ID_OK", 1),
@@ -290,6 +299,7 @@ def test_onboarding_wizard_api_key_link_actions_open_browser(monkeypatch):
     assert opened_urls == [
         "https://openrouter.ai/keys",
         "https://www.visualcrossing.com/sign-up",
+        "https://pirateweather.net/",
     ]
     calls = app.config_manager.update_settings.call_args_list
     assert calls[0].kwargs == {"openrouter_api_key": "FAKE_OR_KEY_TEST"}
@@ -316,6 +326,7 @@ def test_onboarding_summary_includes_readiness_status(monkeypatch):
     _ensure_wx_dialog_constants()
     responses = [
         getattr(wx, "ID_NO", 0),
+        getattr(wx, "ID_CANCEL", 2),
         getattr(wx, "ID_CANCEL", 2),
         getattr(wx, "ID_CANCEL", 2),
         getattr(wx, "ID_OK", 1),
@@ -347,6 +358,7 @@ def test_onboarding_summary_includes_readiness_status(monkeypatch):
     assert "Location configured: Yes" in summary
     assert "OpenRouter key set: Yes" in summary
     assert "Visual Crossing weather provider key set: No" in summary
+    assert "Pirate Weather provider key set: No" in summary
     # portable_auto_bundle_enabled line removed — not relevant in new design
 
 
@@ -368,6 +380,7 @@ def test_onboarding_completion_triggers_deferred_startup_update_check(monkeypatc
         getattr(wx, "ID_NO", 0),
         getattr(wx, "ID_CANCEL", 2),
         getattr(wx, "ID_CANCEL", 2),
+        getattr(wx, "ID_CANCEL", 2),
         getattr(wx, "ID_OK", 1),
     ]
     monkeypatch.setattr(
@@ -387,7 +400,7 @@ def test_onboarding_completion_triggers_deferred_startup_update_check(monkeypatc
 
 
 # ---------------------------------------------------------------------------
-# Tests for wizard step numbering (non-portable = 3 steps, portable = 4)
+# Tests for wizard step numbering (non-portable = 4 steps, portable = 5)
 # ---------------------------------------------------------------------------
 
 
@@ -412,9 +425,10 @@ def _capture_wizard_step_messages(monkeypatch, *, portable: bool):
             super().__init__(responses)
             captured_messages.append(message)
 
-    # Skip location, skip OR key, skip VC key, OK summary
+    # Skip location, skip OR key, skip VC key, skip Pirate key, OK summary
     responses = [
         getattr(wx, "ID_NO", 0),
+        getattr(wx, "ID_CANCEL", 2),
         getattr(wx, "ID_CANCEL", 2),
         getattr(wx, "ID_CANCEL", 2),
         getattr(wx, "ID_OK", 1),
@@ -436,21 +450,21 @@ def _capture_wizard_step_messages(monkeypatch, *, portable: bool):
 
 
 def test_wizard_step_numbering_non_portable(monkeypatch):
-    """Non-portable wizard uses 'of 3' in step labels."""
+    """Non-portable wizard uses 'of 4' in step labels."""
     messages = _capture_wizard_step_messages(monkeypatch, portable=False)
-    step1 = messages[0]
-    assert "Step 1 of 3" in step1, f"Expected 'Step 1 of 3' in: {step1}"
-
-
-def test_wizard_step_numbering_portable(monkeypatch):
-    """Portable wizard uses 'of 4' in step labels."""
-    messages = _capture_wizard_step_messages(monkeypatch, portable=True)
     step1 = messages[0]
     assert "Step 1 of 4" in step1, f"Expected 'Step 1 of 4' in: {step1}"
 
 
-def test_wizard_step2_step3_numbering_non_portable(monkeypatch):
-    """Non-portable wizard passes 'of 3' to _prompt_optional_secret_with_link calls."""
+def test_wizard_step_numbering_portable(monkeypatch):
+    """Portable wizard uses 'of 5' in step labels."""
+    messages = _capture_wizard_step_messages(monkeypatch, portable=True)
+    step1 = messages[0]
+    assert "Step 1 of 5" in step1, f"Expected 'Step 1 of 5' in: {step1}"
+
+
+def test_wizard_step2_step3_step4_numbering_non_portable(monkeypatch):
+    """Non-portable wizard passes 'of 4' to provider key prompts."""
     app = AccessiWeatherApp.__new__(AccessiWeatherApp)
     app._portable_mode = False
     app._force_wizard = False
@@ -483,13 +497,14 @@ def test_wizard_step2_step3_numbering_non_portable(monkeypatch):
 
     app._maybe_show_first_start_onboarding()
 
-    assert len(prompt_messages) == 2
-    assert "Step 2 of 3" in prompt_messages[0], f"Expected 'Step 2 of 3' in: {prompt_messages[0]}"
-    assert "Step 3 of 3" in prompt_messages[1], f"Expected 'Step 3 of 3' in: {prompt_messages[1]}"
+    assert len(prompt_messages) == 3
+    assert "Step 2 of 4" in prompt_messages[0], f"Expected 'Step 2 of 4' in: {prompt_messages[0]}"
+    assert "Step 3 of 4" in prompt_messages[1], f"Expected 'Step 3 of 4' in: {prompt_messages[1]}"
+    assert "Step 4 of 4" in prompt_messages[2], f"Expected 'Step 4 of 4' in: {prompt_messages[2]}"
 
 
-def test_wizard_step2_step3_numbering_portable(monkeypatch):
-    """Portable wizard passes 'of 4' to _prompt_optional_secret_with_link calls."""
+def test_wizard_step2_step3_step4_numbering_portable(monkeypatch):
+    """Portable wizard passes 'of 5' to provider key prompts."""
     app = AccessiWeatherApp.__new__(AccessiWeatherApp)
     app._portable_mode = True
     app._force_wizard = False
@@ -522,9 +537,10 @@ def test_wizard_step2_step3_numbering_portable(monkeypatch):
 
     app._maybe_show_first_start_onboarding()
 
-    assert len(prompt_messages) == 2
-    assert "Step 2 of 4" in prompt_messages[0], f"Expected 'Step 2 of 4' in: {prompt_messages[0]}"
-    assert "Step 3 of 4" in prompt_messages[1], f"Expected 'Step 3 of 4' in: {prompt_messages[1]}"
+    assert len(prompt_messages) == 3
+    assert "Step 2 of 5" in prompt_messages[0], f"Expected 'Step 2 of 5' in: {prompt_messages[0]}"
+    assert "Step 3 of 5" in prompt_messages[1], f"Expected 'Step 3 of 5' in: {prompt_messages[1]}"
+    assert "Step 4 of 5" in prompt_messages[2], f"Expected 'Step 4 of 5' in: {prompt_messages[2]}"
 
 
 # ---------------------------------------------------------------------------
@@ -927,6 +943,7 @@ def test_wizard_portable_export_failure_shows_warning(monkeypatch, tmp_path):
         getattr(wx, "ID_NO", 0),  # step 1: skip location
         getattr(wx, "ID_YES", 1),  # step 2: OR key — choose "Enter key"
         getattr(wx, "ID_CANCEL", 2),  # step 3: VC key — skip
+        getattr(wx, "ID_CANCEL", 2),  # step 4: Pirate key — skip
         getattr(wx, "ID_OK", 1),  # onboarding summary
     ]
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
Adds Pirate Weather API key support to the onboarding wizard and portable setup flows.

## Changes
- Onboarding wizard: PW API key step alongside VC with link to signup page
- Readiness summary: shows PW key status
- Portable hint dialog: mentions both VC and PW keys
- `pirate_weather_api_key` added to `PORTABLE_API_SECRET_KEYS` for encrypted export/import
- Tests updated for all flows

Closes #482