### PR TITLE
feat: separate daily and hourly forecast into navigable sections

### DIFF
--- a/src/accessiweather/display/presentation/forecast.py
+++ b/src/accessiweather/display/presentation/forecast.py
@@ -118,9 +118,9 @@ def build_forecast(
         if hourly_forecast and hourly_forecast.summary
         else None
     )
-    fallback_lines = [f"Forecast for {location.name}:\n"]
+    daily_lines = [f"Daily forecast for {location.name}:"]
     if summary_line:
-        fallback_lines.append(summary_line)
+        daily_lines.append(summary_line)
 
     hourly_hours = getattr(settings, "hourly_forecast_hours", 6) if settings else 6
     hourly_hours = max(1, min(hourly_hours, 168))
@@ -213,25 +213,25 @@ def build_forecast(
             )
         )
 
-        fallback_lines.append(f"{period.name or 'Unknown'}: {temp_pair or 'N/A'}")
+        daily_lines.append(f"{period.name or 'Unknown'}: {temp_pair or 'N/A'}")
         if period.short_forecast:
-            fallback_lines.append(f"  Conditions: {period.short_forecast}")
+            daily_lines.append(f"  Conditions: {period.short_forecast}")
         if wind_value:
-            fallback_lines.append(f"  Wind: {wind_value}")
+            daily_lines.append(f"  Wind: {wind_value}")
         if gust_val:
-            fallback_lines.append(f"  Wind gusts: {gust_val}")
+            daily_lines.append(f"  Wind gusts: {gust_val}")
         if precip_prob:
-            fallback_lines.append(f"  Precipitation: {precip_prob}")
+            daily_lines.append(f"  Precipitation: {precip_prob}")
         if precip_amt:
-            fallback_lines.append(f"  Precipitation amount: {precip_amt}")
+            daily_lines.append(f"  Precipitation amount: {precip_amt}")
         if snowfall_val:
-            fallback_lines.append(f"  Snowfall: {snowfall_val}")
+            daily_lines.append(f"  Snowfall: {snowfall_val}")
         if cloud_val:
-            fallback_lines.append(f"  Cloud cover: {cloud_val}")
+            daily_lines.append(f"  Cloud cover: {cloud_val}")
         if uv_val:
-            fallback_lines.append(f"  UV Index: {uv_val}")
+            daily_lines.append(f"  UV Index: {uv_val}")
         if details:
