### PR TITLE
fix(a11y): replace status_label with wx.StatusBar for NVDA+End support

### DIFF
--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -29,6 +29,16 @@ logger = logging.getLogger(__name__)
 ALL_LOCATIONS_SENTINEL = "All Locations"
 
 
+class _StaleWarningProxy:
+    """Delegates SetLabel() calls to the second field of the wx.StatusBar."""
+
+    def __init__(self, window: MainWindow) -> None:
+        self._window = window
+
+    def SetLabel(self, text: str) -> None:
+        self._window.GetStatusBar().SetStatusText(text, 1)
+
+
 class MainWindow(SizedFrame):
     """
     Main application window using plain wxPython.
@@ -96,14 +106,6 @@ class MainWindow(SizedFrame):
         )
         self.location_dropdown.SetSizerProps(expand=True, proportion=1)
 
-        # Status display
-        self.status_label = wx.StaticText(panel, label="")
-        self.status_label.SetSizerProps(expand=True)
-
-        # Stale/cached data warning
-        self.stale_warning_label = wx.StaticText(panel, label="")
-        self.stale_warning_label.SetSizerProps(expand=True)
-
         # Current conditions section
         wx.StaticText(panel, label="Current Conditions:")
         self.current_conditions = wx.TextCtrl(
@@ -157,6 +159,11 @@ class MainWindow(SizedFrame):
         self.explain_button = wx.Button(button_panel, label="&Explain")
         self.discussion_button = wx.Button(button_panel, label="&Discussion")
         self.settings_button = wx.Button(button_panel, label="&Settings")
+
+        # Status bar — two fields: [0] main status, [1] stale/cached warning
+        self.CreateStatusBar(2)
+        self.GetStatusBar().SetStatusWidths([-2, -1])
+        self.stale_warning_label = _StaleWarningProxy(self)
 
     def _bind_events(self) -> None:
         """Bind all event handlers."""
@@ -1569,8 +1576,8 @@ class MainWindow(SizedFrame):
         return first_with_data, first_with_data_name
 
     def set_status(self, message: str) -> None:
-        """Set the status label text and announce via screen reader."""
-        self.status_label.SetLabel(message)
+        """Set the status bar text and announce via screen reader."""
+        self.GetStatusBar().SetStatusText(message, 0)
         logger.info(f"Status: {message}")
         if message:
             self._announcer.announce(message)

--- a/tests/test_all_locations_view.py
+++ b/tests/test_all_locations_view.py
@@ -41,8 +41,8 @@ def _make_window():
     win.alerts_list = MagicMock()
     win.view_alert_button = MagicMock()
     win.refresh_button = MagicMock()
-    win.status_label = MagicMock()
     win.stale_warning_label = MagicMock()
+    win.GetStatusBar = MagicMock(return_value=MagicMock())
     win._announcer = MagicMock()
 
     # State
@@ -269,7 +269,9 @@ class TestShowAllLocationsSummary:
 
         win._show_all_locations_summary()
 
-        win.status_label.SetLabel.assert_called_with("All Locations summary — 2 location(s)")
+        win.GetStatusBar().SetStatusText.assert_called_with(
+            "All Locations summary — 2 location(s)", 0
+        )
 
     def test_refresh_button_enabled_after_summary(self):
         win = _make_window()

--- a/tests/test_main_window_announcer.py
+++ b/tests/test_main_window_announcer.py
@@ -3,25 +3,28 @@
 from unittest.mock import MagicMock, patch
 
 
-class _StatusLabelStub:
-    """Minimal stub for wx.StaticText used in set_status()."""
+class _StatusBarStub:
+    """Minimal stub for wx.StatusBar used in set_status()."""
 
     def __init__(self):
-        self.label = ""
+        self.fields = ["", ""]
 
-    def SetLabel(self, text):
-        self.label = text
+    def SetStatusText(self, text, field=0):
+        self.fields[field] = text
 
 
 class _MainWindowStub:
     """Minimal stub for MainWindow that exercises set_status() logic."""
 
     def __init__(self, announcer):
-        self.status_label = _StatusLabelStub()
+        self._status_bar = _StatusBarStub()
         self._announcer = announcer
 
+    def GetStatusBar(self):
+        return self._status_bar
+
     def set_status(self, message: str) -> None:
-        self.status_label.SetLabel(message)
+        self.GetStatusBar().SetStatusText(message, 0)
         if message:
             self._announcer.announce(message)
 
@@ -45,11 +48,11 @@ class TestSetStatusAnnounces:
         win.set_status("")
         announcer.announce.assert_not_called()
 
-    def test_status_label_updated_regardless_of_announcer(self):
+    def test_status_bar_updated_regardless_of_announcer(self):
         announcer = _make_announcer(available=False)
         win = _MainWindowStub(announcer)
         win.set_status("Error: fetch failed")
-        assert win.status_label.label == "Error: fetch failed"
+        assert win.GetStatusBar().fields[0] == "Error: fetch failed"
 
     def test_multiple_set_status_calls_each_announce(self):
         announcer = _make_announcer()
@@ -90,7 +93,6 @@ class TestMainWindowAnnouncerInit:
             from accessiweather.ui.main_window import ScreenReaderAnnouncer
 
             win._announcer = ScreenReaderAnnouncer()
-            win.status_label = _StatusLabelStub()
 
         assert win._announcer is mock_announcer
 
@@ -102,7 +104,7 @@ class TestMainWindowAnnouncerInit:
             win = MainWindow.__new__(MainWindow)
 
         win._announcer = mock_announcer
-        win.status_label = _StatusLabelStub()
+        win.GetStatusBar = MagicMock(return_value=MagicMock())
         # Call the real set_status
         MainWindow.set_status(win, "Refresh complete")
         mock_announcer.announce.assert_called_once_with("Refresh complete")


### PR DESCRIPTION
## Summary

- Replaces `self.status_label` (`wx.StaticText`) in the main window with a proper two-field `wx.StatusBar` created via `self.CreateStatusBar(2)`.
- Updates `set_status()` to call `self.GetStatusBar().SetStatusText(message, 0)` instead of `self.status_label.SetLabel()`.
- Adds `_StaleWarningProxy` that forwards `stale_warning_label.SetLabel()` calls to the second status bar field — no call-sites needed to change.
- Updates tests that asserted on `status_label.SetLabel` to use `GetStatusBar().SetStatusText` instead.

## Test plan

- [x] `python3 -m pytest tests/ -q` — 3035 passed, 4 skipped, 0 failures
- [x] Pre-commit hooks (ruff lint + format) pass

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)