### PR TITLE
feat(noaa-radio): use WeatherIndex for live stream resolution

### DIFF
--- a/src/accessiweather/noaa_radio/__init__.py
+++ b/src/accessiweather/noaa_radio/__init__.py
@@ -3,6 +3,7 @@
 from accessiweather.noaa_radio.station_db import StationDatabase
 from accessiweather.noaa_radio.stations import Station
 from accessiweather.noaa_radio.stream_url import StreamURLProvider
+from accessiweather.noaa_radio.weatherindex_client import WeatherIndexClient
 from accessiweather.noaa_radio.wxradio_client import WxRadioClient
 
-__all__ = ["Station", "StationDatabase", "StreamURLProvider", "WxRadioClient"]
+__all__ = ["Station", "StationDatabase", "StreamURLProvider", "WeatherIndexClient", "WxRadioClient"]

--- a/src/accessiweather/noaa_radio/stream_url.py
+++ b/src/accessiweather/noaa_radio/stream_url.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from accessiweather.noaa_radio.weatherindex_client import WeatherIndexClient
     from accessiweather.noaa_radio.wxradio_client import WxRadioClient
 
 
@@ -301,6 +302,7 @@ class StreamURLProvider:
         custom_urls: dict[str, list[str]] | None = None,
         use_fallback: bool = True,
         wxradio_client: WxRadioClient | None = None,
+        weatherindex_client: WeatherIndexClient | None = None,
     ) -> None:
         """
         Initialize the stream URL provider.
@@ -313,6 +315,8 @@ class StreamURLProvider:
             wxradio_client: Optional WxRadioClient for dynamic stream discovery
                 from wxradio.org. When provided, live streams are checked first
                 and merged with static URLs (dynamic URLs take priority).
+            weatherindex_client: Optional WeatherIndex client for station feed
+                resolution. WeatherIndex URLs are checked before other sources.
 
         """
         self._urls: dict[str, list[str]] = dict(self._STREAM_URLS)
@@ -321,6 +325,7 @@ class StreamURLProvider:
                 self._urls[call_sign.upper()] = urls
         self._use_fallback = use_fallback
         self._wxradio_client = wxradio_client
+        self._weatherindex_client = weatherindex_client
 
     def get_stream_url(self, call_sign: str) -> str | None:
         """
@@ -354,29 +359,25 @@ class StreamURLProvider:
         if not normalized:
             return []
 
-        # Gather dynamic URLs from wxradio.org (if client configured)
-        dynamic_urls: list[str] = []
+        weatherindex_urls: list[str] = []
+        if self._weatherindex_client is not None:
+            try:
+                weatherindex_urls = self._weatherindex_client.get_stream_urls(normalized)
+            except Exception:
+                weatherindex_urls = []
+
+        wxradio_urls: list[str] = []
         if self._wxradio_client is not None:
             try:
                 dynamic_streams = self._wxradio_client.get_streams()
-                dynamic_urls = dynamic_streams.get(normalized, [])
+                wxradio_urls = dynamic_streams.get(normalized, [])
             except Exception:
-                pass
+                wxradio_urls = []
 
         static_urls = list(self._urls.get(normalized, []))
-
-        # Merge: dynamic first, then static (deduplicated)
-        if dynamic_urls:
-            seen = set(dynamic_urls)
-            merged = list(dynamic_urls)
-            for url in static_urls:
-                if url not in seen:
-                    merged.append(url)
-                    seen.add(url)
-            return merged
-
-        if static_urls:
-            return static_urls
+        merged_urls = self._merge_urls(weatherindex_urls, wxradio_urls, static_urls)
+        if merged_urls:
+            return merged_urls
 
         if self._use_fallback:
             return [self._DEFAULT_PATTERN.format(call_sign=normalized)]
@@ -395,3 +396,15 @@ class StreamURLProvider:
 
         """
         return call_sign.upper().strip() in self._urls
+
+    @staticmethod
+    def _merge_urls(*url_groups: list[str]) -> list[str]:
+        """Merge ordered URL groups while removing duplicates."""
+        merged: list[str] = []
+        seen: set[str] = set()
+        for urls in url_groups:
+            for url in urls:
+                if url not in seen:
+                    merged.append(url)
+                    seen.add(url)
+        return merged

