### PR TITLE
feat(settings): configurable auto mode source list

### DIFF
--- a/src/accessiweather/models/config.py
+++ b/src/accessiweather/models/config.py
@@ -90,6 +90,8 @@ NON_CRITICAL_SETTINGS: set[str] = {
     "taskbar_icon_text_format",
     "source_priority_us",
     "source_priority_international",
+    "auto_sources_us",
+    "auto_sources_international",
     "openmeteo_weather_model",
     "station_selection_strategy",
 }
@@ -202,6 +204,13 @@ class AppSettings:
     round_values: bool = False
     # Parallel fetch timeout for smart auto mode (seconds)
     parallel_fetch_timeout: float = 5.0
+    # Auto mode source selection — which sources participate in auto mode
+    auto_sources_us: list[str] = field(
+        default_factory=lambda: ["nws", "openmeteo", "visualcrossing", "pirateweather"]
+    )
+    auto_sources_international: list[str] = field(
+        default_factory=lambda: ["openmeteo", "pirateweather", "visualcrossing"]
+    )
 
     @staticmethod
     def _as_bool(value, default: bool) -> bool:
@@ -356,30 +365,24 @@ class AppSettings:
             if value not in valid_strategies:
                 setattr(self, setting_name, "hybrid_default")
 
-        elif setting_name in {"source_priority_us", "source_priority_international"}:
+        elif setting_name in {
+            "source_priority_us",
+            "source_priority_international",
+            "auto_sources_us",
+            "auto_sources_international",
+        }:
             # Ensure valid list of source names
             valid_sources = {"nws", "openmeteo", "visualcrossing", "pirateweather"}
+            us_default = ["nws", "openmeteo", "visualcrossing", "pirateweather"]
+            intl_default = ["openmeteo", "pirateweather", "visualcrossing"]
+            is_us_setting = setting_name in {"source_priority_us", "auto_sources_us"}
             if not isinstance(value, list):
-                if setting_name == "source_priority_us":
-                    setattr(
-                        self, setting_name, ["nws", "openmeteo", "visualcrossing", "pirateweather"]
-                    )
-                else:
-                    setattr(self, setting_name, ["openmeteo", "pirateweather", "visualcrossing"])
+                setattr(self, setting_name, us_default if is_us_setting else intl_default)
             else:
                 # Filter to only valid sources
                 filtered = [s for s in value if s in valid_sources]
                 if not filtered:
-                    if setting_name == "source_priority_us":
-                        setattr(
-                            self,
-                            setting_name,
-                            ["nws", "openmeteo", "visualcrossing", "pirateweather"],
-                        )
-                    else:
-                        setattr(
-                            self, setting_name, ["openmeteo", "pirateweather", "visualcrossing"]
-                        )
+                    setattr(self, setting_name, us_default if is_us_setting else intl_default)
                 elif filtered != value:
                     setattr(self, setting_name, filtered)
 
@@ -459,6 +462,8 @@ class AppSettings:
             "taskbar_icon_text_format": self.taskbar_icon_text_format,
             "source_priority_us": self.source_priority_us,
             "source_priority_international": self.source_priority_international,
+            "auto_sources_us": self.auto_sources_us,
+            "auto_sources_international": self.auto_sources_international,
             "openmeteo_weather_model": self.openmeteo_weather_model,
             "station_selection_strategy": self.station_selection_strategy,
             # AI settings and AVWX key stored in secure storage, not here
@@ -548,6 +553,12 @@ class AppSettings:
             ),
             source_priority_international=data.get(
                 "source_priority_international", ["openmeteo", "pirateweather", "visualcrossing"]
+            ),
+            auto_sources_us=data.get(
+                "auto_sources_us", ["nws", "openmeteo", "visualcrossing", "pirateweather"]
+            ),
+            auto_sources_international=data.get(
+                "auto_sources_international", ["openmeteo", "pirateweather", "visualcrossing"]
             ),
             openmeteo_weather_model=data.get("openmeteo_weather_model", "best_match"),
             station_selection_strategy=data.get("station_selection_strategy", "hybrid_default"),

--- a/src/accessiweather/ui/dialogs/settings_dialog.py
+++ b/src/accessiweather/ui/dialogs/settings_dialog.py
@@ -417,6 +417,42 @@ class SettingsDialogSimple(wx.Dialog):
         self._controls["data_source"].Bind(wx.EVT_CHOICE, self._on_data_source_changed)
         sizer.Add(row1, 0, wx.ALL, 5)
 
