### PR TITLE
feat(settings): move alert timing controls into Advanced dialog

### DIFF
--- a/src/accessiweather/ui/dialogs/settings_dialog.py
+++ b/src/accessiweather/ui/dialogs/settings_dialog.py
@@ -715,11 +715,6 @@ class SettingsDialogSimple(wx.Dialog):
             wx.ALL,
             5,
         )
-        advanced_btn = wx.Button(panel, label="Advanced...")
-        advanced_btn.SetName("Advanced alert timing settings")
-        advanced_btn.SetToolTip("Configure cooldown periods and alert freshness window")
-        advanced_btn.Bind(wx.EVT_BUTTON, self._on_alert_advanced)
-        sizer.Add(advanced_btn, 0, wx.LEFT, 10)
 
         # Max notifications per hour
         row_max = wx.BoxSizer(wx.HORIZONTAL)
@@ -732,6 +727,12 @@ class SettingsDialogSimple(wx.Dialog):
         self._controls["max_notifications"] = wx.SpinCtrl(panel, min=1, max=100, initial=10)
         row_max.Add(self._controls["max_notifications"], 0)
         sizer.Add(row_max, 0, wx.LEFT | wx.TOP, 10)
+
+        advanced_btn = wx.Button(panel, label="Advanced...")
+        advanced_btn.SetName("Advanced alert timing settings")
+        advanced_btn.SetToolTip("Configure cooldown periods and alert freshness window")
+        advanced_btn.Bind(wx.EVT_BUTTON, self._on_alert_advanced)
+        sizer.Add(advanced_btn, 0, wx.LEFT | wx.TOP, 10)
 
         panel.SetSizer(sizer)
         self.notebook.AddPage(panel, "Notifications")


### PR DESCRIPTION
## Summary

- Removes the three alert rate-limiting controls (global cooldown, per-alert cooldown, freshness window) from the Notifications tab to reduce clutter
- Adds an **Advanced...** button in the Rate Limiting section that opens a small `AlertAdvancedSettingsDialog`
- Renames the controls with more descriptive labels:
  - "Global cooldown" → "Minimum time between any alert notifications (minutes)"
  - "Per-alert cooldown" → "Re-notify for same alert after (minutes)"
  - "Alert freshness window" → "Only notify for alerts issued within (minutes)"
- Control keys (`global_cooldown`, `per_alert_cooldown`, `freshness_window`) and all save/load logic remain unchanged — hidden SpinCtrl widgets carry values between the Advanced dialog and the main save path

## Test plan

- [x] Open Settings → Notifications tab — confirm the three cooldown controls are no longer visible inline
- [x] Click **Advanced...** — confirm the dialog opens with all three controls and current values
- [x] Change values, click OK — confirm they are saved correctly when the main Settings OK is pressed
- [ ] Click **Advanced...** then Cancel — confirm values are unchanged
- [ ] All existing tests pass (`pytest tests/ -q`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)