### PR TITLE
refactor(settings): split settings_dialog.py into per-tab modules

### DIFF
--- a/src/accessiweather/ui/dialogs/settings_dialog.py
+++ b/src/accessiweather/ui/dialogs/settings_dialog.py
@@ -97,7 +97,7 @@ class AlertAdvancedSettingsDialog(wx.Dialog):
 
 
 class SettingsDialogSimple(wx.Dialog):
-    """Comprehensive settings dialog matching Toga version functionality."""
+    """Comprehensive settings dialog — thin coordinator over per-tab modules."""
 
     def __init__(self, parent, app: AccessiWeatherApp):
         """Initialize the settings dialog."""
@@ -118,26 +118,64 @@ class SettingsDialogSimple(wx.Dialog):
         self._load_settings()
         self._setup_accessibility()
 
-    def _create_ui(self):
-        """Create the dialog UI."""
-        main_sizer = wx.BoxSizer(wx.VERTICAL)
+    # ------------------------------------------------------------------
+    # Delegation helpers for backward compatibility
+    # ------------------------------------------------------------------
 
-        # Notebook for tabs
+    @classmethod
+    def _build_default_event_sound_states(cls) -> dict[str, bool]:
+        """Return default event sound states (delegates to AudioTab)."""
+        from .settings_tabs.audio import AudioTab
+
+        return AudioTab._build_default_event_sound_states()
+
+    @staticmethod
+    def _build_default_source_settings_states() -> dict:
+        """Return default source settings state (delegates to DataSourcesTab)."""
+        from .settings_tabs.data_sources import DataSourcesTab
+
+        return DataSourcesTab._build_default_source_settings_states()
+
+    # ------------------------------------------------------------------
+    # UI creation
+    # ------------------------------------------------------------------
+
+    def _create_ui(self):
+        """Create the dialog UI using per-tab modules."""
+        from .settings_tabs import (
+            AdvancedTab,
+            AITab,
+            AudioTab,
+            DataSourcesTab,
+            DisplayTab,
+            GeneralTab,
+            NotificationsTab,
+            UpdatesTab,
+        )
+
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
         self.notebook = wx.Notebook(self)
 
-        # Create all tab panels
-        self._create_general_tab()
-        self._create_display_tab()
-        self._create_data_sources_tab()
-        self._create_notifications_tab()
-        self._create_audio_tab()
-        self._create_updates_tab()
-        self._create_ai_tab()
-        self._create_advanced_tab()
+        self._tab_objects = [
+            GeneralTab(self),
+            DisplayTab(self),
+            DataSourcesTab(self),
+            NotificationsTab(self),
+            AudioTab(self),
+            UpdatesTab(self),
+            AITab(self),
+            AdvancedTab(self),
+        ]
+        # Keep named references for methods that need specific tabs
+        self._audio_tab = self._tab_objects[4]
+        self._display_tab = self._tab_objects[1]
+        self._data_sources_tab = self._tab_objects[2]
+
+        for tab in self._tab_objects:
+            tab.create()
 
         main_sizer.Add(self.notebook, 1, wx.EXPAND | wx.ALL, 10)
 
-        # Buttons
         button_sizer = wx.BoxSizer(wx.HORIZONTAL)
         button_sizer.AddStretchSpacer()
 
@@ -151,682 +189,105 @@ class SettingsDialogSimple(wx.Dialog):
 
         self.SetSizer(main_sizer)
 