+        # Auto Mode Source Selection (shown only when data_source == 'auto')
+        auto_sources_box = wx.StaticBox(panel, label="Auto mode sources:")
+        self._auto_sources_sizer = wx.StaticBoxSizer(auto_sources_box, wx.VERTICAL)
+
+        us_label = wx.StaticText(panel, label="US locations:")
+        self._auto_sources_sizer.Add(us_label, 0, wx.ALL, 5)
+        us_cb_row = wx.BoxSizer(wx.HORIZONTAL)
+        self._controls["auto_src_us_nws"] = wx.CheckBox(panel, label="NWS")
+        self._controls["auto_src_us_openmeteo"] = wx.CheckBox(panel, label="Open-Meteo")
+        self._controls["auto_src_us_visualcrossing"] = wx.CheckBox(panel, label="Visual Crossing")
+        self._controls["auto_src_us_pirateweather"] = wx.CheckBox(panel, label="Pirate Weather")
+        for key in (
+            "auto_src_us_nws",
+            "auto_src_us_openmeteo",
+            "auto_src_us_visualcrossing",
+            "auto_src_us_pirateweather",
+        ):
+            us_cb_row.Add(self._controls[key], 0, wx.RIGHT, 10)
+        self._auto_sources_sizer.Add(us_cb_row, 0, wx.LEFT | wx.BOTTOM, 10)
+
+        intl_label = wx.StaticText(panel, label="International locations:")
+        self._auto_sources_sizer.Add(intl_label, 0, wx.ALL, 5)
+        intl_cb_row = wx.BoxSizer(wx.HORIZONTAL)
+        self._controls["auto_src_intl_openmeteo"] = wx.CheckBox(panel, label="Open-Meteo")
+        self._controls["auto_src_intl_visualcrossing"] = wx.CheckBox(panel, label="Visual Crossing")
+        self._controls["auto_src_intl_pirateweather"] = wx.CheckBox(panel, label="Pirate Weather")
+        for key in (
+            "auto_src_intl_openmeteo",
+            "auto_src_intl_visualcrossing",
+            "auto_src_intl_pirateweather",
+        ):
+            intl_cb_row.Add(self._controls[key], 0, wx.RIGHT, 10)
+        self._auto_sources_sizer.Add(intl_cb_row, 0, wx.LEFT | wx.BOTTOM, 10)
+
+        sizer.Add(self._auto_sources_sizer, 0, wx.ALL | wx.EXPAND, 5)
+
         # Visual Crossing Configuration
         self._vc_config_sizer = wx.BoxSizer(wx.VERTICAL)
         self._vc_config_sizer.Add(
@@ -1422,7 +1458,6 @@ class SettingsDialogSimple(wx.Dialog):
                 "pirateweather": 4,
             }
             self._controls["data_source"].SetSelection(source_map.get(data_source, 0))
-            self._update_api_key_visibility()
 
             vc_key = getattr(settings, "visual_crossing_api_key", "") or ""
             self._controls["vc_key"].SetValue(str(vc_key))
@@ -1440,6 +1475,27 @@ class SettingsDialogSimple(wx.Dialog):
                 self._controls["pw_key"].Bind(
                     wx.EVT_TEXT, lambda e: setattr(self, "_pw_key_cleared", True)
                 )
+
+            # Auto mode sources
+            auto_src_us = getattr(
+                settings, "auto_sources_us", ["nws", "openmeteo", "visualcrossing", "pirateweather"]
+            )
+            auto_src_intl = getattr(
+                settings,
+                "auto_sources_international",
+                ["openmeteo", "pirateweather", "visualcrossing"],
+            )
+            self._controls["auto_src_us_nws"].SetValue("nws" in auto_src_us)
+            self._controls["auto_src_us_openmeteo"].SetValue("openmeteo" in auto_src_us)
+            self._controls["auto_src_us_visualcrossing"].SetValue("visualcrossing" in auto_src_us)
+            self._controls["auto_src_us_pirateweather"].SetValue("pirateweather" in auto_src_us)
+            self._controls["auto_src_intl_openmeteo"].SetValue("openmeteo" in auto_src_intl)
+            self._controls["auto_src_intl_visualcrossing"].SetValue(
+                "visualcrossing" in auto_src_intl
+            )
+            self._controls["auto_src_intl_pirateweather"].SetValue("pirateweather" in auto_src_intl)
+
+            self._update_api_key_visibility()
 
             # Source priority
             us_priority = getattr(
@@ -1784,6 +1840,32 @@ class SettingsDialogSimple(wx.Dialog):
                 intl_idx if intl_idx >= 0 else 0
             ]
 
