### PR TITLE
fix: handle Pirate Weather WMO alerts as regional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Added per-event sound toggles in Settings > Audio, so you can mute sounds like weather refreshes without editing the active sound pack. Weather refresh sounds now stay off by default until you turn them back on.
 - Muted and zero-volume sounds now stop before fallback playback, so backends like `playsound3` no longer leak audio when an event should be silent.
 - Pirate Weather alert tracking now keeps a stable ID across provider revisions and no longer announces false cancellations when an alert briefly disappears upstream.
+- Pirate Weather / WMO alerts now stay conservative: lower-severity regional alerts are filtered out, and the remaining alerts are labeled as regional coverage instead of pretending to match your exact county or zone.
 - Fixed PyInstaller bundling for `prismatoid`/`prism` in nightly builds.
 - Enabled "Show Nationwide location" checkbox and correctly handled Nationwide location in `set_current_location()`.
 - Corrected CPC URLs to point to the actual discussion page (`fxus06.html`).

--- a/src/accessiweather/display/presentation/alerts.py
+++ b/src/accessiweather/display/presentation/alerts.py
@@ -12,6 +12,11 @@ if TYPE_CHECKING:
     from accessiweather.alert_lifecycle import AlertLifecycleDiff
 
 
+def _is_pirate_weather_alert(alert: WeatherAlert) -> bool:
+    """Return True when the alert originated from Pirate Weather / WMO."""
+    return "pirateweather" in (alert.source or "").strip().lower()
+
+
 def build_alerts(
     alerts: WeatherAlerts,
     location: Location,
@@ -93,6 +98,7 @@ def build_single_alert(
     severity = alert.severity if alert.severity != "Unknown" else None
     urgency = alert.urgency if alert.urgency != "Unknown" else None
     areas = alert.areas[:3] if alert.areas else []
+    is_regional_pw_alert = _is_pirate_weather_alert(alert)
 
     # Extract time preferences
     if settings:
@@ -135,7 +141,12 @@ def build_single_alert(
         area_text = ", ".join(areas)
         if remaining > 0:
             area_text += f" and {remaining} more"
-        parts.append(f"  Areas: {area_text}")
+        area_label = "Regions" if is_regional_pw_alert else "Areas"
+        parts.append(f"  {area_label}: {area_text}")
+    if is_regional_pw_alert:
+        parts.append(
+            "  Coverage: Regional alert from Pirate Weather/WMO; may not match your exact county or zone."
+        )
     if expires:
         parts.append(f"  Expires: {expires}")
     if description:

--- a/src/accessiweather/pirate_weather_client.py
+++ b/src/accessiweather/pirate_weather_client.py
@@ -34,6 +34,7 @@ from .weather_client_parsers import convert_f_to_c, degrees_to_cardinal
 logger = logging.getLogger(__name__)
 
 _BASE_URL = "https://api.pirateweather.net/forecast"
+_PW_MIN_INCLUDED_SEVERITIES = frozenset({"Severe", "Extreme"})
 
 
 class PirateWeatherApiError(Exception):
@@ -84,6 +85,18 @@ def _build_alert_id(alert_data: dict[str, object]) -> str:
     fingerprint = "|".join([title, severity, onset, ",".join(normalized_regions)])
     digest = hashlib.sha1(fingerprint.encode("utf-8")).hexdigest()[:16]
     return f"pw-wmo-{digest}"
+
+
+def _normalize_regions(regions: object) -> list[str]:
+    """Return a cleaned list of regional area names from the PW payload."""
+    if not isinstance(regions, list):
+        return []
+    normalized: list[str] = []
+    for region in regions:
+        region_name = str(region).strip()
+        if region_name:
+            normalized.append(region_name)
+    return normalized
 
 
 class PirateWeatherClient:
@@ -562,6 +575,13 @@ class PirateWeatherClient:
             title = alert_data.get("title") or "Weather Alert"
             description = alert_data.get("description") or title
             severity = self._map_severity(alert_data.get("severity"))
+            if severity not in _PW_MIN_INCLUDED_SEVERITIES:
+                logger.info(
+                    "Skipping lower-severity Pirate Weather regional alert '%s' (severity=%s)",
+                    title,
+                    severity,
+                )
+                continue
             alert_id = _build_alert_id(alert_data)
 
             onset_raw = alert_data.get("time")
@@ -572,8 +592,7 @@ class PirateWeatherClient:
                 datetime.fromtimestamp(expires_raw_val, tz=location_tz) if expires_raw_val else None
             )
 
-            regions = alert_data.get("regions", [])
-            areas: list[str] = regions if isinstance(regions, list) else []
+            areas = _normalize_regions(alert_data.get("regions"))
 
             alert = WeatherAlert(
                 id=alert_id,

--- a/tests/test_alert_lifecycle_presentation.py
+++ b/tests/test_alert_lifecycle_presentation.py
@@ -203,6 +203,21 @@ class TestBuildAlertsEdgeCases:
         result = build_alerts(empty, _loc())
         assert result.change_summary is None
 
+    def test_pirate_weather_alerts_are_presented_as_regional(self):
+        """Pirate Weather alerts use regional wording instead of precise area wording."""
+        alert = WeatherAlert(
+            title="Winter Storm Warning",
+            description="Heavy snow expected.",
+            severity="Severe",
+            urgency="Expected",
+            areas=["New York", "Hudson Valley"],
+            source="PirateWeather",
+        )
+        result = build_alerts(WeatherAlerts(alerts=[alert]), _loc())
+        assert "Regions: New York, Hudson Valley" in result.fallback_text
+        assert "Areas:" not in result.fallback_text
+        assert "may not match your exact county or zone" in result.fallback_text
+
 
 # ---------------------------------------------------------------------------
 # build_alerts: lifecycle_states labels appended to alert header lines

--- a/tests/test_pirate_weather_client.py
+++ b/tests/test_pirate_weather_client.py
@@ -420,6 +420,38 @@ class TestParseAlerts:
         assert alert.expires is not None
         assert alert.expires > alert.onset
 
+    def test_lower_severity_regional_alerts_are_suppressed(
+        self, client, sample_payload_with_alerts
+    ):
+        payload = dict(sample_payload_with_alerts)
+        payload["alerts"] = [
+            {
+                "title": "Wind Advisory",
+                "severity": "moderate",
+                "time": 1700000000,
+                "description": "Breezy conditions expected.",
+                "regions": ["New York"],
+            }
+        ]
+        result = client._parse_alerts(payload)
+        assert result.alerts == []
+
+    def test_regions_are_normalized_without_fake_precision(
+        self, client, sample_payload_with_alerts
+    ):
+        payload = dict(sample_payload_with_alerts)
+        payload["alerts"] = [
+            {
+                "title": "Winter Storm Warning",
+                "severity": "severe",
+                "time": 1700000000,
+                "description": "Heavy snow expected.",
+                "regions": [" New York ", "", "Hudson Valley"],
+            }
+        ]
+        result = client._parse_alerts(payload)
+        assert result.alerts[0].areas == ["New York", "Hudson Valley"]
+
     def test_severity_mapping(self, client):
         for raw, expected in [
             ("extreme", "Extreme"),


### PR DESCRIPTION
## Summary
- filter Pirate Weather / WMO alerts to severe and extreme only
- present remaining Pirate Weather alerts as regional coverage rather than exact local areas
- preserve existing NWS county/zone behavior and add focused regression tests

## Validation
- pytest -q tests/test_pirate_weather_client.py tests/test_alert_lifecycle_presentation.py
- pytest -q tests/test_pw_coverage.py tests/test_alert_aggregator.py tests/test_alert_lifecycle.py
- ruff check src/accessiweather/pirate_weather_client.py src/accessiweather/display/presentation/alerts.py tests/test_pirate_weather_client.py tests/test_alert_lifecycle_presentation.py
- ruff format --check src/accessiweather/pirate_weather_client.py src/accessiweather/display/presentation/alerts.py tests/test_pirate_weather_client.py tests/test_alert_lifecycle_presentation.py