-    def _create_general_tab(self):
-        """Create the general settings tab."""
-        panel = wx.ScrolledWindow(self.notebook)
-        panel.SetScrollRate(0, 20)
-        sizer = wx.BoxSizer(wx.VERTICAL)
-
-        # Update interval
-        row1 = wx.BoxSizer(wx.HORIZONTAL)
-        row1.Add(
-            wx.StaticText(panel, label="Update Interval (minutes):"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-        self._controls["update_interval"] = wx.SpinCtrl(panel, min=1, max=120, initial=10)
-        row1.Add(self._controls["update_interval"], 0)
-        sizer.Add(row1, 0, wx.ALL, 5)
-
-        # Show Nationwide location (only available with Auto or NWS data source)
-        self._controls["show_nationwide"] = wx.CheckBox(
-            panel, label="Show Nationwide location (requires Auto or NWS data source)"
-        )
-        sizer.Add(self._controls["show_nationwide"], 0, wx.ALL, 5)
-
-        sizer.Add(wx.StaticLine(panel), 0, wx.EXPAND | wx.ALL, 5)
-        sizer.Add(wx.StaticText(panel, label="Taskbar icon text:"), 0, wx.LEFT | wx.TOP, 5)
-
-        self._controls["taskbar_icon_text_enabled"] = wx.CheckBox(
-            panel, label="Show weather text on tray icon"
-        )
-        self._controls["taskbar_icon_text_enabled"].Bind(
-            wx.EVT_CHECKBOX,
-            self._on_taskbar_icon_text_enabled_changed,
-        )
-        sizer.Add(self._controls["taskbar_icon_text_enabled"], 0, wx.ALL, 5)
-
-        self._controls["taskbar_icon_dynamic_enabled"] = wx.CheckBox(
-            panel, label="Update tray text dynamically"
-        )
-        sizer.Add(self._controls["taskbar_icon_dynamic_enabled"], 0, wx.LEFT | wx.BOTTOM, 15)
-
-        row_taskbar_format = wx.BoxSizer(wx.HORIZONTAL)
-        row_taskbar_format.Add(
-            wx.StaticText(panel, label="Current tray text format:"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-        self._controls["taskbar_icon_text_format"] = wx.TextCtrl(
-            panel,
-            size=(280, -1),
-            style=wx.TE_READONLY,
-        )
-        row_taskbar_format.Add(self._controls["taskbar_icon_text_format"], 1)
-        self._controls["taskbar_icon_text_format_dialog"] = wx.Button(panel, label="Edit Format...")
-        self._controls["taskbar_icon_text_format_dialog"].Bind(
-            wx.EVT_BUTTON,
-            self._on_edit_taskbar_text_format,
-        )
-        row_taskbar_format.Add(self._controls["taskbar_icon_text_format_dialog"], 0, wx.LEFT, 8)
-        sizer.Add(row_taskbar_format, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 15)
-
-        panel.SetSizer(sizer)
-        self.notebook.AddPage(panel, "General")
-
-    def _create_display_tab(self):
-        """Create the display settings tab."""
-        panel = wx.ScrolledWindow(self.notebook)
-        panel.SetScrollRate(0, 20)
-        sizer = wx.BoxSizer(wx.VERTICAL)
-
-        # Temperature Display Section
-        sizer.Add(
-            wx.StaticText(panel, label="Temperature Display:"),
-            0,
-            wx.ALL | wx.EXPAND,
-            5,
-        )
-        self._controls["temp_unit"] = wx.Choice(
-            panel,
-            choices=[
-                "Auto (based on location)",
-                "Fahrenheit only",
-                "Celsius only",
-                "Both (Fahrenheit and Celsius)",
-            ],
-        )
-        sizer.Add(self._controls["temp_unit"], 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
-
-        # Metric Visibility Section
-        sizer.Add(
-            wx.StaticText(panel, label="Metric Visibility:", style=wx.BOLD),
-            0,
-            wx.ALL,
-            5,
-        )
-        sizer.Add(
-            wx.StaticText(panel, label="Select which weather metrics to display:"),
-            0,
-            wx.LEFT | wx.BOTTOM,
-            5,
-        )
-
-        self._controls["show_dewpoint"] = wx.CheckBox(panel, label="Show dewpoint")
-        sizer.Add(self._controls["show_dewpoint"], 0, wx.LEFT, 10)
-
-        self._controls["show_visibility"] = wx.CheckBox(panel, label="Show visibility")
-        sizer.Add(self._controls["show_visibility"], 0, wx.LEFT, 10)
-
-        self._controls["show_uv_index"] = wx.CheckBox(panel, label="Show UV index")
-        sizer.Add(self._controls["show_uv_index"], 0, wx.LEFT, 10)
-
-        self._controls["show_pressure_trend"] = wx.CheckBox(panel, label="Show pressure trend")
-        sizer.Add(self._controls["show_pressure_trend"], 0, wx.LEFT, 10)
-
-        self._controls["round_values"] = wx.CheckBox(
-            panel, label="Show values as whole numbers (no decimals)"
-        )
-        sizer.Add(self._controls["round_values"], 0, wx.LEFT | wx.TOP, 10)
-
-        row_forecast_duration = wx.BoxSizer(wx.HORIZONTAL)
-        row_forecast_duration.Add(
-            wx.StaticText(panel, label="Forecast duration:"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-        self._controls["forecast_duration_days"] = wx.Choice(
-            panel,
-            choices=[
-                "3 days",
-                "5 days",
-                "7 days (default)",
-                "10 days",
-                "14 days",
-                "15 days",
-            ],
-        )
-        row_forecast_duration.Add(self._controls["forecast_duration_days"], 0)
-        sizer.Add(row_forecast_duration, 0, wx.LEFT | wx.TOP, 10)
-
-        # Hourly forecast hours
-        row_hourly_hours = wx.BoxSizer(wx.HORIZONTAL)
-        row_hourly_hours.Add(
-            wx.StaticText(panel, label="Hourly forecast hours:"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-        self._controls["hourly_forecast_hours"] = wx.SpinCtrl(panel, min=1, max=168, initial=6)
-        row_hourly_hours.Add(self._controls["hourly_forecast_hours"], 0)
-        sizer.Add(row_hourly_hours, 0, wx.LEFT | wx.TOP, 10)
-
-        # Time & Date Display Section
-        sizer.Add(
-            wx.StaticText(panel, label="Time & Date Display:"),
-            0,
-            wx.ALL,
-            5,
-        )
-
-        row_time_ref = wx.BoxSizer(wx.HORIZONTAL)
-        row_time_ref.Add(
-            wx.StaticText(panel, label="Forecast time display:"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-        self._controls["forecast_time_reference"] = wx.Choice(
-            panel,
-            choices=["Location's timezone (default)", "My local timezone"],
-        )
-        row_time_ref.Add(self._controls["forecast_time_reference"], 0)
-        sizer.Add(row_time_ref, 0, wx.LEFT, 10)
-
-        row_tz = wx.BoxSizer(wx.HORIZONTAL)
-        row_tz.Add(
-            wx.StaticText(panel, label="Time zone display:"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-        self._controls["time_display_mode"] = wx.Choice(
-            panel,
-            choices=["Local time only", "UTC time only", "Both (Local and UTC)"],
-        )
-        row_tz.Add(self._controls["time_display_mode"], 0)
-        sizer.Add(row_tz, 0, wx.LEFT, 10)
-
-        self._controls["time_format_12hour"] = wx.CheckBox(
-            panel, label="Use 12-hour time format (e.g., 3:00 PM)"
-        )
-        sizer.Add(self._controls["time_format_12hour"], 0, wx.LEFT | wx.TOP, 10)
-
-        self._controls["show_timezone_suffix"] = wx.CheckBox(
-            panel, label="Show timezone abbreviations (e.g., EST, UTC)"
-        )
-        sizer.Add(self._controls["show_timezone_suffix"], 0, wx.LEFT, 10)
-
-        # Verbosity Section
-        sizer.Add(
-            wx.StaticText(panel, label="Information Priority:"),
-            0,
-            wx.ALL,
-            5,
-        )
-
-        row_verb = wx.BoxSizer(wx.HORIZONTAL)
-        row_verb.Add(
-            wx.StaticText(panel, label="Verbosity level:"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-        self._controls["verbosity_level"] = wx.Choice(
-            panel,
-            choices=[
-                "Minimal (essentials only)",
-                "Standard (recommended)",
-                "Detailed (all available info)",
-            ],
-        )
-        row_verb.Add(self._controls["verbosity_level"], 0)
-        sizer.Add(row_verb, 0, wx.LEFT, 10)
-
-        # Severe Weather Override
-        self._controls["severe_weather_override"] = wx.CheckBox(
-            panel, label="Automatically prioritize severe weather info"
-        )
-        sizer.Add(self._controls["severe_weather_override"], 0, wx.ALL, 10)
-
-        panel.SetSizer(sizer)
-        self.notebook.AddPage(panel, "Display")
-
-    def _create_data_sources_tab(self):
-        """Create the data sources tab."""
-        panel = wx.ScrolledWindow(self.notebook)
-        panel.SetScrollRate(0, 20)
-        sizer = wx.BoxSizer(wx.VERTICAL)
-
-        # Data source selection
-        row1 = wx.BoxSizer(wx.HORIZONTAL)
-        row1.Add(
-            wx.StaticText(panel, label="Weather Data Source:"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-        self._controls["data_source"] = wx.Choice(
-            panel,
-            choices=[
-                "Automatic (merges all available sources)",
-                "National Weather Service (US only, forecast + alerts)",
-                "Open-Meteo (Global forecast, no alerts, no API key)",
-                "Visual Crossing (Global forecast, US/Canada/Europe alerts, API key)",
-                "Pirate Weather (Global forecast + worldwide alerts, API key)",
-            ],
-        )
-        row1.Add(self._controls["data_source"], 0)
-        self._controls["data_source"].Bind(wx.EVT_CHOICE, self._on_data_source_changed)
-        sizer.Add(row1, 0, wx.ALL, 5)
-
-        # Visual Crossing Configuration
-        self._vc_config_sizer = wx.BoxSizer(wx.VERTICAL)
-        self._vc_config_sizer.Add(
-            wx.StaticText(panel, label="Visual Crossing API Configuration:"),
-            0,
-            wx.ALL,
-            5,
-        )
-
-        row_key = wx.BoxSizer(wx.HORIZONTAL)
-        row_key.Add(
-            wx.StaticText(panel, label="Visual Crossing API Key:"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-        self._controls["vc_key"] = wx.TextCtrl(panel, style=wx.TE_PASSWORD, size=(250, -1))
-        row_key.Add(self._controls["vc_key"], 1)
-        self._vc_config_sizer.Add(row_key, 0, wx.LEFT | wx.EXPAND, 10)
-
-        btn_row = wx.BoxSizer(wx.HORIZONTAL)
-        get_key_btn = wx.Button(panel, label="Get Free API Key")
-        get_key_btn.Bind(wx.EVT_BUTTON, self._on_get_vc_api_key)
-        btn_row.Add(get_key_btn, 0, wx.RIGHT, 10)
-
-        validate_btn = wx.Button(panel, label="Validate API Key")
-        validate_btn.Bind(wx.EVT_BUTTON, self._on_validate_vc_api_key)
-        btn_row.Add(validate_btn, 0)
-        self._vc_config_sizer.Add(btn_row, 0, wx.LEFT | wx.TOP | wx.BOTTOM, 10)
-        sizer.Add(self._vc_config_sizer, 0, wx.EXPAND)
-
-        # Pirate Weather Configuration
-        self._pw_config_sizer = wx.BoxSizer(wx.VERTICAL)
-        self._pw_config_sizer.Add(
-            wx.StaticText(panel, label="Pirate Weather API Configuration:"),
-            0,
-            wx.ALL,
-            5,
-        )
-
-        row_pw_key = wx.BoxSizer(wx.HORIZONTAL)
-        row_pw_key.Add(
-            wx.StaticText(panel, label="Pirate Weather API Key:"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-        self._controls["pw_key"] = wx.TextCtrl(panel, style=wx.TE_PASSWORD, size=(250, -1))
-        row_pw_key.Add(self._controls["pw_key"], 1)
-        self._pw_config_sizer.Add(row_pw_key, 0, wx.LEFT | wx.EXPAND, 10)
-
-        btn_row_pw = wx.BoxSizer(wx.HORIZONTAL)
-        get_pw_key_btn = wx.Button(panel, label="Get Free API Key")
-        get_pw_key_btn.Bind(wx.EVT_BUTTON, self._on_get_pw_api_key)
-        btn_row_pw.Add(get_pw_key_btn, 0, wx.RIGHT, 10)
-
-        validate_pw_btn = wx.Button(panel, label="Validate API Key")
-        validate_pw_btn.Bind(wx.EVT_BUTTON, self._on_validate_pw_api_key)
-        btn_row_pw.Add(validate_pw_btn, 0)
-        self._pw_config_sizer.Add(btn_row_pw, 0, wx.LEFT | wx.TOP | wx.BOTTOM, 10)
-        sizer.Add(self._pw_config_sizer, 0, wx.EXPAND)
-
-        # Source Settings summary + button
-        sizer.Add(
-            wx.StaticText(panel, label="Source Settings:"),
-            0,
-            wx.ALL,
-            5,
-        )
-        self._controls["source_settings_summary"] = wx.TextCtrl(
-            panel,
-            value=self._get_source_settings_summary_text(),
-            size=(-1, 44),
-            style=wx.TE_READONLY | wx.TE_MULTILINE | wx.TE_NO_VSCROLL,
-        )
-        sizer.Add(self._controls["source_settings_summary"], 0, wx.LEFT | wx.BOTTOM | wx.EXPAND, 5)
-        self._controls["configure_source_settings"] = wx.Button(
-            panel, label="Configure Source Settings..."
-        )
-        self._controls["configure_source_settings"].Bind(
-            wx.EVT_BUTTON, self._on_configure_source_settings
-        )
-        sizer.Add(self._controls["configure_source_settings"], 0, wx.LEFT | wx.BOTTOM, 5)
-
-        panel.SetSizer(sizer)
-        self.notebook.AddPage(panel, "Data Sources")
-
-    def _create_notifications_tab(self):
-        """Create the notifications tab."""
-        panel = wx.ScrolledWindow(self.notebook)
-        panel.SetScrollRate(0, 20)
-        sizer = wx.BoxSizer(wx.VERTICAL)
-
-        # Alert Settings Header
-        sizer.Add(
-            wx.StaticText(panel, label="Alert Notification Settings"),
-            0,
-            wx.ALL,
-            5,
-        )
-        sizer.Add(
-            wx.StaticText(
-                panel,
-                label="Configure which weather alerts trigger notifications based on severity.",
-            ),
-            0,
-            wx.LEFT | wx.BOTTOM,
-            5,
-        )
-
-        # Master switches
-        self._controls["enable_alerts"] = wx.CheckBox(panel, label="Enable weather alerts")
-        sizer.Add(self._controls["enable_alerts"], 0, wx.ALL, 5)
-
-        self._controls["alert_notif"] = wx.CheckBox(panel, label="Enable alert notifications")
-        sizer.Add(self._controls["alert_notif"], 0, wx.LEFT | wx.BOTTOM, 5)
-
-        # Alert area setting
-        row_area = wx.BoxSizer(wx.HORIZONTAL)
-        row_area.Add(
-            wx.StaticText(panel, label="Alert Area:"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-        self._controls["alert_radius_type"] = wx.Choice(
-            panel,
-            choices=[
-                "County (recommended — alerts for your county only)",
-                "Point (exact coordinate — may miss alerts)",
-                "Zone (NWS forecast zone — slightly broader than county)",
-                "State (entire state — noisy)",
-            ],
-        )
-        row_area.Add(self._controls["alert_radius_type"], 0)
-        sizer.Add(row_area, 0, wx.ALL, 5)
-
-        # Severity levels
-        sizer.Add(
-            wx.StaticText(panel, label="Alert Severity Levels:"),
-            0,
-            wx.ALL,
-            5,
-        )
-
-        self._controls["notify_extreme"] = wx.CheckBox(
-            panel, label="Extreme - Life-threatening events (e.g., Tornado Warning)"
-        )
-        sizer.Add(self._controls["notify_extreme"], 0, wx.LEFT, 10)
-
-        self._controls["notify_severe"] = wx.CheckBox(
-            panel, label="Severe - Significant hazards (e.g., Severe Thunderstorm Warning)"
-        )
-        sizer.Add(self._controls["notify_severe"], 0, wx.LEFT, 10)
-
-        self._controls["notify_moderate"] = wx.CheckBox(
-            panel, label="Moderate - Potentially hazardous (e.g., Winter Weather Advisory)"
-        )
-        sizer.Add(self._controls["notify_moderate"], 0, wx.LEFT, 10)
-
-        self._controls["notify_minor"] = wx.CheckBox(
-            panel, label="Minor - Low impact events (e.g., Frost Advisory, Fog Advisory)"
-        )
-        sizer.Add(self._controls["notify_minor"], 0, wx.LEFT, 10)
-
-        self._controls["notify_unknown"] = wx.CheckBox(
-            panel, label="Unknown - Uncategorized alerts"
-        )
-        sizer.Add(self._controls["notify_unknown"], 0, wx.LEFT, 10)
-
-        # Event-Based Notifications Section
-        sizer.Add(
-            wx.StaticText(panel, label="Event-Based Notifications:"),
-            0,
-            wx.ALL,
-            5,
-        )
-        sizer.Add(
-            wx.StaticText(
-                panel,
-                label="Get notified when specific weather events occur (disabled by default).",
-            ),
-            0,
-            wx.LEFT | wx.BOTTOM,
-            5,
-        )
-
-        self._controls["notify_discussion_update"] = wx.CheckBox(
-            panel, label="Notify when Area Forecast Discussion is updated (NWS US only)"
-        )
-        sizer.Add(self._controls["notify_discussion_update"], 0, wx.LEFT, 10)
-
-        self._controls["notify_severe_risk_change"] = wx.CheckBox(
-            panel, label="Notify when severe weather risk level changes (Visual Crossing only)"
-        )
-        sizer.Add(self._controls["notify_severe_risk_change"], 0, wx.LEFT | wx.BOTTOM, 10)
-
-        self._controls["notify_minutely_precipitation_start"] = wx.CheckBox(
-            panel, label="Notify when precipitation is expected to start soon (Pirate Weather)"
-        )
-        sizer.Add(self._controls["notify_minutely_precipitation_start"], 0, wx.LEFT, 10)
-
-        self._controls["notify_minutely_precipitation_stop"] = wx.CheckBox(
-            panel, label="Notify when precipitation is expected to stop soon (Pirate Weather)"
-        )
-        sizer.Add(self._controls["notify_minutely_precipitation_stop"], 0, wx.LEFT | wx.BOTTOM, 10)
-
-        # Alert timing controls (hidden; values managed via Advanced dialog)
-        self._controls["global_cooldown"] = wx.SpinCtrl(panel, min=0, max=60, initial=5)
-        self._controls["global_cooldown"].Hide()
-        self._controls["per_alert_cooldown"] = wx.SpinCtrl(panel, min=0, max=1440, initial=60)
-        self._controls["per_alert_cooldown"].Hide()
-        self._controls["freshness_window"] = wx.SpinCtrl(panel, min=0, max=120, initial=15)
-        self._controls["freshness_window"].Hide()
-
-        # Rate Limiting Section
-        sizer.Add(
-            wx.StaticText(panel, label="Rate Limiting:"),
-            0,
-            wx.ALL,
-            5,
-        )
-
-        # Max notifications per hour
-        row_max = wx.BoxSizer(wx.HORIZONTAL)
-        row_max.Add(
-            wx.StaticText(panel, label="Maximum notifications per hour:"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-        self._controls["max_notifications"] = wx.SpinCtrl(panel, min=1, max=100, initial=10)
-        row_max.Add(self._controls["max_notifications"], 0)
-        sizer.Add(row_max, 0, wx.LEFT | wx.TOP, 10)
-
-        advanced_btn = wx.Button(panel, label="Advanced...")
-        advanced_btn.SetName("Advanced alert timing settings")
-        advanced_btn.SetToolTip("Configure cooldown periods and alert freshness window")
-        advanced_btn.Bind(wx.EVT_BUTTON, self._on_alert_advanced)
-        sizer.Add(advanced_btn, 0, wx.LEFT | wx.TOP, 10)
-
-        panel.SetSizer(sizer)
-        self.notebook.AddPage(panel, "Notifications")
-
-    def _create_audio_tab(self):
-        """Create the audio tab."""
-        panel = wx.Panel(self.notebook)
-        sizer = wx.BoxSizer(wx.VERTICAL)
-
-        sizer.Add(
-            wx.StaticText(panel, label="Audio"),
-            0,
-            wx.ALL,
-            5,
-        )
-        sizer.Add(
-            wx.StaticText(
-                panel,
-                label=(
-                    "Choose whether sounds are enabled, which sound pack is active, "
-                    "and which events should play audio."
-                ),
-            ),
-            0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM,
-            5,
-        )
-
-        playback_section = wx.StaticBoxSizer(wx.VERTICAL, panel, "Playback")
-
-        self._controls["sound_enabled"] = wx.CheckBox(panel, label="Play notification sounds")
-        playback_section.Add(
-            self._controls["sound_enabled"],
-            0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM,
-            5,
-        )
-
-        row1 = wx.BoxSizer(wx.HORIZONTAL)
-        row1.Add(
-            wx.StaticText(panel, label="Sound pack:"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-
-        # Load available sound packs
-        self._sound_pack_ids = ["default"]
-        pack_names = ["Default"]
+    # ------------------------------------------------------------------
+    # Load / Save / Accessibility (delegate to tab objects)
+    # ------------------------------------------------------------------
+
+    def _load_settings(self):
+        """Load current settings into UI controls."""
         try:
-            from ...notifications.sound_player import get_available_sound_packs
-
-            packs = get_available_sound_packs()
-            self._sound_pack_ids = list(packs.keys())
-            pack_names = [packs[pid].get("name", pid) for pid in self._sound_pack_ids]
+            settings = self.config_manager.get_settings()
+            for tab in getattr(self, "_tab_objects", []):
+                tab.load(settings)
         except Exception as e:
-            logger.warning(f"Failed to load sound packs: {e}")
+            logger.error(f"Failed to load settings: {e}")
 
-        self._controls["sound_pack"] = wx.Choice(panel, choices=pack_names)
-        row1.Add(self._controls["sound_pack"], 0)
-        playback_section.Add(row1, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
-
-        test_btn = wx.Button(panel, label="Test Sound")
-        test_btn.Bind(wx.EVT_BUTTON, self._on_test_sound)
-        action_row = wx.BoxSizer(wx.HORIZONTAL)
-        action_row.Add(test_btn, 0, wx.RIGHT, 10)
-
-        manage_btn = wx.Button(panel, label="Manage Sound Packs...")
-        manage_btn.Bind(wx.EVT_BUTTON, self._on_manage_soundpacks)
-        action_row.Add(manage_btn, 0)
-        playback_section.Add(action_row, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
-        sizer.Add(playback_section, 0, wx.EXPAND | wx.ALL, 5)
-
-        event_sounds_section = wx.StaticBoxSizer(wx.VERTICAL, panel, "Event sounds")
-        event_sounds_section.Add(
-            wx.StaticText(
-                panel,
-                label="Choose which events can play sounds.",
-            ),
-            0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM,
-            5,
-        )
-        self._controls["event_sounds_summary"] = wx.StaticText(panel, label="")
-        event_sounds_section.Add(
-            self._controls["event_sounds_summary"],
-            0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM,
-            5,
-        )
-        self._controls["configure_event_sounds"] = wx.Button(
-            panel,
-            label="Configure Event Sounds...",
-        )
-        self._controls["configure_event_sounds"].Bind(
-            wx.EVT_BUTTON,
-            self._on_configure_event_sounds,
-        )
-        event_sounds_section.Add(
-            self._controls["configure_event_sounds"],
-            0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM,
-            5,
-        )
-        sizer.Add(event_sounds_section, 0, wx.EXPAND | wx.ALL, 5)
-
-        panel.SetSizer(sizer)
-        self.notebook.AddPage(panel, "Audio")
-
-    @staticmethod
-    def _get_event_sound_sections() -> tuple[tuple[str, str, tuple[str, ...]], ...]:
-        """Return grouped event-sound sections used by the settings UI."""
+    def _save_settings(self) -> bool:
+        """Save settings from UI controls."""
         try:
-            from ...sound_events import SOUND_EVENT_SECTIONS
-        except ImportError:
-            from accessiweather.sound_events import SOUND_EVENT_SECTIONS
+            settings_dict: dict = {}
+            for tab in getattr(self, "_tab_objects", []):
+                settings_dict.update(tab.save())
 
-        return tuple(
-            (title, description, tuple(event_key for event_key, _label in section_events))
-            for title, description, section_events in SOUND_EVENT_SECTIONS
-        )
+            # API key guard: if a key field is blank but the original was non-empty,
+            # only drop it if the user explicitly cleared the field.
+            for key, orig_attr, cleared_attr in (
+                ("visual_crossing_api_key", "_original_vc_key", "_vc_key_cleared"),
+                ("pirate_weather_api_key", "_original_pw_key", "_pw_key_cleared"),
+                ("openrouter_api_key", "_original_openrouter_key", "_openrouter_key_cleared"),
+            ):
+                if not settings_dict.get(key) and getattr(self, orig_attr, ""):
+                    if getattr(self, cleared_attr, False):
+                        logger.info("API key %s explicitly cleared by user.", key)
+                    else:
+                        logger.warning(
+                            "Skipping empty %s save — original value was non-empty; "
+                            "keyring may have failed to load. Existing keyring value preserved.",
+                            key,
+                        )
+                        settings_dict.pop(key, None)
 
-    @staticmethod
-    def _get_mutable_sound_events() -> tuple[tuple[str, str], ...]:
-        """Return user-configurable event sound labels."""
-        try:
-            from ...sound_events import USER_MUTABLE_SOUND_EVENTS
-        except ImportError:
-            from accessiweather.sound_events import USER_MUTABLE_SOUND_EVENTS
+            success = self.config_manager.update_settings(**settings_dict)
+            if success:
+                logger.info("Settings saved successfully")
+                if hasattr(self, "app") and self._is_runtime_portable_mode():
+                    self._maybe_update_portable_bundle_after_save(settings_dict)
+            return success
 
-        return tuple(USER_MUTABLE_SOUND_EVENTS)
+        except Exception as e:
+            logger.error(f"Failed to save settings: {e}")
+            return False
 
-    @classmethod
-    def _build_default_event_sound_states(cls) -> dict[str, bool]:
-        """Return the default enabled state for each mutable sound event."""
-        return {event_key: True for event_key, _label in cls._get_mutable_sound_events()}
+    def _setup_accessibility(self):
+        """Set up accessibility labels for controls."""
+        for tab in getattr(self, "_tab_objects", []):
+            tab.setup_accessibility()
+
+    # ------------------------------------------------------------------
+    # Cross-tab state helpers
+    # ------------------------------------------------------------------
+
+    def _get_source_settings_summary_text(self) -> str:
+        """Build source settings summary text (delegates to DataSourcesTab)."""
+        return self._data_sources_tab._get_source_settings_summary_text()
+
+    def _refresh_source_settings_summary(self) -> None:
+        """Refresh the source settings summary (delegates to DataSourcesTab)."""
+        self._data_sources_tab.refresh_source_settings_summary()
 
     def _set_event_sound_states(self, muted_sound_events: list[str] | tuple[str, ...]) -> None:
-        """Apply muted event settings to the in-memory audio state."""
-        muted_event_set = set(muted_sound_events)
-        self._event_sound_states = {
-            event_key: event_key not in muted_event_set
-            for event_key, _label in self._get_mutable_sound_events()
-        }
-        self._refresh_event_sound_summary()
+        """Apply muted event settings (delegates to AudioTab)."""
+        self._audio_tab.set_event_sound_states(muted_sound_events)
 
     def _get_muted_sound_events(self) -> list[str]:
-        """Return muted event keys in the configured display order."""
-        state_map = (
-            getattr(self, "_event_sound_states", {}) or self._build_default_event_sound_states()
-        )
-        return [
-            event_key
-            for event_key, _label in self._get_mutable_sound_events()
-            if not state_map.get(event_key, True)
-        ]
+        """Return muted event keys (delegates to AudioTab)."""
+        return self._audio_tab._get_muted_sound_events()
 
     def _get_event_sound_summary_text(self) -> str:
-        """Build summary text shown on the audio tab."""
-        total_events = len(self._get_mutable_sound_events())
-        muted_events = self._get_muted_sound_events()
-        enabled_count = total_events - len(muted_events)
-
-        if not muted_events:
-            return f"All {total_events} sound events are enabled."
-        if enabled_count == 0:
-            return "All event sounds are turned off."
-        return f"{enabled_count} of {total_events} sound events are enabled."
+        """Build event sound summary text (delegates to AudioTab)."""
+        return self._audio_tab._get_event_sound_summary_text()
 
     def _refresh_event_sound_summary(self) -> None:
-        """Refresh the event sound summary shown on the audio tab."""
-        summary_control = self._controls.get("event_sounds_summary")
-        if summary_control is not None:
-            summary_control.SetLabel(self._get_event_sound_summary_text())
+        """Refresh event sound summary (delegates to AudioTab)."""
+        self._audio_tab._refresh_event_sound_summary()
+
+    @staticmethod
+    def _get_event_sound_sections():
+        """Return grouped event-sound sections (delegates to AudioTab)."""
+        from .settings_tabs.audio import AudioTab
+
+        return AudioTab._get_event_sound_sections()
+
+    @staticmethod
+    def _get_mutable_sound_events():
+        """Return user-configurable event sound labels (delegates to AudioTab)."""
+        from .settings_tabs.audio import AudioTab
+
+        return AudioTab._get_mutable_sound_events()
+
+    # ------------------------------------------------------------------
+    # Modal helper dialogs
+    # ------------------------------------------------------------------
 
     def _configure_modal_dialog_buttons(
         self,
@@ -861,10 +322,7 @@ class SettingsDialogSimple(wx.Dialog):
 
         main_sizer = wx.BoxSizer(wx.VERTICAL)
         main_sizer.Add(
-            wx.StaticText(
-                dialog,
-                label="Choose which events can play sounds.",
-            ),
+            wx.StaticText(dialog, label="Choose which events can play sounds."),
             0,
             wx.ALL | wx.EXPAND,
             10,
@@ -918,63 +376,6 @@ class SettingsDialogSimple(wx.Dialog):
             if hasattr(dialog, "Destroy"):
                 dialog.Destroy()
 
-    def _on_configure_event_sounds(self, event):
-        """Open the event-sounds modal and persist accepted in-memory state."""
-        updated_states = self._run_event_sounds_dialog()
-        if updated_states is None:
-            return
-        self._event_sound_states = {
-            event_key: updated_states.get(event_key, True)
-            for event_key, _label in self._get_mutable_sound_events()
-        }
-        self._refresh_event_sound_summary()
-
-    @staticmethod
-    def _build_default_source_settings_states() -> dict:
-        """Return default source settings state."""
-        return {
-            "auto_use_nws": True,
-            "auto_use_openmeteo": True,
-            "auto_use_visualcrossing": True,
-            "auto_use_pirateweather": True,
-            "station_selection_strategy": 0,
-        }
-
-    def _get_source_settings_summary_text(self) -> str:
-        """Build summary text shown on the data sources tab."""
-        state = (
-            getattr(self, "_source_settings_states", None)
-            or self._build_default_source_settings_states()
-        )
-        strategy_labels = [
-            "Hybrid default",
-            "Nearest station",
-            "Major airport preferred",
-            "Freshest observation",
-        ]
-        strat_idx = state.get("station_selection_strategy", 0)
-        strat_text = (
-            strategy_labels[strat_idx]
-            if 0 <= strat_idx < len(strategy_labels)
-            else strategy_labels[0]
-        )
-        sources = ["NWS", "Open-Meteo", "Visual Crossing", "Pirate Weather"]
-        keys = [
-            "auto_use_nws",
-            "auto_use_openmeteo",
-            "auto_use_visualcrossing",
-            "auto_use_pirateweather",
-        ]
-        enabled = [s for s, k in zip(sources, keys, strict=True) if state.get(k, True)]
-        enabled_text = ", ".join(enabled) if enabled else "None"
-        return f"Auto sources: {enabled_text} | Station: {strat_text}"
-
-    def _refresh_source_settings_summary(self) -> None:
-        """Refresh the source settings summary shown on the data sources tab."""
-        ctrl = self._controls.get("source_settings_summary")
-        if ctrl is not None:
-            ctrl.SetValue(self._get_source_settings_summary_text())
-
     def _run_source_settings_dialog(self) -> dict | None:
         """Show the source settings modal (tabbed) and return updated state when accepted."""
         state = dict(
@@ -992,7 +393,7 @@ class SettingsDialogSimple(wx.Dialog):
         main_sizer = wx.BoxSizer(wx.VERTICAL)
         notebook = wx.Notebook(dialog)
 
-        # ── Tab 1: Current Conditions ──────────────────────────────────────
+        # Tab 1: Current Conditions
         cc_panel = wx.ScrolledWindow(notebook)
         cc_panel.SetScrollRate(0, 20)
         cc_sizer = wx.BoxSizer(wx.VERTICAL)
@@ -1031,7 +432,7 @@ class SettingsDialogSimple(wx.Dialog):
         cc_panel.SetSizer(cc_sizer)
         notebook.AddPage(cc_panel, "Current Conditions")
 
-        # ── Tab 2: Auto Mode ───────────────────────────────────────────────
+        # Tab 2: Auto Mode
         auto_panel = wx.ScrolledWindow(notebook)
         auto_panel.SetScrollRate(0, 20)
         auto_sizer = wx.BoxSizer(wx.VERTICAL)
@@ -1096,6 +497,21 @@ class SettingsDialogSimple(wx.Dialog):
             if hasattr(dialog, "Destroy"):
                 dialog.Destroy()
 
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+
+    def _on_configure_event_sounds(self, event):
+        """Open the event-sounds modal and persist accepted in-memory state."""
+        updated_states = self._run_event_sounds_dialog()
+        if updated_states is None:
+            return
+        self._event_sound_states = {
+            event_key: updated_states.get(event_key, True)
+            for event_key, _label in self._get_mutable_sound_events()
+        }
+        self._audio_tab._refresh_event_sound_summary()
+
     def _on_configure_source_settings(self, event) -> None:
         """Open the source settings modal and persist accepted in-memory state."""
         updated = self._run_source_settings_dialog()
@@ -1104,887 +520,6 @@ class SettingsDialogSimple(wx.Dialog):
         self._source_settings_states = updated
         self._refresh_source_settings_summary()
 
-    def _create_updates_tab(self):
-        """Create the updates tab."""
-        panel = wx.Panel(self.notebook)
-        sizer = wx.BoxSizer(wx.VERTICAL)
-
-        self._controls["auto_update"] = wx.CheckBox(panel, label="Check for updates automatically")
-        sizer.Add(self._controls["auto_update"], 0, wx.ALL, 5)
-
-        # Update channel
-        row_ch = wx.BoxSizer(wx.HORIZONTAL)
-        row_ch.Add(
-            wx.StaticText(panel, label="Update Channel:"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-        self._controls["update_channel"] = wx.Choice(
-            panel,
-            choices=[
-                "Stable (Production releases only)",
-                "Development (Latest features, may be unstable)",
-            ],
-        )
-        row_ch.Add(self._controls["update_channel"], 0)
-        sizer.Add(row_ch, 0, wx.LEFT, 5)
-
-        # Check interval
-        row_int = wx.BoxSizer(wx.HORIZONTAL)
-        row_int.Add(
-            wx.StaticText(panel, label="Check Interval (hours):"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-        self._controls["update_check_interval"] = wx.SpinCtrl(panel, min=1, max=168, initial=24)
-        row_int.Add(self._controls["update_check_interval"], 0)
-        sizer.Add(row_int, 0, wx.LEFT | wx.TOP, 5)
-
-        # Check now button
-        check_btn = wx.Button(panel, label="Check for Updates Now")
-        check_btn.Bind(wx.EVT_BUTTON, self._on_check_updates)
-        sizer.Add(check_btn, 0, wx.ALL, 10)
-
-        self._controls["update_status"] = wx.StaticText(panel, label="Ready to check for updates")
-        sizer.Add(self._controls["update_status"], 0, wx.LEFT, 10)
-
-        panel.SetSizer(sizer)
-        self.notebook.AddPage(panel, "Updates")
-
-    def _create_ai_tab(self):
-        """Create the AI explanations tab."""
-        panel = wx.ScrolledWindow(self.notebook)
-        panel.SetScrollRate(0, 20)
-        sizer = wx.BoxSizer(wx.VERTICAL)
-
-        # Header
-        sizer.Add(
-            wx.StaticText(panel, label="AI Weather Explanations"),
-            0,
-            wx.ALL,
-            5,
-        )
-        sizer.Add(
-            wx.StaticText(
-                panel,
-                label="Get natural language explanations of weather conditions using AI.",
-            ),
-            0,
-            wx.LEFT | wx.BOTTOM,
-            5,
-        )
-
-        # OpenRouter API Key
-        sizer.Add(
-            wx.StaticText(panel, label="OpenRouter API Key:"),
-            0,
-            wx.ALL,
-            5,
-        )
-        self._controls["openrouter_key"] = wx.TextCtrl(panel, style=wx.TE_PASSWORD, size=(300, -1))
-        sizer.Add(self._controls["openrouter_key"], 0, wx.LEFT, 10)
-
-        validate_btn = wx.Button(panel, label="Validate API Key")
-        validate_btn.Bind(wx.EVT_BUTTON, self._on_validate_openrouter_key)
-        sizer.Add(validate_btn, 0, wx.LEFT | wx.TOP | wx.BOTTOM, 10)
-
-        # Model Preference
-        row_model = wx.BoxSizer(wx.HORIZONTAL)
-        row_model.Add(
-            wx.StaticText(panel, label="Model Preference:"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-        self._controls["ai_model"] = wx.Choice(
-            panel,
-            choices=[
-                "Free Router (Auto, Free)",
-                "Llama 3.3 70B (Free)",
-                "Auto Router (Paid)",
-            ],
-        )
-        row_model.Add(self._controls["ai_model"], 0)
-        sizer.Add(row_model, 0, wx.LEFT, 10)
-
-        browse_btn = wx.Button(panel, label="Browse Models...")
-        browse_btn.Bind(wx.EVT_BUTTON, self._on_browse_models)
-        sizer.Add(browse_btn, 0, wx.LEFT | wx.TOP, 10)
-
-        # Explanation Style
-        row_style = wx.BoxSizer(wx.HORIZONTAL)
-        row_style.Add(
-            wx.StaticText(panel, label="Explanation Style:"),
-            0,
-            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
-            10,
-        )
-        self._controls["ai_style"] = wx.Choice(
-            panel,
-            choices=[
-                "Brief (1-2 sentences)",
-                "Standard (3-4 sentences)",
-                "Detailed (full paragraph)",
-            ],
-        )
-        row_style.Add(self._controls["ai_style"], 0)
-        sizer.Add(row_style, 0, wx.LEFT | wx.TOP, 10)
-
-        # Custom System Prompt
-        sizer.Add(
-            wx.StaticText(panel, label="Custom System Prompt (optional):"),
-            0,
-            wx.LEFT | wx.TOP,
-            10,
-        )
-        self._controls["custom_prompt"] = wx.TextCtrl(panel, style=wx.TE_MULTILINE, size=(400, 60))
-        sizer.Add(self._controls["custom_prompt"], 0, wx.LEFT | wx.EXPAND, 10)
-
-        reset_prompt_btn = wx.Button(panel, label="Reset to Default")
-        reset_prompt_btn.Bind(wx.EVT_BUTTON, self._on_reset_prompt)
-        sizer.Add(reset_prompt_btn, 0, wx.LEFT | wx.TOP, 10)
-
-        # Custom Instructions
-        sizer.Add(
-            wx.StaticText(panel, label="Custom Instructions (optional):"),
-            0,
-            wx.LEFT | wx.TOP,
-            10,
-        )
-        self._controls["custom_instructions"] = wx.TextCtrl(
-            panel, style=wx.TE_MULTILINE, size=(400, 40)
-        )
-        self._controls["custom_instructions"].SetHint(
-            "e.g., Focus on outdoor activities, Keep responses under 50 words"
-        )
-        sizer.Add(self._controls["custom_instructions"], 0, wx.LEFT | wx.EXPAND, 10)
-
-        # Pricing info
-        sizer.Add(
-            wx.StaticText(panel, label="Cost Information:"),
-            0,
-            wx.LEFT | wx.TOP,
-            10,
-        )
-        sizer.Add(
-            wx.StaticText(panel, label="Free models: No cost, may have rate limits"),
-            0,
-            wx.LEFT,
-            15,
-        )
-        sizer.Add(
-            wx.StaticText(panel, label="Paid models: ~$0.001 per explanation (varies by model)"),
-            0,
-            wx.LEFT,
-            15,
-        )
-
-        panel.SetSizer(sizer)
-        self.notebook.AddPage(panel, "AI")
-
-    def _create_advanced_tab(self):
-        """Create the advanced tab."""
-        panel = wx.ScrolledWindow(self.notebook)
-        panel.SetScrollRate(0, 20)
-        sizer = wx.BoxSizer(wx.VERTICAL)
-
-        # System options
-        self._controls["minimize_tray"] = wx.CheckBox(
-            panel, label="Minimize to notification area when closing"
-        )
-        self._controls["minimize_tray"].Bind(wx.EVT_CHECKBOX, self._on_minimize_tray_changed)
-        sizer.Add(self._controls["minimize_tray"], 0, wx.ALL, 5)
-
-        self._controls["minimize_on_startup"] = wx.CheckBox(
-            panel, label="Start minimized to notification area"
-        )
-        sizer.Add(self._controls["minimize_on_startup"], 0, wx.LEFT | wx.BOTTOM, 5)
-
-        self._controls["startup"] = wx.CheckBox(panel, label="Launch automatically at startup")
-        sizer.Add(self._controls["startup"], 0, wx.LEFT | wx.BOTTOM, 5)
-
-        self._controls["weather_history"] = wx.CheckBox(
-            panel, label="Enable weather history comparisons"
-        )
-        sizer.Add(self._controls["weather_history"], 0, wx.LEFT | wx.BOTTOM, 5)
-
-        # Reset Configuration Section
-        sizer.Add(
-            wx.StaticText(panel, label="Reset Configuration"),
-            0,
-            wx.LEFT | wx.TOP,
-            5,
-        )
-        sizer.Add(
-            wx.StaticText(panel, label="Restore all settings to their default values."),
-            0,
-            wx.LEFT,
-            5,
-        )
-
-        reset_btn = wx.Button(panel, label="Reset all settings to defaults")
-        reset_btn.Bind(wx.EVT_BUTTON, self._on_reset_defaults)
-        sizer.Add(reset_btn, 0, wx.LEFT | wx.TOP | wx.BOTTOM, 10)
-
-        # Full Data Reset
-        sizer.Add(
-            wx.StaticText(panel, label="Full Data Reset"),
-            0,
-            wx.LEFT,
-            5,
-        )
-        sizer.Add(
-            wx.StaticText(
-                panel,
-                label="Reset all application data: settings, locations, caches, and alert state.",
-            ),
-            0,
-            wx.LEFT,
-            5,
-        )
-
-        full_reset_btn = wx.Button(panel, label="Reset all app data (settings, locations, caches)")
-        full_reset_btn.Bind(wx.EVT_BUTTON, self._on_full_reset)
-        sizer.Add(full_reset_btn, 0, wx.LEFT | wx.TOP | wx.BOTTOM, 10)
-
-        # Configuration Files
-        sizer.Add(
-            wx.StaticText(panel, label="Configuration Files"),
-            0,
-            wx.LEFT,
-            5,
-        )
-
-        open_config_btn = wx.Button(panel, label="Open current config directory")
-        open_config_btn.Bind(wx.EVT_BUTTON, self._on_open_config_dir)
-        sizer.Add(open_config_btn, 0, wx.LEFT | wx.TOP, 10)
-
-        open_installed_config_btn = wx.Button(
-            panel, label="Open installed config directory (source)"
-        )
-        open_installed_config_btn.Bind(wx.EVT_BUTTON, self._on_open_installed_config_dir)
-        sizer.Add(open_installed_config_btn, 0, wx.LEFT | wx.TOP, 10)
-
-        if self._is_runtime_portable_mode():
-            migrate_config_btn = wx.Button(panel, label="Copy installed config to portable")
-            migrate_config_btn.Bind(wx.EVT_BUTTON, self._on_copy_installed_config_to_portable)
-            sizer.Add(migrate_config_btn, 0, wx.LEFT | wx.TOP | wx.BOTTOM, 10)
-
-        # Settings Backup
-        sizer.Add(
-            wx.StaticText(panel, label="Settings Backup"),
-            0,
-            wx.LEFT | wx.TOP,
-            5,
-        )
-
-        export_btn = wx.Button(panel, label="Export Settings...")
-        export_btn.Bind(wx.EVT_BUTTON, self._on_export_settings)
-        sizer.Add(export_btn, 0, wx.LEFT | wx.TOP, 10)
-
-        import_btn = wx.Button(panel, label="Import Settings...")
-        import_btn.Bind(wx.EVT_BUTTON, self._on_import_settings)
-        sizer.Add(import_btn, 0, wx.LEFT | wx.TOP, 10)
-
-        sizer.Add(
-            wx.StaticText(panel, label="API Key Portability (Encrypted)"),
-            0,
-            wx.LEFT | wx.TOP,
-            5,
-        )
-        sizer.Add(
-            wx.StaticText(
-                panel,
-                label=(
-                    "Optional: export API keys to an encrypted bundle for transfer. "
-                    "Import requires your passphrase and stores keys in this machine's keyring."
-                ),
-            ),
-            0,
-            wx.LEFT,
-            5,
-        )
-
-        export_api_keys_btn = wx.Button(panel, label="Export API keys (encrypted)")
-        export_api_keys_btn.Bind(wx.EVT_BUTTON, self._on_export_encrypted_api_keys)
-        sizer.Add(export_api_keys_btn, 0, wx.LEFT | wx.TOP, 10)
-
-        import_api_keys_btn = wx.Button(panel, label="Import API keys (encrypted)")
-        import_api_keys_btn.Bind(wx.EVT_BUTTON, self._on_import_encrypted_api_keys)
-        sizer.Add(import_api_keys_btn, 0, wx.LEFT | wx.TOP, 10)
-
-        # Sound Pack Files
-        sizer.Add(
-            wx.StaticText(panel, label="Sound Pack Files"),
-            0,
-            wx.LEFT | wx.TOP,
-            5,
-        )
-
-        open_sounds_btn = wx.Button(panel, label="Open sound packs folder")
-        open_sounds_btn.Bind(wx.EVT_BUTTON, self._on_open_soundpacks_dir)
-        sizer.Add(open_sounds_btn, 0, wx.LEFT | wx.TOP | wx.BOTTOM, 10)
-
-        panel.SetSizer(sizer)
-        self.notebook.AddPage(panel, "Advanced")
-
-    def _load_settings(self):
-        """Load current settings into UI controls."""
-        try:
-            settings = self.config_manager.get_settings()
-
-            # General tab
-            self._controls["update_interval"].SetValue(
-                getattr(settings, "update_interval_minutes", 10)
-            )
-            self._controls["show_nationwide"].SetValue(
-                getattr(self.config_manager.get_settings(), "show_nationwide_location", True)
-            )
-            # Disable checkbox if data source isn't NWS-compatible
-            data_source = getattr(settings, "data_source", "auto")
-            if data_source not in ("auto", "nws"):
-                self._controls["show_nationwide"].SetValue(False)
-                self._controls["show_nationwide"].Enable(False)
-            else:
-                self._controls["show_nationwide"].Enable(True)
-
-            # Display tab
-            temp_unit = getattr(settings, "temperature_unit", "both")
-            temp_map = {
-                "auto": 0,
-                "f": 1,
-                "fahrenheit": 1,
-                "c": 2,
-                "celsius": 2,
-                "both": 3,
-            }
-            self._controls["temp_unit"].SetSelection(temp_map.get(temp_unit, 3))
-
-            self._controls["show_dewpoint"].SetValue(getattr(settings, "show_dewpoint", True))
-            self._controls["show_visibility"].SetValue(getattr(settings, "show_visibility", True))
-            self._controls["show_uv_index"].SetValue(getattr(settings, "show_uv_index", True))
-            self._controls["show_pressure_trend"].SetValue(
-                getattr(settings, "show_pressure_trend", True)
-            )
-            self._controls["round_values"].SetValue(getattr(settings, "round_values", False))
-            forecast_duration_days = getattr(settings, "forecast_duration_days", 7)
-            forecast_duration_map = {3: 0, 5: 1, 7: 2, 10: 3, 14: 4, 15: 5}
-            self._controls["forecast_duration_days"].SetSelection(
-                forecast_duration_map.get(forecast_duration_days, 2)
-            )
-
-            self._controls["hourly_forecast_hours"].SetValue(
-                getattr(settings, "hourly_forecast_hours", 6)
-            )
-
-            forecast_time_reference = getattr(settings, "forecast_time_reference", "location")
-            forecast_time_reference_map = {"location": 0, "user_local": 1}
-            self._controls["forecast_time_reference"].SetSelection(
-                forecast_time_reference_map.get(forecast_time_reference, 0)
-            )
-
-            time_mode = getattr(settings, "time_display_mode", "local")
-            time_mode_map = {"local": 0, "utc": 1, "both": 2}
-            self._controls["time_display_mode"].SetSelection(time_mode_map.get(time_mode, 0))
-
-            self._controls["time_format_12hour"].SetValue(
-                getattr(settings, "time_format_12hour", True)
-            )
-            self._controls["show_timezone_suffix"].SetValue(
-                getattr(settings, "show_timezone_suffix", False)
-            )
-
-            verbosity = getattr(settings, "verbosity_level", "standard")
-            verbosity_map = {"minimal": 0, "standard": 1, "detailed": 2}
-            self._controls["verbosity_level"].SetSelection(verbosity_map.get(verbosity, 1))
-
-            self._controls["severe_weather_override"].SetValue(
-                getattr(settings, "severe_weather_override", True)
-            )
-
-            # Data sources tab
-            data_source = getattr(settings, "data_source", "auto")
-            source_map = {
-                "auto": 0,
-                "nws": 1,
-                "openmeteo": 2,
-                "visualcrossing": 3,
-                "pirateweather": 4,
-            }
-            self._controls["data_source"].SetSelection(source_map.get(data_source, 0))
-
-            vc_key = getattr(settings, "visual_crossing_api_key", "") or ""
-            self._controls["vc_key"].SetValue(str(vc_key))
-            self._original_vc_key = str(vc_key)
-            self._vc_key_cleared = False
-            if hasattr(wx, "EVT_TEXT"):
-
-                def _on_vc_key_text(e, _self=self):
-                    _self._vc_key_cleared = True
-                    _self._update_auto_source_key_state()
-
-                self._controls["vc_key"].Bind(wx.EVT_TEXT, _on_vc_key_text)
-            pw_key = getattr(settings, "pirate_weather_api_key", "") or ""
-            self._controls["pw_key"].SetValue(str(pw_key))
-            self._original_pw_key = str(pw_key)
-            self._pw_key_cleared = False
-            if hasattr(wx, "EVT_TEXT"):
-
-                def _on_pw_key_text(e, _self=self):
-                    _self._pw_key_cleared = True
-                    _self._update_auto_source_key_state()
-
-                self._controls["pw_key"].Bind(wx.EVT_TEXT, _on_pw_key_text)
-
-            # Source settings sub-dialog state
-            station_strategy_values = [
-                "hybrid_default",
-                "nearest",
-                "major_airport_preferred",
-                "freshest_observation",
-            ]
-            saved_strategy = getattr(settings, "station_selection_strategy", "hybrid_default")
-            strat_idx = (
-                station_strategy_values.index(saved_strategy)
-                if saved_strategy in station_strategy_values
-                else 0
-            )
-            saved_us = list(
-                getattr(
-                    settings,
-                    "source_priority_us",
-                    ["nws", "openmeteo", "visualcrossing", "pirateweather"],
-                )
-            )
-            saved_intl = list(
-                getattr(
-                    settings,
-                    "source_priority_international",
-                    ["openmeteo", "pirateweather", "visualcrossing"],
-                )
-            )
-            all_sources_combined = set(saved_us) | set(saved_intl)
-            self._source_settings_states = {
-                "auto_use_nws": "nws" in all_sources_combined,
-                "auto_use_openmeteo": "openmeteo" in all_sources_combined,
-                "auto_use_visualcrossing": "visualcrossing" in all_sources_combined,
-                "auto_use_pirateweather": "pirateweather" in all_sources_combined,
-                "station_selection_strategy": strat_idx,
-            }
-            self._refresh_source_settings_summary()
-            self._update_api_key_visibility()
-
-            # Notifications tab
-            self._controls["enable_alerts"].SetValue(getattr(settings, "enable_alerts", True))
-            self._controls["alert_notif"].SetValue(
-                getattr(settings, "alert_notifications_enabled", True)
-            )
-            # Alert radius type: map value to choice index
-            radius_type = getattr(settings, "alert_radius_type", "county")
-            radius_type_map = {"county": 0, "point": 1, "zone": 2, "state": 3}
-            self._controls["alert_radius_type"].SetSelection(radius_type_map.get(radius_type, 0))
-            self._controls["notify_extreme"].SetValue(
-                getattr(settings, "alert_notify_extreme", True)
-            )
-            self._controls["notify_severe"].SetValue(getattr(settings, "alert_notify_severe", True))
-            self._controls["notify_moderate"].SetValue(
-                getattr(settings, "alert_notify_moderate", True)
-            )
-            self._controls["notify_minor"].SetValue(getattr(settings, "alert_notify_minor", False))
-            self._controls["notify_unknown"].SetValue(
-                getattr(settings, "alert_notify_unknown", False)
-            )
-            self._controls["global_cooldown"].SetValue(
-                getattr(settings, "alert_global_cooldown_minutes", 5)
-            )
-            self._controls["per_alert_cooldown"].SetValue(
-                getattr(settings, "alert_per_alert_cooldown_minutes", 60)
-            )
-            self._controls["freshness_window"].SetValue(
-                getattr(settings, "alert_freshness_window_minutes", 15)
-            )
-            self._controls["max_notifications"].SetValue(
-                getattr(settings, "alert_max_notifications_per_hour", 10)
-            )
-
-            # Event-based notifications
-            self._controls["notify_discussion_update"].SetValue(
-                getattr(settings, "notify_discussion_update", True)
-            )
-            self._controls["notify_severe_risk_change"].SetValue(
-                getattr(settings, "notify_severe_risk_change", False)
-            )
-            self._controls["notify_minutely_precipitation_start"].SetValue(
-                getattr(settings, "notify_minutely_precipitation_start", False)
-            )
-            self._controls["notify_minutely_precipitation_stop"].SetValue(
-                getattr(settings, "notify_minutely_precipitation_stop", False)
-            )
-
-            # Audio tab
-            self._controls["sound_enabled"].SetValue(getattr(settings, "sound_enabled", True))
-            current_pack = getattr(settings, "sound_pack", "default")
-            try:
-                pack_idx = self._sound_pack_ids.index(current_pack)
-                self._controls["sound_pack"].SetSelection(pack_idx)
-            except (ValueError, AttributeError):
-                self._controls["sound_pack"].SetSelection(0)
-
-            self._set_event_sound_states(getattr(settings, "muted_sound_events", ["data_updated"]))
-
-            # Updates tab
-            self._controls["auto_update"].SetValue(getattr(settings, "auto_update_enabled", True))
-            channel = getattr(settings, "update_channel", "stable")
-            self._controls["update_channel"].SetSelection(0 if channel == "stable" else 1)
-            self._controls["update_check_interval"].SetValue(
-                getattr(settings, "update_check_interval_hours", 24)
-            )
-
-            # AI tab
-            openrouter_key = getattr(settings, "openrouter_api_key", "") or ""
-            self._controls["openrouter_key"].SetValue(str(openrouter_key))
-            self._original_openrouter_key = str(openrouter_key)
-            self._openrouter_key_cleared = False
-            if hasattr(wx, "EVT_TEXT"):
-                self._controls["openrouter_key"].Bind(
-                    wx.EVT_TEXT, lambda e: setattr(self, "_openrouter_key_cleared", True)
-                )
-
-            ai_model = getattr(settings, "ai_model_preference", "openrouter/free")
-            if ai_model == "openrouter/free":
-                self._controls["ai_model"].SetSelection(0)
-            elif ai_model == "meta-llama/llama-3.3-70b-instruct:free":
-                self._controls["ai_model"].SetSelection(1)
-            elif ai_model == "auto":
-                self._controls["ai_model"].SetSelection(2)
-            else:
-                # Specific model was selected - add it to the dropdown
-                model_display = f"Selected: {ai_model.split('/')[-1]}"
-                self._controls["ai_model"].Append(model_display)
-                self._controls["ai_model"].SetSelection(3)
-                self._selected_specific_model = ai_model
-
-            ai_style = getattr(settings, "ai_explanation_style", "standard")
-            style_map = {"brief": 0, "standard": 1, "detailed": 2}
-            self._controls["ai_style"].SetSelection(style_map.get(ai_style, 1))
-
-            custom_prompt = getattr(settings, "custom_system_prompt", "") or ""
-            self._controls["custom_prompt"].SetValue(custom_prompt)
-
-            custom_instructions = getattr(settings, "custom_instructions", "") or ""
-            self._controls["custom_instructions"].SetValue(custom_instructions)
-
-            # Advanced tab
-            minimize_to_tray = getattr(settings, "minimize_to_tray", False)
-            self._controls["minimize_tray"].SetValue(minimize_to_tray)
-            self._controls["minimize_on_startup"].SetValue(
-                getattr(settings, "minimize_on_startup", False)
-            )
-            # Link settings: disable minimize_on_startup if minimize_to_tray is disabled
-            self._update_minimize_on_startup_state(minimize_to_tray)
-
-            # General tab - taskbar icon text options
-            taskbar_text_enabled = getattr(settings, "taskbar_icon_text_enabled", False)
-            self._controls["taskbar_icon_text_enabled"].SetValue(taskbar_text_enabled)
-            self._controls["taskbar_icon_dynamic_enabled"].SetValue(
-                getattr(settings, "taskbar_icon_dynamic_enabled", True)
-            )
-            self._controls["taskbar_icon_text_format"].SetValue(
-                getattr(settings, "taskbar_icon_text_format", "{temp} {condition}")
-            )
-            self._update_taskbar_text_controls_state(taskbar_text_enabled)
-            self._controls["startup"].SetValue(getattr(settings, "startup_enabled", False))
-            self._controls["weather_history"].SetValue(
-                getattr(settings, "weather_history_enabled", True)
-            )
-        except Exception as e:
-            logger.error(f"Failed to load settings: {e}")
-
-    def _save_settings(self) -> bool:
-        """Save settings from UI controls."""
-        try:
-            # Map selections back to values
-            source_values = ["auto", "nws", "openmeteo", "visualcrossing", "pirateweather"]
-            temp_values = ["auto", "f", "c", "both"]
-            forecast_duration_values = [3, 5, 7, 10, 14, 15]
-            forecast_time_reference_values = ["location", "user_local"]
-            time_mode_values = ["local", "utc", "both"]
-            verbosity_values = ["minimal", "standard", "detailed"]
-            style_values = ["brief", "standard", "detailed"]
-
-            # Update nationwide visibility
-            show_nationwide = self._controls["show_nationwide"].GetValue()
-            # Nationwide visibility is persisted via settings_dict below
-
-            settings_dict = {
-                # General
-                "update_interval_minutes": self._controls["update_interval"].GetValue(),
-                "show_nationwide_location": show_nationwide,
-                "taskbar_icon_text_enabled": self._controls["taskbar_icon_text_enabled"].GetValue(),
-                "taskbar_icon_dynamic_enabled": self._controls[
-                    "taskbar_icon_dynamic_enabled"
-                ].GetValue(),
-                "taskbar_icon_text_format": self._controls["taskbar_icon_text_format"].GetValue(),
-                # Display
-                "temperature_unit": temp_values[self._controls["temp_unit"].GetSelection()],
-                "show_dewpoint": self._controls["show_dewpoint"].GetValue(),
-                "show_visibility": self._controls["show_visibility"].GetValue(),
-                "show_uv_index": self._controls["show_uv_index"].GetValue(),
-                "show_pressure_trend": self._controls["show_pressure_trend"].GetValue(),
-                "round_values": self._controls["round_values"].GetValue(),
-                "forecast_duration_days": forecast_duration_values[
-                    self._controls["forecast_duration_days"].GetSelection()
-                ],
-                "hourly_forecast_hours": self._controls["hourly_forecast_hours"].GetValue(),
-                "forecast_time_reference": forecast_time_reference_values[
-                    self._controls["forecast_time_reference"].GetSelection()
-                ],
-                "time_display_mode": time_mode_values[
-                    self._controls["time_display_mode"].GetSelection()
-                ],
-                "time_format_12hour": self._controls["time_format_12hour"].GetValue(),
-                "show_timezone_suffix": self._controls["show_timezone_suffix"].GetValue(),
-                "verbosity_level": verbosity_values[
-                    self._controls["verbosity_level"].GetSelection()
-                ],
-                "severe_weather_override": self._controls["severe_weather_override"].GetValue(),
-                # Data sources
-                "data_source": source_values[self._controls["data_source"].GetSelection()],
-                "visual_crossing_api_key": self._controls["vc_key"].GetValue(),
-                "pirate_weather_api_key": self._controls["pw_key"].GetValue(),
-                "source_priority_us": [
-                    s
-                    for s in ["nws", "openmeteo", "visualcrossing", "pirateweather"]
-                    if self._source_settings_states.get(
-                        {
-                            "nws": "auto_use_nws",
-                            "openmeteo": "auto_use_openmeteo",
-                            "visualcrossing": "auto_use_visualcrossing",
-                            "pirateweather": "auto_use_pirateweather",
-                        }[s],
-                        True,
-                    )
-                ],
-                "source_priority_international": [
-                    s
-                    for s in ["openmeteo", "visualcrossing", "pirateweather"]
-                    if self._source_settings_states.get(
-                        {
-                            "openmeteo": "auto_use_openmeteo",
-                            "visualcrossing": "auto_use_visualcrossing",
-                            "pirateweather": "auto_use_pirateweather",
-                        }[s],
-                        True,
-                    )
-                ],
-                "auto_sources_us": [
-                    s
-                    for s in ["nws", "openmeteo", "visualcrossing", "pirateweather"]
-                    if self._source_settings_states.get(
-                        {
-                            "nws": "auto_use_nws",
-                            "openmeteo": "auto_use_openmeteo",
-                            "visualcrossing": "auto_use_visualcrossing",
-                            "pirateweather": "auto_use_pirateweather",
-                        }[s],
-                        True,
-                    )
-                ]
-                or ["openmeteo"],
-                "auto_sources_international": [
-                    s
-                    for s in ["openmeteo", "visualcrossing", "pirateweather"]
-                    if self._source_settings_states.get(
-                        {
-                            "openmeteo": "auto_use_openmeteo",
-                            "visualcrossing": "auto_use_visualcrossing",
-                            "pirateweather": "auto_use_pirateweather",
-                        }[s],
-                        True,
-                    )
-                ]
-                or ["openmeteo"],
-                "openmeteo_weather_model": "best_match",
-                "station_selection_strategy": [
-                    "hybrid_default",
-                    "nearest",
-                    "major_airport_preferred",
-                    "freshest_observation",
-                ][max(0, self._source_settings_states.get("station_selection_strategy", 0))],
-                # Notifications
-                "enable_alerts": self._controls["enable_alerts"].GetValue(),
-                "alert_notifications_enabled": self._controls["alert_notif"].GetValue(),
-                "alert_radius_type": ["county", "point", "zone", "state"][
-                    self._controls["alert_radius_type"].GetSelection()
-                ],
-                "alert_notify_extreme": self._controls["notify_extreme"].GetValue(),
-                "alert_notify_severe": self._controls["notify_severe"].GetValue(),
-                "alert_notify_moderate": self._controls["notify_moderate"].GetValue(),
-                "alert_notify_minor": self._controls["notify_minor"].GetValue(),
-                "alert_notify_unknown": self._controls["notify_unknown"].GetValue(),
-                "alert_global_cooldown_minutes": self._controls["global_cooldown"].GetValue(),
-                "alert_per_alert_cooldown_minutes": self._controls["per_alert_cooldown"].GetValue(),
-                "alert_freshness_window_minutes": self._controls["freshness_window"].GetValue(),
-                "alert_max_notifications_per_hour": self._controls["max_notifications"].GetValue(),
-                # Event-based notifications
-                "notify_discussion_update": self._controls["notify_discussion_update"].GetValue(),
-                "notify_severe_risk_change": self._controls["notify_severe_risk_change"].GetValue(),
-                "notify_minutely_precipitation_start": self._controls[
-                    "notify_minutely_precipitation_start"
-                ].GetValue(),
-                "notify_minutely_precipitation_stop": self._controls[
-                    "notify_minutely_precipitation_stop"
-                ].GetValue(),
-                # Audio
-                "sound_enabled": self._controls["sound_enabled"].GetValue(),
-                "sound_pack": self._sound_pack_ids[self._controls["sound_pack"].GetSelection()]
-                if hasattr(self, "_sound_pack_ids")
-                and self._controls["sound_pack"].GetSelection() < len(self._sound_pack_ids)
-                else "default",
-                "muted_sound_events": self._get_muted_sound_events(),
-                # Updates
-                "auto_update_enabled": self._controls["auto_update"].GetValue(),
-                "update_channel": "stable"
-                if self._controls["update_channel"].GetSelection() == 0
-                else "dev",
-                "update_check_interval_hours": self._controls["update_check_interval"].GetValue(),
-                # AI
-                "openrouter_api_key": self._controls["openrouter_key"].GetValue(),
-                "ai_model_preference": self._get_ai_model_preference(),
-                "ai_explanation_style": style_values[self._controls["ai_style"].GetSelection()],
-                "custom_system_prompt": self._controls["custom_prompt"].GetValue() or None,
-                "custom_instructions": self._controls["custom_instructions"].GetValue() or None,
-                # Advanced
-                "minimize_to_tray": self._controls["minimize_tray"].GetValue(),
-                "minimize_on_startup": self._controls["minimize_on_startup"].GetValue(),
-                "startup_enabled": self._controls["startup"].GetValue(),
-                "weather_history_enabled": self._controls["weather_history"].GetValue(),
-            }
-            # If the field is blank but was non-empty when the dialog opened,
-            # only preserve the key if the user never interacted with the field
-            # (i.e. keyring failed to load). If the user explicitly cleared the
-            # field (_key_explicitly_cleared flag), honor the deletion.
-            for key, orig_attr, cleared_attr in (
-                ("visual_crossing_api_key", "_original_vc_key", "_vc_key_cleared"),
-                ("pirate_weather_api_key", "_original_pw_key", "_pw_key_cleared"),
-                ("openrouter_api_key", "_original_openrouter_key", "_openrouter_key_cleared"),
-            ):
-                if not settings_dict.get(key) and getattr(self, orig_attr, ""):
-                    if getattr(self, cleared_attr, False):
-                        # User deliberately cleared the field — allow deletion
-                        logger.info("API key %s explicitly cleared by user.", key)
-                    else:
-                        logger.warning(
-                            "Skipping empty %s save — original value was non-empty; "
-                            "keyring may have failed to load. Existing keyring value preserved.",
-                            key,
-                        )
-                        settings_dict.pop(key, None)
-
-            success = self.config_manager.update_settings(**settings_dict)
-            if success:
-                logger.info("Settings saved successfully")
-                if hasattr(self, "app") and self._is_runtime_portable_mode():
-                    self._maybe_update_portable_bundle_after_save(settings_dict)
-            return success
-
-        except Exception as e:
-            logger.error(f"Failed to save settings: {e}")
-            return False
-
-    def _setup_accessibility(self):
-        """Set up accessibility labels for controls."""
-        control_names = {
-            "update_interval": "Update Interval (minutes)",
-            "show_nationwide": "Show Nationwide location (requires Auto or NWS data source)",
-            "taskbar_icon_text_enabled": "Show weather text on tray icon",
-            "taskbar_icon_dynamic_enabled": "Update tray text dynamically",
-            "taskbar_icon_text_format": "Tray text format",
-            "temp_unit": "Temperature Display",
-            "show_dewpoint": "Show dewpoint",
-            "show_visibility": "Show visibility",
-            "show_uv_index": "Show UV index",
-            "show_pressure_trend": "Show pressure trend",
-            "forecast_duration_days": "Forecast duration",
-            "hourly_forecast_hours": "Hourly forecast hours",
-            "forecast_time_reference": "Forecast time display",
-            "time_display_mode": "Time zone display",
-            "time_format_12hour": "Use 12-hour time format (e.g., 3:00 PM)",
-            "show_timezone_suffix": "Show timezone abbreviations (e.g., EST, UTC)",
-            "verbosity_level": "Verbosity level",
-            "severe_weather_override": "Automatically prioritize severe weather info",
-            "data_source": "Weather Data Source",
-            "vc_key": "Visual Crossing API Key",
-            "pw_key": "Pirate Weather API Key",
-            "source_settings_summary": "Source settings summary",
-            "configure_source_settings": "Configure source settings",
-            "enable_alerts": "Enable weather alerts",
-            "alert_notif": "Enable alert notifications",
-            "alert_radius_type": "Alert Area",
-            "notify_extreme": "Extreme - Life-threatening events (e.g., Tornado Warning)",
-            "notify_severe": "Severe - Significant hazards (e.g., Severe Thunderstorm Warning)",
-            "notify_moderate": "Moderate - Potentially hazardous (e.g., Winter Weather Advisory)",
-            "notify_minor": "Minor - Low impact events (e.g., Frost Advisory, Fog Advisory)",
-            "notify_unknown": "Unknown - Uncategorized alerts",
-            "notify_discussion_update": "Notify when Area Forecast Discussion is updated (NWS US only)",
-            "notify_severe_risk_change": "Notify when severe weather risk level changes (Visual Crossing only)",
-            "notify_minutely_precipitation_start": "Notify when precipitation is expected to start soon (Pirate Weather)",
-            "notify_minutely_precipitation_stop": "Notify when precipitation is expected to stop soon (Pirate Weather)",
-            "global_cooldown": "Minimum time between any alert notifications (minutes)",
-            "per_alert_cooldown": "Re-notify for same alert after (minutes)",
-            "freshness_window": "Only notify for alerts issued within (minutes)",
-            "max_notifications": "Maximum notifications per hour",
-            "sound_enabled": "Enable Sounds",
-            "sound_pack": "Active sound pack",
-            "auto_update": "Check for updates automatically",
-            "update_channel": "Update Channel",
-            "update_check_interval": "Check Interval (hours)",
-            "openrouter_key": "OpenRouter API Key",
-            "ai_model": "Model Preference",
-            "ai_style": "Explanation Style",
-            "custom_prompt": "Custom System Prompt (optional)",
-            "custom_instructions": "Custom Instructions (optional)",
-            "minimize_tray": "Minimize to notification area when closing",
-            "minimize_on_startup": "Start minimized to notification area",
-            "startup": "Launch automatically at startup",
-            "weather_history": "Enable weather history comparisons",
-        }
-
-        control_names["event_sounds_summary"] = "Event sound summary"
-        control_names["configure_event_sounds"] = "Configure event sounds"
-
-        for key, name in control_names.items():
-            self._controls[key].SetName(name)
-
-    def _get_ai_model_preference(self) -> str:
-        """Get the AI model preference based on UI selection."""
-        selection = self._controls["ai_model"].GetSelection()
-        if selection == 0:
-            return "openrouter/free"
-        if selection == 1:
-            return "meta-llama/llama-3.3-70b-instruct:free"
-        if selection == 2:
-            return "auto"
-        if selection == 3 and self._selected_specific_model:
-            return self._selected_specific_model
-        return "openrouter/free"
-
-    def _on_alert_advanced(self, event):
-        """Open the advanced alert timing settings dialog."""
-        dlg = AlertAdvancedSettingsDialog(self, self._controls)
-        dlg.ShowModal()
-        dlg.Destroy()
-
-    def _on_ok(self, event):
-        """Handle OK button press."""
-        if self._save_settings():
-            self.EndModal(wx.ID_OK)
-        else:
-            wx.MessageBox("Failed to save settings.", "Error", wx.OK | wx.ICON_ERROR)
-
-    # Event handlers for buttons
     def _on_data_source_changed(self, event):
         """Update API key section visibility when data source changes."""
         self._update_api_key_visibility()
@@ -1992,13 +527,11 @@ class SettingsDialogSimple(wx.Dialog):
     def _update_api_key_visibility(self):
         """Show/hide API key sections based on selected data source."""
         selection = self._controls["data_source"].GetSelection()
-        # 0=auto, 1=nws, 2=openmeteo, 3=visualcrossing, 4=pirateweather
-        show_vc = selection in (0, 3)  # auto or VC
-        show_pw = selection in (0, 4)  # auto or PW
+        show_vc = selection in (0, 3)
+        show_pw = selection in (0, 4)
         self._vc_config_sizer.ShowItems(show_vc)
         self._pw_config_sizer.ShowItems(show_pw)
         self._update_auto_source_key_state()
-        # Re-layout the panel
         parent = self._controls["data_source"].GetParent()
         parent.Layout()
         parent.FitInside()
@@ -2073,7 +606,6 @@ class SettingsDialogSimple(wx.Dialog):
             wx.MessageBox("Please enter an API key first.", "Validation", wx.OK | wx.ICON_WARNING)
             return
 
-        # Show busy cursor during validation
         wx.BeginBusyCursor()
         try:
             import asyncio
@@ -2081,7 +613,6 @@ class SettingsDialogSimple(wx.Dialog):
             from ...models import Location
             from ...visual_crossing_client import VisualCrossingApiError, VisualCrossingClient
 
-            # Test with a known location (New York City)
             test_location = Location(name="Test", latitude=40.7128, longitude=-74.0060)
             client = VisualCrossingClient(api_key=key)
 
@@ -2098,7 +629,6 @@ class SettingsDialogSimple(wx.Dialog):
                 except Exception as e:
                     return False, str(e)
 
-            # Run the async validation
             loop = asyncio.new_event_loop()
             try:
                 valid, error = loop.run_until_complete(test_key())
@@ -2134,7 +664,6 @@ class SettingsDialogSimple(wx.Dialog):
             wx.MessageBox("Please enter an API key first.", "Validation", wx.OK | wx.ICON_WARNING)
             return
 
-        # Show busy cursor during validation
         wx.BeginBusyCursor()
         try:
             import asyncio
@@ -2143,7 +672,6 @@ class SettingsDialogSimple(wx.Dialog):
 
             explainer = AIExplainer()
 
-            # Run the async validation
             loop = asyncio.new_event_loop()
             try:
                 valid = loop.run_until_complete(explainer.validate_api_key(key))
@@ -2180,8 +708,6 @@ class SettingsDialogSimple(wx.Dialog):
         selected_model_id = show_model_browser_dialog(self, api_key=api_key or None)
 
         if selected_model_id:
-            # Update the model preference based on selection
-            # Check if it's a known preset (indices must match _get_ai_model_preference)
             if selected_model_id == "openrouter/free":
                 self._controls["ai_model"].SetSelection(0)
             elif selected_model_id == "meta-llama/llama-3.3-70b-instruct:free":
@@ -2189,16 +715,12 @@ class SettingsDialogSimple(wx.Dialog):
             elif selected_model_id == "openrouter/auto":
                 self._controls["ai_model"].SetSelection(2)
             else:
-                # Add as "Specific Model" option at index 3 (after the 3 built-in presets)
                 model_display = f"Selected: {selected_model_id.split('/')[-1]}"
                 if self._controls["ai_model"].GetCount() > 3:
-                    # Replace existing specific model choice
                     self._controls["ai_model"].SetString(3, model_display)
                 else:
-                    # Add new specific model choice
                     self._controls["ai_model"].Append(model_display)
                 self._controls["ai_model"].SetSelection(3)
-                # Store the full model ID for saving
                 self._selected_specific_model = selected_model_id
 
     def _on_reset_prompt(self, event):
@@ -2226,8 +748,6 @@ class SettingsDialogSimple(wx.Dialog):
             from .soundpack_manager_dialog import show_soundpack_manager_dialog
 
             show_soundpack_manager_dialog(self, self.app)
-
-            # Refresh sound pack list after managing
             self._refresh_sound_pack_list()
         except Exception as e:
             logger.error(f"Failed to open sound pack manager: {e}")
@@ -2242,7 +762,6 @@ class SettingsDialogSimple(wx.Dialog):
         try:
             from ...notifications.sound_player import get_available_sound_packs
 
-            # Remember current selection
             current_idx = self._controls["sound_pack"].GetSelection()
             current_id = (
                 self._sound_pack_ids[current_idx]
@@ -2250,17 +769,14 @@ class SettingsDialogSimple(wx.Dialog):
                 else "default"
             )
 
-            # Reload packs
             packs = get_available_sound_packs()
             self._sound_pack_ids = list(packs.keys())
             pack_names = [packs[pid].get("name", pid) for pid in self._sound_pack_ids]
 
-            # Update dropdown
             self._controls["sound_pack"].Clear()
             for name in pack_names:
                 self._controls["sound_pack"].Append(name)
 
-            # Restore selection
             try:
                 new_idx = self._sound_pack_ids.index(current_id)
                 self._controls["sound_pack"].SetSelection(new_idx)
@@ -2274,7 +790,6 @@ class SettingsDialogSimple(wx.Dialog):
         """Check for updates using the UpdateService."""
         import sys
 
-        # Skip update checks when running from source
         if not getattr(sys, "frozen", False):
             wx.MessageBox(
                 "Update checking is only available in installed builds.\n"
@@ -2295,16 +810,12 @@ class SettingsDialogSimple(wx.Dialog):
             )
 
             try:
-                # Get current version and nightly date from the app
                 current_version = getattr(self.app, "version", "0.0.0")
-                # Check if running a nightly build (tag embedded at build time)
                 build_tag = getattr(self.app, "build_tag", None)
                 current_nightly_date = parse_nightly_date(build_tag) if build_tag else None
-                # Show nightly date in UI when running a nightly build
                 if current_nightly_date:
                     current_version = current_nightly_date
 
-                # Determine which channel to check
                 channel_idx = self._controls["update_channel"].GetSelection()
                 channel = "nightly" if channel_idx == 1 else "stable"
 
@@ -2322,7 +833,6 @@ class SettingsDialogSimple(wx.Dialog):
                 update_info = asyncio.run(check())
 
                 if update_info is None:
-                    # Provide context-aware message
                     if current_nightly_date and channel == "stable":
                         status_msg = (
                             f"You're on nightly ({current_nightly_date}).\n"
@@ -2333,10 +843,7 @@ class SettingsDialogSimple(wx.Dialog):
                     else:
                         status_msg = f"You're up to date ({current_version})."
 
-                    wx.CallAfter(
-                        self._controls["update_status"].SetLabel,
-                        status_msg,
-                    )
+                    wx.CallAfter(self._controls["update_status"].SetLabel, status_msg)
                     wx.CallAfter(
                         wx.MessageBox,
                         status_msg,
@@ -2345,7 +852,6 @@ class SettingsDialogSimple(wx.Dialog):
                     )
                     return
 
-                # Update available - ask user if they want to download
                 wx.CallAfter(
                     self._controls["update_status"].SetLabel,
                     f"Update available: {update_info.version}",
@@ -2382,7 +888,6 @@ class SettingsDialogSimple(wx.Dialog):
                     wx.OK | wx.ICON_ERROR,
                 )
 
-        # Run update check in background thread
         import threading
 
         thread = threading.Thread(target=do_update_check, daemon=True)
@@ -2399,7 +904,6 @@ class SettingsDialogSimple(wx.Dialog):
         if result == wx.YES:
             try:
                 if self.config_manager.reset_to_defaults():
-                    # Reload settings into UI
                     self._load_settings()
                     wx.MessageBox(
                         "Settings have been reset to defaults.\n\n"
@@ -2435,7 +939,6 @@ class SettingsDialogSimple(wx.Dialog):
             wx.YES_NO | wx.ICON_WARNING,
         )
         if result == wx.YES:
-            # Double-confirm for destructive action
             result2 = wx.MessageBox(
                 "This is your last chance to cancel.\n\n"
                 "Are you absolutely sure you want to delete all data?",
@@ -2445,7 +948,6 @@ class SettingsDialogSimple(wx.Dialog):
             if result2 == wx.YES:
                 try:
                     if self.config_manager.reset_all_data():
-                        # Reload settings into UI
                         self._load_settings()
                         wx.MessageBox(
                             "All application data has been reset.\n\n"
@@ -2482,6 +984,114 @@ class SettingsDialogSimple(wx.Dialog):
                 wx.OK | wx.ICON_ERROR,
             )
 
+    def _on_alert_advanced(self, event):
+        """Open the advanced alert timing settings dialog."""
+        dlg = AlertAdvancedSettingsDialog(self, self._controls)
+        dlg.ShowModal()
+        dlg.Destroy()
+
+    def _on_ok(self, event):
+        """Handle OK button press."""
+        if self._save_settings():
+            self.EndModal(wx.ID_OK)
+        else:
+            wx.MessageBox("Failed to save settings.", "Error", wx.OK | wx.ICON_ERROR)
+
+    def _on_minimize_tray_changed(self, event):
+        """Handle minimize to tray checkbox state change."""
+        minimize_to_tray_enabled = self._controls["minimize_tray"].GetValue()
+        self._update_minimize_on_startup_state(minimize_to_tray_enabled)
+        event.Skip()
+
+    def _on_taskbar_icon_text_enabled_changed(self, event):
+        """Enable/disable taskbar text controls when main toggle changes."""
+        taskbar_text_enabled = self._controls["taskbar_icon_text_enabled"].GetValue()
+        self._update_taskbar_text_controls_state(taskbar_text_enabled)
+        event.Skip()
+
+    def _update_minimize_on_startup_state(self, minimize_to_tray_enabled: bool):
+        """Update the enabled state of minimize_on_startup based on minimize_to_tray."""
+        self._controls["minimize_on_startup"].Enable(minimize_to_tray_enabled)
+        if not minimize_to_tray_enabled:
+            self._controls["minimize_on_startup"].SetValue(False)
+
+    def _update_taskbar_text_controls_state(self, taskbar_text_enabled: bool):
+        """Enable/disable dependent taskbar text controls."""
+        self._controls["taskbar_icon_dynamic_enabled"].Enable(taskbar_text_enabled)
+        self._controls["taskbar_icon_text_format_dialog"].Enable(taskbar_text_enabled)
+
+    def _on_edit_taskbar_text_format(self, event):
+        """Open the focused tray text format dialog."""
+        from ...taskbar_icon_updater import TaskbarIconUpdater
+        from .tray_text_format_dialog import TrayTextFormatDialog
+
+        current_weather = getattr(self.app, "current_weather_data", None)
+        current_location = None
+        if current_weather and getattr(current_weather, "location", None):
+            current_location = getattr(current_weather.location, "name", None)
+
+        updater = TaskbarIconUpdater(
+            text_enabled=True,
+            dynamic_enabled=self._controls["taskbar_icon_dynamic_enabled"].GetValue(),
+            format_string=self._controls["taskbar_icon_text_format"].GetValue(),
+            temperature_unit=self._get_selected_temperature_unit(),
+        )
+
+        dialog = TrayTextFormatDialog(
+            self,
+            updater=updater,
+            weather_data=current_weather,
+            location_name=current_location,
+            initial_format=self._controls["taskbar_icon_text_format"].GetValue(),
+        )
+        if dialog.ShowModal() == wx.ID_OK:
+            self._controls["taskbar_icon_text_format"].SetValue(dialog.get_format_string())
+        dialog.Destroy()
+        event.Skip()
+
+    def _get_selected_temperature_unit(self) -> str:
+        """Return the temperature unit selection currently shown in the dialog."""
+        if hasattr(self, "_display_tab"):
+            return self._display_tab.get_selected_temperature_unit()
+        temp_values = ["auto", "f", "c", "both"]
+        selection = self._controls["temp_unit"].GetSelection()
+        if selection < 0 or selection >= len(temp_values):
+            return "both"
+        return temp_values[selection]
+
+    def _get_ai_model_preference(self) -> str:
+        """Get the AI model preference based on UI selection."""
+        selection = self._controls["ai_model"].GetSelection()
+        if selection == 0:
+            return "openrouter/free"
+        if selection == 1:
+            return "meta-llama/llama-3.3-70b-instruct:free"
+        if selection == 2:
+            return "auto"
+        if selection == 3 and self._selected_specific_model:
+            return self._selected_specific_model
+        return "openrouter/free"
+
+    def _on_open_soundpacks_dir(self, event):
+        """Open sound packs directory."""
+        import subprocess
+
+        from ...soundpack_paths import get_soundpacks_dir
+
+        soundpacks_dir = get_soundpacks_dir()
+        if soundpacks_dir.exists():
+            subprocess.Popen(["explorer", str(soundpacks_dir)])
+        else:
+            wx.MessageBox(
+                f"Sound packs directory not found: {soundpacks_dir}",
+                "Error",
+                wx.OK | wx.ICON_ERROR,
+            )
+
+    # ------------------------------------------------------------------
+    # Portable mode / config file management
+    # ------------------------------------------------------------------
+
     _PORTABLE_KEY_SETTINGS = (
         "visual_crossing_api_key",
         "pirate_weather_api_key",
@@ -2490,13 +1100,7 @@ class SettingsDialogSimple(wx.Dialog):
     )
 
     def _maybe_update_portable_bundle_after_save(self, settings_dict: dict) -> None:
-        """
-        After saving settings in portable mode, keep the bundle in sync.
-
-        If any API key was changed:
-        - Passphrase cached → silently re-encrypt bundle via export_encrypted_api_keys
-        - No cached passphrase → prompt for passphrase, then export
-        """
+        """After saving settings in portable mode, keep the bundle in sync."""
         changed_keys = {
             k: v for k, v in settings_dict.items() if k in self._PORTABLE_KEY_SETTINGS and v
         }
@@ -2515,7 +1119,6 @@ class SettingsDialogSimple(wx.Dialog):
             (config_dir / n for n in bundle_names if (config_dir / n).exists()), None
         )
 
-        # Get or prompt for passphrase.
         passphrase = (SecureStorage.get_password(_PASSPHRASE_KEY) or "").strip()
 
         if not passphrase:
@@ -2542,11 +1145,8 @@ class SettingsDialogSimple(wx.Dialog):
                 passphrase = dlg.GetValue().strip()
             if not passphrase:
                 return
-            # Cache for future use.
             SecureStorage.set_password(_PASSPHRASE_KEY, passphrase)
 
-        # Write/update the bundle — export_encrypted_api_keys reads all keys
-        # from in-memory settings + keyring, so no manual merge needed.
         if bundle_path is None:
             bundle_path = config_dir / "api-keys.keys"
 
@@ -2569,7 +1169,7 @@ class SettingsDialogSimple(wx.Dialog):
             )
 
     def _is_runtime_portable_mode(self) -> bool:
-        """Return portable mode using runtime app/config state (single source of truth)."""
+        """Return portable mode using runtime app/config state."""
         app_portable = getattr(self.app, "_portable_mode", None)
         if app_portable is not None:
             return bool(app_portable)
@@ -2619,7 +1219,6 @@ class SettingsDialogSimple(wx.Dialog):
     def _get_installed_config_dir(self):
         """Return the standard installed config directory path."""
         import os
-        from pathlib import Path
 
         local_appdata = os.environ.get("LOCALAPPDATA")
         author = getattr(self.app.paths, "_author", "Orinks")
@@ -2673,7 +1272,8 @@ class SettingsDialogSimple(wx.Dialog):
             dst_value = dst_settings.get(key)
             if src_value != dst_value:
                 messages.append(
-                    f"Setting '{key}' did not copy correctly (installed={src_value!r}, portable={dst_value!r})."
+                    f"Setting '{key}' did not copy correctly "
+                    f"(installed={src_value!r}, portable={dst_value!r})."
                 )
 
         src_locations = (
@@ -2684,7 +1284,8 @@ class SettingsDialogSimple(wx.Dialog):
         )
         if len(src_locations) != len(dst_locations):
             messages.append(
-                f"Location count mismatch after copy (installed={len(src_locations)}, portable={len(dst_locations)})."
+                f"Location count mismatch after copy "
+                f"(installed={len(src_locations)}, portable={len(dst_locations)})."
             )
 
         if messages:
@@ -2756,7 +1357,6 @@ class SettingsDialogSimple(wx.Dialog):
         if result != wx.YES:
             return
 
-        # Flush pending in-memory state before filesystem mutation.
         self.config_manager.save_config()
 
         try:
@@ -2800,7 +1400,6 @@ class SettingsDialogSimple(wx.Dialog):
                 )
                 return
 
-            # Reload from copied files so future saves preserve migrated data.
             self.config_manager._config = None
             self.config_manager.load_config()
             self._load_settings()
@@ -2819,7 +1418,6 @@ class SettingsDialogSimple(wx.Dialog):
                 wx.OK | wx.ICON_INFORMATION,
             )
 
-            # Offer to export API keys from keyring to encrypted bundle.
             self._offer_api_key_export_after_copy(portable_config_dir)
         except Exception as e:
             logger.error(f"Failed to copy installed config to portable: {e}")
@@ -2905,8 +1503,6 @@ class SettingsDialogSimple(wx.Dialog):
 
     def _on_export_encrypted_api_keys(self, event):
         """Export API keys from keyring to encrypted bundle file."""
-        from pathlib import Path
-
         passphrase = self._prompt_passphrase(
             "Export API keys (encrypted)",
             "Enter a passphrase to encrypt exported API keys.",
@@ -2949,8 +1545,6 @@ class SettingsDialogSimple(wx.Dialog):
 
     def _on_import_encrypted_api_keys(self, event):
         """Import encrypted API key bundle into local secure storage."""
-        from pathlib import Path
-
         with wx.FileDialog(
             self,
             "Import API keys (encrypted)",
@@ -2984,8 +1578,6 @@ class SettingsDialogSimple(wx.Dialog):
 
     def _on_export_settings(self, event):
         """Export settings to file."""
-        from pathlib import Path
-
         with wx.FileDialog(
             self,
             "Export Settings",
@@ -3019,8 +1611,6 @@ class SettingsDialogSimple(wx.Dialog):
 
     def _on_import_settings(self, event):
         """Import settings from file."""
-        from pathlib import Path
-
         with wx.FileDialog(
             self,
             "Import Settings",
@@ -3040,7 +1630,6 @@ class SettingsDialogSimple(wx.Dialog):
                 if result == wx.YES:
                     try:
                         if self.config_manager.import_settings(import_path):
-                            # Reload settings into UI
                             self._load_settings()
                             wx.MessageBox(
                                 "Settings imported successfully!\n\n"
@@ -3063,89 +1652,6 @@ class SettingsDialogSimple(wx.Dialog):
                             wx.OK | wx.ICON_ERROR,
                         )
 
-    def _on_minimize_tray_changed(self, event):
-        """Handle minimize to tray checkbox state change."""
-        minimize_to_tray_enabled = self._controls["minimize_tray"].GetValue()
-        self._update_minimize_on_startup_state(minimize_to_tray_enabled)
-        event.Skip()
-
-    def _on_taskbar_icon_text_enabled_changed(self, event):
-        """Enable/disable taskbar text controls when main toggle changes."""
-        taskbar_text_enabled = self._controls["taskbar_icon_text_enabled"].GetValue()
-        self._update_taskbar_text_controls_state(taskbar_text_enabled)
-        event.Skip()
-
-    def _update_minimize_on_startup_state(self, minimize_to_tray_enabled: bool):
-        """
-        Update the enabled state of minimize_on_startup based on minimize_to_tray.
-
-        Args:
-            minimize_to_tray_enabled: Whether minimize to tray is enabled
-
-        """
-        self._controls["minimize_on_startup"].Enable(minimize_to_tray_enabled)
-        if not minimize_to_tray_enabled:
-            # If minimize to tray is disabled, also uncheck minimize on startup
-            self._controls["minimize_on_startup"].SetValue(False)
-
-    def _update_taskbar_text_controls_state(self, taskbar_text_enabled: bool):
-        """Enable/disable dependent taskbar text controls."""
-        self._controls["taskbar_icon_dynamic_enabled"].Enable(taskbar_text_enabled)
-        self._controls["taskbar_icon_text_format_dialog"].Enable(taskbar_text_enabled)
-
-    def _on_edit_taskbar_text_format(self, event):
-        """Open the focused tray text format dialog."""
-        from ...taskbar_icon_updater import TaskbarIconUpdater
-        from .tray_text_format_dialog import TrayTextFormatDialog
-
-        current_weather = getattr(self.app, "current_weather_data", None)
-        current_location = None
-        if current_weather and getattr(current_weather, "location", None):
-            current_location = getattr(current_weather.location, "name", None)
-
-        updater = TaskbarIconUpdater(
-            text_enabled=True,
-            dynamic_enabled=self._controls["taskbar_icon_dynamic_enabled"].GetValue(),
-            format_string=self._controls["taskbar_icon_text_format"].GetValue(),
-            temperature_unit=self._get_selected_temperature_unit(),
-        )
-
-        dialog = TrayTextFormatDialog(
-            self,
-            updater=updater,
-            weather_data=current_weather,
-            location_name=current_location,
-            initial_format=self._controls["taskbar_icon_text_format"].GetValue(),
-        )
-        if dialog.ShowModal() == wx.ID_OK:
-            self._controls["taskbar_icon_text_format"].SetValue(dialog.get_format_string())
-        dialog.Destroy()
-        event.Skip()
-
-    def _get_selected_temperature_unit(self) -> str:
-        """Return the temperature unit selection currently shown in the dialog."""
-        temp_values = ["auto", "f", "c", "both"]
-        selection = self._controls["temp_unit"].GetSelection()
-        if selection < 0 or selection >= len(temp_values):
-            return "both"
-        return temp_values[selection]
-
-    def _on_open_soundpacks_dir(self, event):
-        """Open sound packs directory."""
-        import subprocess
-
-        from ...soundpack_paths import get_soundpacks_dir
-
-        soundpacks_dir = get_soundpacks_dir()
-        if soundpacks_dir.exists():
-            subprocess.Popen(["explorer", str(soundpacks_dir)])
-        else:
-            wx.MessageBox(
-                f"Sound packs directory not found: {soundpacks_dir}",
-                "Error",
-                wx.OK | wx.ICON_ERROR,
-            )
-
 
 def show_settings_dialog(parent, app: AccessiWeatherApp, tab: str | None = None) -> bool:
     """
@@ -3165,7 +1671,6 @@ def show_settings_dialog(parent, app: AccessiWeatherApp, tab: str | None = None)
 
         dlg = SettingsDialogSimple(parent_ctrl, app)
 
-        # Switch to specified tab if provided
         if tab:
             for i in range(dlg.notebook.GetPageCount()):
                 if dlg.notebook.GetPageText(i) == tab:

--- a/src/accessiweather/ui/dialogs/settings_tabs/__init__.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/__init__.py
@@ -1,0 +1,21 @@
+"""Per-tab modules for the Settings dialog."""
+
+from .advanced import AdvancedTab
+from .ai import AITab
+from .audio import AudioTab
+from .data_sources import DataSourcesTab
+from .display import DisplayTab
+from .general import GeneralTab
+from .notifications import NotificationsTab
+from .updates import UpdatesTab
+
+__all__ = [
+    "GeneralTab",
+    "DisplayTab",
+    "DataSourcesTab",
+    "NotificationsTab",
+    "AudioTab",
+    "UpdatesTab",
+    "AITab",
+    "AdvancedTab",
+]

--- a/src/accessiweather/ui/dialogs/settings_tabs/advanced.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/advanced.py
@@ -1,0 +1,174 @@
+"""Advanced settings tab."""
+
+from __future__ import annotations
+
+import logging
+
+import wx
+
+logger = logging.getLogger(__name__)
+
+
+class AdvancedTab:
+    """Advanced tab: system options, reset functions, config file management, API key portability."""
+
+    def __init__(self, dialog):
+        """Store reference to the parent settings dialog."""
+        self.dialog = dialog
+
+    def create(self):
+        """Build the Advanced tab panel and add it to the notebook."""
+        panel = wx.ScrolledWindow(self.dialog.notebook)
+        panel.SetScrollRate(0, 20)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        controls = self.dialog._controls
+
+        # System options
+        controls["minimize_tray"] = wx.CheckBox(
+            panel, label="Minimize to notification area when closing"
+        )
+        controls["minimize_tray"].Bind(wx.EVT_CHECKBOX, self.dialog._on_minimize_tray_changed)
+        sizer.Add(controls["minimize_tray"], 0, wx.ALL, 5)
+
+        controls["minimize_on_startup"] = wx.CheckBox(
+            panel, label="Start minimized to notification area"
+        )
+        sizer.Add(controls["minimize_on_startup"], 0, wx.LEFT | wx.BOTTOM, 5)
+
+        controls["startup"] = wx.CheckBox(panel, label="Launch automatically at startup")
+        sizer.Add(controls["startup"], 0, wx.LEFT | wx.BOTTOM, 5)
+
+        controls["weather_history"] = wx.CheckBox(panel, label="Enable weather history comparisons")
+        sizer.Add(controls["weather_history"], 0, wx.LEFT | wx.BOTTOM, 5)
+
+        # Reset Configuration
+        sizer.Add(wx.StaticText(panel, label="Reset Configuration"), 0, wx.LEFT | wx.TOP, 5)
+        sizer.Add(
+            wx.StaticText(panel, label="Restore all settings to their default values."),
+            0,
+            wx.LEFT,
+            5,
+        )
+
+        reset_btn = wx.Button(panel, label="Reset all settings to defaults")
+        reset_btn.Bind(wx.EVT_BUTTON, self.dialog._on_reset_defaults)
+        sizer.Add(reset_btn, 0, wx.LEFT | wx.TOP | wx.BOTTOM, 10)
+
+        # Full Data Reset
+        sizer.Add(wx.StaticText(panel, label="Full Data Reset"), 0, wx.LEFT, 5)
+        sizer.Add(
+            wx.StaticText(
+                panel,
+                label="Reset all application data: settings, locations, caches, and alert state.",
+            ),
+            0,
+            wx.LEFT,
+            5,
+        )
+
+        full_reset_btn = wx.Button(panel, label="Reset all app data (settings, locations, caches)")
+        full_reset_btn.Bind(wx.EVT_BUTTON, self.dialog._on_full_reset)
+        sizer.Add(full_reset_btn, 0, wx.LEFT | wx.TOP | wx.BOTTOM, 10)
+
+        # Configuration Files
+        sizer.Add(wx.StaticText(panel, label="Configuration Files"), 0, wx.LEFT, 5)
+
+        open_config_btn = wx.Button(panel, label="Open current config directory")
+        open_config_btn.Bind(wx.EVT_BUTTON, self.dialog._on_open_config_dir)
+        sizer.Add(open_config_btn, 0, wx.LEFT | wx.TOP, 10)
+
+        open_installed_config_btn = wx.Button(
+            panel, label="Open installed config directory (source)"
+        )
+        open_installed_config_btn.Bind(wx.EVT_BUTTON, self.dialog._on_open_installed_config_dir)
+        sizer.Add(open_installed_config_btn, 0, wx.LEFT | wx.TOP, 10)
+
+        if self.dialog._is_runtime_portable_mode():
+            migrate_config_btn = wx.Button(panel, label="Copy installed config to portable")
+            migrate_config_btn.Bind(
+                wx.EVT_BUTTON, self.dialog._on_copy_installed_config_to_portable
+            )
+            sizer.Add(migrate_config_btn, 0, wx.LEFT | wx.TOP | wx.BOTTOM, 10)
+
+        # Settings Backup
+        sizer.Add(wx.StaticText(panel, label="Settings Backup"), 0, wx.LEFT | wx.TOP, 5)
+
+        export_btn = wx.Button(panel, label="Export Settings...")
+        export_btn.Bind(wx.EVT_BUTTON, self.dialog._on_export_settings)
+        sizer.Add(export_btn, 0, wx.LEFT | wx.TOP, 10)
+
+        import_btn = wx.Button(panel, label="Import Settings...")
+        import_btn.Bind(wx.EVT_BUTTON, self.dialog._on_import_settings)
+        sizer.Add(import_btn, 0, wx.LEFT | wx.TOP, 10)
+
+        sizer.Add(
+            wx.StaticText(panel, label="API Key Portability (Encrypted)"),
+            0,
+            wx.LEFT | wx.TOP,
+            5,
+        )
+        sizer.Add(
+            wx.StaticText(
+                panel,
+                label=(
+                    "Optional: export API keys to an encrypted bundle for transfer. "
+                    "Import requires your passphrase and stores keys in this machine's keyring."
+                ),
+            ),
+            0,
+            wx.LEFT,
+            5,
+        )
+
+        export_api_keys_btn = wx.Button(panel, label="Export API keys (encrypted)")
+        export_api_keys_btn.Bind(wx.EVT_BUTTON, self.dialog._on_export_encrypted_api_keys)
+        sizer.Add(export_api_keys_btn, 0, wx.LEFT | wx.TOP, 10)
+
+        import_api_keys_btn = wx.Button(panel, label="Import API keys (encrypted)")
+        import_api_keys_btn.Bind(wx.EVT_BUTTON, self.dialog._on_import_encrypted_api_keys)
+        sizer.Add(import_api_keys_btn, 0, wx.LEFT | wx.TOP, 10)
+
+        # Sound Pack Files
+        sizer.Add(wx.StaticText(panel, label="Sound Pack Files"), 0, wx.LEFT | wx.TOP, 5)
+
+        open_sounds_btn = wx.Button(panel, label="Open sound packs folder")
+        open_sounds_btn.Bind(wx.EVT_BUTTON, self.dialog._on_open_soundpacks_dir)
+        sizer.Add(open_sounds_btn, 0, wx.LEFT | wx.TOP | wx.BOTTOM, 10)
+
+        panel.SetSizer(sizer)
+        self.dialog.notebook.AddPage(panel, "Advanced")
+        return panel
+
+    def load(self, settings):
+        """Populate Advanced tab controls from settings."""
+        controls = self.dialog._controls
+
+        minimize_to_tray = getattr(settings, "minimize_to_tray", False)
+        controls["minimize_tray"].SetValue(minimize_to_tray)
+        controls["minimize_on_startup"].SetValue(getattr(settings, "minimize_on_startup", False))
+        self.dialog._update_minimize_on_startup_state(minimize_to_tray)
+
+        controls["startup"].SetValue(getattr(settings, "startup_enabled", False))
+        controls["weather_history"].SetValue(getattr(settings, "weather_history_enabled", True))
+
+    def save(self) -> dict:
+        """Return Advanced tab settings as a dict."""
+        controls = self.dialog._controls
+        return {
+            "minimize_to_tray": controls["minimize_tray"].GetValue(),
+            "minimize_on_startup": controls["minimize_on_startup"].GetValue(),
+            "startup_enabled": controls["startup"].GetValue(),
+            "weather_history_enabled": controls["weather_history"].GetValue(),
+        }
+
+    def setup_accessibility(self):
+        """Set accessibility names for Advanced tab controls."""
+        controls = self.dialog._controls
+        names = {
+            "minimize_tray": "Minimize to notification area when closing",
+            "minimize_on_startup": "Start minimized to notification area",
+            "startup": "Launch automatically at startup",
+            "weather_history": "Enable weather history comparisons",
+        }
+        for key, name in names.items():
+            controls[key].SetName(name)

--- a/src/accessiweather/ui/dialogs/settings_tabs/ai.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/ai.py
@@ -1,0 +1,189 @@
+"""AI settings tab."""
+
+from __future__ import annotations
+
+import logging
+
+import wx
+
+logger = logging.getLogger(__name__)
+
+_STYLE_VALUES = ["brief", "standard", "detailed"]
+_STYLE_MAP = {"brief": 0, "standard": 1, "detailed": 2}
+
+
+class AITab:
+    """AI tab: OpenRouter API key, model preferences, explanation style, custom prompts."""
+
+    def __init__(self, dialog):
+        """Store reference to the parent settings dialog."""
+        self.dialog = dialog
+
+    def create(self):
+        """Build the AI tab panel and add it to the notebook."""
+        panel = wx.ScrolledWindow(self.dialog.notebook)
+        panel.SetScrollRate(0, 20)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        controls = self.dialog._controls
+
+        sizer.Add(wx.StaticText(panel, label="AI Weather Explanations"), 0, wx.ALL, 5)
+        sizer.Add(
+            wx.StaticText(
+                panel,
+                label="Get natural language explanations of weather conditions using AI.",
+            ),
+            0,
+            wx.LEFT | wx.BOTTOM,
+            5,
+        )
+
+        sizer.Add(wx.StaticText(panel, label="OpenRouter API Key:"), 0, wx.ALL, 5)
+        controls["openrouter_key"] = wx.TextCtrl(panel, style=wx.TE_PASSWORD, size=(300, -1))
+        sizer.Add(controls["openrouter_key"], 0, wx.LEFT, 10)
+
+        validate_btn = wx.Button(panel, label="Validate API Key")
+        validate_btn.Bind(wx.EVT_BUTTON, self.dialog._on_validate_openrouter_key)
+        sizer.Add(validate_btn, 0, wx.LEFT | wx.TOP | wx.BOTTOM, 10)
+
+        row_model = wx.BoxSizer(wx.HORIZONTAL)
+        row_model.Add(
+            wx.StaticText(panel, label="Model Preference:"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        controls["ai_model"] = wx.Choice(
+            panel,
+            choices=[
+                "Free Router (Auto, Free)",
+                "Llama 3.3 70B (Free)",
+                "Auto Router (Paid)",
+            ],
+        )
+        row_model.Add(controls["ai_model"], 0)
+        sizer.Add(row_model, 0, wx.LEFT, 10)
+
+        browse_btn = wx.Button(panel, label="Browse Models...")
+        browse_btn.Bind(wx.EVT_BUTTON, self.dialog._on_browse_models)
+        sizer.Add(browse_btn, 0, wx.LEFT | wx.TOP, 10)
+
+        row_style = wx.BoxSizer(wx.HORIZONTAL)
+        row_style.Add(
+            wx.StaticText(panel, label="Explanation Style:"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        controls["ai_style"] = wx.Choice(
+            panel,
+            choices=[
+                "Brief (1-2 sentences)",
+                "Standard (3-4 sentences)",
+                "Detailed (full paragraph)",
+            ],
+        )
+        row_style.Add(controls["ai_style"], 0)
+        sizer.Add(row_style, 0, wx.LEFT | wx.TOP, 10)
+
+        sizer.Add(
+            wx.StaticText(panel, label="Custom System Prompt (optional):"),
+            0,
+            wx.LEFT | wx.TOP,
+            10,
+        )
+        controls["custom_prompt"] = wx.TextCtrl(panel, style=wx.TE_MULTILINE, size=(400, 60))
+        sizer.Add(controls["custom_prompt"], 0, wx.LEFT | wx.EXPAND, 10)
+
+        reset_prompt_btn = wx.Button(panel, label="Reset to Default")
+        reset_prompt_btn.Bind(wx.EVT_BUTTON, self.dialog._on_reset_prompt)
+        sizer.Add(reset_prompt_btn, 0, wx.LEFT | wx.TOP, 10)
+
+        sizer.Add(
+            wx.StaticText(panel, label="Custom Instructions (optional):"),
+            0,
+            wx.LEFT | wx.TOP,
+            10,
+        )
+        controls["custom_instructions"] = wx.TextCtrl(panel, style=wx.TE_MULTILINE, size=(400, 40))
+        controls["custom_instructions"].SetHint(
+            "e.g., Focus on outdoor activities, Keep responses under 50 words"
+        )
+        sizer.Add(controls["custom_instructions"], 0, wx.LEFT | wx.EXPAND, 10)
+
+        sizer.Add(wx.StaticText(panel, label="Cost Information:"), 0, wx.LEFT | wx.TOP, 10)
+        sizer.Add(
+            wx.StaticText(panel, label="Free models: No cost, may have rate limits"),
+            0,
+            wx.LEFT,
+            15,
+        )
+        sizer.Add(
+            wx.StaticText(panel, label="Paid models: ~$0.001 per explanation (varies by model)"),
+            0,
+            wx.LEFT,
+            15,
+        )
+
+        panel.SetSizer(sizer)
+        self.dialog.notebook.AddPage(panel, "AI")
+        return panel
+
+    def load(self, settings):
+        """Populate AI tab controls from settings."""
+        controls = self.dialog._controls
+
+        openrouter_key = getattr(settings, "openrouter_api_key", "") or ""
+        controls["openrouter_key"].SetValue(str(openrouter_key))
+        self.dialog._original_openrouter_key = str(openrouter_key)
+        self.dialog._openrouter_key_cleared = False
+        if hasattr(wx, "EVT_TEXT"):
+            controls["openrouter_key"].Bind(
+                wx.EVT_TEXT,
+                lambda e: setattr(self.dialog, "_openrouter_key_cleared", True),
+            )
+
+        ai_model = getattr(settings, "ai_model_preference", "openrouter/free")
+        if ai_model == "openrouter/free":
+            controls["ai_model"].SetSelection(0)
+        elif ai_model == "meta-llama/llama-3.3-70b-instruct:free":
+            controls["ai_model"].SetSelection(1)
+        elif ai_model == "auto":
+            controls["ai_model"].SetSelection(2)
+        else:
+            model_display = f"Selected: {ai_model.split('/')[-1]}"
+            controls["ai_model"].Append(model_display)
+            controls["ai_model"].SetSelection(3)
+            self.dialog._selected_specific_model = ai_model
+
+        ai_style = getattr(settings, "ai_explanation_style", "standard")
+        controls["ai_style"].SetSelection(_STYLE_MAP.get(ai_style, 1))
+
+        custom_prompt = getattr(settings, "custom_system_prompt", "") or ""
+        controls["custom_prompt"].SetValue(custom_prompt)
+
+        custom_instructions = getattr(settings, "custom_instructions", "") or ""
+        controls["custom_instructions"].SetValue(custom_instructions)
+
+    def save(self) -> dict:
+        """Return AI tab settings as a dict."""
+        controls = self.dialog._controls
+        return {
+            "openrouter_api_key": controls["openrouter_key"].GetValue(),
+            "ai_model_preference": self.dialog._get_ai_model_preference(),
+            "ai_explanation_style": _STYLE_VALUES[controls["ai_style"].GetSelection()],
+            "custom_system_prompt": controls["custom_prompt"].GetValue() or None,
+            "custom_instructions": controls["custom_instructions"].GetValue() or None,
+        }
+
+    def setup_accessibility(self):
+        """Set accessibility names for AI tab controls."""
+        controls = self.dialog._controls
+        names = {
+            "openrouter_key": "OpenRouter API Key",
+            "ai_model": "Model Preference",
+            "ai_style": "Explanation Style",
+            "custom_prompt": "Custom System Prompt (optional)",
+            "custom_instructions": "Custom Instructions (optional)",
+        }
+        for key, name in names.items():
+            controls[key].SetName(name)

--- a/src/accessiweather/ui/dialogs/settings_tabs/audio.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/audio.py
@@ -1,0 +1,221 @@
+"""Audio settings tab."""
+
+from __future__ import annotations
+
+import logging
+
+import wx
+
+logger = logging.getLogger(__name__)
+
+
+class AudioTab:
+    """Audio tab: sound playback, sound pack selection, event sounds configuration."""
+
+    def __init__(self, dialog):
+        """Store reference to the parent settings dialog."""
+        self.dialog = dialog
+
+    # ------------------------------------------------------------------
+    # Static helpers (also used by SettingsDialogSimple for backward compat)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_event_sound_sections() -> tuple[tuple[str, str, tuple[str, ...]], ...]:
+        """Return grouped event-sound sections used by the settings UI."""
+        try:
+            from ....sound_events import SOUND_EVENT_SECTIONS
+        except ImportError:
+            from accessiweather.sound_events import SOUND_EVENT_SECTIONS
+
+        return tuple(
+            (title, description, tuple(event_key for event_key, _label in section_events))
+            for title, description, section_events in SOUND_EVENT_SECTIONS
+        )
+
+    @staticmethod
+    def _get_mutable_sound_events() -> tuple[tuple[str, str], ...]:
+        """Return user-configurable event sound labels."""
+        try:
+            from ....sound_events import USER_MUTABLE_SOUND_EVENTS
+        except ImportError:
+            from accessiweather.sound_events import USER_MUTABLE_SOUND_EVENTS
+
+        return tuple(USER_MUTABLE_SOUND_EVENTS)
+
+    @classmethod
+    def _build_default_event_sound_states(cls) -> dict[str, bool]:
+        """Return the default enabled state for each mutable sound event."""
+        return {event_key: True for event_key, _label in cls._get_mutable_sound_events()}
+
+    # ------------------------------------------------------------------
+    # Instance helpers (read/write dialog state)
+    # ------------------------------------------------------------------
+
+    def _get_muted_sound_events(self) -> list[str]:
+        """Return muted event keys in the configured display order."""
+        state_map = (
+            getattr(self.dialog, "_event_sound_states", {})
+            or self._build_default_event_sound_states()
+        )
+        return [
+            event_key
+            for event_key, _label in self._get_mutable_sound_events()
+            if not state_map.get(event_key, True)
+        ]
+
+    def _get_event_sound_summary_text(self) -> str:
+        """Build summary text shown on the audio tab."""
+        total_events = len(self._get_mutable_sound_events())
+        muted_events = self._get_muted_sound_events()
+        enabled_count = total_events - len(muted_events)
+
+        if not muted_events:
+            return f"All {total_events} sound events are enabled."
+        if enabled_count == 0:
+            return "All event sounds are turned off."
+        return f"{enabled_count} of {total_events} sound events are enabled."
+
+    def _refresh_event_sound_summary(self) -> None:
+        """Refresh the event sound summary shown on the audio tab."""
+        summary_control = self.dialog._controls.get("event_sounds_summary")
+        if summary_control is not None:
+            summary_control.SetLabel(self._get_event_sound_summary_text())
+
+    def set_event_sound_states(self, muted_sound_events: list[str] | tuple[str, ...]) -> None:
+        """Apply muted event settings to the in-memory audio state."""
+        muted_event_set = set(muted_sound_events)
+        self.dialog._event_sound_states = {
+            event_key: event_key not in muted_event_set
+            for event_key, _label in self._get_mutable_sound_events()
+        }
+        self._refresh_event_sound_summary()
+
+    # ------------------------------------------------------------------
+    # Tab interface
+    # ------------------------------------------------------------------
+
+    def create(self):
+        """Build the Audio tab panel and add it to the notebook."""
+        panel = wx.Panel(self.dialog.notebook)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        controls = self.dialog._controls
+
+        sizer.Add(wx.StaticText(panel, label="Audio"), 0, wx.ALL, 5)
+        sizer.Add(
+            wx.StaticText(
+                panel,
+                label=(
+                    "Choose whether sounds are enabled, which sound pack is active, "
+                    "and which events should play audio."
+                ),
+            ),
+            0,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
+            5,
+        )
+
+        playback_section = wx.StaticBoxSizer(wx.VERTICAL, panel, "Playback")
+
+        controls["sound_enabled"] = wx.CheckBox(panel, label="Play notification sounds")
+        playback_section.Add(controls["sound_enabled"], 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
+
+        row1 = wx.BoxSizer(wx.HORIZONTAL)
+        row1.Add(
+            wx.StaticText(panel, label="Sound pack:"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+
+        # Load available sound packs
+        self.dialog._sound_pack_ids = ["default"]
+        pack_names = ["Default"]
+        try:
+            from ....notifications.sound_player import get_available_sound_packs
+
+            packs = get_available_sound_packs()
+            self.dialog._sound_pack_ids = list(packs.keys())
+            pack_names = [packs[pid].get("name", pid) for pid in self.dialog._sound_pack_ids]
+        except Exception as e:
+            logger.warning(f"Failed to load sound packs: {e}")
+
+        controls["sound_pack"] = wx.Choice(panel, choices=pack_names)
+        row1.Add(controls["sound_pack"], 0)
+        playback_section.Add(row1, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
+
+        test_btn = wx.Button(panel, label="Test Sound")
+        test_btn.Bind(wx.EVT_BUTTON, self.dialog._on_test_sound)
+        action_row = wx.BoxSizer(wx.HORIZONTAL)
+        action_row.Add(test_btn, 0, wx.RIGHT, 10)
+
+        manage_btn = wx.Button(panel, label="Manage Sound Packs...")
+        manage_btn.Bind(wx.EVT_BUTTON, self.dialog._on_manage_soundpacks)
+        action_row.Add(manage_btn, 0)
+        playback_section.Add(action_row, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
+        sizer.Add(playback_section, 0, wx.EXPAND | wx.ALL, 5)
+
+        event_sounds_section = wx.StaticBoxSizer(wx.VERTICAL, panel, "Event sounds")
+        event_sounds_section.Add(
+            wx.StaticText(panel, label="Choose which events can play sounds."),
+            0,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
+            5,
+        )
+        controls["event_sounds_summary"] = wx.StaticText(panel, label="")
+        event_sounds_section.Add(
+            controls["event_sounds_summary"], 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 5
+        )
+        controls["configure_event_sounds"] = wx.Button(panel, label="Configure Event Sounds...")
+        controls["configure_event_sounds"].Bind(
+            wx.EVT_BUTTON, self.dialog._on_configure_event_sounds
+        )
+        event_sounds_section.Add(
+            controls["configure_event_sounds"], 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 5
+        )
+        sizer.Add(event_sounds_section, 0, wx.EXPAND | wx.ALL, 5)
+
+        panel.SetSizer(sizer)
+        self.dialog.notebook.AddPage(panel, "Audio")
+        return panel
+
+    def load(self, settings):
+        """Populate Audio tab controls from settings."""
+        controls = self.dialog._controls
+
+        controls["sound_enabled"].SetValue(getattr(settings, "sound_enabled", True))
+
+        current_pack = getattr(settings, "sound_pack", "default")
+        pack_ids = getattr(self.dialog, "_sound_pack_ids", ["default"])
+        try:
+            pack_idx = pack_ids.index(current_pack)
+            controls["sound_pack"].SetSelection(pack_idx)
+        except (ValueError, AttributeError):
+            controls["sound_pack"].SetSelection(0)
+
+        self.set_event_sound_states(getattr(settings, "muted_sound_events", ["data_updated"]))
+
+    def save(self) -> dict:
+        """Return Audio tab settings as a dict."""
+        controls = self.dialog._controls
+        pack_ids = getattr(self.dialog, "_sound_pack_ids", ["default"])
+        pack_idx = controls["sound_pack"].GetSelection()
+        sound_pack = pack_ids[pack_idx] if pack_idx < len(pack_ids) else "default"
+
+        return {
+            "sound_enabled": controls["sound_enabled"].GetValue(),
+            "sound_pack": sound_pack,
+            "muted_sound_events": self._get_muted_sound_events(),
+        }
+
+    def setup_accessibility(self):
+        """Set accessibility names for Audio tab controls."""
+        controls = self.dialog._controls
+        names = {
+            "sound_enabled": "Enable Sounds",
+            "sound_pack": "Active sound pack",
+            "event_sounds_summary": "Event sound summary",
+            "configure_event_sounds": "Configure event sounds",
+        }
+        for key, name in names.items():
+            controls[key].SetName(name)

--- a/src/accessiweather/ui/dialogs/settings_tabs/data_sources.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/data_sources.py
@@ -1,0 +1,301 @@
+"""Data Sources settings tab."""
+
+from __future__ import annotations
+
+import logging
+
+import wx
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_VALUES = ["auto", "nws", "openmeteo", "visualcrossing", "pirateweather"]
+_SOURCE_MAP = {"auto": 0, "nws": 1, "openmeteo": 2, "visualcrossing": 3, "pirateweather": 4}
+_STATION_STRATEGY_VALUES = [
+    "hybrid_default",
+    "nearest",
+    "major_airport_preferred",
+    "freshest_observation",
+]
+
+
+class DataSourcesTab:
+    """Data Sources tab: data source selection and API key configuration."""
+
+    def __init__(self, dialog):
+        """Store reference to the parent settings dialog."""
+        self.dialog = dialog
+
+    @staticmethod
+    def _build_default_source_settings_states() -> dict:
+        """Return default source settings state."""
+        return {
+            "auto_use_nws": True,
+            "auto_use_openmeteo": True,
+            "auto_use_visualcrossing": True,
+            "auto_use_pirateweather": True,
+            "station_selection_strategy": 0,
+        }
+
+    def create(self):
+        """Build the Data Sources tab panel and add it to the notebook."""
+        panel = wx.ScrolledWindow(self.dialog.notebook)
+        panel.SetScrollRate(0, 20)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        controls = self.dialog._controls
+
+        # Data source selection
+        row1 = wx.BoxSizer(wx.HORIZONTAL)
+        row1.Add(
+            wx.StaticText(panel, label="Weather Data Source:"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        controls["data_source"] = wx.Choice(
+            panel,
+            choices=[
+                "Automatic (merges all available sources)",
+                "National Weather Service (US only, forecast + alerts)",
+                "Open-Meteo (Global forecast, no alerts, no API key)",
+                "Visual Crossing (Global forecast, US/Canada/Europe alerts, API key)",
+                "Pirate Weather (Global forecast + worldwide alerts, API key)",
+            ],
+        )
+        row1.Add(controls["data_source"], 0)
+        controls["data_source"].Bind(wx.EVT_CHOICE, self.dialog._on_data_source_changed)
+        sizer.Add(row1, 0, wx.ALL, 5)
+
+        # Visual Crossing Configuration
+        self.dialog._vc_config_sizer = wx.BoxSizer(wx.VERTICAL)
+        self.dialog._vc_config_sizer.Add(
+            wx.StaticText(panel, label="Visual Crossing API Configuration:"),
+            0,
+            wx.ALL,
+            5,
+        )
+
+        row_key = wx.BoxSizer(wx.HORIZONTAL)
+        row_key.Add(
+            wx.StaticText(panel, label="Visual Crossing API Key:"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        controls["vc_key"] = wx.TextCtrl(panel, style=wx.TE_PASSWORD, size=(250, -1))
+        row_key.Add(controls["vc_key"], 1)
+        self.dialog._vc_config_sizer.Add(row_key, 0, wx.LEFT | wx.EXPAND, 10)
+
+        btn_row = wx.BoxSizer(wx.HORIZONTAL)
+        get_key_btn = wx.Button(panel, label="Get Free API Key")
+        get_key_btn.Bind(wx.EVT_BUTTON, self.dialog._on_get_vc_api_key)
+        btn_row.Add(get_key_btn, 0, wx.RIGHT, 10)
+        validate_btn = wx.Button(panel, label="Validate API Key")
+        validate_btn.Bind(wx.EVT_BUTTON, self.dialog._on_validate_vc_api_key)
+        btn_row.Add(validate_btn, 0)
+        self.dialog._vc_config_sizer.Add(btn_row, 0, wx.LEFT | wx.TOP | wx.BOTTOM, 10)
+        sizer.Add(self.dialog._vc_config_sizer, 0, wx.EXPAND)
+
+        # Pirate Weather Configuration
+        self.dialog._pw_config_sizer = wx.BoxSizer(wx.VERTICAL)
+        self.dialog._pw_config_sizer.Add(
+            wx.StaticText(panel, label="Pirate Weather API Configuration:"),
+            0,
+            wx.ALL,
+            5,
+        )
+
+        row_pw_key = wx.BoxSizer(wx.HORIZONTAL)
+        row_pw_key.Add(
+            wx.StaticText(panel, label="Pirate Weather API Key:"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        controls["pw_key"] = wx.TextCtrl(panel, style=wx.TE_PASSWORD, size=(250, -1))
+        row_pw_key.Add(controls["pw_key"], 1)
+        self.dialog._pw_config_sizer.Add(row_pw_key, 0, wx.LEFT | wx.EXPAND, 10)
+
+        btn_row_pw = wx.BoxSizer(wx.HORIZONTAL)
+        get_pw_key_btn = wx.Button(panel, label="Get Free API Key")
+        get_pw_key_btn.Bind(wx.EVT_BUTTON, self.dialog._on_get_pw_api_key)
+        btn_row_pw.Add(get_pw_key_btn, 0, wx.RIGHT, 10)
+        validate_pw_btn = wx.Button(panel, label="Validate API Key")
+        validate_pw_btn.Bind(wx.EVT_BUTTON, self.dialog._on_validate_pw_api_key)
+        btn_row_pw.Add(validate_pw_btn, 0)
+        self.dialog._pw_config_sizer.Add(btn_row_pw, 0, wx.LEFT | wx.TOP | wx.BOTTOM, 10)
+        sizer.Add(self.dialog._pw_config_sizer, 0, wx.EXPAND)
+
+        # Source Settings summary + button
+        sizer.Add(wx.StaticText(panel, label="Source Settings:"), 0, wx.ALL, 5)
+        controls["source_settings_summary"] = wx.TextCtrl(
+            panel,
+            value=self._get_source_settings_summary_text(),
+            size=(-1, 44),
+            style=wx.TE_READONLY | wx.TE_MULTILINE | wx.TE_NO_VSCROLL,
+        )
+        sizer.Add(controls["source_settings_summary"], 0, wx.LEFT | wx.BOTTOM | wx.EXPAND, 5)
+        controls["configure_source_settings"] = wx.Button(
+            panel, label="Configure Source Settings..."
+        )
+        controls["configure_source_settings"].Bind(
+            wx.EVT_BUTTON, self.dialog._on_configure_source_settings
+        )
+        sizer.Add(controls["configure_source_settings"], 0, wx.LEFT | wx.BOTTOM, 5)
+
+        panel.SetSizer(sizer)
+        self.dialog.notebook.AddPage(panel, "Data Sources")
+        return panel
+
+    def _get_source_settings_summary_text(self) -> str:
+        """Build summary text shown on the data sources tab."""
+        state = (
+            getattr(self.dialog, "_source_settings_states", None)
+            or self._build_default_source_settings_states()
+        )
+        strategy_labels = [
+            "Hybrid default",
+            "Nearest station",
+            "Major airport preferred",
+            "Freshest observation",
+        ]
+        strat_idx = state.get("station_selection_strategy", 0)
+        strat_text = (
+            strategy_labels[strat_idx]
+            if 0 <= strat_idx < len(strategy_labels)
+            else strategy_labels[0]
+        )
+        sources = ["NWS", "Open-Meteo", "Visual Crossing", "Pirate Weather"]
+        keys = [
+            "auto_use_nws",
+            "auto_use_openmeteo",
+            "auto_use_visualcrossing",
+            "auto_use_pirateweather",
+        ]
+        enabled = [s for s, k in zip(sources, keys, strict=True) if state.get(k, True)]
+        enabled_text = ", ".join(enabled) if enabled else "None"
+        return f"Auto sources: {enabled_text} | Station: {strat_text}"
+
+    def refresh_source_settings_summary(self) -> None:
+        """Refresh the source settings summary control."""
+        ctrl = self.dialog._controls.get("source_settings_summary")
+        if ctrl is not None:
+            ctrl.SetValue(self._get_source_settings_summary_text())
+
+    def load(self, settings):
+        """Populate Data Sources tab controls from settings."""
+        controls = self.dialog._controls
+
+        data_source = getattr(settings, "data_source", "auto")
+        controls["data_source"].SetSelection(_SOURCE_MAP.get(data_source, 0))
+
+        vc_key = getattr(settings, "visual_crossing_api_key", "") or ""
+        controls["vc_key"].SetValue(str(vc_key))
+        self.dialog._original_vc_key = str(vc_key)
+        self.dialog._vc_key_cleared = False
+        if hasattr(wx, "EVT_TEXT"):
+
+            def _on_vc_key_text(e, _dlg=self.dialog):
+                _dlg._vc_key_cleared = True
+                _dlg._update_auto_source_key_state()
+
+            controls["vc_key"].Bind(wx.EVT_TEXT, _on_vc_key_text)
+
+        pw_key = getattr(settings, "pirate_weather_api_key", "") or ""
+        controls["pw_key"].SetValue(str(pw_key))
+        self.dialog._original_pw_key = str(pw_key)
+        self.dialog._pw_key_cleared = False
+        if hasattr(wx, "EVT_TEXT"):
+
+            def _on_pw_key_text(e, _dlg=self.dialog):
+                _dlg._pw_key_cleared = True
+                _dlg._update_auto_source_key_state()
+
+            controls["pw_key"].Bind(wx.EVT_TEXT, _on_pw_key_text)
+
+        # Source settings sub-dialog state
+        saved_strategy = getattr(settings, "station_selection_strategy", "hybrid_default")
+        strat_idx = (
+            _STATION_STRATEGY_VALUES.index(saved_strategy)
+            if saved_strategy in _STATION_STRATEGY_VALUES
+            else 0
+        )
+        saved_us = list(
+            getattr(
+                settings,
+                "source_priority_us",
+                ["nws", "openmeteo", "visualcrossing", "pirateweather"],
+            )
+        )
+        saved_intl = list(
+            getattr(
+                settings,
+                "source_priority_international",
+                ["openmeteo", "pirateweather", "visualcrossing"],
+            )
+        )
+        all_sources = set(saved_us) | set(saved_intl)
+        self.dialog._source_settings_states = {
+            "auto_use_nws": "nws" in all_sources,
+            "auto_use_openmeteo": "openmeteo" in all_sources,
+            "auto_use_visualcrossing": "visualcrossing" in all_sources,
+            "auto_use_pirateweather": "pirateweather" in all_sources,
+            "station_selection_strategy": strat_idx,
+        }
+        self.refresh_source_settings_summary()
+        self.dialog._update_api_key_visibility()
+
+    def save(self) -> dict:
+        """Return Data Sources tab settings as a dict."""
+        controls = self.dialog._controls
+        state = getattr(self.dialog, "_source_settings_states", None) or {}
+
+        def _src_enabled(source_key: str, flag_key: str) -> bool:
+            return state.get(flag_key, True)
+
+        source_priority_us = [
+            s
+            for s, k in [
+                ("nws", "auto_use_nws"),
+                ("openmeteo", "auto_use_openmeteo"),
+                ("visualcrossing", "auto_use_visualcrossing"),
+                ("pirateweather", "auto_use_pirateweather"),
+            ]
+            if _src_enabled(s, k)
+        ]
+        source_priority_intl = [
+            s
+            for s, k in [
+                ("openmeteo", "auto_use_openmeteo"),
+                ("visualcrossing", "auto_use_visualcrossing"),
+                ("pirateweather", "auto_use_pirateweather"),
+            ]
+            if _src_enabled(s, k)
+        ]
+
+        strat_idx = max(0, state.get("station_selection_strategy", 0))
+        station_strategy = _STATION_STRATEGY_VALUES[strat_idx]
+
+        return {
+            "data_source": _SOURCE_VALUES[controls["data_source"].GetSelection()],
+            "visual_crossing_api_key": controls["vc_key"].GetValue(),
+            "pirate_weather_api_key": controls["pw_key"].GetValue(),
+            "source_priority_us": source_priority_us,
+            "source_priority_international": source_priority_intl,
+            "auto_sources_us": source_priority_us or ["openmeteo"],
+            "auto_sources_international": source_priority_intl or ["openmeteo"],
+            "openmeteo_weather_model": "best_match",
+            "station_selection_strategy": station_strategy,
+        }
+
+    def setup_accessibility(self):
+        """Set accessibility names for Data Sources tab controls."""
+        controls = self.dialog._controls
+        names = {
+            "data_source": "Weather Data Source",
+            "vc_key": "Visual Crossing API Key",
+            "pw_key": "Pirate Weather API Key",
+            "source_settings_summary": "Source settings summary",
+            "configure_source_settings": "Configure source settings",
+        }
+        for key, name in names.items():
+            controls[key].SetName(name)

--- a/src/accessiweather/ui/dialogs/settings_tabs/display.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/display.py
@@ -1,0 +1,259 @@
+"""Display settings tab."""
+
+from __future__ import annotations
+
+import logging
+
+import wx
+
+logger = logging.getLogger(__name__)
+
+_TEMP_VALUES = ["auto", "f", "c", "both"]
+_TEMP_MAP = {"auto": 0, "f": 1, "fahrenheit": 1, "c": 2, "celsius": 2, "both": 3}
+_FORECAST_DURATION_VALUES = [3, 5, 7, 10, 14, 15]
+_FORECAST_DURATION_MAP = {3: 0, 5: 1, 7: 2, 10: 3, 14: 4, 15: 5}
+_FORECAST_TIME_REF_VALUES = ["location", "user_local"]
+_FORECAST_TIME_REF_MAP = {"location": 0, "user_local": 1}
+_TIME_MODE_VALUES = ["local", "utc", "both"]
+_TIME_MODE_MAP = {"local": 0, "utc": 1, "both": 2}
+_VERBOSITY_VALUES = ["minimal", "standard", "detailed"]
+_VERBOSITY_MAP = {"minimal": 0, "standard": 1, "detailed": 2}
+
+
+class DisplayTab:
+    """Display settings tab: temperature units, metrics, forecast, time/date, verbosity."""
+
+    def __init__(self, dialog):
+        """Store reference to the parent settings dialog."""
+        self.dialog = dialog
+
+    def create(self):
+        """Build the Display tab panel and add it to the notebook."""
+        panel = wx.ScrolledWindow(self.dialog.notebook)
+        panel.SetScrollRate(0, 20)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        controls = self.dialog._controls
+
+        # Temperature Display
+        sizer.Add(wx.StaticText(panel, label="Temperature Display:"), 0, wx.ALL | wx.EXPAND, 5)
+        controls["temp_unit"] = wx.Choice(
+            panel,
+            choices=[
+                "Auto (based on location)",
+                "Fahrenheit only",
+                "Celsius only",
+                "Both (Fahrenheit and Celsius)",
+            ],
+        )
+        sizer.Add(controls["temp_unit"], 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
+
+        # Metric Visibility
+        sizer.Add(wx.StaticText(panel, label="Metric Visibility:", style=wx.BOLD), 0, wx.ALL, 5)
+        sizer.Add(
+            wx.StaticText(panel, label="Select which weather metrics to display:"),
+            0,
+            wx.LEFT | wx.BOTTOM,
+            5,
+        )
+
+        controls["show_dewpoint"] = wx.CheckBox(panel, label="Show dewpoint")
+        sizer.Add(controls["show_dewpoint"], 0, wx.LEFT, 10)
+
+        controls["show_visibility"] = wx.CheckBox(panel, label="Show visibility")
+        sizer.Add(controls["show_visibility"], 0, wx.LEFT, 10)
+
+        controls["show_uv_index"] = wx.CheckBox(panel, label="Show UV index")
+        sizer.Add(controls["show_uv_index"], 0, wx.LEFT, 10)
+
+        controls["show_pressure_trend"] = wx.CheckBox(panel, label="Show pressure trend")
+        sizer.Add(controls["show_pressure_trend"], 0, wx.LEFT, 10)
+
+        controls["round_values"] = wx.CheckBox(
+            panel, label="Show values as whole numbers (no decimals)"
+        )
+        sizer.Add(controls["round_values"], 0, wx.LEFT | wx.TOP, 10)
+
+        row_forecast_duration = wx.BoxSizer(wx.HORIZONTAL)
+        row_forecast_duration.Add(
+            wx.StaticText(panel, label="Forecast duration:"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        controls["forecast_duration_days"] = wx.Choice(
+            panel,
+            choices=["3 days", "5 days", "7 days (default)", "10 days", "14 days", "15 days"],
+        )
+        row_forecast_duration.Add(controls["forecast_duration_days"], 0)
+        sizer.Add(row_forecast_duration, 0, wx.LEFT | wx.TOP, 10)
+
+        row_hourly_hours = wx.BoxSizer(wx.HORIZONTAL)
+        row_hourly_hours.Add(
+            wx.StaticText(panel, label="Hourly forecast hours:"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        controls["hourly_forecast_hours"] = wx.SpinCtrl(panel, min=1, max=168, initial=6)
+        row_hourly_hours.Add(controls["hourly_forecast_hours"], 0)
+        sizer.Add(row_hourly_hours, 0, wx.LEFT | wx.TOP, 10)
+
+        # Time & Date Display
+        sizer.Add(wx.StaticText(panel, label="Time & Date Display:"), 0, wx.ALL, 5)
+
+        row_time_ref = wx.BoxSizer(wx.HORIZONTAL)
+        row_time_ref.Add(
+            wx.StaticText(panel, label="Forecast time display:"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        controls["forecast_time_reference"] = wx.Choice(
+            panel,
+            choices=["Location's timezone (default)", "My local timezone"],
+        )
+        row_time_ref.Add(controls["forecast_time_reference"], 0)
+        sizer.Add(row_time_ref, 0, wx.LEFT, 10)
+
+        row_tz = wx.BoxSizer(wx.HORIZONTAL)
+        row_tz.Add(
+            wx.StaticText(panel, label="Time zone display:"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        controls["time_display_mode"] = wx.Choice(
+            panel,
+            choices=["Local time only", "UTC time only", "Both (Local and UTC)"],
+        )
+        row_tz.Add(controls["time_display_mode"], 0)
+        sizer.Add(row_tz, 0, wx.LEFT, 10)
+
+        controls["time_format_12hour"] = wx.CheckBox(
+            panel, label="Use 12-hour time format (e.g., 3:00 PM)"
+        )
+        sizer.Add(controls["time_format_12hour"], 0, wx.LEFT | wx.TOP, 10)
+
+        controls["show_timezone_suffix"] = wx.CheckBox(
+            panel, label="Show timezone abbreviations (e.g., EST, UTC)"
+        )
+        sizer.Add(controls["show_timezone_suffix"], 0, wx.LEFT, 10)
+
+        # Verbosity
+        sizer.Add(wx.StaticText(panel, label="Information Priority:"), 0, wx.ALL, 5)
+
+        row_verb = wx.BoxSizer(wx.HORIZONTAL)
+        row_verb.Add(
+            wx.StaticText(panel, label="Verbosity level:"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        controls["verbosity_level"] = wx.Choice(
+            panel,
+            choices=[
+                "Minimal (essentials only)",
+                "Standard (recommended)",
+                "Detailed (all available info)",
+            ],
+        )
+        row_verb.Add(controls["verbosity_level"], 0)
+        sizer.Add(row_verb, 0, wx.LEFT, 10)
+
+        controls["severe_weather_override"] = wx.CheckBox(
+            panel, label="Automatically prioritize severe weather info"
+        )
+        sizer.Add(controls["severe_weather_override"], 0, wx.ALL, 10)
+
+        panel.SetSizer(sizer)
+        self.dialog.notebook.AddPage(panel, "Display")
+        return panel
+
+    def load(self, settings):
+        """Populate Display tab controls from settings."""
+        controls = self.dialog._controls
+
+        temp_unit = getattr(settings, "temperature_unit", "both")
+        controls["temp_unit"].SetSelection(_TEMP_MAP.get(temp_unit, 3))
+
+        controls["show_dewpoint"].SetValue(getattr(settings, "show_dewpoint", True))
+        controls["show_visibility"].SetValue(getattr(settings, "show_visibility", True))
+        controls["show_uv_index"].SetValue(getattr(settings, "show_uv_index", True))
+        controls["show_pressure_trend"].SetValue(getattr(settings, "show_pressure_trend", True))
+        controls["round_values"].SetValue(getattr(settings, "round_values", False))
+
+        forecast_duration_days = getattr(settings, "forecast_duration_days", 7)
+        controls["forecast_duration_days"].SetSelection(
+            _FORECAST_DURATION_MAP.get(forecast_duration_days, 2)
+        )
+        controls["hourly_forecast_hours"].SetValue(getattr(settings, "hourly_forecast_hours", 6))
+
+        forecast_time_reference = getattr(settings, "forecast_time_reference", "location")
+        controls["forecast_time_reference"].SetSelection(
+            _FORECAST_TIME_REF_MAP.get(forecast_time_reference, 0)
+        )
+
+        time_mode = getattr(settings, "time_display_mode", "local")
+        controls["time_display_mode"].SetSelection(_TIME_MODE_MAP.get(time_mode, 0))
+
+        controls["time_format_12hour"].SetValue(getattr(settings, "time_format_12hour", True))
+        controls["show_timezone_suffix"].SetValue(getattr(settings, "show_timezone_suffix", False))
+
+        verbosity = getattr(settings, "verbosity_level", "standard")
+        controls["verbosity_level"].SetSelection(_VERBOSITY_MAP.get(verbosity, 1))
+
+        controls["severe_weather_override"].SetValue(
+            getattr(settings, "severe_weather_override", True)
+        )
+
+    def save(self) -> dict:
+        """Return Display tab settings as a dict."""
+        controls = self.dialog._controls
+        return {
+            "temperature_unit": _TEMP_VALUES[controls["temp_unit"].GetSelection()],
+            "show_dewpoint": controls["show_dewpoint"].GetValue(),
+            "show_visibility": controls["show_visibility"].GetValue(),
+            "show_uv_index": controls["show_uv_index"].GetValue(),
+            "show_pressure_trend": controls["show_pressure_trend"].GetValue(),
+            "round_values": controls["round_values"].GetValue(),
+            "forecast_duration_days": _FORECAST_DURATION_VALUES[
+                controls["forecast_duration_days"].GetSelection()
+            ],
+            "hourly_forecast_hours": controls["hourly_forecast_hours"].GetValue(),
+            "forecast_time_reference": _FORECAST_TIME_REF_VALUES[
+                controls["forecast_time_reference"].GetSelection()
+            ],
+            "time_display_mode": _TIME_MODE_VALUES[controls["time_display_mode"].GetSelection()],
+            "time_format_12hour": controls["time_format_12hour"].GetValue(),
+            "show_timezone_suffix": controls["show_timezone_suffix"].GetValue(),
+            "verbosity_level": _VERBOSITY_VALUES[controls["verbosity_level"].GetSelection()],
+            "severe_weather_override": controls["severe_weather_override"].GetValue(),
+        }
+
+    def get_selected_temperature_unit(self) -> str:
+        """Return the temperature unit selection currently shown in the dialog."""
+        selection = self.dialog._controls["temp_unit"].GetSelection()
+        if selection < 0 or selection >= len(_TEMP_VALUES):
+            return "both"
+        return _TEMP_VALUES[selection]
+
+    def setup_accessibility(self):
+        """Set accessibility names for Display tab controls."""
+        controls = self.dialog._controls
+        names = {
+            "temp_unit": "Temperature Display",
+            "show_dewpoint": "Show dewpoint",
+            "show_visibility": "Show visibility",
+            "show_uv_index": "Show UV index",
+            "show_pressure_trend": "Show pressure trend",
+            "forecast_duration_days": "Forecast duration",
+            "hourly_forecast_hours": "Hourly forecast hours",
+            "forecast_time_reference": "Forecast time display",
+            "time_display_mode": "Time zone display",
+            "time_format_12hour": "Use 12-hour time format (e.g., 3:00 PM)",
+            "show_timezone_suffix": "Show timezone abbreviations (e.g., EST, UTC)",
+            "verbosity_level": "Verbosity level",
+            "severe_weather_override": "Automatically prioritize severe weather info",
+        }
+        for key, name in names.items():
+            controls[key].SetName(name)

--- a/src/accessiweather/ui/dialogs/settings_tabs/general.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/general.py
@@ -1,0 +1,135 @@
+"""General settings tab."""
+
+from __future__ import annotations
+
+import logging
+
+import wx
+
+logger = logging.getLogger(__name__)
+
+
+class GeneralTab:
+    """General settings tab: update interval, nationwide location, taskbar icon text."""
+
+    def __init__(self, dialog):
+        """Store reference to the parent settings dialog."""
+        self.dialog = dialog
+
+    def create(self):
+        """Build the General tab panel and add it to the notebook."""
+        panel = wx.ScrolledWindow(self.dialog.notebook)
+        panel.SetScrollRate(0, 20)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        controls = self.dialog._controls
+
+        # Update interval
+        row1 = wx.BoxSizer(wx.HORIZONTAL)
+        row1.Add(
+            wx.StaticText(panel, label="Update Interval (minutes):"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        controls["update_interval"] = wx.SpinCtrl(panel, min=1, max=120, initial=10)
+        row1.Add(controls["update_interval"], 0)
+        sizer.Add(row1, 0, wx.ALL, 5)
+
+        # Show Nationwide location
+        controls["show_nationwide"] = wx.CheckBox(
+            panel, label="Show Nationwide location (requires Auto or NWS data source)"
+        )
+        sizer.Add(controls["show_nationwide"], 0, wx.ALL, 5)
+
+        sizer.Add(wx.StaticLine(panel), 0, wx.EXPAND | wx.ALL, 5)
+        sizer.Add(wx.StaticText(panel, label="Taskbar icon text:"), 0, wx.LEFT | wx.TOP, 5)
+
+        controls["taskbar_icon_text_enabled"] = wx.CheckBox(
+            panel, label="Show weather text on tray icon"
+        )
+        controls["taskbar_icon_text_enabled"].Bind(
+            wx.EVT_CHECKBOX,
+            self.dialog._on_taskbar_icon_text_enabled_changed,
+        )
+        sizer.Add(controls["taskbar_icon_text_enabled"], 0, wx.ALL, 5)
+
+        controls["taskbar_icon_dynamic_enabled"] = wx.CheckBox(
+            panel, label="Update tray text dynamically"
+        )
+        sizer.Add(controls["taskbar_icon_dynamic_enabled"], 0, wx.LEFT | wx.BOTTOM, 15)
+
+        row_taskbar_format = wx.BoxSizer(wx.HORIZONTAL)
+        row_taskbar_format.Add(
+            wx.StaticText(panel, label="Current tray text format:"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        controls["taskbar_icon_text_format"] = wx.TextCtrl(
+            panel,
+            size=(280, -1),
+            style=wx.TE_READONLY,
+        )
+        row_taskbar_format.Add(controls["taskbar_icon_text_format"], 1)
+        controls["taskbar_icon_text_format_dialog"] = wx.Button(panel, label="Edit Format...")
+        controls["taskbar_icon_text_format_dialog"].Bind(
+            wx.EVT_BUTTON,
+            self.dialog._on_edit_taskbar_text_format,
+        )
+        row_taskbar_format.Add(controls["taskbar_icon_text_format_dialog"], 0, wx.LEFT, 8)
+        sizer.Add(row_taskbar_format, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 15)
+
+        panel.SetSizer(sizer)
+        self.dialog.notebook.AddPage(panel, "General")
+        return panel
+
+    def load(self, settings):
+        """Populate General tab controls from settings."""
+        controls = self.dialog._controls
+
+        controls["update_interval"].SetValue(getattr(settings, "update_interval_minutes", 10))
+
+        # Show Nationwide — also gated on data source (cross-tab dep handled by dialog)
+        data_source = getattr(settings, "data_source", "auto")
+        if data_source not in ("auto", "nws"):
+            controls["show_nationwide"].SetValue(False)
+            controls["show_nationwide"].Enable(False)
+        else:
+            controls["show_nationwide"].SetValue(
+                getattr(settings, "show_nationwide_location", True)
+            )
+            controls["show_nationwide"].Enable(True)
+
+        taskbar_text_enabled = getattr(settings, "taskbar_icon_text_enabled", False)
+        controls["taskbar_icon_text_enabled"].SetValue(taskbar_text_enabled)
+        controls["taskbar_icon_dynamic_enabled"].SetValue(
+            getattr(settings, "taskbar_icon_dynamic_enabled", True)
+        )
+        controls["taskbar_icon_text_format"].SetValue(
+            getattr(settings, "taskbar_icon_text_format", "{temp} {condition}")
+        )
+        self.dialog._update_taskbar_text_controls_state(taskbar_text_enabled)
+
+    def save(self) -> dict:
+        """Return General tab settings as a dict."""
+        controls = self.dialog._controls
+        return {
+            "update_interval_minutes": controls["update_interval"].GetValue(),
+            "show_nationwide_location": controls["show_nationwide"].GetValue(),
+            "taskbar_icon_text_enabled": controls["taskbar_icon_text_enabled"].GetValue(),
+            "taskbar_icon_dynamic_enabled": controls["taskbar_icon_dynamic_enabled"].GetValue(),
+            "taskbar_icon_text_format": controls["taskbar_icon_text_format"].GetValue(),
+        }
+
+    def setup_accessibility(self):
+        """Set accessibility names for General tab controls."""
+        controls = self.dialog._controls
+        names = {
+            "update_interval": "Update Interval (minutes)",
+            "show_nationwide": "Show Nationwide location (requires Auto or NWS data source)",
+            "taskbar_icon_text_enabled": "Show weather text on tray icon",
+            "taskbar_icon_dynamic_enabled": "Update tray text dynamically",
+            "taskbar_icon_text_format": "Tray text format",
+        }
+        for key, name in names.items():
+            controls[key].SetName(name)

--- a/src/accessiweather/ui/dialogs/settings_tabs/notifications.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/notifications.py
@@ -1,0 +1,240 @@
+"""Notifications settings tab."""
+
+from __future__ import annotations
+
+import logging
+
+import wx
+
+logger = logging.getLogger(__name__)
+
+_RADIUS_TYPE_VALUES = ["county", "point", "zone", "state"]
+_RADIUS_TYPE_MAP = {"county": 0, "point": 1, "zone": 2, "state": 3}
+
+
+class NotificationsTab:
+    """Notifications tab: alert settings, severity levels, event notifications, rate limiting."""
+
+    def __init__(self, dialog):
+        """Store reference to the parent settings dialog."""
+        self.dialog = dialog
+
+    def create(self):
+        """Build the Notifications tab panel and add it to the notebook."""
+        panel = wx.ScrolledWindow(self.dialog.notebook)
+        panel.SetScrollRate(0, 20)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        controls = self.dialog._controls
+
+        sizer.Add(wx.StaticText(panel, label="Alert Notification Settings"), 0, wx.ALL, 5)
+        sizer.Add(
+            wx.StaticText(
+                panel,
+                label="Configure which weather alerts trigger notifications based on severity.",
+            ),
+            0,
+            wx.LEFT | wx.BOTTOM,
+            5,
+        )
+
+        controls["enable_alerts"] = wx.CheckBox(panel, label="Enable weather alerts")
+        sizer.Add(controls["enable_alerts"], 0, wx.ALL, 5)
+
+        controls["alert_notif"] = wx.CheckBox(panel, label="Enable alert notifications")
+        sizer.Add(controls["alert_notif"], 0, wx.LEFT | wx.BOTTOM, 5)
+
+        row_area = wx.BoxSizer(wx.HORIZONTAL)
+        row_area.Add(
+            wx.StaticText(panel, label="Alert Area:"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        controls["alert_radius_type"] = wx.Choice(
+            panel,
+            choices=[
+                "County (recommended — alerts for your county only)",
+                "Point (exact coordinate — may miss alerts)",
+                "Zone (NWS forecast zone — slightly broader than county)",
+                "State (entire state — noisy)",
+            ],
+        )
+        row_area.Add(controls["alert_radius_type"], 0)
+        sizer.Add(row_area, 0, wx.ALL, 5)
+
+        sizer.Add(wx.StaticText(panel, label="Alert Severity Levels:"), 0, wx.ALL, 5)
+
+        controls["notify_extreme"] = wx.CheckBox(
+            panel, label="Extreme - Life-threatening events (e.g., Tornado Warning)"
+        )
+        sizer.Add(controls["notify_extreme"], 0, wx.LEFT, 10)
+
+        controls["notify_severe"] = wx.CheckBox(
+            panel, label="Severe - Significant hazards (e.g., Severe Thunderstorm Warning)"
+        )
+        sizer.Add(controls["notify_severe"], 0, wx.LEFT, 10)
+
+        controls["notify_moderate"] = wx.CheckBox(
+            panel, label="Moderate - Potentially hazardous (e.g., Winter Weather Advisory)"
+        )
+        sizer.Add(controls["notify_moderate"], 0, wx.LEFT, 10)
+
+        controls["notify_minor"] = wx.CheckBox(
+            panel, label="Minor - Low impact events (e.g., Frost Advisory, Fog Advisory)"
+        )
+        sizer.Add(controls["notify_minor"], 0, wx.LEFT, 10)
+
+        controls["notify_unknown"] = wx.CheckBox(panel, label="Unknown - Uncategorized alerts")
+        sizer.Add(controls["notify_unknown"], 0, wx.LEFT, 10)
+
+        sizer.Add(wx.StaticText(panel, label="Event-Based Notifications:"), 0, wx.ALL, 5)
+        sizer.Add(
+            wx.StaticText(
+                panel,
+                label="Get notified when specific weather events occur (disabled by default).",
+            ),
+            0,
+            wx.LEFT | wx.BOTTOM,
+            5,
+        )
+
+        controls["notify_discussion_update"] = wx.CheckBox(
+            panel, label="Notify when Area Forecast Discussion is updated (NWS US only)"
+        )
+        sizer.Add(controls["notify_discussion_update"], 0, wx.LEFT, 10)
+
+        controls["notify_severe_risk_change"] = wx.CheckBox(
+            panel, label="Notify when severe weather risk level changes (Visual Crossing only)"
+        )
+        sizer.Add(controls["notify_severe_risk_change"], 0, wx.LEFT | wx.BOTTOM, 10)
+
+        controls["notify_minutely_precipitation_start"] = wx.CheckBox(
+            panel, label="Notify when precipitation is expected to start soon (Pirate Weather)"
+        )
+        sizer.Add(controls["notify_minutely_precipitation_start"], 0, wx.LEFT, 10)
+
+        controls["notify_minutely_precipitation_stop"] = wx.CheckBox(
+            panel, label="Notify when precipitation is expected to stop soon (Pirate Weather)"
+        )
+        sizer.Add(controls["notify_minutely_precipitation_stop"], 0, wx.LEFT | wx.BOTTOM, 10)
+
+        # Hidden alert timing controls (values managed via Advanced dialog)
+        controls["global_cooldown"] = wx.SpinCtrl(panel, min=0, max=60, initial=5)
+        controls["global_cooldown"].Hide()
+        controls["per_alert_cooldown"] = wx.SpinCtrl(panel, min=0, max=1440, initial=60)
+        controls["per_alert_cooldown"].Hide()
+        controls["freshness_window"] = wx.SpinCtrl(panel, min=0, max=120, initial=15)
+        controls["freshness_window"].Hide()
+
+        sizer.Add(wx.StaticText(panel, label="Rate Limiting:"), 0, wx.ALL, 5)
+
+        row_max = wx.BoxSizer(wx.HORIZONTAL)
+        row_max.Add(
+            wx.StaticText(panel, label="Maximum notifications per hour:"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        controls["max_notifications"] = wx.SpinCtrl(panel, min=1, max=100, initial=10)
+        row_max.Add(controls["max_notifications"], 0)
+        sizer.Add(row_max, 0, wx.LEFT | wx.TOP, 10)
+
+        advanced_btn = wx.Button(panel, label="Advanced...")
+        advanced_btn.SetName("Advanced alert timing settings")
+        advanced_btn.SetToolTip("Configure cooldown periods and alert freshness window")
+        advanced_btn.Bind(wx.EVT_BUTTON, self.dialog._on_alert_advanced)
+        sizer.Add(advanced_btn, 0, wx.LEFT | wx.TOP, 10)
+
+        panel.SetSizer(sizer)
+        self.dialog.notebook.AddPage(panel, "Notifications")
+        return panel
+
+    def load(self, settings):
+        """Populate Notifications tab controls from settings."""
+        controls = self.dialog._controls
+
+        controls["enable_alerts"].SetValue(getattr(settings, "enable_alerts", True))
+        controls["alert_notif"].SetValue(getattr(settings, "alert_notifications_enabled", True))
+
+        radius_type = getattr(settings, "alert_radius_type", "county")
+        controls["alert_radius_type"].SetSelection(_RADIUS_TYPE_MAP.get(radius_type, 0))
+
+        controls["notify_extreme"].SetValue(getattr(settings, "alert_notify_extreme", True))
+        controls["notify_severe"].SetValue(getattr(settings, "alert_notify_severe", True))
+        controls["notify_moderate"].SetValue(getattr(settings, "alert_notify_moderate", True))
+        controls["notify_minor"].SetValue(getattr(settings, "alert_notify_minor", False))
+        controls["notify_unknown"].SetValue(getattr(settings, "alert_notify_unknown", False))
+
+        controls["global_cooldown"].SetValue(getattr(settings, "alert_global_cooldown_minutes", 5))
+        controls["per_alert_cooldown"].SetValue(
+            getattr(settings, "alert_per_alert_cooldown_minutes", 60)
+        )
+        controls["freshness_window"].SetValue(
+            getattr(settings, "alert_freshness_window_minutes", 15)
+        )
+        controls["max_notifications"].SetValue(
+            getattr(settings, "alert_max_notifications_per_hour", 10)
+        )
+
+        controls["notify_discussion_update"].SetValue(
+            getattr(settings, "notify_discussion_update", True)
+        )
+        controls["notify_severe_risk_change"].SetValue(
+            getattr(settings, "notify_severe_risk_change", False)
+        )
+        controls["notify_minutely_precipitation_start"].SetValue(
+            getattr(settings, "notify_minutely_precipitation_start", False)
+        )
+        controls["notify_minutely_precipitation_stop"].SetValue(
+            getattr(settings, "notify_minutely_precipitation_stop", False)
+        )
+
+    def save(self) -> dict:
+        """Return Notifications tab settings as a dict."""
+        controls = self.dialog._controls
+        return {
+            "enable_alerts": controls["enable_alerts"].GetValue(),
+            "alert_notifications_enabled": controls["alert_notif"].GetValue(),
+            "alert_radius_type": _RADIUS_TYPE_VALUES[controls["alert_radius_type"].GetSelection()],
+            "alert_notify_extreme": controls["notify_extreme"].GetValue(),
+            "alert_notify_severe": controls["notify_severe"].GetValue(),
+            "alert_notify_moderate": controls["notify_moderate"].GetValue(),
+            "alert_notify_minor": controls["notify_minor"].GetValue(),
+            "alert_notify_unknown": controls["notify_unknown"].GetValue(),
+            "alert_global_cooldown_minutes": controls["global_cooldown"].GetValue(),
+            "alert_per_alert_cooldown_minutes": controls["per_alert_cooldown"].GetValue(),
+            "alert_freshness_window_minutes": controls["freshness_window"].GetValue(),
+            "alert_max_notifications_per_hour": controls["max_notifications"].GetValue(),
+            "notify_discussion_update": controls["notify_discussion_update"].GetValue(),
+            "notify_severe_risk_change": controls["notify_severe_risk_change"].GetValue(),
+            "notify_minutely_precipitation_start": controls[
+                "notify_minutely_precipitation_start"
+            ].GetValue(),
+            "notify_minutely_precipitation_stop": controls[
+                "notify_minutely_precipitation_stop"
+            ].GetValue(),
+        }
+
+    def setup_accessibility(self):
+        """Set accessibility names for Notifications tab controls."""
+        controls = self.dialog._controls
+        names = {
+            "enable_alerts": "Enable weather alerts",
+            "alert_notif": "Enable alert notifications",
+            "alert_radius_type": "Alert Area",
+            "notify_extreme": "Extreme - Life-threatening events (e.g., Tornado Warning)",
+            "notify_severe": "Severe - Significant hazards (e.g., Severe Thunderstorm Warning)",
+            "notify_moderate": "Moderate - Potentially hazardous (e.g., Winter Weather Advisory)",
+            "notify_minor": "Minor - Low impact events (e.g., Frost Advisory, Fog Advisory)",
+            "notify_unknown": "Unknown - Uncategorized alerts",
+            "notify_discussion_update": "Notify when Area Forecast Discussion is updated (NWS US only)",
+            "notify_severe_risk_change": "Notify when severe weather risk level changes (Visual Crossing only)",
+            "notify_minutely_precipitation_start": "Notify when precipitation is expected to start soon (Pirate Weather)",
+            "notify_minutely_precipitation_stop": "Notify when precipitation is expected to stop soon (Pirate Weather)",
+            "global_cooldown": "Minimum time between any alert notifications (minutes)",
+            "per_alert_cooldown": "Re-notify for same alert after (minutes)",
+            "freshness_window": "Only notify for alerts issued within (minutes)",
+            "max_notifications": "Maximum notifications per hour",
+        }
+        for key, name in names.items():
+            controls[key].SetName(name)

--- a/src/accessiweather/ui/dialogs/settings_tabs/updates.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/updates.py
@@ -1,0 +1,95 @@
+"""Updates settings tab."""
+
+from __future__ import annotations
+
+import logging
+
+import wx
+
+logger = logging.getLogger(__name__)
+
+
+class UpdatesTab:
+    """Updates tab: auto-update settings, update channel, check interval."""
+
+    def __init__(self, dialog):
+        """Store reference to the parent settings dialog."""
+        self.dialog = dialog
+
+    def create(self):
+        """Build the Updates tab panel and add it to the notebook."""
+        panel = wx.Panel(self.dialog.notebook)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        controls = self.dialog._controls
+
+        controls["auto_update"] = wx.CheckBox(panel, label="Check for updates automatically")
+        sizer.Add(controls["auto_update"], 0, wx.ALL, 5)
+
+        row_ch = wx.BoxSizer(wx.HORIZONTAL)
+        row_ch.Add(
+            wx.StaticText(panel, label="Update Channel:"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        controls["update_channel"] = wx.Choice(
+            panel,
+            choices=[
+                "Stable (Production releases only)",
+                "Development (Latest features, may be unstable)",
+            ],
+        )
+        row_ch.Add(controls["update_channel"], 0)
+        sizer.Add(row_ch, 0, wx.LEFT, 5)
+
+        row_int = wx.BoxSizer(wx.HORIZONTAL)
+        row_int.Add(
+            wx.StaticText(panel, label="Check Interval (hours):"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        controls["update_check_interval"] = wx.SpinCtrl(panel, min=1, max=168, initial=24)
+        row_int.Add(controls["update_check_interval"], 0)
+        sizer.Add(row_int, 0, wx.LEFT | wx.TOP, 5)
+
+        check_btn = wx.Button(panel, label="Check for Updates Now")
+        check_btn.Bind(wx.EVT_BUTTON, self.dialog._on_check_updates)
+        sizer.Add(check_btn, 0, wx.ALL, 10)
+
+        controls["update_status"] = wx.StaticText(panel, label="Ready to check for updates")
+        sizer.Add(controls["update_status"], 0, wx.LEFT, 10)
+
+        panel.SetSizer(sizer)
+        self.dialog.notebook.AddPage(panel, "Updates")
+        return panel
+
+    def load(self, settings):
+        """Populate Updates tab controls from settings."""
+        controls = self.dialog._controls
+        controls["auto_update"].SetValue(getattr(settings, "auto_update_enabled", True))
+        channel = getattr(settings, "update_channel", "stable")
+        controls["update_channel"].SetSelection(0 if channel == "stable" else 1)
+        controls["update_check_interval"].SetValue(
+            getattr(settings, "update_check_interval_hours", 24)
+        )
+
+    def save(self) -> dict:
+        """Return Updates tab settings as a dict."""
+        controls = self.dialog._controls
+        return {
+            "auto_update_enabled": controls["auto_update"].GetValue(),
+            "update_channel": "stable" if controls["update_channel"].GetSelection() == 0 else "dev",
+            "update_check_interval_hours": controls["update_check_interval"].GetValue(),
+        }
+
+    def setup_accessibility(self):
+        """Set accessibility names for Updates tab controls."""
+        controls = self.dialog._controls
+        names = {
+            "auto_update": "Check for updates automatically",
+            "update_channel": "Update Channel",
+            "update_check_interval": "Check Interval (hours)",
+        }
+        for key, name in names.items():
+            controls[key].SetName(name)

--- a/tests/test_settings_dialog_audio_events.py
+++ b/tests/test_settings_dialog_audio_events.py
@@ -1,28 +1,10 @@
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-
-def _load_settings_dialog_class():
-    module_path = (
-        Path(__file__).resolve().parents[1]
-        / "src"
-        / "accessiweather"
-        / "ui"
-        / "dialogs"
-        / "settings_dialog.py"
-    )
-    spec = importlib.util.spec_from_file_location("test_settings_dialog_audio_module", module_path)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module.SettingsDialogSimple
-
-
-SettingsDialogSimple = _load_settings_dialog_class()
+from accessiweather.ui.dialogs.settings_dialog import SettingsDialogSimple
+from accessiweather.ui.dialogs.settings_tabs.audio import AudioTab
 
 
 class _DummyControl:
@@ -88,8 +70,8 @@ def _make_dialog(settings: SimpleNamespace) -> SettingsDialogSimple:
     dialog._controls["configure_event_sounds"] = _DummyControl()
     dialog._sound_pack_ids = ["default"]
     dialog._selected_specific_model = None
-    dialog._event_sound_states = dialog._build_default_event_sound_states()
-    dialog._source_settings_states = dialog._build_default_source_settings_states()
+    dialog._event_sound_states = AudioTab._build_default_event_sound_states()
+    dialog._source_settings_states = SettingsDialogSimple._build_default_source_settings_states()
     dialog._vc_config_sizer = _DummySizer()
     dialog._pw_config_sizer = _DummySizer()
     dialog._auto_sources_sizer = _DummySizer()
@@ -97,6 +79,12 @@ def _make_dialog(settings: SimpleNamespace) -> SettingsDialogSimple:
     dialog.config_manager.get_settings.return_value = settings
     dialog.config_manager.update_settings.return_value = True
     dialog._get_ai_model_preference = lambda: "openrouter/free"
+
+    # Wire up tab objects so _load_settings/_save_settings delegate correctly
+    audio_tab = AudioTab(dialog)
+    dialog._audio_tab = audio_tab
+    dialog._tab_objects = [audio_tab]
+
     return dialog
 
 
@@ -113,7 +101,7 @@ def test_load_settings_updates_event_sound_state_and_summary():
 
     assert dialog._event_sound_states["data_updated"] is False
     assert dialog._event_sound_states["fetch_error"] is True
-    total_events = len(dialog._build_default_event_sound_states())
+    total_events = len(AudioTab._build_default_event_sound_states())
     assert (
         dialog._controls["event_sounds_summary"].GetLabel()
         == f"{total_events - 1} of {total_events} sound events are enabled."
@@ -151,7 +139,7 @@ def test_configure_event_sounds_applies_modal_result_and_refreshes_summary():
 
     assert dialog._event_sound_states["data_updated"] is False
     assert dialog._event_sound_states["severe_risk"] is False
-    total_events = len(dialog._build_default_event_sound_states())
+    total_events = len(AudioTab._build_default_event_sound_states())
     assert (
         dialog._controls["event_sounds_summary"].GetLabel()
         == f"{total_events - 2} of {total_events} sound events are enabled."

--- a/tests/test_settings_dialog_tray_text.py
+++ b/tests/test_settings_dialog_tray_text.py
@@ -1,28 +1,11 @@
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-
-def _load_settings_dialog_class():
-    module_path = (
-        Path(__file__).resolve().parents[1]
-        / "src"
-        / "accessiweather"
-        / "ui"
-        / "dialogs"
-        / "settings_dialog.py"
-    )
-    spec = importlib.util.spec_from_file_location("test_settings_dialog_module", module_path)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module.SettingsDialogSimple
-
-
-SettingsDialogSimple = _load_settings_dialog_class()
+from accessiweather.ui.dialogs.settings_dialog import SettingsDialogSimple
+from accessiweather.ui.dialogs.settings_tabs.display import DisplayTab
+from accessiweather.ui.dialogs.settings_tabs.general import GeneralTab
 
 
 class _DummyControl:
@@ -88,6 +71,13 @@ def _make_dialog_for_settings(settings: SimpleNamespace) -> SettingsDialogSimple
     dialog._auto_sources_sizer = _DummySizer()
     dialog.config_manager = MagicMock()
     dialog.config_manager.get_settings.return_value = settings
+
+    # Wire up tab objects so _load_settings/_save_settings delegate correctly
+    general_tab = GeneralTab(dialog)
+    display_tab = DisplayTab(dialog)
+    dialog._display_tab = display_tab
+    dialog._tab_objects = [general_tab, display_tab]
+
     return dialog
 
 


### PR DESCRIPTION
Splits the 3086-line settings_dialog.py into a settings_tabs/ package — one module per tab. No user-visible behavior change. Closes #547.