### PR TITLE
fix(a11y): remove routine set_status calls to prevent Prism announcing every weather update

### DIFF
--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -991,7 +991,6 @@ class MainWindow(SizedFrame):
         """
         # All Locations view: fetch fresh data for all locations sequentially then re-render.
         if getattr(self, "_all_locations_active", False):
-            self.set_status("Refreshing all locations...")
             self.refresh_button.Disable()
             self.app.run_async(self._fetch_all_locations_data())
             return
@@ -1004,7 +1003,6 @@ class MainWindow(SizedFrame):
             return
 
         self.app.is_updating = True
-        self.set_status("Updating weather data...")
         self.refresh_button.Disable()
 
         # Run async weather fetch with current generation
@@ -1122,7 +1120,6 @@ class MainWindow(SizedFrame):
             self.current_conditions.SetValue(current_text)
             self._set_forecast_sections(forecast_text, "")
             self.stale_warning_label.SetLabel("")
-            self.set_status("Nationwide discussions updated")
         except Exception as e:
             logger.error(f"Error updating nationwide display: {e}")
         finally:
@@ -1232,7 +1229,6 @@ class MainWindow(SizedFrame):
 
             location = self.app.config_manager.get_current_location()
             location_name = location.name if location else "Unknown"
-            self.set_status(f"Weather updated for {location_name}")
 
             # Update system tray tooltip with current weather
             self.app.update_tray_tooltip(weather_data, location_name)
@@ -1399,7 +1395,6 @@ class MainWindow(SizedFrame):
             self._set_forecast_sections("", "")
             self.alerts_list.Clear()
             self.view_alert_button.Disable()
-            self.set_status("All Locations — no locations configured")
             return
 
         lines: list[str] = ["All Locations Summary", ""]
@@ -1470,7 +1465,6 @@ class MainWindow(SizedFrame):
         self.app.update_tray_tooltip(tray_data, tray_loc_name)
 
         self.stale_warning_label.SetLabel("")
-        self.set_status(f"All Locations summary — {len(all_locs)} location(s)")
 
         # Ensure the refresh button stays enabled in this view.
         self.app.is_updating = False

--- a/tests/test_all_locations_view.py
+++ b/tests/test_all_locations_view.py
@@ -261,18 +261,6 @@ class TestShowAllLocationsSummary:
         assert "No locations configured" in text
         win.view_alert_button.Disable.assert_called()
 
-    def test_status_shows_location_count(self):
-        win = _make_window()
-        locs = [_make_location("Boston"), _make_location("Austin")]
-        win.app.config_manager.get_all_locations.return_value = locs
-        win.app.weather_client.get_cached_weather.return_value = None
-
-        win._show_all_locations_summary()
-
-        win.GetStatusBar().SetStatusText.assert_called_with(
-            "All Locations summary — 2 location(s)", 0
-        )
-
     def test_refresh_button_enabled_after_summary(self):
         win = _make_window()
         win.app.config_manager.get_all_locations.return_value = [_make_location("Boston")]


### PR DESCRIPTION
Closes #540

## Problem
The status bar is read by Prism on every change. Routine messages like "Weather updated for Lumberton, NJ" and "Updating weather data..." were being announced via Prism on every background poll, which is noisy and unexpected.

## Fix
Removed all non-error `set_status()` calls from `main_window.py`. The status bar now only updates for error conditions:
- `Error updating display: ...`
- `Error: ...`

Removed:
- `Refreshing all locations...`
- `Updating weather data...`
- `Weather updated for {location_name}`
- `All Locations summary — N location(s)`
- `Nationwide discussions updated`

Sounds, visual feedback, and all other UI behaviour are unchanged — only the status bar text updates were removed.

## Testing
All existing tests pass.