+            # Auto mode sources
+            auto_sources_us = [
+                src
+                for src, key in (
+                    ("nws", "auto_src_us_nws"),
+                    ("openmeteo", "auto_src_us_openmeteo"),
+                    ("visualcrossing", "auto_src_us_visualcrossing"),
+                    ("pirateweather", "auto_src_us_pirateweather"),
+                )
+                if self._controls[key].GetValue()
+            ]
+            settings_dict["auto_sources_us"] = auto_sources_us or ["openmeteo"]
+
+            auto_sources_international = [
+                src
+                for src, key in (
+                    ("openmeteo", "auto_src_intl_openmeteo"),
+                    ("visualcrossing", "auto_src_intl_visualcrossing"),
+                    ("pirateweather", "auto_src_intl_pirateweather"),
+                )
+                if self._controls[key].GetValue()
+            ]
+            settings_dict["auto_sources_international"] = auto_sources_international or [
+                "openmeteo"
+            ]
+
             # If the field is blank but was non-empty when the dialog opened,
             # only preserve the key if the user never interacted with the field
             # (i.e. keyring failed to load). If the user explicitly cleared the
@@ -1841,6 +1923,13 @@ class SettingsDialogSimple(wx.Dialog):
             "data_source": "Weather Data Source",
             "vc_key": "Visual Crossing API Key",
             "pw_key": "Pirate Weather API Key",
+            "auto_src_us_nws": "Auto mode US: NWS",
+            "auto_src_us_openmeteo": "Auto mode US: Open-Meteo",
+            "auto_src_us_visualcrossing": "Auto mode US: Visual Crossing",
+            "auto_src_us_pirateweather": "Auto mode US: Pirate Weather",
+            "auto_src_intl_openmeteo": "Auto mode International: Open-Meteo",
+            "auto_src_intl_visualcrossing": "Auto mode International: Visual Crossing",
+            "auto_src_intl_pirateweather": "Auto mode International: Pirate Weather",
             "us_priority": "US Locations Priority",
             "intl_priority": "International Locations Priority",
             "openmeteo_model": "Open-Meteo Weather Model",
@@ -1922,10 +2011,23 @@ class SettingsDialogSimple(wx.Dialog):
         show_pw = selection in (0, 4)  # auto or PW
         self._vc_config_sizer.ShowItems(show_vc)
         self._pw_config_sizer.ShowItems(show_pw)
+        # Show auto sources section only in auto mode
+        self._auto_sources_sizer.ShowItems(selection == 0)
+        if selection == 0:
+            self._update_auto_source_key_state()
         # Re-layout the panel
         parent = self._controls["data_source"].GetParent()
         parent.Layout()
         parent.FitInside()
+
+    def _update_auto_source_key_state(self):
+        """Enable/disable API-key-requiring checkboxes based on configured keys."""
+        vc_key = self._controls["vc_key"].GetValue().strip()
+        pw_key = self._controls["pw_key"].GetValue().strip()
+        self._controls["auto_src_us_visualcrossing"].Enable(bool(vc_key))
+        self._controls["auto_src_intl_visualcrossing"].Enable(bool(vc_key))
+        self._controls["auto_src_us_pirateweather"].Enable(bool(pw_key))
+        self._controls["auto_src_intl_pirateweather"].Enable(bool(pw_key))
 
     def _on_get_pw_api_key(self, event):
         """Open Pirate Weather signup page."""

