### PR TITLE
docs: fix factual errors and polish user-facing manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Accessible desktop weather for Windows, macOS, and Linux.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Python](https://img.shields.io/badge/Python-3.10%2B-blue)
-[![Built with wxPython](https://img.shields.io/badge/Built%20with-wxPython-blue)](https://wxpython.org/)
+[![Built with Toga](https://img.shields.io/badge/Built%20with-Toga%20%28BeeWare%29-blue)](https://toga.readthedocs.io/)
 ![Platforms](https://img.shields.io/badge/Platforms-Windows%20%7C%20macOS%20%7C%20Linux-informational)
 
 AccessiWeather is a screen-reader-friendly weather app with keyboard navigation, desktop notifications, optional alert sounds, and multiple weather sources. It separates current conditions, daily forecast, hourly forecast, and alerts so the information is easier to scan with speech or braille.
@@ -162,7 +162,7 @@ The Settings dialog currently includes these tabs:
 
 - [User Manual](docs/user_manual.md)
 - [Accessibility Guide](docs/ACCESSIBILITY.md)
-- [Sound Pack System](docs/SOUND_PACK_SYSTEM.md)
+- [Sound Packs](docs/SOUND_PACKS.md)
 - [Update System](docs/UPDATE_SYSTEM.md)
 
 ## Support

--- a/docs/SOUND_PACKS.md
+++ b/docs/SOUND_PACKS.md
@@ -69,8 +69,8 @@ Currently supported sound types:
 
 ### Selecting a Sound Pack
 
-1. Open AccessiWeather settings
-2. Go to the "General" tab
+1. Open AccessiWeather settings (`Ctrl+S`)
+2. Go to the "Audio" tab
 3. Find the "Sound Pack" dropdown
 4. Select your preferred sound pack
 5. Click "Preview Sound" to test the selected pack
@@ -78,8 +78,8 @@ Currently supported sound types:
 
 ### Managing Sound Packs
 
-1. Open AccessiWeather settings
-2. Go to the "General" tab
+1. Open AccessiWeather settings (`Ctrl+S`)
+2. Go to the "Audio" tab
 3. Click "Manage Sound Packs..." button
 4. The Sound Pack Manager dialog will open
 

--- a/docs/UPDATE_SYSTEM.md
+++ b/docs/UPDATE_SYSTEM.md
@@ -140,8 +140,6 @@ AccessiWeather uses GitHub releases for all update channels. There is no user-co
 
 ## 🔗 Related Resources
 
-- **Beta Testing Guide**: `BETA_TESTING.md`
-- **Release Channels Guide**: `update_channels.md`
 - **GitHub Releases**: https://github.com/orinks/accessiweather/releases
 
 ## 📞 Support
@@ -153,6 +151,3 @@ If you encounter issues with the update system:
 3. **GitHub Issues**: Report bugs at https://github.com/orinks/accessiweather/issues
 4. **Include Information**: Provide your platform, version, and error details
 
----
-
-*Last updated: December 2024*

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-AccessiWeather is an accessible desktop weather app built with wxPython. It is designed for screen reader users first, but it is equally usable with keyboard or mouse. The main window separates weather into four core sections:
+AccessiWeather is an accessible desktop weather app built with Toga (BeeWare). It is designed for screen reader users first, but it is equally usable with keyboard or mouse. The main window separates weather into four core sections:
 
 - `Current Conditions`
 - `Daily Forecast`
@@ -85,7 +85,7 @@ The daily forecast is shown in its own section. It is separate from the hourly f
 
 ### Hourly Forecast
 
-The hourly forecast has its own section and is no longer mixed into the daily forecast text. You can choose how many hours to show in `Settings > Display > Hourly forecast hours`.
+The hourly forecast is shown in its own section, separate from the daily forecast. You can choose how many hours to show in `Settings > Display > Hourly forecast hours`.
 
 ### Weather Alerts
 
@@ -214,7 +214,7 @@ Current event-based notification options include:
 
 ## Settings Guide
 
-The Settings dialog currently has these tabs.
+The Settings dialog has these tabs.
 
 ### General
 
@@ -392,7 +392,7 @@ Both AI features require an OpenRouter API key.
 
 ### Weather History
 
-`View > Weather History` shows past weather comparisons. This feature depends on the app's weather history support and may rely on optional source data.
+`View > Weather History` shows past weather comparisons for your selected location. A Visual Crossing API key is required to load historical data. Add it in `Settings > Data Sources`.
 
 ### Air Quality and UV Index
 
@@ -404,7 +404,7 @@ Use `View > Aviation Weather...` to fetch TAF data by ICAO airport code. For int
 
 ### NOAA Weather Radio
 
-Use `View > NOAA Weather Radio...` for NOAA Weather Radio access.
+Use `View > NOAA Weather Radio...` to access NOAA Weather Radio streams for US locations. This opens a dialog where you can browse and play radio broadcasts for your selected area.
 
 ## Keyboard Shortcuts
 


### PR DESCRIPTION
## Summary

Post-PR-#505 manual audit pass. Fixes factual errors and removes internal-sounding language from user-facing docs.

- **Wrong framework badge/prose**: README badge and `user_manual.md` both said "wxPython" — the app uses Toga (BeeWare). Fixed both.
- **Wrong README link**: Documentation section linked `SOUND_PACK_SYSTEM.md` (developer reference) instead of `SOUND_PACKS.md` (user guide). Corrected.
- **Release-note phrasing in user manual**: Hourly Forecast section said "no longer mixed into the daily forecast text" — internal changelog language. Rephrased as a plain current-state description.
- **Hedge language**: "The Settings dialog **currently** has these tabs" removed the word "currently".
- **Vague Weather History**: Section said "may rely on optional source data" with no guidance. Now says a Visual Crossing key is required.
- **Stub NOAA section**: Single unhelpful sentence expanded to tell users what the dialog actually does.
- **Wrong Settings tab in SOUND_PACKS.md**: Sound pack selection instructions pointed to "General" tab — it's "Audio". Fixed.
- **Dead links in UPDATE_SYSTEM.md**: References to `BETA_TESTING.md` and `update_channels.md` removed (neither file exists). Stale "Last updated: December 2024" line removed.

## Files changed

| File | Why |
|------|-----|
| `README.md` | Wrong framework badge; wrong sound pack link |
| `docs/user_manual.md` | Wrong framework prose; release-note language; hedge; vague sections |
| `docs/SOUND_PACKS.md` | Wrong Settings tab name |
| `docs/UPDATE_SYSTEM.md` | Dead links; stale date |

## Test plan

- [ ] Read through each changed section and confirm it reads naturally for a non-developer user
- [ ] Confirm no code files were touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)