-            fallback_lines.append(f"  Details: {wrap_text(details, 80)}")
+            daily_lines.append(f"  Details: {wrap_text(details, 80)}")
 
     generated_at = (
         format_timestamp(
@@ -244,22 +244,25 @@ def build_forecast(
         else None
     )
     if generated_at:
-        fallback_lines.append(f"\nForecast generated: {generated_at}")
-
-    if hourly_summary_line:
-        fallback_lines.append(hourly_summary_line)
-
-    if hourly:
-        fallback_lines.append(render_hourly_fallback(hourly, hours=hourly_hours))
+        daily_lines.append(f"Forecast generated: {generated_at}")
 
     # Append cross-source confidence summary when available
     confidence_label: str | None = None
     if confidence is not None:
         level_str = confidence.level.value  # 'High', 'Medium', 'Low'
-        fallback_lines.append(f"\nForecast confidence: {level_str}. {confidence.rationale}.")
+        daily_lines.append(f"Forecast confidence: {level_str}. {confidence.rationale}.")
         confidence_label = f"Confidence: {level_str}"
 
-    fallback_text = "\n".join(fallback_lines).rstrip()
+    daily_section_text = "\n".join(daily_lines).rstrip()
+    hourly_section_text = build_hourly_section_text(
+        hourly,
+        hours=hourly_hours,
+        summary_line=hourly_summary_line,
+    )
+    fallback_sections = [daily_section_text]
+    if hourly_section_text:
+        fallback_sections.append(hourly_section_text)
+    fallback_text = "\n\n".join(section for section in fallback_sections if section).rstrip()
 
     return ForecastPresentation(
         title=title,
@@ -268,6 +271,8 @@ def build_forecast(
         hourly_summary=hourly_summary_line,
         generated_at=generated_at,
         fallback_text=fallback_text,
+        daily_section_text=daily_section_text,
+        hourly_section_text=hourly_section_text,
         confidence_label=confidence_label,
         summary=summary_line,
     )
@@ -441,6 +446,28 @@ def render_hourly_fallback(hourly: Iterable[HourlyPeriodPresentation], hours: in
             parts.append(f"UV {period.uv_index}")
         lines.append("  " + " - ".join(parts))
     return "\n".join(lines)
+
+
+def build_hourly_section_text(
+    hourly: Iterable[HourlyPeriodPresentation],
+    *,
+    hours: int,
+    summary_line: str | None = None,
+) -> str:
+    """Render hourly forecast as a separate accessibility section."""
+    hourly_periods = list(hourly)
+    if not hourly_periods and not summary_line:
+        return ""
+
+    lines = ["Hourly forecast:"]
+    if summary_line:
+        lines.append(summary_line)
+
+    rendered = render_hourly_fallback(hourly_periods, hours=hours)
+    if rendered:
+        lines.append(rendered)
+
+    return "\n".join(lines).rstrip()
 
 
 def _format_hourly_dewpoint(

--- a/src/accessiweather/display/weather_presenter.py
+++ b/src/accessiweather/display/weather_presenter.py
@@ -103,6 +103,8 @@ class ForecastPresentation:
     hourly_summary: str | None = None
     generated_at: str | None = None
     fallback_text: str = ""
+    daily_section_text: str = ""
+    hourly_section_text: str = ""
     confidence_label: str | None = None
     summary: str | None = None
 

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -99,13 +99,22 @@ class MainWindow(SizedFrame):
         self.current_conditions.SetSizerProps(expand=True, proportion=1)
 
         # Forecast section
-        wx.StaticText(panel, label="Forecast:")
-        self.forecast_display = wx.TextCtrl(
+        wx.StaticText(panel, label="Daily Forecast:")
+        self.daily_forecast_display = wx.TextCtrl(
             panel,
             style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH2,
-            name="Weather forecast",
+            name="Daily weather forecast",
         )
-        self.forecast_display.SetSizerProps(expand=True, proportion=1)
+        self.daily_forecast_display.SetSizerProps(expand=True, proportion=1)
+        self.forecast_display = self.daily_forecast_display
+
+        wx.StaticText(panel, label="Hourly Forecast:")
+        self.hourly_forecast_display = wx.TextCtrl(
+            panel,
+            style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH2,
+            name="Hourly weather forecast",
+        )
+        self.hourly_forecast_display.SetSizerProps(expand=True, proportion=1)
 
         # Weather alerts section
         alerts_panel = SizedPanel(panel)
@@ -954,7 +963,7 @@ class MainWindow(SizedFrame):
                     "Fetching nationwide weather discussions from NWS, SPC, NHC, and CPC...\n"
                     "This may take a moment.",
                 )
-                wx.CallAfter(self.forecast_display.SetValue, "")
+                wx.CallAfter(self._set_forecast_sections, "", "")
                 await self._fetch_nationwide_discussions(generation)
                 return
 
@@ -1038,7 +1047,7 @@ class MainWindow(SizedFrame):
         """Handle received nationwide discussion data (called on main thread)."""
         try:
             self.current_conditions.SetValue(current_text)
-            self.forecast_display.SetValue(forecast_text)
+            self._set_forecast_sections(forecast_text, "")
             self.stale_warning_label.SetLabel("")
             self.set_status("Nationwide discussions updated")
         except Exception as e:
@@ -1096,9 +1105,17 @@ class MainWindow(SizedFrame):
 
             # Update forecast
             if presentation.forecast:
-                self.forecast_display.SetValue(presentation.forecast.fallback_text)
+                daily_text = (
+                    presentation.forecast.daily_section_text or "No daily forecast available."
+                )
+                hourly_text = (
+                    presentation.forecast.hourly_section_text or "No hourly forecast available."
+                )
+                self._set_forecast_sections(daily_text, hourly_text)
             else:
-                self.forecast_display.SetValue("No forecast available.")
+                self._set_forecast_sections(
+                    "No daily forecast available.", "No hourly forecast available."
+                )
 
             # Update lifecycle label map from the current active alerts, then refresh the alerts list.
             if weather_data.alerts is not None:
@@ -1161,6 +1178,11 @@ class MainWindow(SizedFrame):
         finally:
             self.app.is_updating = False
             self.refresh_button.Enable()
+
+    def _set_forecast_sections(self, daily_text: str, hourly_text: str) -> None:
+        """Update the daily and hourly forecast controls together."""
+        self.daily_forecast_display.SetValue(daily_text)
+        self.hourly_forecast_display.SetValue(hourly_text)
 
     def _on_weather_error(self, error_message: str) -> None:
         """Handle weather fetch error (called on main thread)."""

--- a/tests/test_hourly_forecast_presentation.py
+++ b/tests/test_hourly_forecast_presentation.py
@@ -3,10 +3,19 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from accessiweather.display.presentation.forecast import (
+    build_forecast,
+    build_hourly_section_text,
     build_hourly_summary,
     render_hourly_fallback,
 )
-from accessiweather.models import AppSettings, HourlyForecast, HourlyForecastPeriod
+from accessiweather.models import (
+    AppSettings,
+    Forecast,
+    ForecastPeriod,
+    HourlyForecast,
+    HourlyForecastPeriod,
+    Location,
+)
 from accessiweather.utils import TemperatureUnit
 
 
@@ -60,3 +69,49 @@ def test_hourly_fallback_includes_humidity_and_dewpoint():
 
     assert "Humidity 55%" in lines
     assert "Dewpoint 54°F" in lines
+
+
+def test_hourly_section_text_omits_empty_section_without_summary():
+    section_text = build_hourly_section_text([], hours=6)
+
+    assert section_text == ""
+
+
+def test_build_forecast_exposes_daily_and_hourly_sections():
+    forecast = Forecast(
+        periods=[
+            ForecastPeriod(
+                name="Today",
+                temperature=70.0,
+                temperature_low=54.0,
+                temperature_unit="F",
+                short_forecast="Sunny",
+            )
+        ],
+        summary="Dry and pleasant through tomorrow.",
+    )
+    hourly = HourlyForecast(
+        periods=[
+            HourlyForecastPeriod(
+                start_time=datetime(2026, 3, 19, 12, tzinfo=UTC),
+                temperature=72.0,
+                temperature_unit="F",
+                short_forecast="Sunny",
+            )
+        ],
+        summary="Clear through mid afternoon.",
+    )
+    result = build_forecast(
+        forecast,
+        hourly,
+        Location(name="Testville", latitude=40.0, longitude=-75.0),
+        TemperatureUnit.FAHRENHEIT,
+        settings=AppSettings(hourly_forecast_hours=1),
+    )
+
+    assert result.daily_section_text.startswith("Daily forecast for Testville:")
+    assert "Overall: Dry and pleasant through tomorrow." in result.daily_section_text
+    assert result.hourly_section_text.startswith("Hourly forecast:")
+    assert "Hourly outlook: Clear through mid afternoon." in result.hourly_section_text
+    assert "Next 1 Hours:" in result.hourly_section_text
+    assert result.fallback_text == (f"{result.daily_section_text}\n\n{result.hourly_section_text}")

--- a/tests/test_main_window_forecast_sections.py
+++ b/tests/test_main_window_forecast_sections.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from accessiweather.display.weather_presenter import ForecastPresentation
+
+
+def _make_window():
+    from accessiweather.ui.main_window import MainWindow
+
+    with patch.object(MainWindow, "__init__", lambda self, *a, **kw: None):
+        win = MainWindow.__new__(MainWindow)
+
+    win.app = MagicMock()
+    win.app.alert_notification_system = None
+    win.app.config_manager.get_settings.return_value = MagicMock(
+        sound_enabled=False,
+        sound_pack="default",
+        muted_sound_events=[],
+    )
+    win.app.presenter.present.return_value = MagicMock(
+        current_conditions=MagicMock(fallback_text="Current conditions"),
+        source_attribution=None,
+        status_messages=[],
+        forecast=ForecastPresentation(
+            title="Forecast",
+            fallback_text="Combined forecast",
+            daily_section_text="Daily section",
+            hourly_section_text="Hourly section",
+        ),
+    )
+    win.app.is_updating = True
+    win.current_conditions = MagicMock()
+    win.stale_warning_label = MagicMock()
+    win.daily_forecast_display = MagicMock()
+    win.hourly_forecast_display = MagicMock()
+    win.refresh_button = MagicMock()
+    win.set_status = MagicMock()
+    win._update_alerts = MagicMock()
+    win._process_notification_events = MagicMock()
+    win._alert_lifecycle_labels = {}
+    return win
+
+
+def test_on_weather_data_received_sets_daily_and_hourly_forecast_sections():
+    win = _make_window()
+
+    weather_data = MagicMock()
+    weather_data.alerts = None
+    weather_data.alert_lifecycle_diff = None
+
+    win._on_weather_data_received(weather_data)
+
+    win.daily_forecast_display.SetValue.assert_called_once_with("Daily section")
+    win.hourly_forecast_display.SetValue.assert_called_once_with("Hourly section")
+
+
+def test_set_forecast_sections_updates_both_controls():
+    win = _make_window()
+
+    from accessiweather.ui.main_window import MainWindow
+
+    MainWindow._set_forecast_sections(win, "Daily text", "Hourly text")
+
+    win.daily_forecast_display.SetValue.assert_called_with("Daily text")
+    win.hourly_forecast_display.SetValue.assert_called_with("Hourly text")

--- a/tests/test_main_window_sounds.py
+++ b/tests/test_main_window_sounds.py
@@ -54,7 +54,10 @@ class TestMainWindowDataUpdatedSound:
         win.refresh_button = MagicMock()
         win.current_conditions = MagicMock()
         win.stale_warning_label = MagicMock()
-        win.forecast_display = MagicMock()
+        win.daily_forecast_display = MagicMock()
+        win.hourly_forecast_display = MagicMock()
+        win.forecast_display = win.daily_forecast_display
+        win._set_forecast_sections = MagicMock()
         win._update_alerts = MagicMock()
         win._process_notification_events = MagicMock()
         win._alert_lifecycle_labels = {}
@@ -185,7 +188,10 @@ class TestMainWindowFetchErrorSound:
         win.refresh_button = MagicMock()
         win.current_conditions = MagicMock()
         win.stale_warning_label = MagicMock()
-        win.forecast_display = MagicMock()
+        win.daily_forecast_display = MagicMock()
+        win.hourly_forecast_display = MagicMock()
+        win.forecast_display = win.daily_forecast_display
+        win._set_forecast_sections = MagicMock()
         win._update_alerts = MagicMock()
         win._process_notification_events = MagicMock()
         win._alert_lifecycle_labels = {}

--- a/tests/test_pw_coverage.py
+++ b/tests/test_pw_coverage.py
@@ -782,4 +782,5 @@ class TestForecastSummaryPresentation:
         result = build_forecast(forecast, hourly, self._make_location(), TemperatureUnit.FAHRENHEIT)
 
         assert result.hourly_summary == "Hourly outlook: Partly cloudy until this afternoon."
+        assert result.hourly_section_text.startswith("Hourly forecast:")
         assert "Hourly outlook: Partly cloudy until this afternoon." in result.fallback_text


### PR DESCRIPTION
## Summary
- split the wx forecast area into separate daily and hourly read-only sections for cleaner keyboard and screen-reader navigation
- have the presenter emit dedicated daily/hourly section text while keeping Pirate Weather block summaries attached to the right section
- add forecast presentation and main-window regression coverage for the new section behavior

## Testing
- pytest -q tests/test_hourly_forecast_presentation.py tests/test_pw_coverage.py tests/test_main_window_sounds.py tests/test_main_window_forecast_sections.py tests/test_html_formatters.py tests/test_forecast_time_reference.py tests/test_forecast_confidence_presentation.py
- ruff check src/accessiweather/display/presentation/forecast.py src/accessiweather/display/weather_presenter.py src/accessiweather/ui/main_window.py tests/test_hourly_forecast_presentation.py tests/test_pw_coverage.py tests/test_main_window_sounds.py tests/test_main_window_forecast_sections.py