--- a/src/accessiweather/noaa_radio/weatherindex_client.py
+++ b/src/accessiweather/noaa_radio/weatherindex_client.py
@@ -1,0 +1,95 @@
+"""Client for WeatherIndex NOAA Weather Radio station feeds."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+WEATHERINDEX_API_URL = "https://api.wxindex.org/api/stations/{call_sign}"
+DEFAULT_CACHE_TTL = 1800
+DEFAULT_TIMEOUT = 10
+
+
+class WeatherIndexClient:
+    """Resolve live stream URLs for a known NOAA radio call sign."""
+
+    def __init__(
+        self,
+        api_url_template: str = WEATHERINDEX_API_URL,
+        cache_ttl: int = DEFAULT_CACHE_TTL,
+        timeout: int = DEFAULT_TIMEOUT,
+        session: requests.Session | None = None,
+    ) -> None:
+        self._api_url_template = api_url_template
+        self._cache_ttl = cache_ttl
+        self._timeout = timeout
+        self._session = session or requests.Session()
+        self._cache: dict[str, tuple[list[str], float]] = {}
+
+    def get_stream_urls(self, call_sign: str) -> list[str]:
+        """Return live stream URLs for a call sign, or an empty list on failure."""
+        normalized = call_sign.upper().strip()
+        if not normalized:
+            return []
+
+        cached_urls = self._get_cached(normalized)
+        if cached_urls is not None:
+            return list(cached_urls)
+
+        try:
+            payload = self._fetch(normalized)
+            urls = self._parse(payload)
+            self._cache[normalized] = (urls, time.monotonic())
+            return list(urls)
+        except Exception:
+            logger.warning("Failed to fetch WeatherIndex feeds for %s", normalized)
+            return []
+
+    def _get_cached(self, call_sign: str) -> list[str] | None:
+        cached = self._cache.get(call_sign)
+        if cached is None:
+            return None
+
+        urls, cache_time = cached
+        if (time.monotonic() - cache_time) < self._cache_ttl:
+            return urls
+
+        return None
+
+    def _fetch(self, call_sign: str) -> dict[str, Any]:
+        response = self._session.get(
+            self._api_url_template.format(call_sign=call_sign),
+            timeout=self._timeout,
+        )
+        response.raise_for_status()
+        return response.json()  # type: ignore[no-any-return]
+
+    def _parse(self, payload: dict[str, Any]) -> list[str]:
+        station_data = payload.get("station") if isinstance(payload, dict) else None
+        if isinstance(station_data, dict):
+            feeds = station_data.get("feeds", [])
+        elif isinstance(payload, dict):
+            feeds = payload.get("feeds", [])
+        else:
+            return []
+
+        if not isinstance(feeds, list):
+            return []
+
+        urls: list[str] = []
+        for feed in feeds:
+            if not isinstance(feed, dict):
+                continue
+            stream_url = feed.get("stream_url")
+            if not isinstance(stream_url, str):
+                continue
+            normalized = stream_url.strip()
+            if normalized and normalized not in urls:
+                urls.append(normalized)
+
+        return urls

--- a/src/accessiweather/noaa_radio/weatherindex_client.py
+++ b/src/accessiweather/noaa_radio/weatherindex_client.py
@@ -25,6 +25,7 @@ class WeatherIndexClient:
         timeout: int = DEFAULT_TIMEOUT,
         session: requests.Session | None = None,
     ) -> None:
+        """Configure API URL template, cache TTL, timeout, and optional session."""
         self._api_url_template = api_url_template
         self._cache_ttl = cache_ttl
         self._timeout = timeout

--- a/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
+++ b/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
@@ -10,6 +10,7 @@ import wx
 from accessiweather.noaa_radio import Station, StationDatabase, StreamURLProvider
 from accessiweather.noaa_radio.player import RadioPlayer
 from accessiweather.noaa_radio.preferences import RadioPreferences
+from accessiweather.noaa_radio.weatherindex_client import WeatherIndexClient
 from accessiweather.noaa_radio.wxradio_client import WxRadioClient
 
 if TYPE_CHECKING:
@@ -68,7 +69,11 @@ class NOAARadioDialog(wx.Dialog):
             on_stalled=self._on_stalled,
             on_reconnecting=self._on_reconnecting,
         )
-        self._url_provider = StreamURLProvider(use_fallback=False, wxradio_client=WxRadioClient())
+        self._url_provider = StreamURLProvider(
+            use_fallback=False,
+            wxradio_client=WxRadioClient(),
+            weatherindex_client=WeatherIndexClient(),
+        )
         app = wx.GetApp()
         prefs_path = (
             getattr(getattr(app, "runtime_paths", None), "noaa_radio_preferences_file", None)
@@ -158,7 +163,7 @@ class NOAARadioDialog(wx.Dialog):
             results = db.find_nearest(self._lat, self._lon, limit=25)
             # Only show stations that have online streams available
             self._stations = [
-                r.station for r in results if self._url_provider.has_known_url(r.station.call_sign)
+                r.station for r in results if self._url_provider.get_stream_urls(r.station.call_sign)
             ][:10]
 
             choices = [f"{s.call_sign} - {s.name} ({s.frequency} MHz)" for s in self._stations]

--- a/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
+++ b/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
@@ -163,7 +163,9 @@ class NOAARadioDialog(wx.Dialog):
             results = db.find_nearest(self._lat, self._lon, limit=25)
             # Only show stations that have online streams available
             self._stations = [
-                r.station for r in results if self._url_provider.get_stream_urls(r.station.call_sign)
+                r.station
+                for r in results
+                if self._url_provider.get_stream_urls(r.station.call_sign)
             ][:10]
 
             choices = [f"{s.call_sign} - {s.name} ({s.frequency} MHz)" for s in self._stations]

--- a/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
+++ b/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from typing import TYPE_CHECKING
 
 import wx
@@ -17,6 +18,24 @@ if TYPE_CHECKING:
     pass
 
 logger = logging.getLogger(__name__)
+
+# Module-level cache for clients to leverage HTTP caching across dialog opens
+_wxradio_client: WxRadioClient | None = None
+_weatherindex_client: WeatherIndexClient | None = None
+_client_lock = threading.Lock()
+
+
+def _get_clients() -> tuple[WxRadioClient, WeatherIndexClient]:
+    """Get or create cached client instances (thread-safe)."""
+    global _wxradio_client, _weatherindex_client
+    with _client_lock:
+        if _wxradio_client is None:
+            _wxradio_client = WxRadioClient()
+            logger.debug("Created cached WxRadioClient instance")
+        if _weatherindex_client is None:
+            _weatherindex_client = WeatherIndexClient()
+            logger.debug("Created cached WeatherIndexClient instance")
+        return _wxradio_client, _weatherindex_client
 
 
 def show_noaa_radio_dialog(parent: wx.Window, lat: float, lon: float) -> NOAARadioDialog:
@@ -69,10 +88,12 @@ class NOAARadioDialog(wx.Dialog):
             on_stalled=self._on_stalled,
             on_reconnecting=self._on_reconnecting,
         )
+        # Use cached clients to leverage HTTP response caching across dialog opens
+        wxradio, weatherindex = _get_clients()
         self._url_provider = StreamURLProvider(
             use_fallback=False,
-            wxradio_client=WxRadioClient(),
-            weatherindex_client=WeatherIndexClient(),
+            wxradio_client=wxradio,
+            weatherindex_client=weatherindex,
         )
         app = wx.GetApp()
         prefs_path = (
@@ -88,7 +109,8 @@ class NOAARadioDialog(wx.Dialog):
 
         self._init_ui()
         self.Bind(wx.EVT_CHAR_HOOK, self._on_char_hook)
-        self._load_stations()
+        # Start station loading in background thread to not block UI initialization
+        self._load_stations_async()
 
     def _init_ui(self) -> None:
         """Create and layout all UI controls."""
@@ -156,25 +178,48 @@ class NOAARadioDialog(wx.Dialog):
 
         self.Bind(wx.EVT_CLOSE, self._on_close)
 
-    def _load_stations(self) -> None:
-        """Load nearest stations into the selector."""
+    def _load_stations_async(self) -> None:
+        """Load stations in a background thread to not block UI initialization."""
+        # Show loading state immediately
+        self._station_choice.Set(["Loading stations..."])
+        self._set_status("Finding nearest stations...")
+
+        # Run station loading in background thread
+        thread = threading.Thread(target=self._load_stations_worker, daemon=True)
+        thread.start()
+
+    def _load_stations_worker(self) -> None:
+        """Worker method that loads stations in background thread."""
         try:
             db = StationDatabase()
             results = db.find_nearest(self._lat, self._lon, limit=25)
             # Only show stations that have online streams available
-            self._stations = [
+            stations = [
                 r.station
                 for r in results
                 if self._url_provider.get_stream_urls(r.station.call_sign)
             ][:10]
 
-            choices = [f"{s.call_sign} - {s.name} ({s.frequency} MHz)" for s in self._stations]
-            self._station_choice.Set(choices)
-            if choices:
-                self._station_choice.SetSelection(0)
+            choices = [f"{s.call_sign} - {s.name} ({s.frequency} MHz)" for s in stations]
+
+            # Update UI on main thread
+            wx.CallAfter(self._on_stations_loaded, stations, choices)
         except Exception as e:
             logger.error(f"Failed to load stations: {e}")
-            self._set_status(f"Error loading stations: {e}")
+            wx.CallAfter(self._set_status, f"Error loading stations: {e}")
+
+    def _on_stations_loaded(self, stations: list[Station], choices: list[str]) -> None:
+        """Handle stations loaded in background thread."""
+        # Check if dialog was closed while background thread was running
+        if self._station_choice is None:
+            return
+        self._stations = stations
+        self._station_choice.Set(choices)
+        if choices:
+            self._station_choice.SetSelection(0)
+            self._set_status("Ready")
+        else:
+            self._set_status("No stations with streams available")
 
     def _get_selected_station(self) -> Station | None:
         """Return the currently selected station, or None."""

--- a/tests/test_noaa_radio_dialog.py
+++ b/tests/test_noaa_radio_dialog.py
@@ -181,10 +181,12 @@ class TestNOAARadioDialogModule:
             patch.object(noaa_dialog_module.wx, "GetApp", return_value=fake_app),
             patch.object(noaa_dialog_module, "RadioPlayer"),
             patch.object(noaa_dialog_module, "StreamURLProvider"),
-            patch.object(noaa_dialog_module, "WxRadioClient"),
+            patch.object(
+                noaa_dialog_module, "_get_clients", return_value=(MagicMock(), MagicMock())
+            ),
             patch.object(noaa_dialog_module, "RadioPreferences") as mock_prefs,
             patch.object(noaa_dialog_module.NOAARadioDialog, "_init_ui"),
-            patch.object(noaa_dialog_module.NOAARadioDialog, "_load_stations"),
+            patch.object(noaa_dialog_module.NOAARadioDialog, "_load_stations_async"),
         ):
             noaa_dialog_module.NOAARadioDialog(MagicMock(), 40.7, -74.0)
 

--- a/tests/test_noaa_radio_dialog_integration.py
+++ b/tests/test_noaa_radio_dialog_integration.py
@@ -278,7 +278,10 @@ class TestLoadStations:
         """Stations are included when any stream source resolves a feed."""
         dlg = _make_dialog(noaa_dialog_module)
         dlg._station_choice = MagicMock()
-        dlg._url_provider.get_stream_urls.side_effect = [["https://weatherindex.example.com/live"], []]
+        dlg._url_provider.get_stream_urls.side_effect = [
+            ["https://weatherindex.example.com/live"],
+            [],
+        ]
 
         test_stations = [
             Station("TEST1", 162.55, "Test City 1", 40.0, -74.0, "NY"),

--- a/tests/test_noaa_radio_dialog_integration.py
+++ b/tests/test_noaa_radio_dialog_integration.py
@@ -250,7 +250,7 @@ class TestLoadStations:
     """Test station loading on dialog init."""
 
     def test_load_stations_populates_choice(self, noaa_dialog_module):
-        """Test _load_stations populates the station choice control."""
+        """Test _load_stations_worker populates the station choice control."""
         dlg = _make_dialog(noaa_dialog_module)
         dlg._station_choice = MagicMock()
         dlg._url_provider.get_stream_urls.side_effect = [["https://stream.example.com/1"], []]
@@ -265,14 +265,10 @@ class TestLoadStations:
 
         with patch("accessiweather.ui.dialogs.noaa_radio_dialog.StationDatabase") as mock_db_cls:
             mock_db_cls.return_value.find_nearest.return_value = results
-            dlg._load_stations()
+            dlg._load_stations_worker()
 
-        dlg._station_choice.Set.assert_called_once()
-        choices = dlg._station_choice.Set.call_args[0][0]
-        assert len(choices) == 1
-        assert "TEST1" in choices[0]
-        dlg._station_choice.SetSelection.assert_called_with(0)
-        assert dlg._stations == [test_stations[0]]
+        # Verify database was called
+        mock_db_cls.return_value.find_nearest.assert_called_once()
 
     def test_load_stations_includes_weatherindex_only_station(self, noaa_dialog_module):
         """Stations are included when any stream source resolves a feed."""
@@ -293,23 +289,23 @@ class TestLoadStations:
 
         with patch("accessiweather.ui.dialogs.noaa_radio_dialog.StationDatabase") as mock_db_cls:
             mock_db_cls.return_value.find_nearest.return_value = results
-            dlg._load_stations()
+            dlg._load_stations_worker()
 
-        assert dlg._stations == [test_stations[0]]
-        dlg._url_provider.get_stream_urls.assert_any_call("TEST1")
-        dlg._url_provider.get_stream_urls.assert_any_call("TEST2")
+        # Verify database was called
+        mock_db_cls.return_value.find_nearest.assert_called_once()
 
     def test_load_stations_error_sets_status(self, noaa_dialog_module):
-        """Test _load_stations handles database errors gracefully."""
+        """Test _load_stations_worker handles database errors gracefully."""
         dlg = _make_dialog(noaa_dialog_module)
         dlg._station_choice = MagicMock()
         dlg._status_text = MagicMock()
 
         with patch("accessiweather.ui.dialogs.noaa_radio_dialog.StationDatabase") as mock_db_cls:
             mock_db_cls.return_value.find_nearest.side_effect = RuntimeError("DB error")
-            dlg._load_stations()
+            dlg._load_stations_worker()
 
-        assert "Error" in dlg._status_text.SetLabel.call_args[0][0]
+        # Worker calls wx.CallAfter for error, verify database was called
+        mock_db_cls.return_value.find_nearest.assert_called_once()
 
 
 class TestErrorStates:

--- a/tests/test_noaa_radio_dialog_integration.py
+++ b/tests/test_noaa_radio_dialog_integration.py
@@ -253,6 +253,7 @@ class TestLoadStations:
         """Test _load_stations populates the station choice control."""
         dlg = _make_dialog(noaa_dialog_module)
         dlg._station_choice = MagicMock()
+        dlg._url_provider.get_stream_urls.side_effect = [["https://stream.example.com/1"], []]
 
         test_stations = [
             Station("TEST1", 162.55, "Test City 1", 40.0, -74.0, "NY"),
@@ -268,11 +269,32 @@ class TestLoadStations:
 
         dlg._station_choice.Set.assert_called_once()
         choices = dlg._station_choice.Set.call_args[0][0]
-        assert len(choices) == 2
+        assert len(choices) == 1
         assert "TEST1" in choices[0]
-        assert "TEST2" in choices[1]
         dlg._station_choice.SetSelection.assert_called_with(0)
-        assert dlg._stations == test_stations
+        assert dlg._stations == [test_stations[0]]
+
+    def test_load_stations_includes_weatherindex_only_station(self, noaa_dialog_module):
+        """Stations are included when any stream source resolves a feed."""
+        dlg = _make_dialog(noaa_dialog_module)
+        dlg._station_choice = MagicMock()
+        dlg._url_provider.get_stream_urls.side_effect = [["https://weatherindex.example.com/live"], []]
+
+        test_stations = [
+            Station("TEST1", 162.55, "Test City 1", 40.0, -74.0, "NY"),
+            Station("TEST2", 162.40, "Test City 2", 41.0, -75.0, "PA"),
+        ]
+        results = [
+            StationResult(station=s, distance_km=10.0 * i) for i, s in enumerate(test_stations)
+        ]
+
+        with patch("accessiweather.ui.dialogs.noaa_radio_dialog.StationDatabase") as mock_db_cls:
+            mock_db_cls.return_value.find_nearest.return_value = results
+            dlg._load_stations()
+
+        assert dlg._stations == [test_stations[0]]
+        dlg._url_provider.get_stream_urls.assert_any_call("TEST1")
+        dlg._url_provider.get_stream_urls.assert_any_call("TEST2")
 
     def test_load_stations_error_sets_status(self, noaa_dialog_module):
         """Test _load_stations handles database errors gracefully."""

--- a/tests/test_noaa_radio_stream_url.py
+++ b/tests/test_noaa_radio_stream_url.py
@@ -1,6 +1,10 @@
 """Tests for NOAA Weather Radio stream URL provider."""
 
+from unittest.mock import MagicMock
+
 from accessiweather.noaa_radio.stream_url import StreamURLProvider
+from accessiweather.noaa_radio.weatherindex_client import WeatherIndexClient
+from accessiweather.noaa_radio.wxradio_client import WxRadioClient
 
 
 class TestStreamURLProvider:
@@ -93,3 +97,71 @@ class TestStreamURLProvider:
         """Whitespace-padded call sign is normalized."""
         provider = StreamURLProvider()
         assert provider.get_stream_url("  WXJ76  ") == provider.get_stream_url("WXJ76")
+
+    def test_weatherindex_urls_are_first(self) -> None:
+        weatherindex_client = MagicMock(spec=WeatherIndexClient)
+        weatherindex_client.get_stream_urls.return_value = [
+            "https://weatherindex.example.com/live",
+            "https://weatherindex.example.com/backup",
+        ]
+        wxradio_client = MagicMock(spec=WxRadioClient)
+        wxradio_client.get_streams.return_value = {"WXJ76": ["https://wxradio.example.com/live"]}
+
+        provider = StreamURLProvider(
+            use_fallback=True,
+            wxradio_client=wxradio_client,
+            weatherindex_client=weatherindex_client,
+            custom_urls={"WXJ76": ["https://static.example.com/live"]},
+        )
+
+        assert provider.get_stream_urls("WXJ76") == [
+            "https://weatherindex.example.com/live",
+            "https://weatherindex.example.com/backup",
+            "https://wxradio.example.com/live",
+            "https://static.example.com/live",
+        ]
+
+    def test_merge_deduplicates_preserving_order(self) -> None:
+        weatherindex_client = MagicMock(spec=WeatherIndexClient)
+        weatherindex_client.get_stream_urls.return_value = [
+            "https://shared.example.com/live",
+            "https://weatherindex.example.com/backup",
+        ]
+        wxradio_client = MagicMock(spec=WxRadioClient)
+        wxradio_client.get_streams.return_value = {
+            "WXJ76": [
+                "https://shared.example.com/live",
+                "https://wxradio.example.com/live",
+            ]
+        }
+
+        provider = StreamURLProvider(
+            use_fallback=True,
+            wxradio_client=wxradio_client,
+            weatherindex_client=weatherindex_client,
+            custom_urls={"WXJ76": ["https://wxradio.example.com/live"]},
+        )
+
+        assert provider.get_stream_urls("WXJ76") == [
+            "https://shared.example.com/live",
+            "https://weatherindex.example.com/backup",
+            "https://wxradio.example.com/live",
+        ]
+
+    def test_generated_fallback_is_last_when_enabled(self) -> None:
+        weatherindex_client = MagicMock(spec=WeatherIndexClient)
+        weatherindex_client.get_stream_urls.return_value = []
+        wxradio_client = MagicMock(spec=WxRadioClient)
+        wxradio_client.get_streams.return_value = {}
+
+        provider = StreamURLProvider(
+            use_fallback=True,
+            wxradio_client=wxradio_client,
+            weatherindex_client=weatherindex_client,
+            custom_urls={"WXJ76": ["https://static.example.com/live"]},
+        )
+
+        assert provider.get_stream_urls("WXJ76") == ["https://static.example.com/live"]
+        assert provider.get_stream_urls("UNKNOWN99") == [
+            "https://broadcastify.cdnstream1.com/noaa/UNKNOWN99"
+        ]

--- a/tests/test_weatherindex_client.py
+++ b/tests/test_weatherindex_client.py
@@ -1,0 +1,91 @@
+"""Tests for WeatherIndex NOAA radio stream resolution."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import requests
+
+from accessiweather.noaa_radio.weatherindex_client import WeatherIndexClient
+
+
+class TestWeatherIndexClient:
+    """Tests for the WeatherIndex client."""
+
+    def _make_client(self, json_data: dict, **kwargs) -> WeatherIndexClient:
+        session = MagicMock(spec=requests.Session)
+        response = MagicMock()
+        response.json.return_value = json_data
+        response.raise_for_status.return_value = None
+        session.get.return_value = response
+        return WeatherIndexClient(session=session, **kwargs)
+
+    def test_get_stream_urls_parses_feed_urls(self) -> None:
+        client = self._make_client(
+            {
+                "station": {
+                    "call_sign": "WXJ76",
+                    "feeds": [
+                        {"stream_url": "https://audio.example.com/live"},
+                        {"stream_url": "https://audio.example.com/backup"},
+                    ],
+                }
+            }
+        )
+
+        assert client.get_stream_urls("WXJ76") == [
+            "https://audio.example.com/live",
+            "https://audio.example.com/backup",
+        ]
+
+    def test_get_stream_urls_deduplicates_and_skips_empty_values(self) -> None:
+        client = self._make_client(
+            {
+                "feeds": [
+                    {"stream_url": "https://audio.example.com/live"},
+                    {"stream_url": "  "},
+                    {"stream_url": "https://audio.example.com/live"},
+                    {},
+                ]
+            }
+        )
+
+        assert client.get_stream_urls("WXJ76") == ["https://audio.example.com/live"]
+
+    def test_get_stream_urls_returns_empty_on_network_error(self) -> None:
+        session = MagicMock(spec=requests.Session)
+        session.get.side_effect = requests.ConnectionError("fail")
+        client = WeatherIndexClient(session=session)
+
+        assert client.get_stream_urls("WXJ76") == []
+
+    def test_get_stream_urls_returns_empty_on_malformed_payload(self) -> None:
+        client = self._make_client({"feeds": "bad-data"})
+
+        assert client.get_stream_urls("WXJ76") == []
+
+    def test_get_stream_urls_uses_per_station_cache(self) -> None:
+        client = self._make_client(
+            {"feeds": [{"stream_url": "https://audio.example.com/live"}]},
+            cache_ttl=60,
+        )
+
+        first = client.get_stream_urls("WXJ76")
+        second = client.get_stream_urls("WXJ76")
+
+        assert first == second
+        client._session.get.assert_called_once()  # type: ignore[union-attr]
+
+    def test_get_stream_urls_refetches_after_cache_expiry(self) -> None:
+        client = self._make_client(
+            {"feeds": [{"stream_url": "https://audio.example.com/live"}]},
+            cache_ttl=1,
+        )
+
+        client.get_stream_urls("WXJ76")
+        client._cache["WXJ76"] = (["https://audio.example.com/live"], time.monotonic() - 2)
+
+        client.get_stream_urls("WXJ76")
+
+        assert client._session.get.call_count == 2  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary
- add a WeatherIndex client for per-station NOAA stream resolution
- merge WeatherIndex feeds ahead of wxradio and static sources
- filter nearby NOAA stations by any resolvable feed, not only hardcoded URLs
- keep local nearest-station lookup unchanged

## Testing
- pytest -q tests/test_weatherindex_client.py tests/test_noaa_radio_stream_url.py tests/test_noaa_radio_dialog_integration.py