### PR TITLE
fix: preserve Pirate Weather source preference across restarts

### DIFF
--- a/src/accessiweather/config/settings.py
+++ b/src/accessiweather/config/settings.py
@@ -56,13 +56,6 @@ class SettingsOperations:
             settings.data_source = "auto"
             config_changed = True
 
-        if settings.data_source == "pirateweather" and not settings.pirate_weather_api_key:
-            self.logger.warning(
-                "Pirate Weather selected but no API key provided, switching to 'auto'"
-            )
-            settings.data_source = "auto"
-            config_changed = True
-
         if settings.data_source == "visualcrossing" and not settings.visual_crossing_api_key:
             self.logger.warning(
                 "Visual Crossing selected but no API key provided, switching to 'auto'"

--- a/tests/test_pw_coverage.py
+++ b/tests/test_pw_coverage.py
@@ -452,16 +452,16 @@ class TestSettingsPirateWeatherValidation:
 
         return manager
 
-    def test_pirateweather_without_api_key_falls_back_to_auto(self, mock_manager):
-        """Lines 60, 63-64: pirateweather selected but no key → switch to auto."""
+    def test_pirateweather_without_api_key_preserves_saved_preference(self, mock_manager):
+        """Load-time validation should not rewrite a persisted Pirate Weather preference."""
         from accessiweather.config.settings import SettingsOperations
 
         ops = SettingsOperations(mock_manager)
         ops._validate_and_fix_config()
 
         config = mock_manager.get_config()
-        assert config.settings.data_source == "auto"
-        mock_manager.save_config.assert_called()
+        assert config.settings.data_source == "pirateweather"
+        mock_manager.save_config.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_settings_operations.py
+++ b/tests/test_settings_operations.py
@@ -77,21 +77,34 @@ class TestValidateAndFixConfig:
 
     def test_valid_data_sources_unchanged(self, mock_manager, operations):
         """Test that valid data sources are not changed."""
-        valid_sources = ["auto", "nws", "openmeteo", "visualcrossing"]
+        valid_sources = ["auto", "nws", "openmeteo", "visualcrossing", "pirateweather"]
 
         for source in valid_sources:
             mock_manager._config.settings.data_source = source
-            # visualcrossing requires an API key to stay valid
+            # visualcrossing requires an API key to stay valid at load time
             if source == "visualcrossing":
                 mock_manager._config.settings.visual_crossing_api_key = "test_key"
             else:
                 mock_manager._config.settings.visual_crossing_api_key = ""
+            mock_manager._config.settings.pirate_weather_api_key = ""
             mock_manager.save_config.reset_mock()
 
             operations._validate_and_fix_config()
 
             assert mock_manager._config.settings.data_source == source
             mock_manager.save_config.assert_not_called()
+
+    def test_pirateweather_without_api_key_preserves_saved_preference(
+        self, mock_manager, operations
+    ):
+        """Test that pirateweather remains selected without rewriting persisted preference."""
+        mock_manager._config.settings.data_source = "pirateweather"
+        mock_manager._config.settings.pirate_weather_api_key = ""
+
+        operations._validate_and_fix_config()
+
+        assert mock_manager._config.settings.data_source == "pirateweather"
+        mock_manager.save_config.assert_not_called()
 
     def test_visualcrossing_without_api_key_switches_to_auto(self, mock_manager, operations):
         """Test that visualcrossing without API key switches to auto."""


### PR DESCRIPTION
## Summary
- stop load-time config validation from rewriting a saved  data source to  when the API key is unavailable
- add regression coverage that preserves the persisted preference during settings validation
- keep runtime fallback behavior unchanged in  when Pirate Weather is selected without a usable key

## Testing
- pytest -q tests/test_settings_operations.py
- pytest -q tests/test_settings_operations.py tests/test_pw_coverage.py tests/test_pirate_weather_client.py -k "pirateweather_without_api_key_preserves_saved_preference or determine_api_choice_pirateweather_falls_back_without_key"