### PR TITLE
feat: add historical anomaly callout enrichment

### DIFF
--- a/src/accessiweather/weather_client_base.py
+++ b/src/accessiweather/weather_client_base.py
@@ -7,7 +7,7 @@ import inspect
 import logging
 import os
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import date, datetime
 
 import httpx
 
@@ -17,6 +17,7 @@ except ImportError:  # pragma: no cover
     Mock = None
 
 from . import (
+    weather_anomaly,
     weather_client_enrichment as enrichment,
     weather_client_nws as nws_client,
     weather_client_openmeteo as openmeteo_client,
@@ -42,6 +43,7 @@ from .models import (
     WeatherData,
 )
 from .notifications.minutely_precipitation import parse_pirate_weather_minutely_block
+from .openmeteo_client import OpenMeteoApiClient
 from .pirate_weather_client import PirateWeatherApiError, PirateWeatherClient
 from .services import EnvironmentalDataClient
 from .units import resolve_auto_unit_system
@@ -98,6 +100,7 @@ class WeatherClient:
         self._visual_crossing_client: VisualCrossingClient | None = None
         self._pirate_weather_api_key = pirate_weather_api_key
         self._pirate_weather_client: PirateWeatherClient | None = None
+        self._openmeteo_archive_client: OpenMeteoApiClient | None = None
 
         # AVWX API key for international aviation weather (stored as a plain string or
         # LazySecureStorage; resolved to str on first access via avwx_api_key property).
@@ -177,6 +180,21 @@ class WeatherClient:
     def pirate_weather_client(self, value: PirateWeatherClient | None) -> None:
         """Allow direct assignment for backward compatibility and testing."""
         self._pirate_weather_client = value
+
+    @property
+    def openmeteo_archive_client(self) -> OpenMeteoApiClient:
+        """Get the Open-Meteo archive client, creating it lazily on first use."""
+        if self._openmeteo_archive_client is None:
+            self._openmeteo_archive_client = OpenMeteoApiClient(
+                user_agent=self.user_agent,
+                timeout=self.timeout,
+            )
+        return self._openmeteo_archive_client
+
+    @openmeteo_archive_client.setter
+    def openmeteo_archive_client(self, value: OpenMeteoApiClient | None) -> None:
+        """Allow tests to inject an archive client."""
+        self._openmeteo_archive_client = value
 
     @property
     def avwx_api_key(self) -> str:
@@ -1177,7 +1195,48 @@ class WeatherClient:
             enrichment.enrich_with_aviation_data(self, weather_data, location)
         )
 
+        current_temp_f = self._current_temperature_f(weather_data.current)
+        if not self._test_mode and current_temp_f is not None:
+            tasks["anomaly_callout"] = asyncio.create_task(
+                self._enrich_with_anomaly_callout(weather_data, location)
+            )
+
         return tasks
