### PR TITLE
docs: rewrite user manual to match current UI and auto mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,89 +7,76 @@ Accessible desktop weather for Windows, macOS, and Linux.
 [![Built with wxPython](https://img.shields.io/badge/Built%20with-wxPython-blue)](https://wxpython.org/)
 ![Platforms](https://img.shields.io/badge/Platforms-Windows%20%7C%20macOS%20%7C%20Linux-informational)
 
-AccessiWeather is a screen-reader-friendly weather app with keyboard navigation, desktop notifications, optional alert sounds, and multiple weather sources. It separates current conditions, daily forecast, hourly forecast, and alerts so the information is easier to scan with speech or braille.
+AccessiWeather is a screen-reader-friendly weather app with keyboard navigation, desktop notifications, optional alert sounds, and multiple weather providers. It keeps current conditions, daily forecast, hourly forecast, and alerts in separate sections so the information is easier to scan with speech or braille.
 
-## What It Does
+## User Manual
 
-- Combines multiple weather sources instead of locking you to one provider
-- Shows separate `Current Conditions`, `Daily Forecast`, `Hourly Forecast`, and `Weather Alerts` sections
-- Supports US and international locations
-- Tracks alert lifecycle changes such as new, updated, escalated, extended, and cancelled alerts
-- Offers optional AI weather explanations and a conversational Weather Assistant
-- Includes weather history, air quality, UV index, aviation weather, NOAA Weather Radio, and sound pack support
+For setup instructions, everyday workflows, settings, troubleshooting, and weather-source guidance, see the full [User Manual](docs/user_manual.md).
+
+## Highlights
+
+- Accessible desktop weather designed for screen readers and keyboard use
+- Separate Current Conditions, Daily Forecast, Hourly Forecast, and Weather Alerts sections
+- Support for US and international locations
+- Forecast discussions, weather history, air quality, UV, aviation weather, and NOAA Weather Radio
+- Optional AI explanations and Weather Assistant chat through OpenRouter
+- Optional notification sounds and sound packs
 
 ## Weather Sources
 
-AccessiWeather supports four weather providers:
+AccessiWeather supports four providers:
 
-- **National Weather Service (NWS)**: Best for US forecasts, US alerts, and forecast discussions. This is the authoritative alert source for US locations.
-- **Open-Meteo**: No API key required. Good global baseline forecasts, Open-Meteo model selection, and broad international coverage. It does not provide weather alerts in AccessiWeather.
-- **Pirate Weather**: Optional API key. Best when you want worldwide WMO alerts, minutely precipitation guidance, and Dark Sky-style daily summaries. It is especially useful outside the US.
-- **Visual Crossing**: Optional API key. Useful for weather history, global forecasts, and some alert coverage where available.
+- National Weather Service (NWS): best for US forecasts, US alerts, and forecast discussions
+- Open-Meteo: global no-key forecast coverage
+- Pirate Weather: optional key, global alerts, minutely precipitation, and summary-style forecasts
+- Visual Crossing: optional key, global forecast enrichment and weather history support
 
-### Automatic Mode
+### Automatic mode
 
-`Automatic` is the default. It merges available sources and uses source priority rules to fill gaps.
+Automatic is the default source mode.
 
-- For **US locations**, AccessiWeather uses **NWS alerts only**. Pirate Weather and Visual Crossing alerts are intentionally ignored there to avoid duplicate alerts with weaker metadata.
-- For **international locations**, AccessiWeather uses **Pirate Weather alerts when available**, otherwise **Visual Crossing** if configured.
-- If you add a Pirate Weather key, Automatic mode can also pull **minutely precipitation** guidance.
-- `Automatic` still uses your configured **US** and **International** source-priority presets for current conditions and forecast merging.
+- Default behavior is Max coverage, a fusion-first mode that combines all enabled and available sources for the current region.
+- Economy and Balanced are optional reduced-call modes.
+- US and international automatic source lists are configured separately.
+- Automatic mode follows your saved source ordering.
+- US alerts use NWS as the authoritative source when available.
+- International alerts prefer Pirate Weather, then Visual Crossing.
 
-## Alerts
-
-Alert behavior depends on the source and location:
-
-- **NWS alerts**: Best for US users. They include stronger metadata such as severity, urgency, certainty, and NWS-specific targeting options.
-- **Pirate Weather alerts**: Based on worldwide WMO alert feeds. These are useful outside the US, but they may be broader regional alerts and may not match your exact county or zone.
-- **Visual Crossing alerts**: Available in some regions, but they are generally less detailed than NWS for US use.
-
-In the app you can:
-
-- Enable or disable alerts entirely
-- Enable desktop alert notifications separately
-- Choose alert area behavior for NWS alerts: county, point, zone, or state
-- Filter notifications by severity
-- Turn on event notifications for forecast discussion updates, severe risk changes, and minutely precipitation start/stop
+For the full explanation of source behavior, see the [User Manual](docs/user_manual.md#6-weather-sources-and-automatic-mode).
 
 ## Optional API Keys
 
 AccessiWeather works without paid services, but some features need optional keys:
 
-- **Pirate Weather**: Global alerts, minutely precipitation, Dark Sky-style summaries
-  - Get a key at [pirate-weather.apiable.io](https://pirate-weather.apiable.io/)
-- **Visual Crossing**: Weather history, global forecast enrichment, some regional alerts
-  - Get a key at [visualcrossing.com/weather-api](https://www.visualcrossing.com/weather-api)
-- **OpenRouter**: Required for `Explain Weather` and `Weather Assistant`
-  - Get a key at [openrouter.ai/keys](https://openrouter.ai/keys)
-- **AVWX**: Optional for better international aviation weather translations and speech output
-  - Entered from the `Aviation Weather` dialog, not the main Settings dialog
-  - Get a key at [account.avwx.rest](https://account.avwx.rest)
+- Pirate Weather: global alerts, minutely precipitation, Dark Sky-style summaries
+  - https://pirate-weather.apiable.io/
+- Visual Crossing: weather history and additional global coverage
+  - https://www.visualcrossing.com/weather-api
+- OpenRouter: Explain Weather and Weather Assistant
+  - https://openrouter.ai/keys
+- AVWX: optional extra support for international aviation weather
+  - https://account.avwx.rest
 
-API keys are stored in your system keyring by default.
-
-### Portable API Key Transfer
-
-Settings export/import does not include API keys. If you want to move keys between machines:
-
-1. Open `Settings > Advanced`.
-2. Choose `Export API keys (encrypted)`.
-3. Save the encrypted bundle and remember the passphrase.
-4. On the other machine, use `Import API keys (encrypted)` and enter the same passphrase.
+API keys are stored in your system keyring by default. In portable mode, encrypted API key bundles are used instead.
 
 ## Install
 
-### Prebuilt Downloads
+### Prebuilt downloads
 
-Download builds from [orinks.net/accessiweather](https://orinks.net/accessiweather) or the [GitHub releases page](https://github.com/Orinks/AccessiWeather/releases).
+Download builds from:
 
-- **Windows**: MSI installer or portable ZIP
-- **macOS**: DMG
-- **Linux**: Build from source for now
+- https://orinks.net/accessiweather
+- https://github.com/Orinks/AccessiWeather/releases
 
-### Run From Source
+Packages currently include:
 
-Using `uv`:
+- Windows: MSI installer or portable ZIP
+- macOS: DMG
+- Linux: run from source
+
+### Run from source
+
+Using uv:
 
 ```bash
 git clone https://github.com/Orinks/AccessiWeather.git
@@ -109,64 +96,19 @@ pip install -e ".[dev]"
 accessiweather
 ```
 
-Portable mode is also available:
+Portable mode:
 
 ```bash
 accessiweather --portable
 ```
 
-## First Run
-
-On a fresh setup, AccessiWeather shows a short onboarding wizard.
+## Quick start
 
 1. Launch AccessiWeather.
-2. In the onboarding wizard, add your first location or skip it for now.
-3. Optionally enter OpenRouter, Visual Crossing, and Pirate Weather API keys during onboarding.
-4. In portable mode, if you enter API keys, you can also create an encrypted portable key bundle during onboarding.
-5. After the wizard closes, review the readiness summary, then refresh to load current conditions, daily forecast, hourly forecast, and alerts.
-
-If you need to run the onboarding wizard again manually, launch the app with `--wizard`.
-
-## Main Views
-
-- **Current Conditions**: Temperature, condition, wind, humidity, and other enabled metrics
-- **Daily Forecast**: Multi-day forecast in its own section
-- **Hourly Forecast**: Separate short-range outlook with configurable hour count
-- **Weather Alerts**: Active alerts with lifecycle labels when alerts change
-- **Forecast Discussion**: NWS Area Forecast Discussion for US locations
-- **Explain Weather**: One-shot AI summary of the current weather
-- **Weather Assistant**: Chat-style AI weather help
-
-The main window also includes quick-action buttons for common tasks such as Add, Remove, Refresh, Explain, Discussion, Settings, and View Alert Details.
-
-If Pirate Weather minutely data is available, AccessiWeather adds a short precipitation outlook to current conditions and can notify you when precipitation is about to start or stop.
-
-## Settings Overview
-
-The Settings dialog currently includes these tabs:
-
-- **General**: Update interval, Nationwide location, tray text
-- **Display**: Units, visible metrics, forecast length, hourly hours, time display, verbosity
-- **Data Sources**: Source selection, Pirate Weather key, Visual Crossing key, Open-Meteo model, NWS station selection
-- **Notifications**: Alert behavior, severities, event notifications, cooldowns
-- **Audio**: Sound packs and per-event sound controls
-- **Updates**: Update channel and check interval
-- **AI**: OpenRouter key, model, explanation style, custom prompts
-- **Advanced**: Portable/config tools, settings backup, encrypted API key transfer, resets
-
-## Keyboard Shortcuts
-
-The current code binds these global shortcuts:
-
-- `Ctrl+R` or `F5`: Refresh weather
-- `Ctrl+L`: Add location
-- `Ctrl+D`: Remove location
-- `Ctrl+H`: Weather history
-- `Ctrl+S`: Open settings
-- `Ctrl+Q`: Quit
-- `Ctrl+E`: Explain Weather
-- `Ctrl+T`: Open Weather Assistant
-- `Ctrl+Shift+R`: Open NOAA Weather Radio
+2. Add your first location when prompted, or later with Ctrl+L.
+3. Leave the weather source on Automatic unless you want a specific provider.
+4. Refresh to load current conditions, forecast, and alerts.
+5. Open the [User Manual](docs/user_manual.md) for detailed settings and troubleshooting help.
 
 ## Documentation
 
@@ -177,10 +119,10 @@ The current code binds these global shortcuts:
 
 ## Support
 
-- [GitHub Issues](https://github.com/Orinks/AccessiWeather/issues)
-- [GitHub Discussions](https://github.com/Orinks/AccessiWeather/discussions)
-- [Project website](https://orinks.net/accessiweather)
-- [GitHub Releases](https://github.com/Orinks/AccessiWeather/releases)
+- https://github.com/Orinks/AccessiWeather/issues
+- https://github.com/Orinks/AccessiWeather/discussions
+- https://orinks.net/accessiweather
+- https://github.com/Orinks/AccessiWeather/releases
 
 ## Contributing
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -486,7 +486,7 @@ The Settings dialog is organized in this order:
 
 1. General
 2. Display
-3. Notifications
+3. Alerts
 4. Audio
 5. Data Sources
 6. AI
@@ -574,9 +574,9 @@ You can choose:
 
 Use these controls to make the forecast shorter or more detailed.
 
-### Notifications
+### Alerts
 
-Use the Notifications tab to control alerts, event notifications, and rate limiting.
+Use the Alerts tab to control alert handling, event notifications, and rate limiting.
 
 #### Alert delivery
 
@@ -827,7 +827,7 @@ What to try:
 1. Check whether the location is in the US or outside it.
 2. For US locations, remember that NWS is the authoritative alert source in Automatic mode.
 3. For international locations, add a Pirate Weather key if you want broader alert coverage.
-4. Review Alert Area and severity settings in Settings > Notifications.
+4. Review Alert Area and severity settings in Settings > Alerts.
 5. Make sure alert monitoring and alert notifications are enabled.
 
 ### Problem: Forecast discussion is unavailable

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1,31 +1,38 @@
 # AccessiWeather User Manual
 
-## What AccessiWeather Is
+## 1. Introduction
 
-AccessiWeather is an accessible desktop weather app built with wxPython. It is designed to work well with screen readers, keyboard navigation, and standard desktop notifications.
+AccessiWeather is an accessible desktop weather application for Windows, macOS, and Linux. It is designed to work well with screen readers, keyboard navigation, desktop notifications, and clear text layouts.
 
-The main window keeps weather split into separate sections so you do not have to dig through one long block of text:
+Instead of mixing everything into one long report, AccessiWeather separates weather into practical sections:
 
-- `Current Conditions`
-- `Daily Forecast`
-- `Hourly Forecast`
-- `Weather Alerts`
+- Current Conditions
+- Daily Forecast
+- Hourly Forecast
+- Weather Alerts
 
-The app also includes forecast discussions, air quality, UV index, aviation weather, NOAA Weather Radio, AI weather explanations, Weather Assistant chat, and optional alert sounds.
+The app can also provide forecast discussions, air quality details, UV details, aviation weather, NOAA Weather Radio access, AI weather explanations, Weather Assistant chat, and optional notification sounds.
 
-## Install and Launch
+This manual explains how to install the app, add locations, read the weather, choose weather sources, manage alerts and notifications, and adjust settings.
 
-### Prebuilt Downloads
+## 2. Installing and starting AccessiWeather
 
-Download builds from [orinks.net/accessiweather](https://orinks.net/accessiweather) or the [GitHub releases page](https://github.com/Orinks/AccessiWeather/releases).
+### Downloading a build
+
+Prebuilt downloads are available from:
+
+- https://orinks.net/accessiweather
+- https://github.com/Orinks/AccessiWeather/releases
+
+Typical download options are:
 
 - Windows: MSI installer or portable ZIP
 - macOS: DMG
 - Linux: run from source
 
-### Run From Source
+### Running from source
 
-Using `uv`:
+Using uv:
 
 ```bash
 git clone https://github.com/Orinks/AccessiWeather.git
@@ -45,1331 +52,920 @@ pip install -e ".[dev]"
 accessiweather
 ```
 
-### Portable Mode
+### Portable mode
 
-Portable mode keeps the app's data next to the app instead of using your normal per-user config location.
+Portable mode keeps AccessiWeather's configuration next to the app instead of storing it in your normal user profile.
+
+Use portable mode when:
+
+- you want to carry the app on removable storage
+- you want the app and its settings to travel together
+- you do not want this installation to use your usual per-user config location
+
+Start portable mode with:
 
 ```bash
 accessiweather --portable
 ```
 
-## First-Time Setup
+In portable mode, encrypted API key bundles are used instead of normal keyring storage.
 
-On a fresh setup, AccessiWeather shows a short onboarding wizard.
+## 3. First-time setup
 
-What the onboarding wizard does:
+When you start AccessiWeather for the first time, it shows a short onboarding wizard.
 
-1. Offers to add your first location right away.
-2. Lets you enter an optional OpenRouter API key for AI features.
-3. Lets you enter an optional Visual Crossing API key.
-4. Lets you enter an optional Pirate Weather API key.
-5. In portable mode, if you entered keys, offers to save them in an encrypted portable key bundle.
-6. Ends with a readiness summary showing what was configured.
+The wizard walks you through these steps:
 
-You can skip any optional key step and configure those features later in `Settings`.
+1. Add your first location, or skip it for now.
+2. Enter an OpenRouter API key if you want AI features.
+3. Enter a Visual Crossing API key if you want that provider.
+4. Enter a Pirate Weather API key if you want that provider.
+5. In portable mode, choose a passphrase to save entered keys into an encrypted portable bundle.
 
-After onboarding:
+At the end, AccessiWeather shows a readiness summary.
 
-1. Leave `Nationwide` visible if you want access to national forecast discussions; hide it later if you do not use it.
-2. If you skipped adding a location during onboarding, add one with `Location > Add Location` or `Ctrl+L`.
-3. Leave `Settings > Data Sources > Weather Data Source` on `Automatic` unless you have a specific reason to force one provider.
-4. Refresh weather if the app has not already done it for you.
+You can safely skip any optional key step. The app works without paid services, and you can add keys later in Settings.
 
-If you want to force the onboarding wizard to appear again later, start AccessiWeather with:
+To run the onboarding wizard again manually, start the app with:
 
 ```bash
 accessiweather --wizard
 ```
 
-## Adding and Managing Locations
+### Recommended first setup
 
-Use `Location > Add Location` to add places to your saved list.
+For the smoothest first experience, do the following:
 
-The add-location dialog works like this:
+1. Add at least one location.
+2. Leave the weather source set to Automatic unless you have a reason to force one provider.
+3. Refresh weather if the app has not already done so.
+4. Open Settings only after you have seen the basic forecast once.
 
-1. Type a friendly name in `Location Name`.
-2. Search by city name or ZIP/postal code.
-3. Select one of the search results.
-4. Save the location.
+## 4. Everyday tasks
 
-Important details:
+### Add your first location
 
-- The location name must be unique in your saved list.
-- You cannot save a location until you search and select a result.
+To add a location:
+
+1. Open Location > Add Location, or press Ctrl+L.
+2. Enter a friendly name in Location Name.
+3. Search by city name or ZIP or postal code.
+4. Select one result from the results list.
+5. Save the location.
+
+Important things to know:
+
+- The name must be unique in your saved list.
+- You cannot save the location until you choose a search result.
 - Double-clicking a search result also saves it.
-- `Nationwide` is a built-in pseudo-location, not a normal city.
 
-Use `Location > Remove Location` or `Ctrl+D` to remove the currently selected saved location. The app will not let you remove your last remaining location.
+### Switch locations
 
-## Main Window
+Use the location selector near the top of the main window to switch between saved places.
 
-The main window is not just a read-only weather display. It also includes a row of quick-action buttons so you do not have to open the menu bar for common tasks.
+When you switch locations, AccessiWeather may show cached weather first and then refresh in the background.
 
-### Quick-Action Buttons
+### Refresh weather now
 
-The main window includes these buttons:
+To refresh the selected location immediately:
 
-- `Add`: open the add-location dialog
-- `Remove`: remove the currently selected saved location
-- `Refresh`: refresh the selected location now
-- `Explain`: open a one-shot AI explanation of the current weather
-- `Discussion`: open the forecast discussion for the current location
-- `Settings`: open the Settings dialog
-- `View Alert Details`: open the full text of the selected alert when alerts are present
+- press F5
+- press Ctrl+R
+- choose View > Refresh
+- use the Refresh button in the main window
 
-### Location Selector
+### Remove a location
 
-The location drop-down at the top picks which saved location the app should show. When you switch locations, AccessiWeather may show cached data first and then refresh in the background.
+To remove the current location:
+
+- choose Location > Remove Location
+- or press Ctrl+D
+- or use the Remove button
+
+AccessiWeather will not let you remove your last remaining location.
+
+### Open the forecast discussion
+
+To open a forecast discussion:
+
+- use the Discussion button
+- or choose View > Forecast Discussion
+
+For normal US locations, this opens the local NWS Area Forecast Discussion.
+
+If Nationwide is selected, AccessiWeather opens national discussion products instead.
+
+If your current source or location does not support forecast discussions, the discussion may be unavailable.
+
+### View alert details
+
+To read the full text of an alert:
+
+1. Move to the Weather Alerts section.
+2. Select the alert you want.
+3. Choose View Alert Details, or press Enter or Space on the selected alert.
+
+### Open Settings
+
+To open Settings:
+
+- press Ctrl+S
+- choose File > Settings
+- use the Settings button
+
+## 5. Understanding the main window
+
+The main window is designed for quick keyboard and screen-reader use.
+
+### Quick-action buttons
+
+The button row provides common actions without requiring the menu bar:
+
+- Add
+- Remove
+- Refresh
+- Explain
+- Discussion
+- Settings
+- View Alert Details
+
+### Location selector
+
+The location selector chooses which saved place is currently shown.
 
 ### Current Conditions
 
-This section shows the latest current weather. Depending on source availability and your display settings, it can include:
+This section shows the latest current weather report. Depending on source availability and your display settings, it may include:
 
-- Temperature
-- Feels-like temperature
-- Wind
-- Humidity
-- Dew point
-- Visibility
+- temperature
+- feels-like temperature
+- wind
+- humidity
+- dew point
+- visibility
 - UV index
-- Pressure trend
-- Air quality
-- Pollen
+- pressure trend
+- air quality
+- pollen or impact summaries when available
 
-If Pirate Weather minutely data is available, current conditions can also include a short precipitation outlook such as rain starting or stopping soon.
+If Pirate Weather minutely precipitation data is available, this section can also mention near-term precipitation start or stop timing.
 
 ### Daily Forecast
 
-This section shows the multi-day forecast. The number of days depends on your `Forecast duration` setting and the source data available.
+This section shows the multi-day forecast. The number of days depends on your Display settings and on what the source can provide.
 
 ### Hourly Forecast
 
-This section shows the short-range hourly forecast. You choose how many hours it includes in `Settings > Display > Hourly forecast hours`.
+This section shows the short-range hourly forecast. You can choose how many hours appear in Settings > Display.
 
 ### Weather Alerts
 
-This section shows active alerts for the selected location. Select an alert and choose `View Alert Details`, or press Enter or Space on the selected alert, to open the full text.
+This section lists active alerts for the selected location.
 
-Between refreshes, alerts may be tagged with lifecycle labels such as:
+When alerts change between refreshes, you may hear or read labels such as:
 
-- `New`
-- `Updated`
-- `Escalated`
-- `Extended`
+- New
+- Updated
+- Escalated
+- Extended
 
-Cancelled alerts can still generate notifications even after they are no longer in the active list.
+Cancelled alerts may still trigger notifications even after they leave the active list.
 
-## Weather Sources
+## 6. Weather sources and Automatic mode
 
-AccessiWeather does not treat all weather sources the same. Choosing the right source matters.
+AccessiWeather can use multiple weather providers. You can force a single provider, but most users will get the best results from Automatic mode.
 
-### Automatic
+### Weather providers at a glance
 
-`Automatic` is the default. It fetches from all available sources it can use and merges the results.
-
-What `Automatic` does:
-
-- Always fetches Open-Meteo because it works globally and does not need a key.
-- Fetches NWS for US locations.
-- Fetches Visual Crossing only if you have a Visual Crossing key.
-- Fetches Pirate Weather only if you have a Pirate Weather key.
-- Merges current conditions, daily forecast, and hourly forecast using your source-priority choices.
-
-What `Automatic` does not do:
-
-- It does not merge alerts from every source equally.
-- For US locations, it intentionally uses NWS alerts only.
-- For non-US locations, it prefers Pirate Weather alerts and falls back to Visual Crossing alerts if Pirate Weather is not available.
-
-Why most users should keep it on:
-
-- It fills gaps better than any one provider alone.
-- It keeps US alerts on the most detailed source.
-- It can add Pirate Weather minutely precipitation when you have a Pirate Weather key.
-
-### National Weather Service (NWS)
+#### National Weather Service (NWS)
 
 Best for:
 
 - US forecasts
 - US alerts
-- Forecast discussions
-- NOAA Weather Radio use with US locations
+- US forecast discussions
+- NOAA Weather Radio features
 
-Important limitations:
+Important limits:
 
 - US only
-- Outside the US, NWS-specific features such as area forecast discussions do not apply
+- not available for international locations
 
-### Open-Meteo
-
-Best for:
-
-- Global coverage
-- No-key use
-- Fast baseline forecast data
-- Open-Meteo model selection
-
-Important limitations:
-
-- No weather alerts in AccessiWeather
-- No NWS forecast discussions
-
-### Visual Crossing
+#### Open-Meteo
 
 Best for:
 
-- Weather history enrichment
-- Extra global forecast coverage
-- Some alert coverage outside the US
+- global forecast coverage
+- no-key setup
+- strong baseline forecast coverage
 
-Important limitations:
+Important limits:
 
-- Requires an API key
-- For US alerts, AccessiWeather still treats NWS as the authoritative source
-- Visual Crossing alerts are less detailed than NWS in the current app
+- no weather alerts in AccessiWeather
+- no forecast discussion support
 
-### Pirate Weather
+#### Pirate Weather
 
 Best for:
 
-- Worldwide alerts
-- Minutely precipitation guidance
-- Dark Sky-style daily summaries
-- Non-US alert coverage
-
-Important limitations:
-
-- Requires an API key
-- Alerts can be broader regional alerts rather than highly specific local targeting
-- Minutely precipitation depends on Pirate Weather data being available for that location and time
-
-## How Alerts Behave
-
-Alert behavior depends on both source and location.
-
-### US Locations
-
-- In `Automatic`, AccessiWeather uses NWS alerts only.
-- Visual Crossing and Pirate Weather alerts are ignored there to avoid duplicates and weaker metadata.
-- `Alert Area` applies to NWS alert targeting only.
-
-### Non-US Locations
-
-- NWS alerts do not apply.
-- If Pirate Weather is configured and returns alerts, AccessiWeather prefers those.
-- If Pirate Weather is not available, AccessiWeather can use Visual Crossing alerts where supported.
-
-### Why Alerts Can Feel Different Between Sources
-
-NWS alerts usually include stronger metadata such as severity, urgency, certainty, and more precise targeting. Pirate Weather alerts are useful for worldwide coverage, but they can be broader. Visual Crossing can help in some regions, but it is not the strongest alert source in the app.
-
-## Forecast Discussions
-
-You can open forecast discussions either from the main window `Discussion` button or from `View > Forecast Discussion...`.
-
-`View > Forecast Discussion...` behaves differently depending on the selected location:
-
-- For a normal US location, it opens the local NWS Area Forecast Discussion.
-- For `Nationwide`, it opens national discussion products instead of a local office discussion.
-- Outside NWS coverage, forecast discussion may simply not be available.
-
-The discussion window also has an `Explain with AI` button when you have an OpenRouter key configured.
-
-## Weather History
-
-`View > Weather History` shows comparison text built from the current weather payload, including:
-
-- Recent daily history when available
-- Trend insights when available
-- A simple today-versus-yesterday comparison when the data supports it
-
-Important caveat:
-
-- The app has a `Enable weather history comparisons` setting, but the menu item is still present either way. Turning the setting off stops the deferred weather-history service from being initialized, so history features may be more limited or unavailable.
-
-## Air Quality and UV Index
-
-Use the `View` menu to open dedicated dialogs for air quality and UV details.
-
-Air quality can show:
-
-- Current AQI
-- AQI category
-- Dominant pollutant
-- Hourly air-quality forecast
-- Pollutant detail values
-
-UV can show:
-
-- Current UV index
-- UV category
-- Hourly UV forecast
-- Sun-safety guidance
-
-These dialogs depend on environmental data being available for the selected location. If the source data is missing, the dialog will say so directly.
-
-## Aviation Weather
-
-Use `View > Aviation Weather...` to fetch decoded TAF information by four-letter ICAO airport code such as `KJFK`.
-
-How it works:
-
-- Enter a four-letter ICAO code.
-- Press Enter or choose `Get Aviation Data`.
-- The dialog shows both the raw TAF and a decoded version.
-- It can also show aviation advisories.
-
-About the optional AVWX key:
-
-- You enter it in the aviation dialog itself, not in the main Settings dialog.
-- It is mainly for better international airport support.
-- US airports use the NWS/AWC path by default.
-- The AVWX hint in the app explicitly calls out enhanced translations, flight rules, and screen-reader-friendly speech for international airports.
-
-## NOAA Weather Radio
-
-Use `View > NOAA Weather Radio...` to open the radio player for the current location.
-
-What the dialog does:
-
-- Finds nearby stations based on the current location
-- Lists up to 10 nearby stations that have known online streams
-- Lets you play, stop, try the next stream, change volume, and mark a stream as preferred
-
-Important caveats:
-
-- Not every NOAA Weather Radio station has an online stream.
-- The dialog is non-modal, so you can leave it open while using the main window.
-- This feature is oriented around NOAA Weather Radio stations, so it is most useful in NOAA coverage areas.
-
-## AI Features
-
-AccessiWeather has two separate AI features. Both require an OpenRouter API key.
-
-### Explain Weather
-
-You can open this from the main window `Explain` button or from `View > Explain Weather`.
-
-`View > Explain Weather` generates a one-shot explanation of the currently loaded weather.
-
-The explanation dialog shows:
-
-- The generated explanation text
-- The model used
-- Token count
-- Estimated cost
-- Whether the result came from cache
-
-You can regenerate the explanation from inside the dialog.
-
-### Weather Assistant
-
-`View > Weather Assistant...` opens a chat window. It is a multi-turn tool, not just a one-shot summary.
-
-The assistant can use the app's live weather tools, including:
-
-- Current weather
-- Forecasts
-- Alerts
-- Location search
-- Saved locations
-- Open-Meteo variable queries
-- Forecast discussions and national outlook products
-
-Use it when you want follow-up questions, not just a quick summary.
-
-## Optional API Keys
-
-AccessiWeather works without paid services, but some features require optional keys.
-
-### Pirate Weather
-
-Needed for:
-
-- Pirate Weather as a direct source
-- Worldwide non-NWS alerts in many regions
-- Minutely precipitation guidance
+- global forecast coverage with an API key
+- worldwide alert coverage in many regions
+- minutely precipitation guidance
 - Dark Sky-style summary text
 
-Where to enter it:
+Important limits:
 
-- `Settings > Data Sources`
+- requires an API key
+- alerts may be broader than local US NWS targeting
+- minutely precipitation is only available where Pirate Weather provides it
 
-### Visual Crossing
+#### Visual Crossing
 
-Needed for:
+Best for:
 
-- Visual Crossing as a direct source
-- Weather history enrichment
-- Some forecast and alert fallback coverage
+- global forecast enrichment with an API key
+- weather history support
+- some alert coverage outside the US
 
-Where to enter it:
+Important limits:
 
-- `Settings > Data Sources`
+- requires an API key
+- not the authoritative US alert source in AccessiWeather
 
-### OpenRouter
+### What Automatic mode means now
 
-Needed for:
+Automatic mode is the default weather-source choice.
 
-- `Explain Weather`
-- `Weather Assistant`
-- `Explain with AI` in the discussion dialog
+Its default behavior is fusion-first using the Max coverage budget. In plain language, that means AccessiWeather tries every enabled source it can use for your region, then merges the results so one provider can fill gaps left by another.
 
-Where to enter it:
+Automatic mode is not limited to one built-in fetch order. It follows the source order you save in the Automatic mode configuration.
 
-- `Settings > AI`
+Automatic mode also keeps separate source lists for:
 
-### AVWX
+- US locations
+- international locations
 
-Needed for:
+This lets you choose a different preferred order for domestic and international use.
 
-- Better international aviation weather handling
+### Automatic mode budgets
 
-Where to enter it:
+AccessiWeather provides three Automatic mode API budget choices.
 
-- `View > Aviation Weather...`
+#### Max coverage
 
-## Settings Guide
+This is the default.
 
-This section explains every tab and control in the current settings dialog.
+Use this when:
+
+- you want the richest merged result
+- you want Automatic mode to behave in its full fusion-first form
+- you want the best chance of filling forecast gaps from multiple sources
+
+What it does:
+
+- fans out to every enabled source that is available for the current location
+- merges current conditions, daily forecast, and hourly forecast from those results
+- uses your saved source order when deciding how to merge overlapping data
+
+#### Economy
+
+This is an opt-in reduced-call mode.
+
+Use this when:
+
+- you want to minimize API usage
+- you are trying to stay within optional-provider quotas
+- you prefer a simpler, lower-call Automatic mode
+
+What it does:
+
+- starts with your first enabled source for the region
+- only adds limited fallback behavior when needed
+- keeps call volume lower than Max coverage
+
+#### Balanced
+
+This is also an opt-in reduced-call mode.
+
+Use this when:
+
+- you want fewer API calls than Max coverage
+- but you still want one useful fallback in more situations than Economy
+
+What it does:
+
+- starts with your first enabled source for the region
+- allows one additional fallback source when Automatic mode needs it
+- offers a middle ground between Economy and Max coverage
+
+### Separate US and international source lists
+
+Automatic mode uses separate saved source lists for US and international locations.
+
+Default order:
+
+- US: NWS, Open-Meteo, Visual Crossing, Pirate Weather
+- International: Open-Meteo, Pirate Weather, Visual Crossing
+
+You can change these lists in Settings > Data Sources > Configure automatic mode budget and sources.
+
+The staged fetch order follows the source order you save.
+
+### Alerts in Automatic mode
+
+Automatic mode does not treat every alert source equally.
+
+#### US locations
+
+For US locations, NWS alerts are authoritative when NWS is available.
+
+That means:
+
+- AccessiWeather uses NWS alerts as the official alert feed in Automatic mode
+- Pirate Weather and Visual Crossing alerts are not used as equal co-authorities for US alerts
+- the Alert Area setting applies to NWS-style US alert targeting
+
+#### International locations
+
+For international locations:
+
+- NWS alerts do not apply
+- Pirate Weather alerts are preferred when available
+- Visual Crossing is used as the fallback alert source when Pirate Weather is unavailable
+
+### Forecast discussion behavior in Automatic mode
+
+Forecast discussions come from NWS.
+
+That means:
+
+- US users can open discussions when NWS is part of the active path
+- Nationwide can open national discussion products
+- if Automatic mode does not use NWS for the current weather path, forecast discussion may be unavailable
+- Open-Meteo, Pirate Weather, and Visual Crossing do not provide forecast discussions in AccessiWeather
+
+### Minutely precipitation
+
+Minutely precipitation guidance depends on Pirate Weather.
+
+When Pirate Weather minutely data is available, AccessiWeather can:
+
+- include near-term precipitation timing in current conditions
+- notify you when precipitation is expected to start soon
+- notify you when precipitation is expected to stop soon
+
+If Pirate Weather is not configured, or if minutely data is unavailable for the location, those features will not appear.
+
+## 7. Alerts and notifications
+
+Alerts and notifications are related, but they are not the same thing.
+
+- Alerts are the weather hazards AccessiWeather receives from a source.
+- Notifications are the desktop popups and optional sounds AccessiWeather sends when something changes.
+
+### Standard alert monitoring
+
+You can choose whether AccessiWeather should:
+
+- monitor alerts at all
+- send alert notifications
+- open alert details immediately while the app is running
+
+### Alert area
+
+For NWS-based US alerts, the Alert Area setting controls how broad the targeting should be.
+
+Choices are:
+
+- County: recommended for most users
+- Point: exact coordinate, but may miss nearby alerts
+- Zone: somewhat broader than county
+- State: broadest and noisiest
+
+Use smaller areas when you want fewer notifications. Use broader areas when you do not want to miss alerts that affect a wider region.
+
+### Severity filters
+
+You can choose which alert severities are allowed to notify you:
+
+- Extreme
+- Severe
+- Moderate
+- Minor
+- Uncategorized
+
+A severity being turned off means the alert can still exist in the weather data, but AccessiWeather will not notify you for that level.
+
+### Extra weather event notifications
+
+In addition to standard alerts, AccessiWeather can notify you about:
+
+- Area Forecast Discussion updates for NWS US locations
+- severe weather risk changes from Visual Crossing
+- minutely precipitation start soon from Pirate Weather
+- minutely precipitation stop soon from Pirate Weather
+
+These are optional and should be turned on only if you want those extra updates.
+
+### Cooldowns and notification limits
+
+Cooldown settings help prevent repeated notifications from becoming overwhelming.
+
+In user terms:
+
+- global cooldown is the minimum time between any alert notifications
+- per-alert cooldown is how long AccessiWeather waits before repeating the same alert
+- freshness window limits notifications to recently issued alerts
+- maximum notifications per hour puts an upper cap on how noisy the app can be
+
+Use these controls when you want fewer repeat notifications without turning alerts off completely.
+
+## 8. Settings reference
+
+The Settings dialog is organized in this order:
+
+1. General
+2. Display
+3. Notifications
+4. Audio
+5. Data Sources
+6. AI
+7. Updates
+8. Advanced
 
 ### General
 
-#### Update Interval (minutes)
+Use the General tab for everyday app behavior.
 
-How often the app refreshes weather automatically in the background.
+#### Refresh weather every (minutes)
 
-Change it when:
+Controls how often AccessiWeather refreshes weather automatically.
 
-- You want fresher data more often
-- You want fewer background refreshes
+Use a shorter interval when you want faster background updates. Use a longer interval when you prefer less network activity.
 
-Tradeoff:
+#### Show the Nationwide location when a supported data source is selected
 
-- Shorter intervals can mean more network activity and more opportunities for alerts and status changes to be detected quickly.
+Shows or hides the built-in Nationwide location.
 
-#### Show Nationwide location (requires Auto or NWS data source)
+Nationwide is available when your weather source is set to Automatic or NWS.
 
-Shows or hides the built-in `Nationwide` location.
+Use this when you want quick access to national discussion products.
 
-Turn it on when:
+#### Tray icon text options
 
-- You want quick access to national forecast discussion products
+The General tab also includes tray text controls:
 
-Turn it off when:
+- Show weather text on the tray icon
+- Update tray text as conditions change
+- Current tray text format
+- Edit tray text format
 
-- You never use nationwide products and want a shorter location list
-
-Important caveat:
-
-- The checkbox is disabled unless your source is `Automatic` or `National Weather Service`.
-
-#### Show weather text on tray icon
-
-Lets AccessiWeather replace the plain tray tooltip with live weather text.
-
-Turn it on when:
-
-- You want the notification area tooltip to say more than just `AccessiWeather`
-
-Turn it off when:
-
-- You prefer a simpler tray icon with no changing weather text
-
-#### Update tray text dynamically
-
-Lets the tray text formatter adapt to live weather data and formatting rules.
-
-Turn it on when:
-
-- You want the tray text to update as weather changes
-
-Turn it off when:
-
-- You want a fixed custom format without dynamic behavior changing the result
-
-#### Current tray text format / Edit Format...
-
-Shows the current format string and opens the tray-format editor.
-
-Use it when:
-
-- You want to control exactly which values appear in tray text
-
-The editor includes:
-
-- A live preview
-- A list of supported placeholders such as `{temp}`, `{condition}`, `{feels_like}`, `{humidity}`, `{wind}`, `{high}`, and `{low}`
-
-Important caveat:
-
-- Invalid format strings with unbalanced braces fall back to the default tray text.
+Use these options when you want the notification-area icon to show a short live weather summary instead of a plain app name.
 
 ### Display
 
-#### Unit Preference
+Use the Display tab to control units, detail level, and forecast layout.
 
-Choices:
+#### Temperature units
 
-- `Auto (based on location)`
-- `Imperial (°F)`
-- `Metric (°C)`
-- `Both (°F and °C)`
+Choices are:
 
-Change it when:
+- Auto based on location
+- Imperial (Fahrenheit)
+- Metric (Celsius)
+- Both
 
-- You want one unit system everywhere
-- You want the app to follow location defaults automatically
-- You want both systems spoken or shown together
+You can also choose to show values as whole numbers when possible.
 
-#### Show dewpoint
+#### Forecast range
 
-Adds dew point to current conditions when available.
+The Display tab lets you choose:
 
-Turn it on when:
+- Daily forecast range: 3, 5, 7, 10, 14, or 15 days
+- Hourly forecast range: 1 to 168 hours
 
-- You want a better sense of muggy or dry air
+#### Extra weather details
 
-#### Show visibility
+You can turn these details on or off:
 
-Adds visibility to current conditions when available.
+- dew point
+- visibility
+- UV index
+- pressure trend
+- impact summaries for outdoor, driving, and allergy conditions
 
-Useful for:
+#### Time display
 
-- Fog
-- Smoke
-- Driving conditions
-- Aviation awareness
+Time controls include:
 
-#### Show UV index
+- whether forecast times follow the location timezone or your own local timezone
+- whether times are shown as local only, UTC only, or both
+- 12-hour time format
+- timezone abbreviations
 
-Adds UV index to current conditions when available.
+#### Reading priority
 
-Useful for:
+You can choose:
 
-- Outdoor planning
-- Sun-safety awareness
+- Minimal verbosity
+- Standard verbosity
+- Detailed verbosity
+- Automatically prioritize severe weather details
 
-#### Show pressure trend
-
-Adds pressure-trend information when available.
-
-Useful for:
-
-- Users who track changing weather systems closely
-
-#### Show values as whole numbers (no decimals)
-
-Rounds many displayed values.
-
-Turn it on when:
-
-- You want cleaner, faster-to-hear speech output
-
-Turn it off when:
-
-- You want more precise values
-
-#### Show detailed forecast information
-
-Controls how much detail the forecast text includes.
-
-Turn it on when:
-
-- You want fuller forecast text
-
-Turn it off when:
-
-- You want quicker summaries
-
-#### Forecast duration
-
-Choices in the current UI:
-
-- 3 days
-- 5 days
-- 7 days
-- 10 days
-- 14 days
-- 15 days
-
-Change it when:
-
-- You want a shorter or longer daily forecast
-
-Important caveat:
-
-- The app can request up to 15 days in the UI, but what you actually get still depends on source support.
-
-#### Hourly forecast hours
-
-How many hours the hourly section should show.
-
-Change it when:
-
-- You want a quick near-term look
-- You want a longer hour-by-hour view
-
-#### Forecast time display
-
-Choices:
-
-- `Location's timezone`
-- `My local timezone`
-
-Use location time when:
-
-- You want the forecast as locals would read it
-
-Use your local time when:
-
-- You are monitoring weather somewhere else from home
-
-#### Time zone display
-
-Choices:
-
-- `Local time only`
-- `UTC time only`
-- `Both (Local and UTC)`
-
-Useful when:
-
-- You work with UTC regularly
-- You want both local and UTC for clarity
-
-#### Use 12-hour time format
-
-Switches between 12-hour and 24-hour style for displayed times.
-
-#### Show timezone abbreviations
-
-Adds suffixes such as `EST` or `UTC` where the display supports them.
-
-Turn it on when:
-
-- You want less ambiguity in spoken or read times
-
-#### Verbosity level
-
-Choices:
-
-- `Minimal`
-- `Standard`
-- `Detailed`
-
-This controls how much information AccessiWeather prioritizes in presentation.
-
-Use:
-
-- `Minimal` for shorter output
-- `Standard` for most users
-- `Detailed` for maximum available detail
-
-#### Automatically prioritize severe weather info
-
-Moves severe weather information higher in importance when conditions warrant it.
-
-Turn it on when:
-
-- You want dangerous weather surfaced more aggressively
-
-### Data Sources
-
-#### Weather Data Source
-
-Choices:
-
-- `Automatic`
-- `National Weather Service`
-- `Open-Meteo`
-- `Visual Crossing`
-- `Pirate Weather`
-
-Use:
-
-- `Automatic` for most users
-- `NWS` if you only care about US weather and alerts
-- `Open-Meteo` if you want a no-key global source
-- `Visual Crossing` if you want to force that source and already have a key
-- `Pirate Weather` if you want to force worldwide alerts/minutely support and already have a key
-
-Important caveats:
-
-- `Visual Crossing` and `Pirate Weather` require keys when chosen directly.
-- `Open-Meteo` has no alerts.
-- `NWS` is US-only.
-
-#### Visual Crossing API Key / Get Free API Key / Validate API Key
-
-Use these controls to add and test your Visual Crossing key.
-
-Use Visual Crossing when:
-
-- You want history enrichment
-- You want another fallback source in Automatic mode
-- You want to force Visual Crossing directly
-
-#### Pirate Weather API Key / Get Free API Key / Validate API Key
-
-Use these controls to add and test your Pirate Weather key.
-
-Use Pirate Weather when:
-
-- You want worldwide alert support
-- You want minutely precipitation start/stop guidance
-- You want Pirate Weather as a direct source
-
-#### US Locations Priority
-
-Controls the merge order used by `Automatic` for US locations.
-
-Current choices:
-
-- `NWS → Open-Meteo → Visual Crossing`
-- `NWS → Visual Crossing → Open-Meteo`
-- `Open-Meteo → NWS → Visual Crossing`
-
-Change it when:
-
-- You want Open-Meteo or Visual Crossing to win more often for current/forecast values
-
-Important caveat:
-
-- This affects data merging, not US alert authority. US alerts still come from NWS only.
-
-#### International Locations Priority
-
-Controls the merge order used by `Automatic` for non-US locations.
-
-Current choices:
-
-- `Open-Meteo → Visual Crossing`
-- `Visual Crossing → Open-Meteo`
-
-Important caveat:
-
-- Internally, Pirate Weather can still participate in Automatic mode when you have a Pirate Weather key. The UI only exposes two priority presets here, so this setting is simpler than the actual full internal source list.
-
-#### Open-Meteo Weather Model
-
-Choices in the current UI:
-
-- `Best Match`
-- `ICON Seamless`
-- `ICON Global`
-- `ICON EU`
-- `ICON D2`
-- `GFS Seamless`
-- `GFS Global`
-- `ECMWF IFS`
-- `Météo-France`
-- `GEM`
-- `JMA`
-
-What it does:
-
-- Chooses which Open-Meteo model AccessiWeather asks for
-
-When to leave it on `Best Match`:
-
-- Almost always, unless you have a reason to prefer a specific regional model
-
-When to change it:
-
-- You know a specific regional model usually performs better for your area
-- You want to compare how Open-Meteo-based output changes
-
-Practical guidance:
-
-- `ICON` variants are most relevant for Europe and Germany
-- `GFS` is NOAA-based and broadly useful for the Americas and global coverage
-- `ECMWF IFS` is a global model many users prefer for general forecasting
-- `GEM` is Canada/North America oriented
-- `JMA` is Japan/Asia oriented
-
-Important caveat:
-
-- This only affects Open-Meteo requests. It matters most when Open-Meteo is your direct source or when Automatic mode is using Open-Meteo data to fill gaps or win a merge.
-
-#### NWS Station Selection (Current Conditions)
-
-Controls how AccessiWeather chooses an NWS observation station for current conditions.
-
-Choices:
-
-- `Hybrid default`
-- `Nearest station`
-- `Major airport preferred`
-- `Freshest observation`
-
-Use:
-
-- `Hybrid default` if you want the safest general choice
-- `Nearest station` if local distance matters most to you
-- `Major airport preferred` if you trust staffed airport observations more
-- `Freshest observation` if recency matters more than distance
-
-Important caveat:
-
-- This applies to NWS current conditions only.
-- In `Automatic`, it matters when NWS is selected for current conditions or used as fallback.
+Use these controls to make the forecast shorter or more detailed.
 
 ### Notifications
 
-#### Enable weather alerts
+Use the Notifications tab to control alerts, event notifications, and rate limiting.
 
-Turns weather-alert handling on or off in the app.
+#### Alert delivery
 
-Turn it off when:
+Controls include:
 
-- You do not want alerts at all
+- Monitor weather alerts
+- Send alert notifications
+- Open alert details immediately while AccessiWeather is running
 
-#### Enable alert notifications
+#### Coverage and severity
 
-Controls desktop alert pop-ups separately from alert handling itself.
+Controls include:
 
-Turn it off when:
+- Alert Area
+- Extreme severity alerts
+- Severe severity alerts
+- Moderate severity alerts
+- Minor severity alerts
+- Uncategorized alerts
 
-- You still want to read alerts in the app, but do not want pop-up notifications
+#### Extra weather event notifications
 
-#### Alert Area
+Controls include:
 
-Choices:
+- discussion update notifications
+- severe risk change notifications
+- minutely precipitation start notifications
+- minutely precipitation stop notifications
 
-- `County`
-- `Point`
-- `Zone`
-- `State`
+#### Rate limiting and advanced timing
 
-What it does:
+Controls include:
 
-- Chooses how NWS alert matching should work
+- Maximum notifications per hour
+- Advanced timing dialog for global cooldown, per-alert cooldown, and freshness window
 
-Use:
-
-- `County` for the least noisy local NWS targeting
-- `Point` for the narrowest location match, with the risk of missing some alerts
-- `Zone` for a somewhat broader NWS area
-- `State` only if you want very broad alert coverage
-
-Important caveat:
-
-- This is an NWS setting. It does not make Pirate Weather or Visual Crossing alerts more precise.
-
-#### Severity checkboxes
-
-Choices:
-
-- `Extreme`
-- `Severe`
-- `Moderate`
-- `Minor`
-- `Unknown`
-
-What they do:
-
-- Decide which severities can notify you
-
-Typical use:
-
-- Leave `Extreme`, `Severe`, and `Moderate` on for important alerts
-- Turn on `Minor` only if you want more low-impact notifications
-- Turn on `Unknown` only if you would rather risk extra noise than miss poorly categorized alerts
-
-#### Notify when Area Forecast Discussion is updated
-
-Alerts you when the NWS Area Forecast Discussion issuance time changes.
-
-Useful when:
-
-- You follow forecaster reasoning closely
-
-Important caveat:
-
-- NWS US only
-
-#### Notify when severe weather risk level changes
-
-Alerts you when the severe-weather risk category changes.
-
-Important caveat:
-
-- Visual Crossing only
-
-#### Notify when precipitation is expected to start soon
-
-Uses Pirate Weather minutely data to notify you when the app detects a dry-to-wet transition.
-
-Useful when:
-
-- You want a heads-up before rain, snow, sleet, or other precipitation starts
-
-Important caveat:
-
-- Requires Pirate Weather and available minutely data
-
-#### Notify when precipitation is expected to stop soon
-
-Uses Pirate Weather minutely data to notify you when the app detects a wet-to-dry transition.
-
-Useful when:
-
-- You want to know when precipitation is about to end
-
-#### Global cooldown (minutes)
-
-Sets a broad cooldown between notifications.
-
-Raise it when:
-
-- You want fewer notifications overall
-
-#### Per-alert cooldown (minutes)
-
-Limits how often the same alert can notify you again.
-
-Raise it when:
-
-- Repeated updates for the same alert feel too noisy
-
-#### Alert freshness window (minutes)
-
-Controls how new an alert must be to count as fresh for notification purposes.
-
-Lower it when:
-
-- You only want very recent alerts
-
-Raise it when:
-
-- You would rather hear about slightly older alerts than miss them
-
-#### Maximum notifications per hour
-
-Caps the total number of notifications the app can send in one hour.
-
-Lower it when:
-
-- You want a hard limit during active weather
+Use these controls when you want to keep notifications useful without letting them repeat too often.
 
 ### Audio
 
-#### Play notification sounds
+Use the Audio tab to control sounds.
 
-Master switch for app sounds.
+#### Playback
 
-Turn it off when:
+Controls include:
 
-- You want visual notifications only
+- Play notification sounds
+- Sound pack
+- Play sample sound
+- Manage sound packs
 
-#### Sound pack
+#### When sounds play
 
-Chooses which installed sound pack is active.
+Audio also includes event-sound controls so you can decide which event types are allowed to make noise.
 
-Change it when:
+Use this when:
 
-- You prefer a different alert style
-- You have installed community or custom packs
+- you want sounds for major alerts but not for routine updates
+- you want to keep audio on without making every event noisy
 
-#### Test Sound
+### Data Sources
 
-Plays a quick sample using the active sound setup.
+Use the Data Sources tab to choose the weather provider and configure Automatic mode.
 
-Use it when:
+#### Weather source
 
-- You want to confirm your current sound pack works
+Choices are:
 
-#### Manage Sound Packs...
+- Automatic
+- National Weather Service
+- Open-Meteo
+- Visual Crossing
+- Pirate Weather
 
-Opens the sound pack manager.
+Choose a single source when you want predictable provider-specific behavior. Choose Automatic when you want merged results and source fallbacks.
 
-Use it when:
+#### Automatic mode summary and configuration
 
-- You want to install, remove, preview, or manage packs
+The Data Sources tab shows a plain-language summary of your current Automatic mode settings, including:
 
-#### Event sound summary
+- Automatic mode budget
+- US automatic sources
+- International automatic sources
+- NWS station strategy
 
-Shows how many sound-capable events are currently enabled.
+Use Configure automatic mode budget and sources to change:
 
-#### Configure Event Sounds...
+- Max coverage, Economy, or Balanced
+- separate US automatic source order
+- separate international automatic source order
+- the station strategy used when NWS chooses a current-conditions station
 
-Opens a detailed sound-event chooser.
+#### NWS station strategy
 
-What you can control there:
+The available strategies are:
 
-- Core app sounds such as refresh complete or refresh failed
-- Discussion-update and severe-risk-change sounds
-- Startup and exit sounds
-- Severity fallback sounds
-- Generic warning/watch/advisory/statement sounds
-- Many specific alert-event sounds such as tornado, flood, winter, wind, tropical, marine, fog, fire, and air-quality events
+- Hybrid default
+- Nearest station
+- Major airport preferred
+- Freshest observation
 
-Use it when:
+Use this when you want to influence which NWS observation station is preferred for current conditions.
 
-- You want sounds for only a few events
-- You want to mute less important events without muting everything
+#### Provider API keys
 
-### Updates
+The Data Sources tab includes API key fields and validation actions for:
 
-#### Check for updates automatically
+- Visual Crossing
+- Pirate Weather
 
-Turns scheduled update checks on or off.
+Each provider includes:
 
-Turn it off when:
+- an API key field
+- a button to get a key
+- a button to validate the key
 
-- You prefer to check manually
-
-Important caveat:
-
-- Update checking is only available in installed builds. If you run from source, manual update checking tells you to update with `git pull` instead.
-
-#### Update Channel
-
-Current choices:
-
-- `Stable`
-- `Development`
-
-Use `Stable` when:
-
-- You want production releases only
-
-Use `Development` when:
-
-- You want newer features sooner and accept more instability
-
-#### Check Interval (hours)
-
-How often automatic update checks run.
-
-#### Check for Updates Now
-
-Runs a manual update check immediately.
-
-#### Update status
-
-Shows the current update-check state inside the settings window.
+Stored keys remain in secure storage unless you explicitly export them.
 
 ### AI
 
-#### OpenRouter API Key / Validate API Key
+Use the AI tab if you want Explain Weather or Weather Assistant.
 
-Required for all AI features in the current app, including free models.
+#### OpenRouter access
 
-Use `Validate API Key` when:
+Controls include:
 
-- You want to confirm the key works before closing settings
+- OpenRouter API key
+- Validate OpenRouter key
 
-#### Model Preference
+#### Model and explanation style
 
-Current built-in choices:
+Controls include:
 
-- `Free Router (Auto, Free)`
-- `Llama 3.3 70B (Free)`
-- `Auto Router (Paid)`
+- model preference
+- Browse OpenRouter models
+- explanation style: brief, standard, or detailed
 
-What they mean:
+#### Custom prompts
 
-- `Free Router` uses OpenRouter's free routing path
-- `Llama 3.3 70B (Free)` forces that specific free model
-- `Auto Router (Paid)` lets OpenRouter choose among paid options
+Optional fields include:
 
-Use:
+- custom system prompt
+- custom instructions
+- Reset prompt to default
 
-- A free option if you want zero-cost explanations and can accept free-tier limits
-- `Auto Router (Paid)` if you want broader model routing and are comfortable with usage costs
+Leave these blank unless you want to change the AI's tone or focus.
 
-#### Browse Models...
+### Updates
 
-Lets you choose a specific OpenRouter model beyond the built-in presets.
+Use the Updates tab to control release checks.
 
-Use it when:
+Controls include:
 
-- You want to lock the app to a particular model
+- Check for updates automatically
+- Release channel: Stable or Development
+- Check every (hours)
+- Check for updates now
 
-#### Explanation Style
-
-Choices:
-
-- `Brief`
-- `Standard`
-- `Detailed`
-
-Applies to AI-generated explanations.
-
-Use:
-
-- `Brief` for fast summaries
-- `Standard` for general use
-- `Detailed` for fuller explanations
-
-#### Custom System Prompt
-
-Overrides the default system prompt used for AI explanations.
-
-Use it only when:
-
-- You know exactly how you want the explanation behavior changed
-
-Important caveat:
-
-- This is powerful, but it can make AI output worse or less predictable if overused.
-
-#### Reset to Default
-
-Clears your custom system prompt back to the app default.
-
-#### Custom Instructions
-
-Adds extra instructions on top of the normal AI prompt.
-
-Good use cases:
-
-- Keep responses short
-- Focus on outdoor activity impact
-- Prefer plainer language
-
-#### Cost Information
-
-The AI tab also shows a simple reminder that free models have no direct cost and paid models vary by model.
+Use Stable for everyday use. Use Development only if you want newer changes sooner and are comfortable with more risk.
 
 ### Advanced
 
-#### Minimize to notification area when closing
+Use the Advanced tab for startup behavior, backup tools, file locations, and reset actions.
 
-Changes the close behavior so closing the main window hides it to the tray instead of exiting.
+#### Startup and window behavior
 
-Turn it on when:
+Controls include:
 
-- You want AccessiWeather running in the background
+- Minimize to the notification area when closing
+- Start minimized to the notification area
+- Launch automatically at startup
+- Enable weather history comparisons
 
-#### Start minimized to notification area
+#### Backup and transfer
 
-Starts the app hidden in the tray.
+Tools include:
 
-Turn it on when:
+- Export settings
+- Import settings
+- Export API keys (encrypted)
+- Import API keys (encrypted)
 
-- You want AccessiWeather available at startup without opening a window
+This is the place to move settings between machines and to transfer API keys securely.
 
-Important caveat:
+#### Folders and files
 
-- This control is only enabled when `Minimize to notification area when closing` is on.
-- It also depends on a working tray icon on your platform.
+Tools include:
 
-#### Launch automatically at startup
+- Open current config folder
+- Open installed config folder (source)
+- Open sound packs folder
+- Copy installed config to portable, when running in portable mode
 
-Tries to launch AccessiWeather when you sign in.
+Use these tools when you need to inspect, back up, or migrate AccessiWeather files.
 
-Turn it on when:
+#### Reset and maintenance
 
-- You want background weather updates and alerts without manually opening the app every time
+Tools include:
 
-#### Enable weather history comparisons
+- Reset settings to defaults
+- Reset all app data (settings, locations, caches)
 
-Allows the app to initialize its deferred weather-history service.
+Reset all app data is a major cleanup action. Use it only when normal troubleshooting has not solved the problem.
 
-Turn it off when:
+## 9. Keyboard shortcuts
 
-- You do not care about history/trend comparisons and want a slightly simpler startup path
+These shortcuts are available in the current app:
 
-Important caveat:
+- F5 or Ctrl+R: Refresh weather
+- Ctrl+L: Add location
+- Ctrl+D: Remove location
+- Ctrl+S: Open Settings
+- Ctrl+H: Open Weather History
+- Ctrl+E: Explain Weather
+- Ctrl+T: Open Weather Assistant
+- Ctrl+Shift+R: Open NOAA Weather Radio
+- Ctrl+Q: Quit
 
-- The `Weather History` menu item still exists even when this is off.
+## 10. Troubleshooting
 
-#### Reset all settings to defaults
+### Problem: No weather data appears
 
-Resets settings back to default values.
+What it usually means:
 
-Use it when:
+- the selected source failed
+- your network connection is unavailable
+- the location has not refreshed yet
+- an API-key-based source is selected without a working key
 
-- You want to undo many setting changes quickly
+What to try:
 
-#### Reset all app data (settings, locations, caches)
+1. Press F5 to refresh.
+2. Switch the weather source to Automatic.
+3. Confirm the location is valid and still selected.
+4. If using Visual Crossing or Pirate Weather directly, validate the API key in Settings > Data Sources.
+5. Try another saved location to see whether the issue is location-specific.
 
-Wipes settings, locations, cache files, and alert state.
+### Problem: Alerts are missing or seem different between sources
 
-Use it when:
+What it usually means:
 
-- You want a true clean start
+- different providers do not offer the same alert coverage
+- US alerts and international alerts follow different authority rules
+- your Alert Area or severity filters are too narrow
 
-Important caveat:
+What to try:
 
-- This is much broader than resetting settings alone.
+1. Check whether the location is in the US or outside it.
+2. For US locations, remember that NWS is the authoritative alert source in Automatic mode.
+3. For international locations, add a Pirate Weather key if you want broader alert coverage.
+4. Review Alert Area and severity settings in Settings > Notifications.
+5. Make sure alert monitoring and alert notifications are enabled.
 
-#### Open current config directory
+### Problem: Forecast discussion is unavailable
 
-Opens the config directory the running app is currently using.
+What it usually means:
 
-Useful for:
+- the current location is outside NWS coverage
+- the current provider does not support discussions
+- Automatic mode did not use NWS for the current path
 
-- Backups
-- Troubleshooting
-- Portable-mode inspection
+What to try:
 
-#### Open installed config directory (source)
+1. Switch to a US location.
+2. Use Automatic or NWS as the weather source.
+3. If you need national products, enable and select Nationwide.
+4. Refresh and try again.
 
-Opens the standard installed config directory.
+### Problem: AI features are unavailable
 
-Most useful when:
+What it usually means:
 
-- You are in portable mode and need to compare or copy data
+- no OpenRouter key is configured
+- the key is invalid
+- the selected model is unavailable or rate limited
 
-#### Copy installed config to portable
+What to try:
 
-Only shown in portable mode.
+1. Open Settings > AI.
+2. Enter or validate your OpenRouter API key.
+3. Try a free model first.
+4. If responses are empty, switch models and try again.
 
-Use it when:
+### Problem: API key validation fails
 
-- You want to migrate an existing installed config into your portable setup
+What it usually means:
 
-#### Export Settings...
+- the key was entered incorrectly
+- the provider account is not active yet
+- the provider site is temporarily unavailable
 
-Exports app settings and saved locations.
+What to try:
 
-Important caveat:
+1. Paste the key again carefully.
+2. Make sure there are no extra spaces before or after it.
+3. Confirm you copied the correct provider's key.
+4. Wait a few minutes and validate again if the key was just created.
 
-- API keys are not included in normal settings export.
+### Problem: Portable mode behavior is confusing
 
-#### Import Settings...
+What it usually means:
 
-Imports a previously exported settings file.
+- portable mode stores configuration differently from a standard install
+- keys are expected to live in the encrypted bundle, not your normal keyring
 
-#### Export API keys (encrypted)
+What to try:
 
-Creates an encrypted bundle of saved API keys for transfer to another machine.
+1. Confirm you actually started the app with --portable.
+2. Use Settings > Advanced to export or import encrypted API keys.
+3. If needed, use Copy installed config to portable while running in portable mode.
+4. Remember that blank or skipped bundle setup means keys may not persist.
 
-Use it when:
+### Problem: Update checks are not happening when expected
 
-- You are moving to another computer
-- You want a safer backup than plain text
+What it usually means:
 
-#### Import API keys (encrypted)
+- automatic update checks are disabled
+- the check interval is longer than you expected
+- you are on a different update channel than you intended
 
-Imports an encrypted API-key bundle and stores the keys in this machine's secure storage.
+What to try:
 
-#### Open sound packs folder
+1. Open Settings > Updates.
+2. Confirm automatic checking is enabled.
+3. Review the release channel.
+4. Use Check for updates now to test immediately.
 
-Opens the folder where sound packs live.
+### Problem: Automatic mode did not use the source I expected
 
-Use it when:
+What it usually means:
 
-- You want to manually add, inspect, or remove pack files
+- your saved US or international source order is different from what you remember
+- the provider you expected is not currently available
+- you selected Economy or Balanced instead of Max coverage
 
-## Menus and Workflows
+What to try:
 
-### File
+1. Open Settings > Data Sources.
+2. Review the Automatic mode summary.
+3. Open Configure automatic mode budget and sources.
+4. Check whether you are looking at the US list or the international list.
+5. If you want full fusion-first behavior, choose Max coverage.
+6. Confirm any required API key is present and valid.
 
-- `Settings`: opens the settings dialog
-- `Exit`: quits the app
+## 11. Additional features
 
-### Location
+### Weather History
 
-- `Add Location`: search and save a new location
-- `Remove Location`: removes the selected saved location
+Use View > Weather History to compare current conditions with recent history when that data is available.
 
-### View
+This feature can be turned on or off in Settings > Advanced.
 
-- `Refresh`
-- `Explain Weather`
-- `Weather History`
-- `Forecast Discussion`
-- `Aviation Weather`
-- `Air Quality`
-- `UV Index`
-- `NOAA Weather Radio`
-- `Weather Assistant`
+### Air Quality and UV details
 
-### Tools
+Use the View menu to open dedicated air quality and UV windows.
 
-- `Soundpack Manager`
+These windows can show current values, categories, forecasts, and guidance when the underlying weather data includes them.
 
-### Help
+### Aviation Weather
 
-- `Check for Updates`
-- `Report Issue`
-- `About`
+Use View > Aviation Weather to fetch decoded aviation weather by four-letter ICAO airport code, such as KJFK.
 
-## Keyboard Shortcuts
+This is useful when you want raw and decoded TAF information and related advisories.
 
-The current code binds these global shortcuts:
+An optional AVWX key can improve international aviation support.
 
-- `Ctrl+R` or `F5`: Refresh weather
-- `Ctrl+L`: Add location
-- `Ctrl+D`: Remove selected location
-- `Ctrl+H`: Open Weather History
-- `Ctrl+S`: Open Settings
-- `Ctrl+Q`: Quit
-- `Ctrl+E`: Explain Weather
-- `Ctrl+T`: Open Weather Assistant
-- `Ctrl+Shift+R`: Open NOAA Weather Radio
+### NOAA Weather Radio
 
-## Config and Portability
+Use View > NOAA Weather Radio to open the radio player for the current location.
 
-AccessiWeather stores normal settings in the standard per-user config area unless you run in portable mode.
+This feature is most useful in NOAA coverage areas and depends on online station streams being available.
 
-Regular settings export/import:
+### Explain Weather
 
-- Includes settings and saved locations
-- Does not include API keys
+Explain Weather gives you a one-shot AI explanation of the current weather.
 
-Encrypted API-key transfer:
+Use it when you want a quick plain-language summary.
 
-1. Open `Settings > Advanced`.
-2. Choose `Export API keys (encrypted)`.
-3. Save the bundle and remember the passphrase.
-4. On the other machine, choose `Import API keys (encrypted)`.
-5. Enter the same passphrase.
+### Weather Assistant
 
-## Troubleshooting
+Weather Assistant is the chat-style AI tool.
 
-### I am not seeing alerts
+Use it when you want follow-up questions, practical advice, or a longer conversation about the current weather and forecast.
 
-Check these first:
+## 12. Where to get help
 
-- `Open-Meteo` does not provide alerts in AccessiWeather.
-- For US locations, use `Automatic` or `National Weather Service`.
-- For non-US locations, add a Pirate Weather key if you want the best alert coverage the app currently supports.
-- In `Settings > Notifications`, make sure `Enable weather alerts` and `Enable alert notifications` are set the way you expect.
+If you need help, updates, or downloads, use these resources:
 
-### Alerts feel too broad outside the US
-
-That can be normal. Pirate Weather alerts can be regional WMO-style alerts rather than tightly targeted county-style alerts.
-
-### I want rain-start or rain-stop notifications
-
-You need:
-
-- A Pirate Weather API key
-- Pirate Weather minutely data to be available for the location
-- The matching notification setting turned on in `Settings > Notifications`
-
-### Forecast times look wrong for a remote city
-
-Check:
-
-- `Forecast time display`
-- `Time zone display`
-- `Use 12-hour time format`
-- `Show timezone abbreviations`
-
-### Explain Weather or Weather Assistant does not work
-
-Check:
-
-- A valid OpenRouter key is saved in `Settings > AI`
-- The selected model still exists on OpenRouter
-- You have weather data loaded for the current location
-
-### Forecast Discussion says it is unavailable
-
-That can happen when:
-
-- The selected location is outside NWS coverage
-- No recent NWS discussion was issued
-- NWS is temporarily unavailable
-
-### NOAA Weather Radio says no stream is available
-
-That can be normal. The app only lists stations with known online streams, and not every NOAA Weather Radio station has one.
+- Project website: https://orinks.net/accessiweather
+- GitHub issues: https://github.com/Orinks/AccessiWeather/issues
+- GitHub discussions: https://github.com/Orinks/AccessiWeather/discussions
+- GitHub releases: https://github.com/Orinks/AccessiWeather/releases


### PR DESCRIPTION
## Summary
- fully rewrite the user manual so it reads like an end-user guide instead of a feature dump
- update Automatic mode documentation to match the current post-#585 behavior
- clean up the README so it works as a landing page and points readers to the full manual

## What changed
- rewrote `docs/user_manual.md` around install, first-run setup, everyday tasks, main-window reference, weather-source behavior, alerts, settings, shortcuts, troubleshooting, and help
- updated the settings reference to reflect the current tab order: General, Display, Alerts, Audio, Data Sources, AI, Updates, Advanced
- documented Automatic mode as fusion-first by default via Max coverage, with Economy and Balanced as opt-in reduced-call modes
- documented separate US and international automatic source lists and saved-order behavior
- documented current alert authority rules for US and international locations
- trimmed README detail and made the user manual link prominent

## Verification
- checked current settings dialog tab order and visible tab labels in code
- checked current Data Sources UI and source settings modal in code
- checked `weather_client_base.py` Automatic-mode behavior for source ordering, budgets, and alert handling
- searched the rewritten docs for stale wording from the old manual