### PR TITLE
fix(notifications): preserve alert toasts when activation payloads include alert IDs

### DIFF
--- a/src/accessiweather/alert_manager.py
+++ b/src/accessiweather/alert_manager.py
@@ -283,6 +283,20 @@ class AlertManager:
         self._state_loaded = False
 
         logger.info("AlertManager initialized with runtime state file: %s", self.state_file)
+        logger.debug("[alertmgr] Initial settings: %s", self._settings_debug_summary())
+
+    def _settings_debug_summary(self) -> dict[str, object]:
+        """Return a compact settings snapshot for debug logging."""
+        return {
+            "notifications_enabled": self.settings.notifications_enabled,
+            "sound_enabled": self.settings.sound_enabled,
+            "min_severity_priority": self.settings.min_severity_priority,
+            "global_cooldown_minutes": self.settings.global_cooldown,
+            "per_alert_cooldown_minutes": self.settings.per_alert_cooldown,
+            "freshness_window_minutes": self.settings.freshness_window_minutes,
+            "max_notifications_per_hour": self.settings.max_notifications_per_hour,
+            "ignored_categories": sorted(self.settings.ignored_categories),
+        }
 
     def _ensure_state_loaded(self):
         """Ensure state is loaded before first use (lazy loading)."""
@@ -511,6 +525,11 @@ class AlertManager:
         notifications_to_send = []
         active_alerts = alerts.get_active_alerts()
         current_time = datetime.now(UTC)
+        logger.debug(
+            "[alertmgr] process_alerts: active_alerts=%d settings=%s",
+            len(active_alerts),
+            self._settings_debug_summary(),
+        )
 
         for alert in active_alerts:
             alert_id = alert.get_unique_id()
@@ -524,10 +543,15 @@ class AlertManager:
             should_notify, reason = self._should_notify_alert(alert)
             if not should_notify:
                 logger.info(
-                    "[alertmgr] Skipping alert %r: %s (severity=%s)",
+                    "[alertmgr] Skipping alert %r: %s (severity=%s, threshold=%s, "
+                    "notifications_enabled=%s, global_cooldown=%sm, available_tokens=%.2f)",
                     alert_id,
                     reason,
                     alert.severity,
+                    self.settings.min_severity_priority,
+                    self.settings.notifications_enabled,
+                    self.settings.global_cooldown,
+                    self._rate_limit_tokens,
                 )
                 continue
 
@@ -639,6 +663,7 @@ class AlertManager:
 
     def update_settings(self, new_settings: AlertSettings):
         """Update alert settings and reconfigure rate limiter."""
+        old_summary = self._settings_debug_summary()
         old_max = self.settings.max_notifications_per_hour
         self.settings = new_settings
 
@@ -662,7 +687,11 @@ class AlertManager:
                 f"refill_rate={self._rate_limit_refill_rate:.4f} tokens/sec"
             )
 
-        logger.info("Alert settings updated")
+        logger.info(
+            "[alertmgr] Alert settings updated: old=%s new=%s",
+            old_summary,
+            self._settings_debug_summary(),
+        )
 
     def clear_state(self):
         """Clear all alert state (for testing or reset)."""

--- a/src/accessiweather/alert_notification_system.py
+++ b/src/accessiweather/alert_notification_system.py
@@ -30,6 +30,25 @@ from .notifications.toast_notifier import SafeDesktopNotifier
 logger = logging.getLogger(__name__)
 
 
