### PR TITLE
fix(pirate-weather): normalize daily dates across DST and reject discontinuous forecasts

### DIFF
--- a/src/accessiweather/pirate_weather_client.py
+++ b/src/accessiweather/pirate_weather_client.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, time, timedelta, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import httpx
 
@@ -97,6 +98,32 @@ def _normalize_regions(regions: object) -> list[str]:
         if region_name:
             normalized.append(region_name)
     return normalized
+
+
+def _resolve_response_timezone(data: dict) -> timezone | ZoneInfo:
+    """Resolve the response timezone, preferring IANA names over fixed offsets."""
+    timezone_name = data.get("timezone")
+    if isinstance(timezone_name, str) and timezone_name:
+        try:
+            return ZoneInfo(timezone_name)
+        except ZoneInfoNotFoundError:
+            logger.warning(
+                "Unknown Pirate Weather timezone '%s'; falling back to offset", timezone_name
+            )
+
+    tz_offset = data.get("offset", 0)
+    return timezone(timedelta(hours=tz_offset))
+
+
+def _normalize_daily_start_time(
+    timestamp: int | float,
+    response_tz: timezone | ZoneInfo,
+) -> tuple[date, datetime]:
+    """Convert a Pirate Weather daily timestamp into the local calendar date at noon."""
+    local_dt = datetime.fromtimestamp(timestamp, tz=response_tz)
+    local_date = local_dt.date()
+    normalized = datetime.combine(local_date, time(hour=12), tzinfo=response_tz)
+    return local_date, normalized
 
 
 class PirateWeatherClient:
@@ -347,7 +374,7 @@ class PirateWeatherClient:
             sunset_time=sunset_time,
         )
 
-    def _parse_forecast(self, data: dict, days: int | None = None) -> Forecast:
+    def _parse_forecast(self, data: dict, days: int | None = None) -> Forecast | None:
         """
         Parse Pirate Weather ``daily`` block into a Forecast.
 
@@ -358,23 +385,25 @@ class PirateWeatherClient:
         longer used to limit the output.
         """
         daily_data = data.get("daily", {}).get("data", [])
-        tz_offset = data.get("offset", 0)
-        location_tz = timezone(timedelta(hours=tz_offset))
+        location_tz = _resolve_response_timezone(data)
         using_us = self.units == "us"
 
         periods: list[ForecastPeriod] = []
+        parsed_dates: list[date] = []
         for i, day in enumerate(daily_data):
             time_val = day.get("time")
             if time_val:
-                dt = datetime.fromtimestamp(time_val, tz=location_tz)
+                local_date, start_time = _normalize_daily_start_time(time_val, location_tz)
+                parsed_dates.append(local_date)
                 if i == 0:
                     name = "Today"
                 elif i == 1:
                     name = "Tomorrow"
                 else:
-                    name = dt.strftime("%A")
+                    name = start_time.strftime("%A")
             else:
                 name = f"Day {i + 1}"
+                start_time = None
 
             temp_high = day.get("temperatureHigh") if using_us else day.get("temperatureMax")
             temp_low = day.get("temperatureLow") if using_us else day.get("temperatureMin")
@@ -418,8 +447,6 @@ class PirateWeatherClient:
 
             condition = day.get("summary") or _icon_to_condition(day.get("icon"))
 
-            start_time = datetime.fromtimestamp(time_val, tz=location_tz) if time_val else None
-
             period = ForecastPeriod(
                 name=name,
                 temperature=temp_high,
@@ -437,6 +464,15 @@ class PirateWeatherClient:
                 start_time=start_time,
             )
             periods.append(period)
+
+        if parsed_dates:
+            expected_dates = [parsed_dates[0] + timedelta(days=i) for i in range(len(parsed_dates))]
+            if parsed_dates != expected_dates or len(parsed_dates) != len(set(parsed_dates)):
+                logger.warning(
+                    "Rejecting Pirate Weather daily forecast with non-consecutive local dates: %s",
+                    [day.isoformat() for day in parsed_dates],
+                )
+                return None
 
         daily_summary = data.get("daily", {}).get("summary")
         return Forecast(periods=periods, generated_at=datetime.now(UTC), summary=daily_summary)

