### PR TITLE
perf(poll): skip PW minutely fetch in lightweight poll when disabled

### DIFF
--- a/src/accessiweather/weather_client_base.py
+++ b/src/accessiweather/weather_client_base.py
@@ -518,15 +518,11 @@ class WeatherClient:
             # wants precipitation start/stop notifications AND a PW client exists.
             # This avoids an extra API call every 60s for users who don't use it.
             if self.pirate_weather_client and self.settings:
-                _want_start = getattr(
-                    self.settings, "notify_minutely_precipitation_start", False
-                )
-                _want_stop = getattr(
-                    self.settings, "notify_minutely_precipitation_stop", False
-                )
+                _want_start = getattr(self.settings, "notify_minutely_precipitation_start", False)
+                _want_stop = getattr(self.settings, "notify_minutely_precipitation_stop", False)
                 if _want_start or _want_stop:
-                    weather_data.minutely_precipitation = (
-                        await self._get_pirate_weather_minutely(location)
+                    weather_data.minutely_precipitation = await self._get_pirate_weather_minutely(
+                        location
                     )
 
             loc_key = self._location_key(location)


### PR DESCRIPTION
Skip the Pirate Weather minutely precipitation API call in the 60-second lightweight event poll when the user does not have minutely precipitation notifications enabled. Restores the original lightweight poll speed for users without PW minutely notifications.