+def _app_settings_debug_summary(settings: AppSettings | None) -> dict[str, object]:
+    """Return a compact app-settings snapshot for debug logging."""
+    if settings is None:
+        return {"present": False}
+    return {
+        "present": True,
+        "alert_notifications_enabled": getattr(settings, "alert_notifications_enabled", None),
+        "sound_enabled": getattr(settings, "sound_enabled", None),
+        "alert_global_cooldown_minutes": getattr(settings, "alert_global_cooldown_minutes", None),
+        "alert_per_alert_cooldown_minutes": getattr(
+            settings, "alert_per_alert_cooldown_minutes", None
+        ),
+        "alert_freshness_window_minutes": getattr(settings, "alert_freshness_window_minutes", None),
+        "alert_max_notifications_per_hour": getattr(
+            settings, "alert_max_notifications_per_hour", None
+        ),
+    }
+
+
 def format_accessible_message(
     alert: WeatherAlert,
     reason: str,
@@ -159,12 +178,37 @@ class AlertNotificationSystem:
         """
         try:
             alert_count = len(alerts.alerts) if alerts else 0
-            logger.debug(f"[notify] process_and_notify: {alert_count} alert(s) received")
+            active_alerts = alerts.get_active_alerts() if alerts and alerts.has_alerts() else []
+            logger.debug(
+                "[notify] process_and_notify: alerts=%d app_settings=%s manager_settings=%s",
+                alert_count,
+                _app_settings_debug_summary(self.settings),
+                self.alert_manager._settings_debug_summary(),
+            )
+            if active_alerts:
+                logger.info(
+                    "[notify] process_and_notify received %d active alert(s): %s",
+                    len(active_alerts),
+                    [
+                        {
+                            "id": alert.get_unique_id(),
+                            "event": alert.event,
+                            "severity": alert.severity,
+                        }
+                        for alert in active_alerts
+                    ],
+                )
 
             # Use AlertManager to determine which alerts need notifications
             notifications_to_send = self.alert_manager.process_alerts(alerts)
 
             if not notifications_to_send:
+                logger.info(
+                    "[notify] AlertManager queued 0 notifications for active alerts; "
+                    "manager_settings=%s tracked_alerts=%d",
+                    self.alert_manager._settings_debug_summary(),
+                    len(self.alert_manager.alert_states),
+                )
                 logger.debug(
                     f"[notify] AlertManager returned 0 notifications to send "
                     f"(all {alert_count} alert(s) already seen / in cooldown)"
@@ -277,6 +321,15 @@ class AlertNotificationSystem:
 
             # Send the notification, providing candidate-based sound selection
             logger.debug(f"[notify] Calling notifier.send_notification for: {title!r}")
+            logger.info(
+                "[notify] Sending alert notification: alert_id=%r reason=%s play_sound=%s "
+                "title=%r activation=%r",
+                alert.get_unique_id(),
+                reason,
+                play_sound,
+                title,
+                "alert_details",
+            )
             success = self.notifier.send_notification(
                 title=title,
                 message=message,
@@ -422,6 +475,19 @@ class AlertNotificationSystem:
         settings: AlertSettings,
     ):
         """Update alert notification settings."""
+        logger.debug(
+            "[notify] update_settings: app_settings=%s incoming_manager_settings=%s",
+            _app_settings_debug_summary(self.settings),
+            {
+                "notifications_enabled": settings.notifications_enabled,
+                "sound_enabled": settings.sound_enabled,
+                "min_severity_priority": settings.min_severity_priority,
+                "global_cooldown_minutes": settings.global_cooldown,
+                "per_alert_cooldown_minutes": settings.per_alert_cooldown,
+                "freshness_window_minutes": settings.freshness_window_minutes,
+                "max_notifications_per_hour": settings.max_notifications_per_hour,
+            },
+        )
         self.alert_manager.update_settings(settings)
         logger.info("Alert notification settings updated")
 

--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -1327,6 +1327,7 @@ class AccessiWeatherApp(wx.App):
 
             if self.alert_notification_system:
                 self.alert_notification_system.settings = settings
+                self.alert_notification_system.update_settings(settings.to_alert_settings())
 
             # Update taskbar icon updater settings
             if self.taskbar_icon_updater:

--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -874,7 +874,17 @@ class AccessiWeatherApp(wx.App):
     def run_async(self, coro) -> None:
         """Run a coroutine in the background async loop."""
         if self._async_loop:
-            asyncio.run_coroutine_threadsafe(coro, self._async_loop)
+            future = asyncio.run_coroutine_threadsafe(coro, self._async_loop)
+            logger.debug("[async] scheduled coroutine: %r", coro)
+
+            def _log_future_result(done_future) -> None:
+                try:
+                    result = done_future.result()
+                    logger.debug("[async] coroutine completed: %r -> %r", coro, result)
+                except Exception as exc:
+                    logger.error("[async] coroutine failed: %r (%s)", coro, exc, exc_info=True)
+
+            future.add_done_callback(_log_future_result)
 
     def call_after_async(self, callback, *args) -> None:
         """Call a function on the main thread after async operation."""
@@ -1326,6 +1336,18 @@ class AccessiWeatherApp(wx.App):
                 )
 
             if self.alert_notification_system:
+                logger.debug(
+                    "[notify] refresh_runtime_settings: applying alert settings "
+                    "(app_enabled=%s, sound_enabled=%s, threshold_flags={extreme:%s,severe:%s,"
+                    "moderate:%s,minor:%s,unknown:%s})",
+                    getattr(settings, "alert_notifications_enabled", None),
+                    getattr(settings, "sound_enabled", None),
+                    getattr(settings, "alert_notify_extreme", None),
+                    getattr(settings, "alert_notify_severe", None),
+                    getattr(settings, "alert_notify_moderate", None),
+                    getattr(settings, "alert_notify_minor", None),
+                    getattr(settings, "alert_notify_unknown", None),
+                )
                 self.alert_notification_system.settings = settings
                 self.alert_notification_system.update_settings(settings.to_alert_settings())
 

--- a/src/accessiweather/notifications/toast_notifier.py
+++ b/src/accessiweather/notifications/toast_notifier.py
@@ -123,6 +123,11 @@ def _uses_protocol_activation(activation_arguments: str | None) -> bool:
     )
 
 
+def _escape_xml_attribute(value: str) -> str:
+    """Escape a string for safe use inside XML attributes."""
+    return _xml_escape(value, {'"': "&quot;", "'": "&apos;"})
+
+
 def _apply_protocol_activation_to_xml(xml_payload: str, activation_arguments: str | None) -> str:
     """Force protocol activation on the toast root element for stub-CLSID mode."""
     if not _uses_protocol_activation(activation_arguments):
@@ -290,9 +295,10 @@ class ToastedWindowsNotifier:
         """Attach launch arguments to the toast when the backend supports it."""
         if not activation_arguments:
             return
+        escaped_arguments = _escape_xml_attribute(activation_arguments)
         for attr in ("arguments", "launch"):
             with contextlib.suppress(Exception):
-                setattr(toast, attr, activation_arguments)
+                setattr(toast, attr, escaped_arguments)
         if _uses_protocol_activation(activation_arguments):
             for attr in ("activation_type", "activationType"):
                 with contextlib.suppress(Exception):

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -1203,6 +1203,19 @@ class MainWindow(SizedFrame):
                 and weather_data.alerts.has_alerts()
                 and self.app.alert_notification_system
             ):
+                active_alerts = weather_data.alerts.get_active_alerts()
+                logger.info(
+                    "[notify-ui] full refresh scheduling alert processing for %d active alert(s): %s",
+                    len(active_alerts),
+                    [
+                        {
+                            "id": alert.get_unique_id(),
+                            "event": alert.event,
+                            "severity": alert.severity,
+                        }
+                        for alert in active_alerts
+                    ],
+                )
                 self.app.run_async(
                     self.app.alert_notification_system.process_and_notify(weather_data.alerts)
                 )

--- a/src/accessiweather/ui/main_window_notification_events.py
+++ b/src/accessiweather/ui/main_window_notification_events.py
@@ -85,6 +85,19 @@ def on_notification_event_data_received(window: MainWindow, weather_data) -> Non
             and weather_data.alerts.has_alerts()
             and window.app.alert_notification_system
         ):
+            active_alerts = weather_data.alerts.get_active_alerts()
+            logger.info(
+                "[notify-ui] lightweight poll scheduling alert processing for %d active alert(s): %s",
+                len(active_alerts),
+                [
+                    {
+                        "id": alert.get_unique_id(),
+                        "event": alert.event,
+                        "severity": alert.severity,
+                    }
+                    for alert in active_alerts
+                ],
+            )
             window.app.run_async(
                 window.app.alert_notification_system.process_and_notify(weather_data.alerts)
             )
@@ -94,6 +107,15 @@ def on_notification_event_data_received(window: MainWindow, weather_data) -> Non
             and weather_data.alert_lifecycle_diff is not None
             and weather_data.alert_lifecycle_diff.has_changes
         ):
+            diff = weather_data.alert_lifecycle_diff
+            logger.info(
+                "[notify-ui] lightweight poll scheduling lifecycle notifications: "
+                "updated=%d escalated=%d extended=%d cancelled=%d",
+                len(diff.updated_alerts),
+                len(diff.escalated_alerts),
+                len(diff.extended_alerts),
+                len(diff.cancelled_alerts),
+            )
             window.app.run_async(
                 window.app.alert_notification_system.notify_lifecycle_changes(
                     weather_data.alert_lifecycle_diff

--- a/tests/test_alert_notification_system.py
+++ b/tests/test_alert_notification_system.py
@@ -8,14 +8,19 @@ are processed simultaneously.
 
 from __future__ import annotations
 
+import asyncio
+import shutil
+import threading
 from datetime import UTC, datetime, timedelta
-from unittest.mock import MagicMock
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from accessiweather.alert_manager import AlertManager
 from accessiweather.alert_notification_system import AlertNotificationSystem
-from accessiweather.models import WeatherAlert, WeatherAlerts
+from accessiweather.models import AppSettings, WeatherAlert, WeatherAlerts
+from accessiweather.notifications import toast_notifier
 
 
 class TestAlertNotificationBatchSound:
@@ -501,3 +506,172 @@ class TestNotifyLifecycleChanges:
 
         assert result == 2
         assert mock_notifier.send_notification.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_update_settings_refreshes_alert_manager_runtime_filters():
+    """Runtime settings refresh should re-enable alert delivery without restart."""
+    disabled_root = Path(".pytest_alert_runtime_disabled")
+    enabled_root = Path(".pytest_alert_runtime_enabled")
+    shutil.rmtree(disabled_root, ignore_errors=True)
+    shutil.rmtree(enabled_root, ignore_errors=True)
+    disabled_root.mkdir(exist_ok=True)
+    enabled_root.mkdir(exist_ok=True)
+
+    try:
+        initial_settings = AppSettings(alert_notifications_enabled=False)
+        enabled_settings = AppSettings(alert_notifications_enabled=True)
+
+        alert = WeatherAlert(
+            id="runtime-refresh-alert",
+            title="Severe Thunderstorm Warning",
+            description="Severe thunderstorms expected.",
+            severity="Severe",
+            urgency="Immediate",
+            certainty="Observed",
+            event="Severe Thunderstorm Warning",
+            headline="Warning in effect",
+            expires=datetime.now(UTC) + timedelta(hours=1),
+        )
+        alerts = WeatherAlerts(alerts=[alert])
+
+        stale_manager = AlertManager(str(disabled_root), initial_settings.to_alert_settings())
+        stale_system = AlertNotificationSystem(
+            alert_manager=stale_manager,
+            notifier=MagicMock(send_notification=MagicMock(return_value=True)),
+            settings=initial_settings,
+        )
+        stale_system.settings = enabled_settings
+
+        assert await stale_system.process_and_notify(alerts) == 0
+
+        refreshed_manager = AlertManager(str(enabled_root), initial_settings.to_alert_settings())
+        refreshed_notifier = MagicMock()
+        refreshed_notifier.send_notification = MagicMock(return_value=True)
+        refreshed_system = AlertNotificationSystem(
+            alert_manager=refreshed_manager,
+            notifier=refreshed_notifier,
+            settings=initial_settings,
+        )
+        refreshed_system.settings = enabled_settings
+        refreshed_system.update_settings(enabled_settings.to_alert_settings())
+
+        assert await refreshed_system.process_and_notify(alerts) == 1
+        refreshed_notifier.send_notification.assert_called_once()
+    finally:
+        shutil.rmtree(disabled_root, ignore_errors=True)
+        shutil.rmtree(enabled_root, ignore_errors=True)
+
+
+def test_process_and_notify_reaches_winrt_with_escaped_alert_activation():
+    """Alert notifications should reach WinRT with XML-safe alert-details activation."""
+
+    class _FakeToast:
+        def __init__(self, app_id=None, sound=None, **_kw):
+            self.app_id = app_id
+            self.sound = sound
+            self.elements = []
+            self.arguments = None
+            self.activation_type = None
+
+        def to_xml_string(self):
+            launch_attr = f' launch="{self.arguments}"' if self.arguments else ""
+            activation_attr = (
+                f' activationType="{self.activation_type}"' if self.activation_type else ""
+            )
+            return f"<toast{activation_attr}{launch_attr}><visual></visual></toast>"
+
+        @staticmethod
+        def register_app_id(handle, **_kw):
+            return handle
+
+        @staticmethod
+        def is_registered_app_id(_handle):
+            return True
+
+    class _FakeText:
+        def __init__(self, content):
+            self.content = content
+
+    runtime_root = Path(".pytest_alert_winrt")
+    shutil.rmtree(runtime_root, ignore_errors=True)
+    runtime_root.mkdir(exist_ok=True)
+
+    try:
+        settings = AppSettings(alert_notifications_enabled=True)
+        alert_manager = AlertManager(str(runtime_root), settings.to_alert_settings())
+        alert = WeatherAlert(
+            id="winrt-alert",
+            title="Special Weather Statement",
+            description="Localized gusty winds & reduced visibility.",
+            severity="Moderate",
+            urgency="Expected",
+            certainty="Likely",
+            event="Special Weather Statement",
+            headline="Localized gusty winds & reduced visibility expected.",
+            expires=datetime.now(UTC) + timedelta(hours=1),
+        )
+        weather_alerts = WeatherAlerts(alerts=[alert])
+
+        mock_xml_doc = MagicMock()
+        mock_notification = MagicMock()
+        mock_notifier_mgr = MagicMock()
+
+        with (
+            patch.object(toast_notifier, "TOASTED_AVAILABLE", True),
+            patch.object(toast_notifier, "WINRT_AVAILABLE", True),
+            patch.object(toast_notifier, "_Toast", _FakeToast),
+            patch.object(toast_notifier, "_Text", _FakeText),
+            patch.object(toast_notifier, "_WinRT_XmlDocument", return_value=mock_xml_doc),
+            patch.object(
+                toast_notifier, "_WinRT_ToastNotification", return_value=mock_notification
+            ),
+            patch.object(toast_notifier, "_WinRT_ToastNotificationManager", mock_notifier_mgr),
+            patch.object(
+                toast_notifier.ToastedWindowsNotifier, "_ensure_worker", return_value=True
+            ),
+        ):
+            notifier = toast_notifier.ToastedWindowsNotifier(sound_enabled=False)
+            notifier._worker_loop = MagicMock()
+            notifier._worker_loop.is_running.return_value = True
+            notifier._worker_thread = MagicMock()
+            notifier._worker_thread.is_alive.return_value = True
+            notification_system = AlertNotificationSystem(
+                alert_manager=alert_manager,
+                notifier=notifier,
+                settings=settings,
+            )
+
+            try:
+
+                def _run_in_thread(coro, _loop):
+                    holder: dict[str, object] = {}
+
+                    def _runner():
+                        holder["result"] = asyncio.run(coro)
+
+                    thread = threading.Thread(target=_runner, daemon=True)
+                    thread.start()
+                    thread.join(timeout=5)
+                    assert not thread.is_alive()
+                    return MagicMock(result=lambda: holder.get("result"))
+
+                with patch.object(
+                    toast_notifier.asyncio,
+                    "run_coroutine_threadsafe",
+                    _run_in_thread,
+                ):
+                    result = asyncio.run(notification_system.process_and_notify(weather_alerts))
+
+                assert result == 1
+                mock_notifier_mgr.create_toast_notifier.assert_called_once()
+                xml_payload = mock_xml_doc.load_xml.call_args.args[0]
+                assert 'activationType="protocol"' in xml_payload
+                assert "kind=alert_details&amp;alert_id=" in xml_payload
+            finally:
+                if notifier._worker_loop and notifier._worker_loop.is_running():
+                    notifier._worker_loop.call_soon_threadsafe(notifier._worker_loop.stop)
+                if notifier._worker_thread:
+                    notifier._worker_thread.join(timeout=2)
+    finally:
+        shutil.rmtree(runtime_root, ignore_errors=True)

--- a/tests/test_app_auto_update_checks.py
+++ b/tests/test_app_auto_update_checks.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 import types
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import wx
 
@@ -18,6 +18,62 @@ class _ImmediateThread:
 
     def start(self):
         self._target()
+
+
+def test_run_async_schedules_coroutine_when_loop_exists():
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    loop = object()
+    coro = object()
+    app._async_loop = loop
+
+    future = MagicMock()
+    future.add_done_callback.side_effect = lambda callback: callback(future)
+    future.result.return_value = "done"
+
+    with patch(
+        "accessiweather.app.asyncio.run_coroutine_threadsafe", return_value=future
+    ) as mock_run:
+        app.run_async(coro)
+
+    mock_run.assert_called_once_with(coro, loop)
+    future.add_done_callback.assert_called_once()
+    future.result.assert_called_once_with()
+
+
+def test_run_async_logs_future_exceptions():
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    loop = object()
+    coro = object()
+    app._async_loop = loop
+
+    future = MagicMock()
+    future.add_done_callback.side_effect = lambda callback: callback(future)
+    future.result.side_effect = RuntimeError("boom")
+
+    with patch("accessiweather.app.asyncio.run_coroutine_threadsafe", return_value=future):
+        app.run_async(coro)
+
+    future.add_done_callback.assert_called_once()
+    future.result.assert_called_once_with()
+
+
+def test_call_after_async_uses_wx_call_after():
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    callback = MagicMock()
+
+    with patch("accessiweather.app.wx.CallAfter") as mock_call_after:
+        app.call_after_async(callback, "arg", 123)
+
+    mock_call_after.assert_called_once_with(callback, "arg", 123)
+
+
+def test_initialize_components_delegates_to_initialization_module():
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+
+    with patch("accessiweather.app_initialization.initialize_components") as mock_initialize:
+        app._initialize_components()
+
+    mock_initialize.assert_called_once_with(app)
 
 
 def test_start_auto_update_checks_uses_configured_interval(monkeypatch):

--- a/tests/test_app_auto_update_checks.py
+++ b/tests/test_app_auto_update_checks.py
@@ -125,6 +125,7 @@ def test_request_exit_stops_timers_when_present():
 
 def test_refresh_runtime_settings_restarts_auto_update_checks():
     app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    alert_settings = object()
     settings = SimpleNamespace(
         data_source="auto",
         enable_alerts=True,
@@ -135,6 +136,7 @@ def test_refresh_runtime_settings_restarts_auto_update_checks():
         taskbar_icon_text_format="{temp} {condition}",
         temperature_unit="both",
         verbosity_level="standard",
+        to_alert_settings=MagicMock(return_value=alert_settings),
     )
     app.config_manager = MagicMock()
     app.config_manager.get_settings.return_value = settings
@@ -142,13 +144,16 @@ def test_refresh_runtime_settings_restarts_auto_update_checks():
     app.presenter = None
     app._notifier = None
     app._force_wizard = False
-    app.alert_notification_system = None
+    app.alert_notification_system = MagicMock()
     app.taskbar_icon_updater = None
     app._start_auto_update_checks = MagicMock()
+    app._start_background_updates = MagicMock()
     app._force_wizard = False
 
     app.refresh_runtime_settings()
 
+    settings.to_alert_settings.assert_called_once_with()
+    app.alert_notification_system.update_settings.assert_called_once_with(alert_settings)
     app._start_auto_update_checks.assert_called_once()
 
 

--- a/tests/test_toasted_windows_notifier.py
+++ b/tests/test_toasted_windows_notifier.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from unittest.mock import MagicMock, patch
 
@@ -27,6 +28,13 @@ class _FakeToast:
     async def show(self, mute_sound=False):
         self._shown = True
         return MagicMock(is_dismissed=False)
+
+    def to_xml_string(self):
+        launch_attr = f' launch="{self.arguments}"' if self.arguments else ""
+        activation_attr = ""
+        if getattr(self, "activation_type", None):
+            activation_attr = f' activationType="{self.activation_type}"'
+        return f"<toast{activation_attr}{launch_attr}><visual></visual></toast>"
 
     @staticmethod
     def register_app_id(handle, **_kw):
@@ -211,6 +219,21 @@ class TestToastedWindowsNotifierWorker:
 
         assert toast.arguments == "accessiweather-toast:kind=discussion"
 
+    def test_set_activation_arguments_escapes_xml_unsafe_characters(self):
+        """Protocol launch arguments with query separators are XML-escaped before toast rendering."""
+        with patch.object(toast_notifier, "TOASTED_AVAILABLE", False):
+            notifier = toast_notifier.ToastedWindowsNotifier(sound_enabled=False)
+
+        toast = _FakeToast()
+        notifier._set_activation_arguments(
+            toast,
+            "accessiweather-toast:kind=alert_details&alert_id=https%3A%2F%2Fapi.weather.gov",
+        )
+
+        assert toast.arguments == (
+            "accessiweather-toast:kind=alert_details&amp;alert_id=https%3A%2F%2Fapi.weather.gov"
+        )
+
     def test_worker_registers_app_id(self):
         """Worker thread registers the AUMID on first run."""
         _FakeToast._registered.clear()
@@ -250,25 +273,37 @@ class TestToastedWindowsNotifierWorker:
 
         with (
             patch.object(toast_notifier, "TOASTED_AVAILABLE", True),
+            patch.object(toast_notifier, "WINRT_AVAILABLE", False),
             patch.object(toast_notifier, "_Toast", _FakeToast),
             patch.object(toast_notifier, "_Text", _FakeText),
         ):
             notifier = toast_notifier.ToastedWindowsNotifier(sound_enabled=False)
             tracking = _TrackingSet()
             notifier._pending_tasks = tracking
+            notifier._worker_loop = MagicMock()
+            notifier._worker_loop.is_running.return_value = True
+            notifier._worker_thread = MagicMock()
+            notifier._worker_thread.is_alive.return_value = True
+            notifier._ensure_worker = MagicMock(return_value=True)
 
-            notifier._send_in_worker("Title", "Body")
-            # Give worker loop time to process the coroutine
-            time.sleep(0.3)
+            def _run_immediately(coro, _loop):
+                class _CompletedTask:
+                    def add_done_callback(self, callback):
+                        callback(self)
+
+                def _create_task(task_coro):
+                    task_coro.close()
+                    return _CompletedTask()
+
+                with patch.object(toast_notifier.asyncio, "create_task", _create_task):
+                    asyncio.run(coro)
+                return MagicMock()
+
+            with patch.object(toast_notifier.asyncio, "run_coroutine_threadsafe", _run_immediately):
+                notifier._send_in_worker("Title", "Body")
 
             # At least one task should have been added (even if already completed)
             assert len(tracking.ever_added) >= 1
-
-            # Clean up
-            if notifier._worker_loop and notifier._worker_loop.is_running():
-                notifier._worker_loop.call_soon_threadsafe(notifier._worker_loop.stop)
-            if notifier._worker_thread:
-                notifier._worker_thread.join(timeout=2)
 
 
 # ---------------------------------------------------------------------------
@@ -322,6 +357,7 @@ class TestToastedActivationCallback:
 
         with (
             patch.object(toast_notifier, "TOASTED_AVAILABLE", True),
+            patch.object(toast_notifier, "WINRT_AVAILABLE", False),
             patch.object(toast_notifier, "_Toast", _FakeToastWithCallback),
             patch.object(toast_notifier, "_Text", _FakeText),
         ):
@@ -329,16 +365,29 @@ class TestToastedActivationCallback:
             callback = MagicMock()
             notifier.on_activation = callback
 
-            notifier._send_in_worker("Title", "Body")  # no activation_arguments
-            time.sleep(0.3)
+            notifier._worker_loop = MagicMock()
+            notifier._worker_loop.is_running.return_value = True
+            notifier._worker_thread = MagicMock()
+            notifier._worker_thread.is_alive.return_value = True
+            notifier._ensure_worker = MagicMock(return_value=True)
+
+            def _run_immediately(coro, _loop):
+                class _CompletedTask:
+                    def add_done_callback(self, callback):
+                        callback(self)
+
+                def _create_task(task_coro):
+                    task_coro.close()
+                    return _CompletedTask()
+
+                with patch.object(toast_notifier.asyncio, "create_task", _create_task):
+                    asyncio.run(coro)
+                return MagicMock()
+
+            with patch.object(toast_notifier.asyncio, "run_coroutine_threadsafe", _run_immediately):
+                notifier._send_in_worker("Title", "Body")  # no activation_arguments
 
             callback.assert_not_called()
-
-            # Clean up
-            if notifier._worker_loop and notifier._worker_loop.is_running():
-                notifier._worker_loop.call_soon_threadsafe(notifier._worker_loop.stop)
-            if notifier._worker_thread:
-                notifier._worker_thread.join(timeout=2)
 
 
 # ---------------------------------------------------------------------------
@@ -451,6 +500,38 @@ class TestDirectWinRTActivation:
             xml_payload = mock_xml_doc.load_xml.call_args.args[0]
             assert 'activationType="protocol"' in xml_payload
             assert 'launch="accessiweather-toast:kind=discussion"' in xml_payload
+
+    def test_show_toast_direct_escapes_protocol_launch_query_separators(self):
+        """Alert-details protocol activation escapes '&' so WinRT XML stays valid."""
+        mock_xml_doc = MagicMock()
+        mock_notification = MagicMock()
+        mock_notifier_mgr = MagicMock()
+
+        with (
+            patch.object(toast_notifier, "TOASTED_AVAILABLE", True),
+            patch.object(toast_notifier, "WINRT_AVAILABLE", True),
+            patch.object(toast_notifier, "_WinRT_XmlDocument", return_value=mock_xml_doc),
+            patch.object(
+                toast_notifier, "_WinRT_ToastNotification", return_value=mock_notification
+            ),
+            patch.object(toast_notifier, "_WinRT_ToastNotificationManager", mock_notifier_mgr),
+        ):
+            notifier = toast_notifier.ToastedWindowsNotifier(sound_enabled=False)
+            fake_toast = MagicMock()
+            fake_toast.to_xml_string.return_value = (
+                '<toast launch="accessiweather-toast:kind=alert_details&amp;'
+                'alert_id=https%3A%2F%2Fapi.weather.gov"><visual></visual></toast>'
+            )
+
+            result = notifier._show_toast_direct(
+                fake_toast,
+                "accessiweather-toast:kind=alert_details&alert_id=https%3A%2F%2Fapi.weather.gov",
+            )
+
+            assert result is True
+            xml_payload = mock_xml_doc.load_xml.call_args.args[0]
+            assert 'activationType="protocol"' in xml_payload
+            assert "alert_details&amp;alert_id=" in xml_payload
 
     def test_live_notifications_trimmed_at_max(self):
         """Old notifications are trimmed when _MAX_LIVE_NOTIFICATIONS is exceeded."""


### PR DESCRIPTION
## Summary
- refresh runtime alert manager settings immediately after Settings changes so alert gating updates without a restart
- preserve Windows alert toasts when `alert_details` activation payloads include alert IDs by XML-escaping protocol launch arguments
- add end-to-end diagnostics plus regression tests covering runtime refresh, alert-to-WinRT delivery, and toast activation escaping

## What was happening
Real alert notifications were being detected and queued, but Windows rejected the alert toast XML when the activation payload included `&alert_id=...`.
That meant:
- alert sounds played
- alerts appeared in the UI
- no toast banner was shown

The latest debug Boston reproduction now shows the full path succeeding, including:
- alert scheduling from the main window
- `AlertManager` queuing 1 notification
- notifier dispatch
- `Toast shown via direct WinRT`

## Test Plan
- `ruff check src/accessiweather/notifications/toast_notifier.py tests/test_toasted_windows_notifier.py tests/test_alert_notification_system.py src/accessiweather/alert_manager.py src/accessiweather/alert_notification_system.py src/accessiweather/app.py src/accessiweather/ui/main_window.py src/accessiweather/ui/main_window_notification_events.py`
- `pytest -q -n 0 -p no:cacheprovider tests/test_toasted_windows_notifier.py tests/test_alert_notification_system.py::test_update_settings_refreshes_alert_manager_runtime_filters tests/test_alert_notification_system.py::test_process_and_notify_reaches_winrt_with_escaped_alert_activation tests/test_app_auto_update_checks.py::test_refresh_runtime_settings_restarts_auto_update_checks`
- manual debug reproduction on Windows source run:
  - clear alert runtime state
  - `uv run accessiweather --debug`
  - switch to Boston with active alert
  - verify alert processing logs and successful WinRT toast show

## Follow-up
- Portable build / Action Center cold-start click-through reliability should be handled in a separate follow-up PR.

Closes #579