### PR TITLE
fix(auto): preserve fusion-first automatic mode with opt-in weather source API budgeting

### DIFF
--- a/src/accessiweather/models/config.py
+++ b/src/accessiweather/models/config.py
@@ -92,6 +92,7 @@ NON_CRITICAL_SETTINGS: set[str] = {
     "source_priority_international",
     "auto_sources_us",
     "auto_sources_international",
+    "auto_mode_api_budget",
     "openmeteo_weather_model",
     "station_selection_strategy",
     "show_impact_summaries",
@@ -208,6 +209,7 @@ class AppSettings:
     # Parallel fetch timeout for smart auto mode (seconds)
     parallel_fetch_timeout: float = 5.0
     # Auto mode source selection — which sources participate in auto mode
+    auto_mode_api_budget: str = "economy"
     auto_sources_us: list[str] = field(
         default_factory=lambda: ["nws", "openmeteo", "visualcrossing", "pirateweather"]
     )
@@ -368,6 +370,11 @@ class AppSettings:
             if value not in valid_strategies:
                 setattr(self, setting_name, "hybrid_default")
 
+        elif setting_name == "auto_mode_api_budget":
+            valid_budgets = {"economy", "balanced", "max_coverage"}
+            if value not in valid_budgets:
+                setattr(self, setting_name, "economy")
+
         elif setting_name in {
             "source_priority_us",
             "source_priority_international",
@@ -465,6 +472,7 @@ class AppSettings:
             "taskbar_icon_text_format": self.taskbar_icon_text_format,
             "source_priority_us": self.source_priority_us,
             "source_priority_international": self.source_priority_international,
+            "auto_mode_api_budget": self.auto_mode_api_budget,
             "auto_sources_us": self.auto_sources_us,
             "auto_sources_international": self.auto_sources_international,
             "openmeteo_weather_model": self.openmeteo_weather_model,
@@ -560,6 +568,7 @@ class AppSettings:
             source_priority_international=data.get(
                 "source_priority_international", ["openmeteo", "pirateweather", "visualcrossing"]
             ),
+            auto_mode_api_budget=data.get("auto_mode_api_budget", "economy"),
             auto_sources_us=data.get(
                 "auto_sources_us", ["nws", "openmeteo", "visualcrossing", "pirateweather"]
             ),

--- a/src/accessiweather/models/config.py
+++ b/src/accessiweather/models/config.py
@@ -209,7 +209,7 @@ class AppSettings:
     # Parallel fetch timeout for smart auto mode (seconds)
     parallel_fetch_timeout: float = 5.0
     # Auto mode source selection — which sources participate in auto mode
-    auto_mode_api_budget: str = "economy"
+    auto_mode_api_budget: str = "max_coverage"
     auto_sources_us: list[str] = field(
         default_factory=lambda: ["nws", "openmeteo", "visualcrossing", "pirateweather"]
     )
@@ -373,7 +373,7 @@ class AppSettings:
         elif setting_name == "auto_mode_api_budget":
             valid_budgets = {"economy", "balanced", "max_coverage"}
             if value not in valid_budgets:
-                setattr(self, setting_name, "economy")
+                setattr(self, setting_name, "max_coverage")
 
         elif setting_name in {
             "source_priority_us",
@@ -497,7 +497,7 @@ class AppSettings:
     @classmethod
     def from_dict(cls, data: dict) -> AppSettings:
         """Create from dictionary."""
-        return cls(
+        settings = cls(
             temperature_unit=data.get("temperature_unit", "both"),
             update_interval_minutes=data.get("update_interval_minutes", 10),
             enable_alerts=cls._as_bool(data.get("enable_alerts"), True),
@@ -568,7 +568,7 @@ class AppSettings:
             source_priority_international=data.get(
                 "source_priority_international", ["openmeteo", "pirateweather", "visualcrossing"]
             ),
-            auto_mode_api_budget=data.get("auto_mode_api_budget", "economy"),
+            auto_mode_api_budget=data.get("auto_mode_api_budget", "max_coverage"),
             auto_sources_us=data.get(
                 "auto_sources_us", ["nws", "openmeteo", "visualcrossing", "pirateweather"]
             ),
@@ -607,6 +607,8 @@ class AppSettings:
             round_values=cls._as_bool(data.get("round_values"), False),
             show_impact_summaries=cls._as_bool(data.get("show_impact_summaries"), False),
         )
+        settings.validate_on_access("auto_mode_api_budget")
+        return settings
 
     def to_alert_settings(self):
         """Convert to AlertSettings for the alert management system."""

--- a/src/accessiweather/ui/dialogs/settings_dialog.py
+++ b/src/accessiweather/ui/dialogs/settings_dialog.py
@@ -587,8 +587,8 @@ class SettingsDialogSimple(wx.Dialog):
                 auto_panel,
                 label=(
                     "Choose how aggressively Automatic mode should spend API calls. "
-                    "Then select which weather sources it is allowed to use when extra coverage is needed. "
-                    "Unchecking a source prevents it from being fetched entirely. NWS is only available for US locations."
+                    "Max coverage keeps the historical fusion-first behavior. Economy and Balanced are reduced-call opt-in modes. "
+                    "Set US and international source lists separately so each region keeps its own exact ordering."
                 ),
             ),
             0,
@@ -613,21 +613,49 @@ class SettingsDialogSimple(wx.Dialog):
         )
         auto_budget_ctrl.SetSelection(state.get("auto_mode_api_budget", 0))
 
-        nws_cb = wx.CheckBox(auto_panel, label="National Weather Service (US locations only)")
-        nws_cb.SetValue(state.get("auto_use_nws", True))
-        auto_sizer.Add(nws_cb, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
+        us_sources = list(
+            state.get("auto_sources_us", ["nws", "openmeteo", "visualcrossing", "pirateweather"])
+        )
+        intl_sources = list(
+            state.get(
+                "auto_sources_international", ["openmeteo", "pirateweather", "visualcrossing"]
+            )
+        )
 
-        openmeteo_cb = wx.CheckBox(auto_panel, label="Open-Meteo")
-        openmeteo_cb.SetValue(state.get("auto_use_openmeteo", True))
-        auto_sizer.Add(openmeteo_cb, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
+        auto_sizer.Add(
+            wx.StaticText(auto_panel, label="US automatic sources:"),
+            0,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
+            10,
+        )
+        us_nws_cb = wx.CheckBox(auto_panel, label="National Weather Service")
+        us_nws_cb.SetValue("nws" in us_sources)
+        auto_sizer.Add(us_nws_cb, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 20)
+        us_openmeteo_cb = wx.CheckBox(auto_panel, label="Open-Meteo")
+        us_openmeteo_cb.SetValue("openmeteo" in us_sources)
+        auto_sizer.Add(us_openmeteo_cb, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 20)
+        us_vc_cb = wx.CheckBox(auto_panel, label="Visual Crossing (requires API key)")
+        us_vc_cb.SetValue("visualcrossing" in us_sources)
+        auto_sizer.Add(us_vc_cb, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 20)
+        us_pw_cb = wx.CheckBox(auto_panel, label="Pirate Weather (requires API key)")
+        us_pw_cb.SetValue("pirateweather" in us_sources)
+        auto_sizer.Add(us_pw_cb, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 20)
 
-        vc_cb = wx.CheckBox(auto_panel, label="Visual Crossing (requires API key)")
-        vc_cb.SetValue(state.get("auto_use_visualcrossing", True))
-        auto_sizer.Add(vc_cb, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
-
-        pw_cb = wx.CheckBox(auto_panel, label="Pirate Weather (requires API key)")
-        pw_cb.SetValue(state.get("auto_use_pirateweather", True))
-        auto_sizer.Add(pw_cb, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
+        auto_sizer.Add(
+            wx.StaticText(auto_panel, label="International automatic sources:"),
+            0,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
+            10,
+        )
+        intl_openmeteo_cb = wx.CheckBox(auto_panel, label="Open-Meteo")
+        intl_openmeteo_cb.SetValue("openmeteo" in intl_sources)
+        auto_sizer.Add(intl_openmeteo_cb, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 20)
+        intl_vc_cb = wx.CheckBox(auto_panel, label="Visual Crossing (requires API key)")
+        intl_vc_cb.SetValue("visualcrossing" in intl_sources)
+        auto_sizer.Add(intl_vc_cb, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 20)
+        intl_pw_cb = wx.CheckBox(auto_panel, label="Pirate Weather (requires API key)")
+        intl_pw_cb.SetValue("pirateweather" in intl_sources)
+        auto_sizer.Add(intl_pw_cb, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 20)
 
         auto_panel.SetSizer(auto_sizer)
         notebook.AddPage(auto_panel, "Auto Mode")
@@ -648,12 +676,30 @@ class SettingsDialogSimple(wx.Dialog):
         try:
             if dialog.ShowModal() != wx.ID_OK:
                 return None
+            auto_sources_us = [
+                source
+                for source, enabled in [
+                    ("nws", us_nws_cb.GetValue()),
+                    ("openmeteo", us_openmeteo_cb.GetValue()),
+                    ("visualcrossing", us_vc_cb.GetValue()),
+                    ("pirateweather", us_pw_cb.GetValue()),
+                ]
+                if enabled
+            ] or ["openmeteo"]
+            auto_sources_international = [
+                source
+                for source, enabled in [
+                    ("openmeteo", intl_openmeteo_cb.GetValue()),
+                    ("pirateweather", intl_pw_cb.GetValue()),
+                    ("visualcrossing", intl_vc_cb.GetValue()),
+                ]
+                if enabled
+            ] or ["openmeteo"]
+
             return {
                 "auto_mode_api_budget": auto_budget_ctrl.GetSelection(),
-                "auto_use_nws": nws_cb.GetValue(),
-                "auto_use_openmeteo": openmeteo_cb.GetValue(),
-                "auto_use_visualcrossing": vc_cb.GetValue(),
-                "auto_use_pirateweather": pw_cb.GetValue(),
+                "auto_sources_us": auto_sources_us,
+                "auto_sources_international": auto_sources_international,
                 "station_selection_strategy": strategy_ctrl.GetSelection(),
             }
         finally:

--- a/src/accessiweather/ui/dialogs/settings_dialog.py
+++ b/src/accessiweather/ui/dialogs/settings_dialog.py
@@ -586,15 +586,32 @@ class SettingsDialogSimple(wx.Dialog):
             wx.StaticText(
                 auto_panel,
                 label=(
-                    "Select which weather sources are used when Automatic mode is active. "
-                    "Unchecking a source prevents it from being fetched entirely. "
-                    "NWS is only available for US locations."
+                    "Choose how aggressively Automatic mode should spend API calls. "
+                    "Then select which weather sources it is allowed to use when extra coverage is needed. "
+                    "Unchecking a source prevents it from being fetched entirely. NWS is only available for US locations."
                 ),
             ),
             0,
             wx.ALL | wx.EXPAND,
             10,
         )
+
+        auto_budget_ctrl = self.add_labeled_control_row(
+            auto_panel,
+            auto_sizer,
+            "Automatic mode API budget:",
+            lambda parent: wx.Choice(
+                parent,
+                choices=[
+                    "Economy (use the fewest API calls that still cover the basics)",
+                    "Balanced (allow one useful fallback when Automatic mode needs it)",
+                    "Max coverage (fan out to every enabled source)",
+                ],
+            ),
+            expand_control=True,
+            bottom=10,
+        )
+        auto_budget_ctrl.SetSelection(state.get("auto_mode_api_budget", 0))
 
         nws_cb = wx.CheckBox(auto_panel, label="National Weather Service (US locations only)")
         nws_cb.SetValue(state.get("auto_use_nws", True))
@@ -632,6 +649,7 @@ class SettingsDialogSimple(wx.Dialog):
             if dialog.ShowModal() != wx.ID_OK:
                 return None
             return {
+                "auto_mode_api_budget": auto_budget_ctrl.GetSelection(),
                 "auto_use_nws": nws_cb.GetValue(),
                 "auto_use_openmeteo": openmeteo_cb.GetValue(),
                 "auto_use_visualcrossing": vc_cb.GetValue(),

--- a/src/accessiweather/ui/dialogs/settings_tabs/data_sources.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/data_sources.py
@@ -12,6 +12,9 @@ _SOURCE_VALUES = ["auto", "nws", "openmeteo", "visualcrossing", "pirateweather"]
 _SOURCE_MAP = {"auto": 0, "nws": 1, "openmeteo": 2, "visualcrossing": 3, "pirateweather": 4}
 _AUTO_MODE_BUDGET_VALUES = ["economy", "balanced", "max_coverage"]
 _AUTO_MODE_BUDGET_LABELS = ["Economy", "Balanced", "Max coverage"]
+_DEFAULT_AUTO_SOURCES_US = ["nws", "openmeteo", "visualcrossing", "pirateweather"]
+_DEFAULT_AUTO_SOURCES_INTERNATIONAL = ["openmeteo", "pirateweather", "visualcrossing"]
+_DEFAULT_BUDGET_INDEX = _AUTO_MODE_BUDGET_VALUES.index("max_coverage")
 _STATION_STRATEGY_VALUES = [
     "hybrid_default",
     "nearest",
@@ -24,6 +27,12 @@ _STATION_STRATEGY_LABELS = [
     "Major airport preferred",
     "Freshest observation",
 ]
+_SOURCE_LABELS = {
+    "nws": "NWS",
+    "openmeteo": "Open-Meteo",
+    "visualcrossing": "Visual Crossing",
+    "pirateweather": "Pirate Weather",
+}
 
 
 class DataSourcesTab:
@@ -37,22 +46,34 @@ class DataSourcesTab:
     def _build_default_source_settings_states() -> dict:
         """Return default source settings state."""
         return {
-            "auto_mode_api_budget": 0,
-            "auto_use_nws": True,
-            "auto_use_openmeteo": True,
-            "auto_use_visualcrossing": True,
-            "auto_use_pirateweather": True,
+            "auto_mode_api_budget": _DEFAULT_BUDGET_INDEX,
+            "auto_sources_us": list(_DEFAULT_AUTO_SOURCES_US),
+            "auto_sources_international": list(_DEFAULT_AUTO_SOURCES_INTERNATIONAL),
             "station_selection_strategy": 0,
         }
 
     @staticmethod
+    def _get_state_sources(state: dict, region: str) -> list[str]:
+        """Return the normalized configured source order for a region."""
+        key = "auto_sources_us" if region == "us" else "auto_sources_international"
+        default_sources = (
+            _DEFAULT_AUTO_SOURCES_US if region == "us" else _DEFAULT_AUTO_SOURCES_INTERNATIONAL
+        )
+        saved_sources = state.get(key, default_sources)
+        if not isinstance(saved_sources, list):
+            return list(default_sources)
+        valid_sources = set(_SOURCE_LABELS)
+        normalized = [source for source in saved_sources if source in valid_sources]
+        return normalized or list(default_sources)
+
+    @staticmethod
     def build_source_settings_summary_text(state: dict) -> str:
         """Build plain-language summary text shown on the data sources tab."""
-        budget_idx = state.get("auto_mode_api_budget", 0)
+        budget_idx = state.get("auto_mode_api_budget", _DEFAULT_BUDGET_INDEX)
         if 0 <= budget_idx < len(_AUTO_MODE_BUDGET_LABELS):
             budget_text = _AUTO_MODE_BUDGET_LABELS[budget_idx]
         else:
-            budget_text = _AUTO_MODE_BUDGET_LABELS[0]
+            budget_text = _AUTO_MODE_BUDGET_LABELS[_DEFAULT_BUDGET_INDEX]
 
         strat_idx = state.get("station_selection_strategy", 0)
         if 0 <= strat_idx < len(_STATION_STRATEGY_LABELS):
@@ -60,18 +81,14 @@ class DataSourcesTab:
         else:
             strat_text = _STATION_STRATEGY_LABELS[0]
 
-        sources = ["NWS", "Open-Meteo", "Visual Crossing", "Pirate Weather"]
-        keys = [
-            "auto_use_nws",
-            "auto_use_openmeteo",
-            "auto_use_visualcrossing",
-            "auto_use_pirateweather",
-        ]
-        enabled = [s for s, k in zip(sources, keys, strict=True) if state.get(k, True)]
-        enabled_text = ", ".join(enabled) if enabled else "Open-Meteo only"
+        us_enabled = DataSourcesTab._get_state_sources(state, "us")
+        intl_enabled = DataSourcesTab._get_state_sources(state, "international")
+        us_text = ", ".join(_SOURCE_LABELS[source] for source in us_enabled)
+        intl_text = ", ".join(_SOURCE_LABELS[source] for source in intl_enabled)
         return (
             f"Automatic mode budget: {budget_text}. "
-            f"Allowed automatic sources: {enabled_text}. "
+            f"US automatic sources: {us_text}. "
+            f"International automatic sources: {intl_text}. "
             f"NWS station strategy: {strat_text}."
         )
 
@@ -279,33 +296,20 @@ class DataSourcesTab:
             if saved_strategy in _STATION_STRATEGY_VALUES
             else 0
         )
-        saved_budget = getattr(settings, "auto_mode_api_budget", "economy")
+        saved_budget = getattr(settings, "auto_mode_api_budget", "max_coverage")
         budget_idx = (
             _AUTO_MODE_BUDGET_VALUES.index(saved_budget)
             if saved_budget in _AUTO_MODE_BUDGET_VALUES
-            else 0
+            else _DEFAULT_BUDGET_INDEX
         )
-        saved_us = list(
-            getattr(
-                settings,
-                "source_priority_us",
-                ["nws", "openmeteo", "visualcrossing", "pirateweather"],
-            )
-        )
+        saved_us = list(getattr(settings, "auto_sources_us", _DEFAULT_AUTO_SOURCES_US))
         saved_intl = list(
-            getattr(
-                settings,
-                "source_priority_international",
-                ["openmeteo", "pirateweather", "visualcrossing"],
-            )
+            getattr(settings, "auto_sources_international", _DEFAULT_AUTO_SOURCES_INTERNATIONAL)
         )
-        all_sources = set(saved_us) | set(saved_intl)
         self.dialog._source_settings_states = {
             "auto_mode_api_budget": budget_idx,
-            "auto_use_nws": "nws" in all_sources,
-            "auto_use_openmeteo": "openmeteo" in all_sources,
-            "auto_use_visualcrossing": "visualcrossing" in all_sources,
-            "auto_use_pirateweather": "pirateweather" in all_sources,
+            "auto_sources_us": saved_us or list(_DEFAULT_AUTO_SOURCES_US),
+            "auto_sources_international": saved_intl or list(_DEFAULT_AUTO_SOURCES_INTERNATIONAL),
             "station_selection_strategy": strat_idx,
         }
         self.refresh_source_settings_summary()
@@ -316,32 +320,12 @@ class DataSourcesTab:
         controls = self.dialog._controls
         state = getattr(self.dialog, "_source_settings_states", None) or {}
 
-        def _src_enabled(_source_key: str, flag_key: str) -> bool:
-            return state.get(flag_key, True)
-
-        source_priority_us = [
-            s
-            for s, k in [
-                ("nws", "auto_use_nws"),
-                ("openmeteo", "auto_use_openmeteo"),
-                ("visualcrossing", "auto_use_visualcrossing"),
-                ("pirateweather", "auto_use_pirateweather"),
-            ]
-            if _src_enabled(s, k)
-        ]
-        source_priority_intl = [
-            s
-            for s, k in [
-                ("openmeteo", "auto_use_openmeteo"),
-                ("visualcrossing", "auto_use_visualcrossing"),
-                ("pirateweather", "auto_use_pirateweather"),
-            ]
-            if _src_enabled(s, k)
-        ]
+        source_priority_us = self._get_state_sources(state, "us")
+        source_priority_intl = self._get_state_sources(state, "international")
 
         strat_idx = max(0, state.get("station_selection_strategy", 0))
         station_strategy = _STATION_STRATEGY_VALUES[strat_idx]
-        budget_idx = max(0, state.get("auto_mode_api_budget", 0))
+        budget_idx = max(0, state.get("auto_mode_api_budget", _DEFAULT_BUDGET_INDEX))
         auto_mode_api_budget = _AUTO_MODE_BUDGET_VALUES[
             min(budget_idx, len(_AUTO_MODE_BUDGET_VALUES) - 1)
         ]

--- a/src/accessiweather/ui/dialogs/settings_tabs/data_sources.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/data_sources.py
@@ -10,6 +10,8 @@ logger = logging.getLogger(__name__)
 
 _SOURCE_VALUES = ["auto", "nws", "openmeteo", "visualcrossing", "pirateweather"]
 _SOURCE_MAP = {"auto": 0, "nws": 1, "openmeteo": 2, "visualcrossing": 3, "pirateweather": 4}
+_AUTO_MODE_BUDGET_VALUES = ["economy", "balanced", "max_coverage"]
+_AUTO_MODE_BUDGET_LABELS = ["Economy", "Balanced", "Max coverage"]
 _STATION_STRATEGY_VALUES = [
     "hybrid_default",
     "nearest",
@@ -35,6 +37,7 @@ class DataSourcesTab:
     def _build_default_source_settings_states() -> dict:
         """Return default source settings state."""
         return {
+            "auto_mode_api_budget": 0,
             "auto_use_nws": True,
             "auto_use_openmeteo": True,
             "auto_use_visualcrossing": True,
@@ -45,6 +48,12 @@ class DataSourcesTab:
     @staticmethod
     def build_source_settings_summary_text(state: dict) -> str:
         """Build plain-language summary text shown on the data sources tab."""
+        budget_idx = state.get("auto_mode_api_budget", 0)
+        if 0 <= budget_idx < len(_AUTO_MODE_BUDGET_LABELS):
+            budget_text = _AUTO_MODE_BUDGET_LABELS[budget_idx]
+        else:
+            budget_text = _AUTO_MODE_BUDGET_LABELS[0]
+
         strat_idx = state.get("station_selection_strategy", 0)
         if 0 <= strat_idx < len(_STATION_STRATEGY_LABELS):
             strat_text = _STATION_STRATEGY_LABELS[strat_idx]
@@ -60,7 +69,11 @@ class DataSourcesTab:
         ]
         enabled = [s for s, k in zip(sources, keys, strict=True) if state.get(k, True)]
         enabled_text = ", ".join(enabled) if enabled else "Open-Meteo only"
-        return f"Automatic mode uses: {enabled_text}. NWS station strategy: {strat_text}."
+        return (
+            f"Automatic mode budget: {budget_text}. "
+            f"Allowed automatic sources: {enabled_text}. "
+            f"NWS station strategy: {strat_text}."
+        )
 
     def create(self, page_label: str = "Data Sources"):
         """Build the Data Sources tab panel and add it to the notebook."""
@@ -103,7 +116,7 @@ class DataSourcesTab:
             panel,
             sizer,
             "Automatic mode",
-            "Fine-tune which sources Automatic mode can use and how NWS picks a station for current conditions.",
+            "Choose how aggressively Automatic mode uses APIs, then fine-tune which sources it may use and how NWS picks a station for current conditions.",
         )
         controls["source_settings_summary"] = wx.TextCtrl(
             panel,
@@ -119,7 +132,7 @@ class DataSourcesTab:
         )
         controls["configure_source_settings"] = wx.Button(
             panel,
-            label="Choose automatic mode sources...",
+            label="Configure automatic mode budget and sources...",
         )
         controls["configure_source_settings"].Bind(
             wx.EVT_BUTTON,
@@ -266,6 +279,12 @@ class DataSourcesTab:
             if saved_strategy in _STATION_STRATEGY_VALUES
             else 0
         )
+        saved_budget = getattr(settings, "auto_mode_api_budget", "economy")
+        budget_idx = (
+            _AUTO_MODE_BUDGET_VALUES.index(saved_budget)
+            if saved_budget in _AUTO_MODE_BUDGET_VALUES
+            else 0
+        )
         saved_us = list(
             getattr(
                 settings,
@@ -282,6 +301,7 @@ class DataSourcesTab:
         )
         all_sources = set(saved_us) | set(saved_intl)
         self.dialog._source_settings_states = {
+            "auto_mode_api_budget": budget_idx,
             "auto_use_nws": "nws" in all_sources,
             "auto_use_openmeteo": "openmeteo" in all_sources,
             "auto_use_visualcrossing": "visualcrossing" in all_sources,
@@ -321,6 +341,10 @@ class DataSourcesTab:
 
         strat_idx = max(0, state.get("station_selection_strategy", 0))
         station_strategy = _STATION_STRATEGY_VALUES[strat_idx]
+        budget_idx = max(0, state.get("auto_mode_api_budget", 0))
+        auto_mode_api_budget = _AUTO_MODE_BUDGET_VALUES[
+            min(budget_idx, len(_AUTO_MODE_BUDGET_VALUES) - 1)
+        ]
 
         return {
             "data_source": _SOURCE_VALUES[controls["data_source"].GetSelection()],
@@ -328,6 +352,7 @@ class DataSourcesTab:
             "pirate_weather_api_key": controls["pw_key"].GetValue(),
             "source_priority_us": source_priority_us,
             "source_priority_international": source_priority_intl,
+            "auto_mode_api_budget": auto_mode_api_budget,
             "auto_sources_us": source_priority_us or ["openmeteo"],
             "auto_sources_international": source_priority_intl or ["openmeteo"],
             "openmeteo_weather_model": "best_match",
@@ -342,7 +367,7 @@ class DataSourcesTab:
             "vc_key": "Visual Crossing API key",
             "pw_key": "Pirate Weather API key",
             "source_settings_summary": "Automatic mode source summary",
-            "configure_source_settings": "Choose automatic mode sources",
+            "configure_source_settings": "Configure automatic mode budget and sources",
         }
         for key, name in names.items():
             controls[key].SetName(name)

--- a/src/accessiweather/weather_client_base.py
+++ b/src/accessiweather/weather_client_base.py
@@ -835,8 +835,8 @@ class WeatherClient:
 
     def _get_auto_mode_api_budget(self) -> str:
         """Return the validated automatic-mode API budget setting."""
-        budget = getattr(self.settings, "auto_mode_api_budget", "economy")
-        return budget if budget in {"economy", "balanced", "max_coverage"} else "economy"
+        budget = getattr(self.settings, "auto_mode_api_budget", "max_coverage")
+        return budget if budget in {"economy", "balanced", "max_coverage"} else "max_coverage"
 
     @staticmethod
     def _source_has_core_section(
@@ -855,14 +855,18 @@ class WeatherClient:
         )
 
     @staticmethod
-    def _auto_primary_source(
-        preferred_order: list[str], active_sources: Sequence[str]
-    ) -> str | None:
-        """Pick the first enabled primary source from a preferred order."""
-        for source in preferred_order:
-            if source in active_sources:
-                return source
-        return None
+    def _configured_sources_in_fetch_order(
+        active_sources: Sequence[str],
+        fetchers: dict[str, object],
+        fetched_sources: set[str] | None = None,
+    ) -> list[str]:
+        """Return configured sources that are currently fetchable, preserving user order."""
+        already_fetched = fetched_sources or set()
+        return [
+            source
+            for source in active_sources
+            if source in fetchers and source not in already_fetched
+        ]
 
     async def _fetch_auto_mode_sources(
         self,
@@ -973,12 +977,8 @@ class WeatherClient:
                 location, coordinator, fetchers, active_sources
             )
         else:
-            preferred_order = (
-                ["nws", "openmeteo", "visualcrossing", "pirateweather"]
-                if is_us
-                else ["openmeteo", "pirateweather", "visualcrossing"]
-            )
-            primary_source = self._auto_primary_source(preferred_order, active_sources)
+            configured_sources = self._configured_sources_in_fetch_order(active_sources, fetchers)
+            primary_source = configured_sources[0] if configured_sources else None
             primary_sources = (
                 [primary_source] if primary_source and primary_source in fetchers else []
             )
@@ -1005,19 +1005,25 @@ class WeatherClient:
             )
             needs_intl_core_fallback = not is_us and not core_complete
 
+            remaining_sources = self._configured_sources_in_fetch_order(
+                active_sources, fetchers, fetched_sources
+            )
+
+            def _pick_secondary_candidate(predicate) -> list[str]:
+                for source in remaining_sources:
+                    if predicate(source):
+                        return [source]
+                return []
+
             secondary_sources: list[str] = []
-            if needs_us_openmeteo:
-                secondary_sources = ["openmeteo"]
-            elif needs_intl_alert_source or needs_intl_core_fallback:
-                if "pirateweather" in fetchers and "pirateweather" not in fetched_sources:
-                    secondary_sources = ["pirateweather"]
-                elif "visualcrossing" in fetchers and "visualcrossing" not in fetched_sources:
-                    secondary_sources = ["visualcrossing"]
-            elif auto_budget == "balanced" and is_us and not core_complete:
-                if "visualcrossing" in fetchers and "visualcrossing" not in fetched_sources:
-                    secondary_sources = ["visualcrossing"]
-                elif "pirateweather" in fetchers and "pirateweather" not in fetched_sources:
-                    secondary_sources = ["pirateweather"]
+            if needs_us_openmeteo or (auto_budget == "balanced" and is_us and not core_complete):
+                secondary_sources = _pick_secondary_candidate(lambda _source: True)
+            elif needs_intl_alert_source:
+                secondary_sources = _pick_secondary_candidate(
+                    lambda source: source in {"pirateweather", "visualcrossing"}
+                )
+            elif needs_intl_core_fallback:
+                secondary_sources = _pick_secondary_candidate(lambda _source: True)
 
             if secondary_sources:
                 source_results.extend(

--- a/src/accessiweather/weather_client_base.py
+++ b/src/accessiweather/weather_client_base.py
@@ -833,29 +833,67 @@ class WeatherClient:
 
         return weather_data
 
+    def _get_auto_mode_api_budget(self) -> str:
+        """Return the validated automatic-mode API budget setting."""
+        budget = getattr(self.settings, "auto_mode_api_budget", "economy")
+        return budget if budget in {"economy", "balanced", "max_coverage"} else "economy"
+
+    @staticmethod
+    def _source_has_core_section(
+        section: CurrentConditions | Forecast | HourlyForecast | None,
+    ) -> bool:
+        """Return True when a current/forecast/hourly section is present and populated."""
+        return bool(section is not None and section.has_data())
+
+    def _source_has_complete_core_data(self, source_data: SourceData | None) -> bool:
+        """Return True when a single-source result includes current, forecast, and hourly data."""
+        if source_data is None:
+            return False
+        return all(
+            self._source_has_core_section(section)
+            for section in (source_data.current, source_data.forecast, source_data.hourly_forecast)
+        )
+
+    @staticmethod
+    def _auto_primary_source(
+        preferred_order: list[str], active_sources: Sequence[str]
+    ) -> str | None:
+        """Pick the first enabled primary source from a preferred order."""
+        for source in preferred_order:
+            if source in active_sources:
+                return source
+        return None
+
+    async def _fetch_auto_mode_sources(
+        self,
+        location: Location,
+        coordinator: ParallelFetchCoordinator,
+        fetchers: dict[str, object],
+        requested_sources: Sequence[str],
+    ) -> list[SourceData]:
+        """Fetch a selected subset of automatic-mode sources."""
+        sources_to_fetch = [source for source in requested_sources if source in fetchers]
+        if not sources_to_fetch:
+            return []
+
+        return await coordinator.fetch_all(
+            location=location,
+            fetch_nws=fetchers["nws"]() if "nws" in sources_to_fetch else None,
+            fetch_openmeteo=fetchers["openmeteo"]() if "openmeteo" in sources_to_fetch else None,
+            fetch_visualcrossing=(
+                fetchers["visualcrossing"]() if "visualcrossing" in sources_to_fetch else None
+            ),
+            fetch_pirateweather=(
+                fetchers["pirateweather"]() if "pirateweather" in sources_to_fetch else None
+            ),
+        )
+
     async def _fetch_smart_auto_source(
         self, location: Location, skip_notifications: bool = False
     ) -> WeatherData:
-        """
-        Fetch weather data from all sources in parallel and merge results.
+        """Fetch weather data using staged automatic-source decisions."""
+        logger.info("Using smart auto source for %s", location.name)
 
-        This implements the smart auto source feature that:
-        1. Fetches from all available sources concurrently
-        2. Merges data using configurable priorities
-        3. Deduplicates alerts from multiple sources
-        4. Tracks source attribution for transparency
-
-        Args:
-            location: The location to fetch weather for
-            skip_notifications: If True, skip triggering alert notifications
-
-        Returns:
-            Merged WeatherData from all successful sources
-
-        """
-        logger.info(f"Using smart auto source for {location.name}")
-
-        # Get user-configured auto mode source lists
         auto_sources_us = getattr(
             self.settings,
             "auto_sources_us",
@@ -867,37 +905,34 @@ class WeatherClient:
             ["openmeteo", "pirateweather", "visualcrossing"],
         )
 
-        # Initialize components with user's source priority settings
         config = SourcePriorityConfig(
-            us_default=auto_sources_us, international_default=auto_sources_international
+            us_default=auto_sources_us,
+            international_default=auto_sources_international,
         )
+        auto_budget = self._get_auto_mode_api_budget()
         parallel_timeout = getattr(self.settings, "parallel_fetch_timeout", 5.0)
         coordinator = ParallelFetchCoordinator(timeout=parallel_timeout)
         fusion_engine = DataFusionEngine(config)
         alert_aggregator = AlertAggregator()
 
-        # Prepare fetch coroutines for available sources
         is_us = self._is_us_location(location)
-        active_sources = auto_sources_us if is_us else auto_sources_international
+        active_sources = list(auto_sources_us if is_us else auto_sources_international)
 
-        # Always fetch from Open-Meteo (works globally)
         async def fetch_openmeteo():
             current, forecast, hourly = await self._fetch_openmeteo_data(location)
             return (current, forecast, hourly)
 
-        # Fetch from NWS for US locations
         async def fetch_nws():
             (
                 current,
                 forecast,
-                discussion,
-                discussion_time,
+                _discussion,
+                _discussion_time,
                 alerts,
                 hourly,
             ) = await self._fetch_nws_data(location)
             return (current, forecast, hourly, alerts)
 
-        # Fetch from Visual Crossing if configured
         async def fetch_vc():
             if not self.visual_crossing_client:
                 return (None, None, None, None)
@@ -910,7 +945,6 @@ class WeatherClient:
             alerts = await self.visual_crossing_client.get_alerts(location)
             return (current, forecast, hourly, alerts)
 
-        # Fetch from Pirate Weather if configured
         async def fetch_pw():
             pirate_weather_client = self._pirate_weather_client_for_location(location)
             if not pirate_weather_client:
@@ -924,63 +958,106 @@ class WeatherClient:
             alerts = await pirate_weather_client.get_alerts(location)
             return (current, forecast, hourly, alerts)
 
-        # Fetch from all sources in parallel, respecting user's auto source selection
-        source_results = await coordinator.fetch_all(
-            location=location,
-            fetch_nws=fetch_nws() if (is_us and "nws" in active_sources) else None,
-            fetch_openmeteo=fetch_openmeteo() if "openmeteo" in active_sources else None,
-            fetch_visualcrossing=(
-                fetch_vc()
-                if (self.visual_crossing_client and "visualcrossing" in active_sources)
-                else None
-            ),
-            fetch_pirateweather=(
-                fetch_pw()
-                if (self.pirate_weather_api_key and "pirateweather" in active_sources)
-                else None
-            ),
-        )
+        fetchers: dict[str, object] = {}
+        if "openmeteo" in active_sources:
+            fetchers["openmeteo"] = fetch_openmeteo
+        if is_us and "nws" in active_sources:
+            fetchers["nws"] = fetch_nws
+        if self.visual_crossing_client and "visualcrossing" in active_sources:
+            fetchers["visualcrossing"] = fetch_vc
+        if self._pirate_weather_client_for_location(location) and "pirateweather" in active_sources:
+            fetchers["pirateweather"] = fetch_pw
 
-        # Check if all sources failed
+        if auto_budget == "max_coverage":
+            source_results = await self._fetch_auto_mode_sources(
+                location, coordinator, fetchers, active_sources
+            )
+        else:
+            preferred_order = (
+                ["nws", "openmeteo", "visualcrossing", "pirateweather"]
+                if is_us
+                else ["openmeteo", "pirateweather", "visualcrossing"]
+            )
+            primary_source = self._auto_primary_source(preferred_order, active_sources)
+            primary_sources = (
+                [primary_source] if primary_source and primary_source in fetchers else []
+            )
+            source_results = await self._fetch_auto_mode_sources(
+                location, coordinator, fetchers, primary_sources
+            )
+
+            fetched_sources = {source.source for source in source_results}
+            primary_result = source_results[0] if source_results else None
+            core_complete = self._source_has_complete_core_data(primary_result)
+            needs_us_openmeteo = (
+                is_us
+                and "openmeteo" in fetchers
+                and "openmeteo" not in fetched_sources
+                and (
+                    self._should_use_openmeteo_for_extended_forecast(location, source="auto")
+                    or not core_complete
+                )
+            )
+            needs_intl_alert_source = (
+                not is_us
+                and primary_source == "openmeteo"
+                and not ({"pirateweather", "visualcrossing"} & fetched_sources)
+            )
+            needs_intl_core_fallback = not is_us and not core_complete
+
+            secondary_sources: list[str] = []
+            if needs_us_openmeteo:
+                secondary_sources = ["openmeteo"]
+            elif needs_intl_alert_source or needs_intl_core_fallback:
+                if "pirateweather" in fetchers and "pirateweather" not in fetched_sources:
+                    secondary_sources = ["pirateweather"]
+                elif "visualcrossing" in fetchers and "visualcrossing" not in fetched_sources:
+                    secondary_sources = ["visualcrossing"]
+            elif auto_budget == "balanced" and is_us and not core_complete:
+                if "visualcrossing" in fetchers and "visualcrossing" not in fetched_sources:
+                    secondary_sources = ["visualcrossing"]
+                elif "pirateweather" in fetchers and "pirateweather" not in fetched_sources:
+                    secondary_sources = ["pirateweather"]
+
+            if secondary_sources:
+                source_results.extend(
+                    await self._fetch_auto_mode_sources(
+                        location, coordinator, fetchers, secondary_sources
+                    )
+                )
+
         successful_sources = [s for s in source_results if s.success]
         if not successful_sources:
-            logger.warning(f"All sources failed for {location.name}, checking cache")
+            logger.warning("All sources failed for %s, checking cache", location.name)
             return self._handle_all_sources_failed(location, source_results)
 
-        # Merge current conditions
         merged_current, current_attribution = fusion_engine.merge_current_conditions(
             source_results, location
         )
-
-        # Merge forecasts
         requested_days = getattr(self.settings, "forecast_duration_days", 7)
         merged_forecast, forecast_attribution = fusion_engine.merge_forecasts(
             source_results, location, requested_days=requested_days
         )
-
-        # Merge hourly forecasts
         merged_hourly, hourly_attribution = fusion_engine.merge_hourly_forecasts(
             source_results, location
         )
 
+        _want_start = getattr(self.settings, "notify_minutely_precipitation_start", False)
+        _want_stop = getattr(self.settings, "notify_minutely_precipitation_stop", False)
+        _pw_fetched = any(source.source == "pirateweather" for source in source_results)
         merged_minutely = None
-        if self.pirate_weather_api_key:
+        if self.pirate_weather_api_key and (_pw_fetched or _want_start or _want_stop):
             merged_minutely = await self._get_pirate_weather_minutely(location)
 
-        # Check if we got any actual data
         has_any_data = (
-            (merged_current is not None and merged_current.has_data())
-            or (merged_forecast is not None and merged_forecast.has_data())
-            or (merged_hourly is not None and merged_hourly.has_data())
+            self._source_has_core_section(merged_current)
+            or self._source_has_core_section(merged_forecast)
+            or self._source_has_core_section(merged_hourly)
         )
-
         if not has_any_data:
-            # All sources returned empty data, treat as failure
-            logger.warning(f"All sources returned empty data for {location.name}")
+            logger.warning("All sources returned empty data for %s", location.name)
             return self._handle_all_sources_failed(location, source_results)
 
-        # Aggregate alerts - for US locations, use only NWS (authoritative source)
-        # Visual Crossing mirrors NWS alerts but lacks severity/urgency metadata
         nws_alerts = None
         vc_alerts_data = None
         pw_alerts_data = None
@@ -992,22 +1069,27 @@ class WeatherClient:
             elif source.source == "pirateweather" and source.alerts:
                 pw_alerts_data = source.alerts
 
-        # For US locations, skip VC/PW alerts to avoid duplicates with missing metadata
-        if is_us:
+        if is_us and nws_alerts is not None:
             merged_alerts = alert_aggregator.aggregate_alerts(nws_alerts, None)
         else:
-            # Use whichever non-NWS source has alerts (PW preferred over VC when both present)
             non_nws_alerts = pw_alerts_data or vc_alerts_data
             merged_alerts = alert_aggregator.aggregate_alerts(nws_alerts, non_nws_alerts)
 
-        # Compute alert lifecycle diff (compare against previous fetch for this location)
         _loc_key = self._location_key(location)
         _prev_alerts = self._previous_alerts.get(_loc_key)
-        _cancel_refs = await self._fetch_nws_cancel_references()
+        _cancel_refs = (
+            await self._fetch_nws_cancel_references() if nws_alerts is not None else set()
+        )
         _alert_diff = diff_alerts(_prev_alerts, merged_alerts, confirmed_cancel_ids=_cancel_refs)
         self._previous_alerts[_loc_key] = merged_alerts
 
-        # Build source attribution
+        failed_sources = {source.source for source in source_results if not source.success}
+        contributing_sources = (
+            current_attribution.contributing_sources
+            | set(forecast_attribution.values())
+            | set(hourly_attribution.values())
+            | {source.source for source in source_results if source.alerts is not None}
+        )
         attribution = SourceAttribution(
             field_sources={
                 **current_attribution.field_sources,
@@ -1015,15 +1097,10 @@ class WeatherClient:
                 **hourly_attribution,
             },
             conflicts=current_attribution.conflicts,
-            contributing_sources=(
-                current_attribution.contributing_sources
-                | set(forecast_attribution.values())
-                | set(hourly_attribution.values())
-            ),
-            failed_sources=current_attribution.failed_sources,
+            contributing_sources=contributing_sources,
+            failed_sources=current_attribution.failed_sources | failed_sources,
         )
 
-        # Track incomplete sections
         incomplete_sections: set[str] = set()
         if merged_current is None:
             incomplete_sections.add("current")
@@ -1032,18 +1109,19 @@ class WeatherClient:
         if merged_hourly is None:
             incomplete_sections.add("hourly_forecast")
 
-        # Set appropriate discussion message based on location
-        if is_us:
+        if is_us and any(source.source == "nws" for source in source_results):
             discussion = "Forecast discussion available from NWS for US locations."
-            discussion_issuance_time = None  # Will be populated by enrichment
+            discussion_issuance_time = None
+        elif is_us:
+            discussion = (
+                "Forecast discussion is unavailable because Automatic mode did not use NWS."
+            )
+            discussion_issuance_time = None
         else:
             discussion = "Forecast discussion not available from Open-Meteo."
             discussion_issuance_time = None
 
-        # Compute cross-source forecast confidence
         confidence = calculate_forecast_confidence(source_results)
-
-        # Create the merged WeatherData
         weather_data = WeatherData(
             location=location,
             current=merged_current,
@@ -1059,20 +1137,19 @@ class WeatherClient:
         )
         weather_data.alert_lifecycle_diff = _alert_diff
 
-        # Run enrichment tasks
         if weather_data.has_any_data():
             enrichment_tasks = self._launch_enrichment_tasks(
                 weather_data, location, skip_notifications
             )
             await self._await_enrichments(enrichment_tasks, weather_data)
 
-        # Cache the result
         if weather_data.has_any_data() and self.offline_cache:
             self._persist_weather_data(location, weather_data)
 
         logger.info(
-            f"Smart auto source completed for {location.name}: "
-            f"{len(successful_sources)} sources succeeded"
+            "Smart auto source completed for %s: %d sources succeeded",
+            location.name,
+            len(successful_sources),
         )
         return weather_data
 

--- a/tests/test_auto_mode_api_budget.py
+++ b/tests/test_auto_mode_api_budget.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from accessiweather.models.config import AppSettings
+from accessiweather.models.weather import (
+    CurrentConditions,
+    Forecast,
+    ForecastPeriod,
+    HourlyForecast,
+    HourlyForecastPeriod,
+    Location,
+    WeatherAlerts,
+)
+from accessiweather.ui.dialogs.settings_tabs.data_sources import DataSourcesTab
+from accessiweather.weather_client import WeatherClient
+from accessiweather.weather_client_parallel import ParallelFetchCoordinator
+
+
+class _FakeChoice:
+    def __init__(self, selection: int = 0):
+        self.selection = selection
+        self.name = None
+
+    def SetSelection(self, selection: int) -> None:
+        self.selection = selection
+
+    def GetSelection(self) -> int:
+        return self.selection
+
+    def SetName(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeTextCtrl:
+    def __init__(self, value: str = ""):
+        self.value = value
+        self.name = None
+
+    def SetValue(self, value: str) -> None:
+        self.value = value
+
+    def GetValue(self) -> str:
+        return self.value
+
+    def Bind(self, *_args, **_kwargs) -> None:
+        return None
+
+    def SetName(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeDialog:
+    def __init__(self):
+        self._controls = {
+            "data_source": _FakeChoice(),
+            "vc_key": _FakeTextCtrl(),
+            "pw_key": _FakeTextCtrl(),
+            "source_settings_summary": _FakeTextCtrl(),
+            "configure_source_settings": _FakeChoice(),
+        }
+        self._source_settings_states = DataSourcesTab._build_default_source_settings_states()
+        self._original_vc_key = ""
+        self._original_pw_key = ""
+        self._vc_key_cleared = False
+        self._pw_key_cleared = False
+        self.api_visibility_updates = 0
+
+    def _update_api_key_visibility(self) -> None:
+        self.api_visibility_updates += 1
+
+    def _update_auto_source_key_state(self) -> None:
+        return None
+
+
+@pytest.fixture
+def us_location() -> Location:
+    return Location(name="New York", latitude=40.7128, longitude=-74.0060, country_code="US")
+
+
+@pytest.fixture
+def intl_location() -> Location:
+    return Location(name="London", latitude=51.5074, longitude=-0.1278, country_code="GB")
+
+
+def _forecast(label: str = "Today") -> Forecast:
+    return Forecast(periods=[ForecastPeriod(name=label, temperature=70)])
+
+
+def _hourly() -> HourlyForecast:
+    return HourlyForecast(
+        periods=[HourlyForecastPeriod(start_time=datetime.now(UTC), temperature=70)]
+    )
+
+
+def _current() -> CurrentConditions:
+    return CurrentConditions(temperature_f=70.0, condition="Sunny")
+
+
+async def _execute_fetch_all(self, location, **kwargs):
+    results = []
+    for name, coro in kwargs.items():
+        if coro is None:
+            continue
+        results.append(self._create_source_data(name.removeprefix("fetch_"), await coro))
+    return results
+
+
+def _stub_enrichments(client: WeatherClient) -> None:
+    client._launch_enrichment_tasks = MagicMock(return_value={})
+    client._await_enrichments = AsyncMock(return_value=None)
+    client._fetch_nws_cancel_references = AsyncMock(return_value=set())
+
+
+def test_auto_mode_api_budget_defaults_and_round_trips() -> None:
+    settings = AppSettings()
+    assert settings.auto_mode_api_budget == "economy"
+
+    restored = AppSettings.from_dict(settings.to_dict())
+    assert restored.auto_mode_api_budget == "economy"
+
+    restored.auto_mode_api_budget = "nope"
+    assert restored.validate_on_access("auto_mode_api_budget") is True
+    assert restored.auto_mode_api_budget == "economy"
+
+
+def test_data_sources_tab_budget_load_save_round_trip() -> None:
+    dialog = _FakeDialog()
+    tab = DataSourcesTab(dialog)
+    settings = AppSettings(
+        auto_mode_api_budget="balanced",
+        data_source="auto",
+        source_priority_us=["nws", "openmeteo"],
+        source_priority_international=["openmeteo", "pirateweather"],
+        auto_sources_us=["nws", "openmeteo"],
+        auto_sources_international=["openmeteo", "pirateweather"],
+        station_selection_strategy="major_airport_preferred",
+    )
+
+    tab.load(settings)
+    saved = tab.save()
+
+    assert dialog._source_settings_states["auto_mode_api_budget"] == 1
+    assert saved["auto_mode_api_budget"] == "balanced"
+    assert saved["auto_sources_us"] == ["nws", "openmeteo", "pirateweather"]
+    assert saved["auto_sources_international"] == ["openmeteo", "pirateweather"]
+    assert "Automatic mode budget: Balanced." in tab._get_source_settings_summary_text()
+
+
+@pytest.mark.asyncio
+async def test_economy_us_fetches_nws_then_openmeteo_for_extended_forecast(
+    us_location: Location,
+) -> None:
+    settings = AppSettings(
+        auto_mode_api_budget="economy",
+        forecast_duration_days=10,
+    )
+    client = WeatherClient(data_source="auto", settings=settings)
+    _stub_enrichments(client)
+    client._fetch_nws_data = AsyncMock(
+        return_value=(_current(), _forecast("NWS"), None, None, WeatherAlerts(alerts=[]), _hourly())
+    )
+    client._fetch_openmeteo_data = AsyncMock(return_value=(_current(), _forecast("OM"), _hourly()))
+    client._visual_crossing_client = MagicMock()
+    client._visual_crossing_client.get_current_conditions = AsyncMock(return_value=_current())
+    client._visual_crossing_client.get_forecast = AsyncMock(return_value=_forecast("VC"))
+    client._visual_crossing_client.get_hourly_forecast = AsyncMock(return_value=_hourly())
+    client._visual_crossing_client.get_alerts = AsyncMock(return_value=WeatherAlerts(alerts=[]))
+
+    calls: list[list[str]] = []
+
+    async def _recording_fetch_all(self, location, **kwargs):
+        calls.append(
+            [name.removeprefix("fetch_") for name, coro in kwargs.items() if coro is not None]
+        )
+        return await _execute_fetch_all(self, location, **kwargs)
+
+    with patch.object(ParallelFetchCoordinator, "fetch_all", new=_recording_fetch_all):
+        result = await client._fetch_smart_auto_source(us_location)
+
+    assert calls == [["nws"], ["openmeteo"]]
+    assert client._fetch_nws_data.await_count == 1
+    assert client._fetch_openmeteo_data.await_count == 1
+    client._visual_crossing_client.get_current_conditions.assert_not_called()
+    assert result.source_attribution is not None
+    assert "nws" in result.source_attribution.contributing_sources
+    assert "openmeteo" in result.source_attribution.contributing_sources
+
+
+@pytest.mark.asyncio
+async def test_economy_us_skips_pw_and_vc_when_nws_is_sufficient(us_location: Location) -> None:
+    settings = AppSettings(auto_mode_api_budget="economy", forecast_duration_days=7)
+    client = WeatherClient(data_source="auto", settings=settings)
+    _stub_enrichments(client)
+    client._fetch_nws_data = AsyncMock(
+        return_value=(_current(), _forecast("NWS"), None, None, WeatherAlerts(alerts=[]), _hourly())
+    )
+    client._fetch_openmeteo_data = AsyncMock(return_value=(_current(), _forecast("OM"), _hourly()))
+
+    vc_client = MagicMock()
+    vc_client.get_current_conditions = AsyncMock(return_value=_current())
+    vc_client.get_forecast = AsyncMock(return_value=_forecast("VC"))
+    vc_client.get_hourly_forecast = AsyncMock(return_value=_hourly())
+    vc_client.get_alerts = AsyncMock(return_value=WeatherAlerts(alerts=[]))
+    client._visual_crossing_client = vc_client
+
+    with patch.object(ParallelFetchCoordinator, "fetch_all", new=_execute_fetch_all):
+        await client._fetch_smart_auto_source(us_location)
+
+    client._fetch_openmeteo_data.assert_not_called()
+    vc_client.get_current_conditions.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_balanced_us_can_use_one_non_openmeteo_secondary_when_needed(
+    us_location: Location,
+) -> None:
+    settings = AppSettings(
+        auto_mode_api_budget="balanced",
+        auto_sources_us=["nws", "visualcrossing"],
+        forecast_duration_days=7,
+    )
+    client = WeatherClient(
+        data_source="auto", settings=settings, visual_crossing_api_key="test-key"
+    )
+    _stub_enrichments(client)
+    client._fetch_nws_data = AsyncMock(
+        return_value=(None, _forecast("NWS"), None, None, WeatherAlerts(alerts=[]), None)
+    )
+
+    vc_client = MagicMock()
+    vc_client.get_current_conditions = AsyncMock(return_value=_current())
+    vc_client.get_forecast = AsyncMock(return_value=_forecast("VC"))
+    vc_client.get_hourly_forecast = AsyncMock(return_value=_hourly())
+    vc_client.get_alerts = AsyncMock(return_value=WeatherAlerts(alerts=[]))
+    client._visual_crossing_client = vc_client
+
+    calls: list[list[str]] = []
+
+    async def _recording_fetch_all(self, location, **kwargs):
+        calls.append(
+            [name.removeprefix("fetch_") for name, coro in kwargs.items() if coro is not None]
+        )
+        return await _execute_fetch_all(self, location, **kwargs)
+
+    with patch.object(ParallelFetchCoordinator, "fetch_all", new=_recording_fetch_all):
+        result = await client._fetch_smart_auto_source(us_location)
+
+    assert calls == [["nws"], ["visualcrossing"]]
+    vc_client.get_current_conditions.assert_awaited_once()
+    assert result.source_attribution is not None
+    assert "visualcrossing" in result.source_attribution.contributing_sources
+
+
+@pytest.mark.asyncio
+async def test_notification_event_data_keeps_pirate_weather_minutely_path(
+    intl_location: Location,
+) -> None:
+    settings = AppSettings(notify_minutely_precipitation_start=True)
+    client = WeatherClient(data_source="auto", settings=settings, pirate_weather_api_key="test-key")
+
+    vc_client = MagicMock()
+    vc_client.get_current_conditions = AsyncMock(return_value=_current())
+    vc_client.get_alerts = AsyncMock(return_value=WeatherAlerts(alerts=[]))
+    client._visual_crossing_client = vc_client
+
+    pw_client = MagicMock()
+    client._pirate_weather_client = pw_client
+    client._get_pirate_weather_minutely = AsyncMock(
+        return_value=SimpleNamespace(summary="rain soon")
+    )
+
+    result = await client.get_notification_event_data(intl_location)
+
+    vc_client.get_current_conditions.assert_awaited_once_with(intl_location)
+    vc_client.get_alerts.assert_awaited_once_with(intl_location)
+    client._get_pirate_weather_minutely.assert_awaited_once_with(intl_location)
+    assert result.minutely_precipitation is not None

--- a/tests/test_auto_mode_api_budget.py
+++ b/tests/test_auto_mode_api_budget.py
@@ -118,14 +118,20 @@ def _stub_enrichments(client: WeatherClient) -> None:
 
 def test_auto_mode_api_budget_defaults_and_round_trips() -> None:
     settings = AppSettings()
-    assert settings.auto_mode_api_budget == "economy"
+    assert settings.auto_mode_api_budget == "max_coverage"
 
     restored = AppSettings.from_dict(settings.to_dict())
-    assert restored.auto_mode_api_budget == "economy"
+    assert restored.auto_mode_api_budget == "max_coverage"
+
+    restored = AppSettings.from_dict({})
+    assert restored.auto_mode_api_budget == "max_coverage"
 
     restored.auto_mode_api_budget = "nope"
     assert restored.validate_on_access("auto_mode_api_budget") is True
-    assert restored.auto_mode_api_budget == "economy"
+    assert restored.auto_mode_api_budget == "max_coverage"
+
+    restored = AppSettings.from_dict({"auto_mode_api_budget": "nope"})
+    assert restored.auto_mode_api_budget == "max_coverage"
 
 
 def test_data_sources_tab_budget_load_save_round_trip() -> None:
@@ -146,9 +152,86 @@ def test_data_sources_tab_budget_load_save_round_trip() -> None:
 
     assert dialog._source_settings_states["auto_mode_api_budget"] == 1
     assert saved["auto_mode_api_budget"] == "balanced"
-    assert saved["auto_sources_us"] == ["nws", "openmeteo", "pirateweather"]
+    assert saved["auto_sources_us"] == ["nws", "openmeteo"]
     assert saved["auto_sources_international"] == ["openmeteo", "pirateweather"]
     assert "Automatic mode budget: Balanced." in tab._get_source_settings_summary_text()
+
+
+def test_data_sources_tab_preserves_exact_regional_auto_source_split() -> None:
+    dialog = _FakeDialog()
+    tab = DataSourcesTab(dialog)
+    settings = AppSettings(
+        auto_sources_us=["nws", "openmeteo", "visualcrossing"],
+        auto_sources_international=["openmeteo", "pirateweather"],
+        source_priority_us=["nws", "openmeteo", "visualcrossing"],
+        source_priority_international=["openmeteo", "pirateweather"],
+    )
+
+    tab.load(settings)
+    saved = tab.save()
+
+    assert dialog._source_settings_states["auto_sources_us"] == [
+        "nws",
+        "openmeteo",
+        "visualcrossing",
+    ]
+    assert dialog._source_settings_states["auto_sources_international"] == [
+        "openmeteo",
+        "pirateweather",
+    ]
+    assert saved["auto_sources_us"] == ["nws", "openmeteo", "visualcrossing"]
+    assert saved["auto_sources_international"] == ["openmeteo", "pirateweather"]
+    assert saved["source_priority_us"] == ["nws", "openmeteo", "visualcrossing"]
+    assert saved["source_priority_international"] == ["openmeteo", "pirateweather"]
+
+
+@pytest.mark.asyncio
+async def test_default_auto_mode_max_coverage_fetches_all_enabled_sources(
+    us_location: Location,
+) -> None:
+    client = WeatherClient(
+        data_source="auto",
+        settings=AppSettings(),
+        visual_crossing_api_key="test-key",
+        pirate_weather_api_key="test-key",
+    )
+    _stub_enrichments(client)
+    client._fetch_nws_data = AsyncMock(
+        return_value=(_current(), _forecast("NWS"), None, None, WeatherAlerts(alerts=[]), _hourly())
+    )
+    client._fetch_openmeteo_data = AsyncMock(return_value=(_current(), _forecast("OM"), _hourly()))
+
+    vc_client = MagicMock()
+    vc_client.get_current_conditions = AsyncMock(return_value=_current())
+    vc_client.get_forecast = AsyncMock(return_value=_forecast("VC"))
+    vc_client.get_hourly_forecast = AsyncMock(return_value=_hourly())
+    vc_client.get_alerts = AsyncMock(return_value=WeatherAlerts(alerts=[]))
+    client._visual_crossing_client = vc_client
+
+    pw_client = MagicMock()
+    pw_client.get_current_conditions = AsyncMock(return_value=_current())
+    pw_client.get_forecast = AsyncMock(return_value=_forecast("PW"))
+    pw_client.get_hourly_forecast = AsyncMock(return_value=_hourly())
+    pw_client.get_alerts = AsyncMock(return_value=WeatherAlerts(alerts=[]))
+    client._pirate_weather_client = pw_client
+    client._pirate_weather_client_for_location = MagicMock(return_value=pw_client)
+
+    calls: list[list[str]] = []
+
+    async def _recording_fetch_all(self, location, **kwargs):
+        calls.append(
+            [name.removeprefix("fetch_") for name, coro in kwargs.items() if coro is not None]
+        )
+        return await _execute_fetch_all(self, location, **kwargs)
+
+    with patch.object(ParallelFetchCoordinator, "fetch_all", new=_recording_fetch_all):
+        result = await client._fetch_smart_auto_source(us_location)
+
+    assert calls == [["nws", "openmeteo", "visualcrossing", "pirateweather"]]
+    assert result.source_attribution is not None
+    assert {"nws", "openmeteo", "visualcrossing", "pirateweather"}.issubset(
+        result.source_attribution.contributing_sources
+    )
 
 
 @pytest.mark.asyncio
@@ -254,6 +337,92 @@ async def test_balanced_us_can_use_one_non_openmeteo_secondary_when_needed(
     vc_client.get_current_conditions.assert_awaited_once()
     assert result.source_attribution is not None
     assert "visualcrossing" in result.source_attribution.contributing_sources
+
+
+@pytest.mark.asyncio
+async def test_balanced_us_uses_user_configured_secondary_order(us_location: Location) -> None:
+    settings = AppSettings(
+        auto_mode_api_budget="balanced",
+        auto_sources_us=["nws", "pirateweather", "visualcrossing"],
+    )
+    client = WeatherClient(data_source="auto", settings=settings, pirate_weather_api_key="test-key")
+    _stub_enrichments(client)
+    client._fetch_nws_data = AsyncMock(
+        return_value=(None, _forecast("NWS"), None, None, WeatherAlerts(alerts=[]), None)
+    )
+
+    pw_client = MagicMock()
+    pw_client.get_current_conditions = AsyncMock(return_value=_current())
+    pw_client.get_forecast = AsyncMock(return_value=_forecast("PW"))
+    pw_client.get_hourly_forecast = AsyncMock(return_value=_hourly())
+    pw_client.get_alerts = AsyncMock(return_value=WeatherAlerts(alerts=[]))
+    client._pirate_weather_client = pw_client
+    client._pirate_weather_client_for_location = MagicMock(return_value=pw_client)
+
+    vc_client = MagicMock()
+    vc_client.get_current_conditions = AsyncMock(return_value=_current())
+    vc_client.get_forecast = AsyncMock(return_value=_forecast("VC"))
+    vc_client.get_hourly_forecast = AsyncMock(return_value=_hourly())
+    vc_client.get_alerts = AsyncMock(return_value=WeatherAlerts(alerts=[]))
+    client._visual_crossing_client = vc_client
+
+    calls: list[list[str]] = []
+
+    async def _recording_fetch_all(self, location, **kwargs):
+        calls.append(
+            [name.removeprefix("fetch_") for name, coro in kwargs.items() if coro is not None]
+        )
+        return await _execute_fetch_all(self, location, **kwargs)
+
+    with patch.object(ParallelFetchCoordinator, "fetch_all", new=_recording_fetch_all):
+        await client._fetch_smart_auto_source(us_location)
+
+    assert calls == [["nws"], ["pirateweather"]]
+    pw_client.get_current_conditions.assert_awaited_once()
+    vc_client.get_current_conditions.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_balanced_international_uses_configured_primary_order(
+    intl_location: Location,
+) -> None:
+    settings = AppSettings(
+        auto_mode_api_budget="balanced",
+        auto_sources_international=["visualcrossing", "pirateweather"],
+    )
+    client = WeatherClient(
+        data_source="auto", settings=settings, visual_crossing_api_key="test-key"
+    )
+    _stub_enrichments(client)
+
+    vc_client = MagicMock()
+    vc_client.get_current_conditions = AsyncMock(return_value=_current())
+    vc_client.get_forecast = AsyncMock(return_value=_forecast("VC"))
+    vc_client.get_hourly_forecast = AsyncMock(return_value=_hourly())
+    vc_client.get_alerts = AsyncMock(return_value=WeatherAlerts(alerts=[]))
+    client._visual_crossing_client = vc_client
+
+    pw_client = MagicMock()
+    pw_client.get_current_conditions = AsyncMock(return_value=_current())
+    pw_client.get_forecast = AsyncMock(return_value=_forecast("PW"))
+    pw_client.get_hourly_forecast = AsyncMock(return_value=_hourly())
+    pw_client.get_alerts = AsyncMock(return_value=WeatherAlerts(alerts=[]))
+    client._pirate_weather_client = pw_client
+
+    calls: list[list[str]] = []
+
+    async def _recording_fetch_all(self, location, **kwargs):
+        calls.append(
+            [name.removeprefix("fetch_") for name, coro in kwargs.items() if coro is not None]
+        )
+        return await _execute_fetch_all(self, location, **kwargs)
+
+    with patch.object(ParallelFetchCoordinator, "fetch_all", new=_recording_fetch_all):
+        await client._fetch_smart_auto_source(intl_location)
+
+    assert calls == [["visualcrossing"]]
+    vc_client.get_current_conditions.assert_awaited_once()
+    pw_client.get_current_conditions.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_settings_dialog_ux_metadata.py
+++ b/tests/test_settings_dialog_ux_metadata.py
@@ -53,7 +53,8 @@ def test_source_settings_summary_uses_plain_language():
     }
 
     assert DataSourcesTab.build_source_settings_summary_text(state) == (
-        "Automatic mode uses: NWS, Open-Meteo, Pirate Weather. "
+        "Automatic mode budget: Economy. "
+        "Allowed automatic sources: NWS, Open-Meteo, Pirate Weather. "
         "NWS station strategy: Major airport preferred."
     )
 

--- a/tests/test_settings_dialog_ux_metadata.py
+++ b/tests/test_settings_dialog_ux_metadata.py
@@ -45,16 +45,16 @@ def test_audio_event_sound_summary_mentions_sound_choices_clearly():
 
 def test_source_settings_summary_uses_plain_language():
     state = {
-        "auto_use_nws": True,
-        "auto_use_openmeteo": True,
-        "auto_use_visualcrossing": False,
-        "auto_use_pirateweather": True,
+        "auto_mode_api_budget": 2,
+        "auto_sources_us": ["nws", "openmeteo", "pirateweather"],
+        "auto_sources_international": ["openmeteo", "pirateweather"],
         "station_selection_strategy": 2,
     }
 
     assert DataSourcesTab.build_source_settings_summary_text(state) == (
-        "Automatic mode budget: Economy. "
-        "Allowed automatic sources: NWS, Open-Meteo, Pirate Weather. "
+        "Automatic mode budget: Max coverage. "
+        "US automatic sources: NWS, Open-Meteo, Pirate Weather. "
+        "International automatic sources: Open-Meteo, Pirate Weather. "
         "NWS station strategy: Major airport preferred."
     )
 


### PR DESCRIPTION
## Summary
- preserve Automatic mode as a fusion-first experience by default via `max_coverage`
- keep `economy` and `balanced` as explicit opt-in reduced-call modes instead of redefining Automatic mode for everyone
- preserve exact US and international automatic-source customization in the settings UI and saved config
- make staged automatic fetches honor the user-configured source order for primary and fallback decisions
- preserve notification and Pirate Weather minutely behavior while adding regression coverage for the auto-mode semantics above

## Why
Automatic mode is supposed to combine the enabled sources to get the richest result from each provider. This PR keeps that product behavior intact by default while still offering lower-call modes for users who explicitly want them.

## Auto mode behavior after this change
- Default (`max_coverage`): fetch all enabled automatic sources and fuse them
- `economy`: reduced-call staged fetching, explicit opt-in
- `balanced`: reduced-call staged fetching with one useful fallback, explicit opt-in
- staged fetch order follows the saved user-configured source ordering
- US and international source lists remain separate and round-trip exactly

## Testing
- `ruff format src/accessiweather/models/config.py src/accessiweather/ui/dialogs/settings_dialog.py src/accessiweather/ui/dialogs/settings_tabs/data_sources.py src/accessiweather/weather_client_base.py tests/test_auto_mode_api_budget.py tests/test_settings_dialog_ux_metadata.py`
- `ruff check src/accessiweather/models/config.py src/accessiweather/ui/dialogs/settings_dialog.py src/accessiweather/ui/dialogs/settings_tabs/data_sources.py src/accessiweather/weather_client_base.py tests/test_auto_mode_api_budget.py tests/test_settings_dialog_ux_metadata.py`
- `pytest -q tests/test_auto_mode_api_budget.py tests/test_settings_dialog_ux_metadata.py tests/test_split_notification_timers.py tests/test_nws_afd_notification.py tests/test_models.py`
- `pytest -q`

## Verification highlights
- default Automatic mode still fans out across all enabled sources and fuses the combined result
- reduced-call behavior only applies when the user explicitly selects `economy` or `balanced`
- US and international auto-source lists round-trip exactly
- staged fetch order follows the saved source lists rather than hardcoded provider precedence