### PR TITLE
fix(rate-limits): reduce Pirate Weather duplicate fetches

### DIFF
--- a/src/accessiweather/pirate_weather_client.py
+++ b/src/accessiweather/pirate_weather_client.py
@@ -11,9 +11,18 @@ API endpoint: https://api.pirateweather.net/forecast/{apikey}/{lat},{lon}
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
-from datetime import UTC, date, datetime, time, timedelta, timezone
+import time
+from datetime import (
+    UTC,
+    date,
+    datetime,
+    time as datetime_time,
+    timedelta,
+    timezone,
+)
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import httpx
@@ -122,7 +131,7 @@ def _normalize_daily_start_time(
     """Convert a Pirate Weather daily timestamp into the local calendar date at noon."""
     local_dt = datetime.fromtimestamp(timestamp, tz=response_tz)
     local_date = local_dt.date()
-    normalized = datetime.combine(local_date, time(hour=12), tzinfo=response_tz)
+    normalized = datetime.combine(local_date, datetime_time(hour=12), tzinfo=response_tz)
     return local_date, normalized
 
 
@@ -149,18 +158,55 @@ class PirateWeatherClient:
         self.user_agent = user_agent
         self.units = "uk2" if units == "uk" else units
         self.timeout = 15.0
+        self._recent_payload_ttl_seconds = 2.0
+        self._rate_limit_cooldown_seconds = 300.0
+        self._recent_payloads: dict[str, tuple[float, dict]] = {}
+        self._in_flight_payloads: dict[str, asyncio.Task[dict | None]] = {}
+        self._rate_limited_until: float = 0.0
 
     def _build_url(self, lat: float, lon: float) -> str:
         return f"{_BASE_URL}/{self.api_key}/{lat},{lon}"
 
-    @async_retry_with_backoff(max_attempts=3, base_delay=1.0, timeout=20.0)
-    async def get_forecast_data(self, location: Location) -> dict | None:
-        """
-        Fetch the full forecast payload from Pirate Weather.
+    def _cache_key(self, location: Location) -> str:
+        """Build a stable cache key for a location+unit combination."""
+        return f"{location.latitude:.6f},{location.longitude:.6f}:{self.units}"
 
-        Returns the raw API response dict (with ``currently``, ``hourly``,
-        ``daily``, ``minutely``, ``alerts`` keys) or ``None`` on error.
-        """
+    def _get_cached_payload(self, cache_key: str) -> dict | None:
+        """Return a recent payload if it is still fresh."""
+        cached = self._recent_payloads.get(cache_key)
+        if not cached:
+            return None
+
+        fetched_at, payload = cached
+        if (time.monotonic() - fetched_at) > self._recent_payload_ttl_seconds:
+            self._recent_payloads.pop(cache_key, None)
+            return None
+        return payload
+
+    def _enforce_rate_limit_cooldown(self) -> None:
+        """Short-circuit requests while a recent 429 cooldown is active."""
+        if time.monotonic() < self._rate_limited_until:
+            raise PirateWeatherApiError("API rate limit exceeded", 429)
+
+    def _finalize_in_flight_payload(self, cache_key: str, task: asyncio.Task[dict | None]) -> None:
+        """Clean up in-flight bookkeeping when a shared fetch task completes."""
+        if self._in_flight_payloads.get(cache_key) is task:
+            self._in_flight_payloads.pop(cache_key, None)
+
+        if task.cancelled():
+            return
+
+        try:
+            payload = task.result()
+        except Exception:
+            return
+
+        if payload is not None:
+            self._recent_payloads[cache_key] = (time.monotonic(), payload)
+
+    @async_retry_with_backoff(max_attempts=3, base_delay=1.0, timeout=20.0)
+    async def _request_forecast_data(self, location: Location) -> dict | None:
+        """Issue a single network request for the Pirate Weather payload."""
         url = self._build_url(location.latitude, location.longitude)
         params = {
             "units": self.units,
@@ -179,6 +225,7 @@ class PirateWeatherClient:
                 if response.status_code == 401:
                     raise PirateWeatherApiError("Invalid API key", response.status_code)
                 if response.status_code == 429:
+                    self._rate_limited_until = time.monotonic() + self._rate_limit_cooldown_seconds
                     raise PirateWeatherApiError("API rate limit exceeded", response.status_code)
                 if response.status_code != 200:
                     raise PirateWeatherApiError(
@@ -200,6 +247,30 @@ class PirateWeatherClient:
             logger.error(f"Unexpected Pirate Weather error: {e}")
             raise PirateWeatherApiError(f"Unexpected error: {e}") from e
 
+    async def get_forecast_data(self, location: Location) -> dict | None:
+        """
+        Fetch the full forecast payload from Pirate Weather.
+
+        Returns the raw API response dict (with ``currently``, ``hourly``,
+        ``daily``, ``minutely``, ``alerts`` keys) or ``None`` on error.
+        """
+        self._enforce_rate_limit_cooldown()
+        cache_key = self._cache_key(location)
+        cached_payload = self._get_cached_payload(cache_key)
+        if cached_payload is not None:
+            return cached_payload
+
+        existing_task = self._in_flight_payloads.get(cache_key)
+        if existing_task is not None:
+            return await asyncio.shield(existing_task)
+
+        task = asyncio.create_task(self._request_forecast_data(location))
+        self._in_flight_payloads[cache_key] = task
+        task.add_done_callback(
+            lambda done_task: self._finalize_in_flight_payload(cache_key, done_task)
+        )
+        return await asyncio.shield(task)
+
     async def get_current_conditions(self, location: Location) -> CurrentConditions | None:
         """Get current weather conditions."""
         data = await self.get_forecast_data(location)
@@ -220,6 +291,10 @@ class PirateWeatherClient:
         if data is None:
             return None
         return self._parse_hourly_forecast(data)
+
+    async def get_minutely_forecast(self, location: Location) -> dict | None:
+        """Return the raw payload for minutely precipitation consumers."""
+        return await self.get_forecast_data(location)
 
     async def get_alerts(self, location: Location) -> WeatherAlerts:
         """Get weather alerts."""

--- a/tests/test_pw_coverage.py
+++ b/tests/test_pw_coverage.py
@@ -12,6 +12,7 @@ Covers lines missed in:
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -96,6 +97,90 @@ class TestPirateWeatherHttpErrors:
 
         assert "Unexpected error" in str(exc_info.value)
 
+    @pytest.mark.asyncio
+    async def test_concurrent_views_share_single_http_fetch(self, client, location):
+        """Concurrent current/forecast/hourly/alert reads should reuse one raw payload fetch."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "currently": {"temperature": 72.0, "humidity": 0.5},
+            "hourly": {"data": []},
+            "daily": {"data": []},
+            "alerts": [],
+            "offset": 0,
+        }
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_http = AsyncMock()
+            mock_cls.return_value.__aenter__.return_value = mock_http
+            mock_http.get.return_value = mock_resp
+
+            await asyncio.gather(
+                client.get_current_conditions(location),
+                client.get_forecast(location),
+                client.get_hourly_forecast(location),
+                client.get_alerts(location),
+            )
+
+        assert mock_http.get.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_http_429_enters_short_cooldown(self, client, location):
+        """A 429 should prevent an immediate retry from issuing another HTTP request."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 429
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_http = AsyncMock()
+            mock_cls.return_value.__aenter__.return_value = mock_http
+            mock_http.get.return_value = mock_resp
+
+            with pytest.raises(PirateWeatherApiError) as exc_info:
+                await client.get_forecast_data(location)
+            assert exc_info.value.status_code == 429
+
+            with pytest.raises(PirateWeatherApiError) as exc_info:
+                await client.get_forecast_data(location)
+
+        assert exc_info.value.status_code == 429
+        assert mock_http.get.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_cancelling_one_waiter_does_not_cancel_shared_fetch(self, client, location):
+        """Cancelling one waiter should not abort the shared in-flight fetch for others."""
+        started = asyncio.Event()
+        release = asyncio.Event()
+        payload = {
+            "currently": {"temperature": 72.0, "humidity": 0.5},
+            "hourly": {"data": []},
+            "daily": {"data": []},
+            "alerts": [],
+            "offset": 0,
+        }
+
+        async def fake_request(_location):
+            started.set()
+            await release.wait()
+            return payload
+
+        with patch.object(client, "_request_forecast_data", AsyncMock(side_effect=fake_request)):
+            first_waiter = asyncio.create_task(client.get_forecast_data(location))
+            await started.wait()
+            second_waiter = asyncio.create_task(client.get_forecast_data(location))
+            await asyncio.sleep(0)
+
+            first_waiter.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await first_waiter
+
+            third_waiter = asyncio.create_task(client.get_forecast_data(location))
+            await asyncio.sleep(0)
+
+            release.set()
+            assert await second_waiter == payload
+            assert await third_waiter == payload
+            client._request_forecast_data.assert_awaited_once_with(location)
+
 
 # ---------------------------------------------------------------------------
 # pirate_weather_client.py – None return paths
@@ -103,6 +188,13 @@ class TestPirateWeatherHttpErrors:
 
 
 class TestNoneDataPaths:
+    @pytest.mark.asyncio
+    async def test_get_minutely_forecast_none_when_data_none(self, client, location):
+        """Minutely helper should mirror the shared raw-payload fetch path."""
+        with patch.object(client, "get_forecast_data", return_value=None):
+            result = await client.get_minutely_forecast(location)
+        assert result is None
+
     @pytest.mark.asyncio
     async def test_get_current_conditions_none_when_data_none(self, client, location):
         """Line 151: returns None when get_forecast_data returns None."""


### PR DESCRIPTION
## Summary
- coalesce concurrent Pirate Weather payload reads so current, forecast, hourly, alerts, and minutely consumers can share one raw fetch
- add a short post-429 cooldown so immediate follow-up calls do not keep hammering an exhausted key
- add a raw get_minutely_forecast helper and regression tests for shared-fetch and cancellation behavior

## Test Plan
- pytest tests/test_pw_coverage.py::TestPirateWeatherHttpErrors::test_concurrent_views_share_single_http_fetch tests/test_pw_coverage.py::TestPirateWeatherHttpErrors::test_http_429_enters_short_cooldown tests/test_pw_coverage.py::TestPirateWeatherHttpErrors::test_cancelling_one_waiter_does_not_cancel_shared_fetch tests/test_pw_coverage.py::TestNoneDataPaths::test_get_minutely_forecast_none_when_data_none -q
- pytest tests/test_pw_coverage.py tests/test_split_notification_timers.py -q
- ruff check src/accessiweather/pirate_weather_client.py tests/test_pw_coverage.py