### PR TITLE
fix(openmeteo): pass through visibility from Open-Meteo instead of hardcoding None

### DIFF
--- a/src/accessiweather/openmeteo_mapper.py
+++ b/src/accessiweather/openmeteo_mapper.py
@@ -168,9 +168,9 @@ class OpenMeteoMapper:
                         "qualityControl": "qc:V",
                     },
                     "visibility": {
-                        "value": None,  # Open-Meteo doesn't provide visibility
+                        "value": current.get("visibility"),  # meters
                         "unitCode": "wmoUnit:m",
-                        "qualityControl": "qc:Z",
+                        "qualityControl": "qc:V",
                     },
                     "uvIndex": {
                         "value": uv_index_value,

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -1043,6 +1043,12 @@ class MainWindow(SizedFrame):
                 )
                 return
 
+            # Debug: log visibility before display
+            if weather_data.current:
+                logger.info(
+                    f"DEBUG visibility before display: {weather_data.current.visibility_miles} mi "
+                    f"(source: {getattr(weather_data.source_attribution, 'contributing_sources', 'unknown')})"
+                )
             # Update UI on main thread
             wx.CallAfter(self._on_weather_data_received, weather_data)
 


### PR DESCRIPTION
## Bug

`openmeteo_mapper.py` had a comment saying 'Open-Meteo doesn't provide visibility' and was setting `value: None` for the visibility field. This was wrong — Open-Meteo absolutely provides visibility in meters via the `visibility` current field.

The result was that when Open-Meteo was selected as the data source, visibility was always null from the mapper, causing the display to fall back to stale cached data from another source (e.g. showing 49 mi when Open-Meteo was actually returning 11.1 mi).

## Fix

Pass through `current.get('visibility')` (meters) in the mapper, same as every other field. The existing unit conversion in the Open-Meteo client handles meters → miles/km correctly.