--- a/src/accessiweather/weather_client_base.py
+++ b/src/accessiweather/weather_client_base.py
@@ -853,18 +853,22 @@ class WeatherClient:
         """
         logger.info(f"Using smart auto source for {location.name}")
 
-        # Initialize components with user's source priority settings
-        us_priority = getattr(
+        # Get user-configured auto mode source lists
+        auto_sources_us = getattr(
             self.settings,
-            "source_priority_us",
+            "auto_sources_us",
             ["nws", "openmeteo", "visualcrossing", "pirateweather"],
         )
-        intl_priority = getattr(
+        auto_sources_international = getattr(
             self.settings,
-            "source_priority_international",
+            "auto_sources_international",
             ["openmeteo", "pirateweather", "visualcrossing"],
         )
-        config = SourcePriorityConfig(us_default=us_priority, international_default=intl_priority)
+
+        # Initialize components with user's source priority settings
+        config = SourcePriorityConfig(
+            us_default=auto_sources_us, international_default=auto_sources_international
+        )
         parallel_timeout = getattr(self.settings, "parallel_fetch_timeout", 5.0)
         coordinator = ParallelFetchCoordinator(timeout=parallel_timeout)
         fusion_engine = DataFusionEngine(config)
@@ -872,6 +876,7 @@ class WeatherClient:
 
         # Prepare fetch coroutines for available sources
         is_us = self._is_us_location(location)
+        active_sources = auto_sources_us if is_us else auto_sources_international
 
         # Always fetch from Open-Meteo (works globally)
         async def fetch_openmeteo():
@@ -917,13 +922,21 @@ class WeatherClient:
             alerts = await pirate_weather_client.get_alerts(location)
             return (current, forecast, hourly, alerts)
 
-        # Fetch from all sources in parallel
+        # Fetch from all sources in parallel, respecting user's auto source selection
         source_results = await coordinator.fetch_all(
             location=location,
-            fetch_nws=fetch_nws() if is_us else None,
-            fetch_openmeteo=fetch_openmeteo(),
-            fetch_visualcrossing=fetch_vc() if self.visual_crossing_client else None,
-            fetch_pirateweather=fetch_pw() if self.pirate_weather_api_key else None,
+            fetch_nws=fetch_nws() if (is_us and "nws" in active_sources) else None,
+            fetch_openmeteo=fetch_openmeteo() if "openmeteo" in active_sources else None,
+            fetch_visualcrossing=(
+                fetch_vc()
+                if (self.visual_crossing_client and "visualcrossing" in active_sources)
+                else None
+            ),
+            fetch_pirateweather=(
+                fetch_pw()
+                if (self.pirate_weather_api_key and "pirateweather" in active_sources)
+                else None
+            ),
         )
 
         # Check if all sources failed

--- a/tests/test_settings_dialog_audio_events.py
+++ b/tests/test_settings_dialog_audio_events.py
@@ -91,6 +91,7 @@ def _make_dialog(settings: SimpleNamespace) -> SettingsDialogSimple:
     dialog._event_sound_states = dialog._build_default_event_sound_states()
     dialog._vc_config_sizer = _DummySizer()
     dialog._pw_config_sizer = _DummySizer()
+    dialog._auto_sources_sizer = _DummySizer()
     dialog.config_manager = MagicMock()
     dialog.config_manager.get_settings.return_value = settings
     dialog.config_manager.update_settings.return_value = True

--- a/tests/test_settings_dialog_source_priority.py
+++ b/tests/test_settings_dialog_source_priority.py
@@ -81,6 +81,7 @@ def _make_dialog_for_settings(settings: SimpleNamespace) -> SettingsDialogSimple
     dialog._update_minimize_on_startup_state = lambda _enabled: None
     dialog._vc_config_sizer = _DummySizer()
     dialog._pw_config_sizer = _DummySizer()
+    dialog._auto_sources_sizer = _DummySizer()
     dialog.config_manager = MagicMock()
     dialog.config_manager.get_settings.return_value = settings
     return dialog

--- a/tests/test_settings_dialog_tray_text.py
+++ b/tests/test_settings_dialog_tray_text.py
@@ -84,6 +84,7 @@ def _make_dialog_for_settings(settings: SimpleNamespace) -> SettingsDialogSimple
     dialog._selected_specific_model = None
     dialog._vc_config_sizer = _DummySizer()
     dialog._pw_config_sizer = _DummySizer()
+    dialog._auto_sources_sizer = _DummySizer()
     dialog.config_manager = MagicMock()
     dialog.config_manager.get_settings.return_value = settings
     return dialog


### PR DESCRIPTION
## Summary

- Adds `auto_sources_us` and `auto_sources_international` settings fields so users can control which weather sources participate in auto mode for US and international locations separately
- Adds a checkbox UI section in the **Data Sources** tab that appears only when the data source is set to **Automatic**; sources requiring API keys are automatically disabled if no key is configured
- Wires the user's selection into both the `SourcePriorityConfig` (fusion engine) and the parallel fetch coordinator, so only checked sources are fetched and merged

## Changes

| File | Change |
|------|--------|
| `models/config.py` | New `auto_sources_us` / `auto_sources_international` fields with defaults, validation, serialization |
| `ui/dialogs/settings_dialog.py` | Checkbox group in Data Sources tab; show/hide on source change; disable API-key sources when keys absent |
| `weather_client_base.py` | Use new fields for `SourcePriorityConfig` and filter `coordinator.fetch_all()` by active sources |
| `tests/test_settings_dialog_*.py` | Add `_auto_sources_sizer` to test helpers |

## Test plan

- [x] Open settings → Data Sources; verify checkbox section is hidden when source ≠ Automatic
- [x] Switch to Automatic; verify checkbox section appears with all 4 US sources and 3 international sources
- [ ] Remove a Visual Crossing / Pirate Weather API key; verify those checkboxes become disabled
- [ ] Uncheck Open-Meteo for US, save, reopen — checkbox remains unchecked
- [ ] With Open-Meteo unchecked for US, trigger a weather refresh for a US location; verify Open-Meteo is not fetched (check logs)
- [ ] All 3026 existing tests pass (`pytest tests/ -q`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)