--- a/tests/test_pirate_weather_client.py
+++ b/tests/test_pirate_weather_client.py
@@ -6,6 +6,7 @@ Tests the Pirate Weather API client (https://pirateweather.net).
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -335,6 +336,76 @@ class TestParseForecast:
         result = client._parse_forecast(payload)
         assert result.summary == "Possible drizzle on Thursday."
         assert result.periods == []
+
+    def test_uses_timezone_name_to_normalize_london_dst_daily_dates(self, client):
+        """Europe/London daily periods should normalize to consecutive local noon dates."""
+        start_dates = [
+            datetime(2025, 10, 26, 0, 0, tzinfo=UTC),
+            datetime(2025, 10, 27, 0, 0, tzinfo=UTC),
+            datetime(2025, 10, 28, 0, 0, tzinfo=UTC),
+        ]
+        payload = {
+            "timezone": "Europe/London",
+            "offset": 1,
+            "daily": {
+                "data": [
+                    {
+                        "time": int(start.timestamp()),
+                        "temperatureHigh": 60.0 + i,
+                        "temperatureLow": 45.0 + i,
+                        "summary": "Cloudy",
+                    }
+                    for i, start in enumerate(start_dates)
+                ]
+            },
+        }
+
+        result = client._parse_forecast(payload)
+
+        assert result is not None
+        dates = [
+            period.start_time.date() for period in result.periods if period.start_time is not None
+        ]
+        assert dates == [
+            datetime(2025, 10, 26).date(),
+            datetime(2025, 10, 27).date(),
+            datetime(2025, 10, 28).date(),
+        ]
+        assert len(dates) == len(set(dates))
+        for idx in range(1, len(dates)):
+            assert dates[idx] - dates[idx - 1] == timedelta(days=1)
+        assert all(period.start_time.hour == 12 for period in result.periods if period.start_time)
+
+    def test_rejects_duplicate_local_dates_after_london_dst_fallback(self, client):
+        """Malformed PW daily timestamps should be rejected instead of shown with duplicates."""
+        payload = {
+            "timezone": "Europe/London",
+            "offset": 1,
+            "daily": {
+                "data": [
+                    {
+                        "time": int(datetime(2025, 10, 25, 23, 0, tzinfo=UTC).timestamp()),
+                        "temperatureHigh": 60.0,
+                        "temperatureLow": 45.0,
+                        "summary": "Cloudy",
+                    },
+                    {
+                        "time": int(datetime(2025, 10, 26, 23, 0, tzinfo=UTC).timestamp()),
+                        "temperatureHigh": 61.0,
+                        "temperatureLow": 46.0,
+                        "summary": "Cloudy",
+                    },
+                    {
+                        "time": int(datetime(2025, 10, 27, 23, 0, tzinfo=UTC).timestamp()),
+                        "temperatureHigh": 62.0,
+                        "temperatureLow": 47.0,
+                        "summary": "Cloudy",
+                    },
+                ]
+            },
+        }
+
+        assert client._parse_forecast(payload) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the Pirate Weather daily forecast sequencing bug where DST/timezone handling could produce output like Today, Tomorrow, Sunday, Sunday, Monday... with missing intervening days.

## Root cause

AccessiWeather was interpreting Pirate Weather daily timestamps using a single fixed numeric offset for the whole forecast window. That breaks across DST boundaries (for example Europe/London), and the parser also did no contiguity validation before presenting the resulting dates.

## Fix

- Prefer the response timezone name via ZoneInfo when parsing Pirate Weather daily periods
- Normalize each daily period to the local calendar date at local noon
- Reject Pirate Weather daily forecasts when the resulting dates are duplicated or non-consecutive

## Tests

Added regression coverage for:
- Europe/London DST normalization
- rejecting malformed duplicate local dates after DST fallback