+
+    @staticmethod
+    def _current_temperature_f(current: CurrentConditions | None) -> float | None:
+        """Return current temperature in Fahrenheit when available."""
+        if current is None:
+            return None
+        if current.temperature_f is not None:
+            return current.temperature_f
+        if current.temperature_c is not None:
+            return (current.temperature_c * 9.0 / 5.0) + 32.0
+        return None
+
+    async def _enrich_with_anomaly_callout(
+        self, weather_data: WeatherData, location: Location
+    ) -> None:
+        """Attach historical temperature anomaly context when enough archive data exists."""
+        current_temp_f = self._current_temperature_f(weather_data.current)
+        if current_temp_f is None:
+            return
+
+        try:
+            callout = await asyncio.to_thread(
+                weather_anomaly.compute_anomaly,
+                location.latitude,
+                location.longitude,
+                current_temp_f,
+                date.today(),
+                self.openmeteo_archive_client,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Failed to compute historical anomaly callout: %s", exc)
+            return
+
+        if callout is not None:
+            weather_data.anomaly_callout = callout
 
     async def _await_enrichments(
         self, tasks: dict[str, asyncio.Task], weather_data: WeatherData

--- a/tests/test_weather_client_anomaly.py
+++ b/tests/test_weather_client_anomaly.py
@@ -1,0 +1,200 @@
+"""Tests for WeatherClient anomaly callout enrichment."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from accessiweather.models import CurrentConditions, Location, WeatherData
+from accessiweather.weather_anomaly import AnomalyCallout
+from accessiweather.weather_client import WeatherClient
+
+
+def _make_location() -> Location:
+    return Location(name="Test City", latitude=40.0, longitude=-74.0)
+
+
+def _make_weather_data(temp_f: float | None = 72.0) -> WeatherData:
+    current = CurrentConditions()
+    current.temperature_f = temp_f
+    return WeatherData(location=_make_location(), current=current)
+
+
+def _make_callout(anomaly: float = 5.0) -> AnomalyCallout:
+    return AnomalyCallout(
+        temp_anomaly=anomaly,
+        temp_anomaly_description=f"Currently {abs(anomaly):.1f} F warmer than average.",
+        precip_anomaly_description=None,
+        severity="significant",
+    )
+
+
+async def _cancel_tasks(tasks: dict[str, asyncio.Task]) -> None:
+    for task in tasks.values():
+        task.cancel()
+    await asyncio.gather(*tasks.values(), return_exceptions=True)
+
+
+class TestEnrichWithAnomalyCallout:
+    @pytest.fixture()
+    def client(self) -> WeatherClient:
+        weather_client = WeatherClient()
+        weather_client._test_mode = False
+        weather_client.openmeteo_archive_client = MagicMock()
+        return weather_client
+
+    @pytest.mark.asyncio
+    async def test_sets_anomaly_callout_on_success(self, client: WeatherClient) -> None:
+        expected = _make_callout(5.0)
+        weather_data = _make_weather_data(72.0)
+        location = _make_location()
+
+        with patch("accessiweather.weather_anomaly.compute_anomaly", return_value=expected):
+            await client._enrich_with_anomaly_callout(weather_data, location)
+
+        assert weather_data.anomaly_callout is expected
+
+    @pytest.mark.asyncio
+    async def test_leaves_callout_unset_when_anomaly_has_insufficient_history(
+        self, client: WeatherClient
+    ) -> None:
+        weather_data = _make_weather_data(72.0)
+        location = _make_location()
+
+        with patch("accessiweather.weather_anomaly.compute_anomaly", return_value=None):
+            await client._enrich_with_anomaly_callout(weather_data, location)
+
+        assert weather_data.anomaly_callout is None
+
+    @pytest.mark.asyncio
+    async def test_skips_when_temperature_is_missing(self, client: WeatherClient) -> None:
+        weather_data = _make_weather_data(temp_f=None)
+        location = _make_location()
+
+        with patch("accessiweather.weather_anomaly.compute_anomaly") as mock_compute:
+            await client._enrich_with_anomaly_callout(weather_data, location)
+
+        mock_compute.assert_not_called()
+        assert weather_data.anomaly_callout is None
+
+    @pytest.mark.asyncio
+    async def test_skips_when_current_conditions_are_missing(self, client: WeatherClient) -> None:
+        weather_data = WeatherData(location=_make_location())
+        location = _make_location()
+
+        with patch("accessiweather.weather_anomaly.compute_anomaly") as mock_compute:
+            await client._enrich_with_anomaly_callout(weather_data, location)
+
+        mock_compute.assert_not_called()
+        assert weather_data.anomaly_callout is None
+
+    @pytest.mark.asyncio
+    async def test_archive_errors_do_not_abort_weather_update(self, client: WeatherClient) -> None:
+        weather_data = _make_weather_data(72.0)
+        location = _make_location()
+
+        with patch(
+            "accessiweather.weather_anomaly.compute_anomaly",
+            side_effect=RuntimeError("archive unavailable"),
+        ):
+            await client._enrich_with_anomaly_callout(weather_data, location)
+
+        assert weather_data.anomaly_callout is None
+
+
+class TestOpenMeteoArchiveClientProperty:
+    def test_lazy_creation_reuses_archive_client(self) -> None:
+        client = WeatherClient()
+
+        assert client._openmeteo_archive_client is None
+
+        archive_client = client.openmeteo_archive_client
+
+        assert archive_client is not None
+        assert client.openmeteo_archive_client is archive_client
+
+    def test_setter_allows_tests_to_inject_archive_client(self) -> None:
+        client = WeatherClient()
+        archive_client = MagicMock()
+
+        client.openmeteo_archive_client = archive_client
+
+        assert client.openmeteo_archive_client is archive_client
+
+
+class TestLaunchEnrichmentTasksAnomaly:
+    @pytest.mark.asyncio
+    async def test_anomaly_task_skipped_in_test_mode(self) -> None:
+        client = WeatherClient(data_source="openmeteo")
+        client.trend_insights_enabled = False
+        assert client._test_mode is True
+        weather_data = _make_weather_data(72.0)
+
+        with (
+            patch(
+                "accessiweather.weather_client_enrichment.populate_environmental_metrics",
+                new=AsyncMock(),
+            ),
+            patch(
+                "accessiweather.weather_client_enrichment.enrich_with_aviation_data",
+                new=AsyncMock(),
+            ),
+        ):
+            tasks = client._launch_enrichment_tasks(weather_data, _make_location())
+
+        try:
+            assert "anomaly_callout" not in tasks
+        finally:
+            await _cancel_tasks(tasks)
+
+    @pytest.mark.asyncio
+    async def test_anomaly_task_created_when_not_test_mode_and_temperature_exists(self) -> None:
+        client = WeatherClient(data_source="openmeteo")
+        client._test_mode = False
+        client.trend_insights_enabled = False
+        client._enrich_with_anomaly_callout = AsyncMock()
+        weather_data = _make_weather_data(72.0)
+
+        with (
+            patch(
+                "accessiweather.weather_client_enrichment.populate_environmental_metrics",
+                new=AsyncMock(),
+            ),
+            patch(
+                "accessiweather.weather_client_enrichment.enrich_with_aviation_data",
+                new=AsyncMock(),
+            ),
+        ):
+            tasks = client._launch_enrichment_tasks(weather_data, _make_location())
+
+        try:
+            assert "anomaly_callout" in tasks
+        finally:
+            await _cancel_tasks(tasks)
+
+    @pytest.mark.asyncio
+    async def test_anomaly_task_not_created_when_temperature_is_missing(self) -> None:
+        client = WeatherClient(data_source="openmeteo")
+        client._test_mode = False
+        client.trend_insights_enabled = False
+        client._enrich_with_anomaly_callout = AsyncMock()
+        weather_data = _make_weather_data(temp_f=None)
+
+        with (
+            patch(
+                "accessiweather.weather_client_enrichment.populate_environmental_metrics",
+                new=AsyncMock(),
+            ),
+            patch(
+                "accessiweather.weather_client_enrichment.enrich_with_aviation_data",
+                new=AsyncMock(),
+            ),
+        ):
+            tasks = client._launch_enrichment_tasks(weather_data, _make_location())
+
+        try:
+            assert "anomaly_callout" not in tasks
+        finally:
+            await _cancel_tasks(tasks)


### PR DESCRIPTION
Closes #325.

## Summary
- Add a lazy Open-Meteo archive client to WeatherClient for historical anomaly lookups.
- Attach historical anomaly callouts during enrichment when current temperature is available.
- Add regression coverage for successful enrichment, skip/error cases, lazy archive client reuse, and task launch gating.

## Tests
- ruff format .
- ruff check .
- pytest tests/test_weather_anomaly.py tests/test_weather_client_anomaly.py tests/test_weather_client.py -q
- pytest tests/test_current_conditions.py -q