### PR TITLE
fix(tray): format numeric wind directions as cardinal

### DIFF
--- a/src/accessiweather/taskbar_icon_updater.py
+++ b/src/accessiweather/taskbar_icon_updater.py
@@ -19,6 +19,7 @@ from .utils.temperature_utils import (
     fahrenheit_to_celsius,
 )
 from .utils.unit_utils import (
+    convert_wind_direction_to_cardinal,
     format_precipitation,
     format_pressure,
     format_visibility,
@@ -221,9 +222,7 @@ class TaskbarIconUpdater:
         data["humidity"] = self._format_numeric(humidity, "%")
         data["wind"] = self._format_wind(current)
         data["wind_speed"] = self._format_wind_speed(current)
-        # wind_direction can be str ("NW") or int (270 degrees) - ensure it's a string
-        wind_dir = getattr(current, "wind_direction", None)
-        data["wind_dir"] = str(wind_dir) if wind_dir is not None else PLACEHOLDER_NA
+        data["wind_dir"] = self._format_wind_direction(getattr(current, "wind_direction", None))
         data["pressure"] = self._format_pressure(current)
         data["feels_like"] = self._format_feels_like(current)
         data["uv"] = self._format_numeric(getattr(current, "uv_index", None), "")
@@ -315,6 +314,14 @@ class TaskbarIconUpdater:
             return f"{value:.1f}{suffix}"
         return f"{value}{suffix}"
 
+    def _format_wind_direction(self, direction: Any) -> str:
+        """Format wind direction as a cardinal string when possible."""
+        if direction is None:
+            return PLACEHOLDER_NA
+        if isinstance(direction, (int, float)):
+            return convert_wind_direction_to_cardinal(float(direction))
+        return str(direction)
+
     def _format_wind(self, current: Any) -> str:
         """Format wind direction and speed."""
         direction = getattr(current, "wind_direction", None)
@@ -324,9 +331,9 @@ class TaskbarIconUpdater:
             return PLACEHOLDER_NA
 
         parts = []
-        if direction is not None:
-            # Convert to string - direction can be str ("NW") or int (270 degrees)
-            parts.append(str(direction))
+        formatted_direction = self._format_wind_direction(direction)
+        if formatted_direction != PLACEHOLDER_NA:
+            parts.append(formatted_direction)
         if speed is not None:
             parts.append(f"at {speed:.0f} mph")
 

--- a/tests/test_tray_text_format_dialog.py
+++ b/tests/test_tray_text_format_dialog.py
@@ -8,6 +8,7 @@ Covers:
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -120,6 +121,31 @@ class TestTrayTextFormatDialogPreview:
         updater = TaskbarIconUpdater(text_enabled=True)
         result = updater.build_preview("{temp}", weather_data=None)
         assert "72F" in result or "22C" in result
+
+    def test_format_tooltip_converts_numeric_wind_direction_to_cardinal(self):
+        """Numeric wind directions should not leak raw degrees into tray placeholders."""
+        updater = TaskbarIconUpdater(text_enabled=True, format_string="{wind} | {wind_dir}")
+        current = SimpleNamespace(
+            temperature_f=36.0,
+            temperature_c=2.2,
+            condition="Clear",
+            humidity=75,
+            wind_speed=0.0,
+            wind_direction=297,
+            pressure_in=30.0,
+            feels_like_f=27.0,
+            feels_like_c=-2.8,
+        )
+        current.has_data = lambda: True
+        weather_data = SimpleNamespace(
+            current_conditions=current,
+            forecast=None,
+            location=SimpleNamespace(country_code="US"),
+        )
+
+        result = updater.format_tooltip(weather_data, "Test City")
+
+        assert result == "WNW at 0 mph | WNW"
 
     @pytest.mark.parametrize(
         ("temperature_unit", "expected"),


### PR DESCRIPTION
## Summary
- convert numeric wind directions to cardinal labels in tray text placeholders
- apply the same normalization to both `{wind}` and `{wind_dir}`
- add a regression test for automatic mode leaking raw degrees into tray text

## Testing
- pytest -q tests/test_tray_text_format_dialog.py -k 'wind_direction or build_preview'