### PR TITLE
feat(UI): complete event center and navigation polish

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -79,6 +79,7 @@
 
 #### Core Features
 - [ACCESSIBILITY.md](ACCESSIBILITY.md) - Accessibility features, guidelines, and screen reader support
+- [main-window-navigation.md](main-window-navigation.md) - Canonical main-window section order, F6 cycle, Ctrl+1..Ctrl+5 jumps, and Event Center behavior
 - [SOUND_PACK_SYSTEM.md](SOUND_PACK_SYSTEM.md) - Sound pack system architecture
 - [SOUND_PACKS.md](SOUND_PACKS.md) - Sound pack creation and usage guide
 - [weather_history_feature.md](weather_history_feature.md) - Historical weather tracking

--- a/docs/main-window-navigation.md
+++ b/docs/main-window-navigation.md
@@ -1,0 +1,104 @@
+# Main Window Navigation Reference
+
+This document is the canonical reference for AccessiWeather's current top-level main-window section model. Update it whenever the visible order, focus targets, or jump shortcuts change.
+
+## Canonical top-level order
+
+Visible top-level order:
+
+1. Location selector
+2. Current Conditions
+3. Hourly Forecast / near-term
+4. Daily Forecast
+5. Weather Alerts
+6. Event Center
+
+This order must stay aligned across:
+
+- visible UI layout
+- F6 cycle order
+- direct-jump shortcuts
+- user-facing docs
+- contributor guidance
+
+## Top-level navigation
+
+### F6 cycle
+
+F6 cycles through the visible top-level sections in on-screen order.
+
+Current cycle order:
+
+1. Location selector
+2. Current Conditions
+3. Hourly Forecast / near-term
+4. Daily Forecast
+5. Weather Alerts
+6. Event Center (when visible)
+
+If Event Center is hidden, F6 skips it.
+
+### Direct jumps
+
+Ctrl+1 through Ctrl+5 jump directly to the main forecast sections:
+
+- Ctrl+1 → Current Conditions
+- Ctrl+2 → Hourly Forecast / near-term
+- Ctrl+3 → Daily Forecast
+- Ctrl+4 → Weather Alerts
+- Ctrl+5 → Event Center
+
+If Event Center is hidden, Ctrl+5 does nothing until the user enables View > Event Center again.
+
+## Focus targets
+
+Each section jump should land on the primary readable control for that section:
+
+- Location selector → location dropdown
+- Current Conditions → current conditions text region
+- Hourly Forecast / near-term → hourly forecast text region
+- Daily Forecast → daily forecast text region
+- Weather Alerts → alerts list
+- Event Center → event center text region
+
+## Event Center behavior
+
+The Event Center is:
+
+- embedded in the main window
+- visible by default
+- toggleable from View > Event Center
+- a read-only multiline review surface with plain timestamped entries
+
+When visible:
+
+- it participates in F6 cycling
+- Ctrl+5 focuses it
+
+When hidden:
+
+- F6 skips it
+- Ctrl+5 does nothing
+- the View menu checkbox controls whether it is shown again
+
+## What gets logged
+
+The Event Center is intended for user-facing reviewable text, not internal debug state.
+
+Current first-pass contents include:
+
+- mobility briefings and spoken/surfaced summaries
+- reviewable notification or event text that the app surfaces to the user
+
+Entries should preserve the same user-facing wording, or a very close reviewable equivalent.
+
+## Hourly / near-term behavior
+
+The Hourly Forecast / near-term section may include a one-sentence mobility briefing for roughly the next 90 minutes.
+
+When present:
+
+- the mobility briefing appears at the top of the hourly section
+- the regular hourly outlook summary remains below it
+
+This means the mobility briefing supplements the hourly outlook instead of replacing it.

--- a/docs/plans/2026-04-12-aw-event-center-mobility-implementation-plan.md
+++ b/docs/plans/2026-04-12-aw-event-center-mobility-implementation-plan.md
@@ -1,0 +1,430 @@
+# AccessiWeather implementation plan: Event Center, section jumps, and 90-minute mobility briefing
+
+Date: 2026-04-12
+Branch: docs/aw-polish-event-center-mobility
+Status: implementation-ready plan
+
+## Goal
+
+Implement the approved polish design in a staged, test-driven way:
+
+1. Toggleable main-window Event Center
+2. F6 section cycling plus Ctrl+1..Ctrl+5 direct jumps
+3. 90-minute mobility briefing in the hourly / near-term section
+4. Cleaner confidence wording built on existing confidence plumbing
+5. Follow-on hazard surfacing hooks without overbuilding the first slice
+
+## Current code reality
+
+### Main window ownership
+
+The visible top-level weather UI already lives in:
+- `src/accessiweather/ui/main_window.py`
+
+Current visible order in the default single-location view is effectively:
+1. Location chooser
+2. Current Conditions
+3. Daily Forecast
+4. Hourly Forecast
+5. Weather Alerts
+6. Action buttons
+
+This means the approved canonical order maps naturally to the existing widgets, with one wording adjustment in implementation/docs:
+- Current conditions
+- Hourly / near-term
+- Daily forecast
+- Alerts
+- Event Center
+
+Because the current layout renders daily above hourly, implementation must decide whether to:
+- preserve current visual order and adjust number mapping, or
+- reorder the two forecast sections to match the approved jump order.
+
+Recommendation: reorder visible forecast sections so Hourly / near-term appears before Daily Forecast. That keeps the keyboard model, docs, and visible layout aligned rather than teaching an exception.
+
+### Shortcut ownership
+
+Global accelerators currently live in:
+- `src/accessiweather/app.py`
+
+Existing shortcuts include:
+- Ctrl+R, Ctrl+L, Ctrl+D, Ctrl+H, Ctrl+S, Ctrl+Q, F5
+
+This is the right place to add:
+- F6 section cycling
+- Ctrl+1..Ctrl+5 direct section jumps
+
+### Notification/event plumbing
+
+Relevant notification paths already exist in:
+- `src/accessiweather/ui/main_window_notification_events.py`
+- `src/accessiweather/ui/main_window.py`
+- `src/accessiweather/alert_notification_system.py`
+- `src/accessiweather/screen_reader.py`
+
+Important current behavior:
+- lightweight polling already processes discussion/severe-risk/minutely event notifications
+- full refresh path already processes alert notifications and event notifications
+- `MainWindow` already owns a `ScreenReaderAnnouncer`
+
+This means the Event Center should not invent a third notification system. It should be a reviewable capture surface for user-facing spoken/event text.
+
+### Forecast presentation ownership
+
+Forecast text currently comes from:
+- `src/accessiweather/display/presentation/forecast.py`
+- `src/accessiweather/display/weather_presenter.py`
+
+Relevant existing support:
+- `ForecastPresentation.daily_section_text`
+- `ForecastPresentation.hourly_section_text`
+- `ForecastPresentation.confidence_label`
+- existing confidence text is already appended into the daily section
+
+The mobility briefing belongs in this presentation layer, not directly in `MainWindow` string assembly.
+
+### Weather data model
+
+Relevant weather model fields already exist in:
+- `src/accessiweather/models/weather.py`
+
+Important existing fields:
+- `WeatherData.hourly_forecast`
+- `WeatherData.minutely_precipitation`
+- `WeatherData.forecast_confidence`
+- `CurrentConditions.visibility_*`
+- `CurrentConditions.severe_weather_risk`
+- `ForecastPeriod.precipitation_probability`, `wind_gust`, etc.
+
+This is enough to implement a first-pass mobility briefing without introducing a brand-new persisted weather model.
+
+## Data-source research summary
+
+Research used:
+- existing AccessiWeather clients
+- provider official docs pages fetched with curl
+- direct inspection of current request parameters already in repo
+
+### Pirate Weather
+
+Current client:
+- `src/accessiweather/pirate_weather_client.py`
+
+Current request already uses:
+- `extend=hourly`
+- full payload fetch returning `currently`, `hourly`, `daily`, `minutely`, `alerts`
+
+Docs/page evidence from official docs page indicates support for:
+- `minutely`
+- `include`
+- `extend=hourly`
+- `visibility`
+- `cape` / `capeMaxTime`
+
+Practical implication:
+- AW already has a single full-payload request path for PW
+- first-pass mobility briefing can reuse `weather_data.minutely_precipitation` when available
+- if we later want richer PW-driven risk phrasing, CAPE is a plausible extension point
+
+### Open-Meteo
+
+Current client:
+- `src/accessiweather/openmeteo_client.py`
+
+Current repo already requests/supports:
+- current visibility
+- hourly precipitation probability
+- hourly visibility
+- hourly wind gusts
+
+Official docs page content confirms support for:
+- `minutely_15`
+- 15-minute variables including precipitation-oriented and wind-oriented series
+- hourly `visibility`
+- hourly `wind_gusts_10m`
+- hourly `cape`
+
+Practical implication:
+- Open-Meteo is the strongest fallback for a near-term mobility summary when Pirate Weather minutely data is absent
+- first-pass implementation can likely begin with existing hourly data path, then add a narrower `minutely_15` enhancement path if needed
+- visibility and CAPE can support better confidence/hazard messaging later
+
+### Visual Crossing
+
+Current client:
+- `src/accessiweather/visual_crossing_client.py`
+
+Current repo already uses official API parameters like:
+- `include=current,days`
+- `include=days`
+- `include=hours`
+- `include=alerts`
+- `elements=...visibility...windgust...precip...severerisk...`
+
+Official docs page and examples confirm:
+- `include=days`
+- `hours`
+- `alerts`
+- `visibility`
+- `severerisk`
+- configurable `elements`
+
+Practical implication:
+- Visual Crossing is already a usable fallback source for hourly wind/visibility/severe-risk context
+- it is not the first choice for the mobility briefing, but it is useful for fallback and hazard enrichment
+
+## Implementation strategy
+
+## Phase 1: Event Center foundation
+
+### Production changes
+
+Add a simple Event Center section to `MainWindow`:
+- label: `Event Center:`
+- widget: multiline read-only `wx.TextCtrl`
+- visible by default
+- toggleable from the View menu
+- append-only timestamped text
+
+Recommended widget shape:
+- `wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH2`
+- explicit helper methods on `MainWindow`:
+  - `append_event_center_entry(text: str, *, category: str | None = None)`
+  - `show_event_center()`
+  - `hide_event_center()`
+  - `toggle_event_center()`
+  - `_focus_event_center()`
+
+### Test-first slices
+
+1. RED: Event Center helper appends timestamped text to the control
+2. RED: toggle hides and shows the Event Center section
+3. RED: hidden Event Center can be revealed and focused
+4. RED: F6 traversal skips Event Center when hidden
+
+### Notes
+
+Do not couple Event Center logging directly to desktop notifications. It should capture user-facing text, not notifier internals.
+
+## Phase 2: Section navigation
+
+### Production changes
+
+Implement a canonical section map in `MainWindow`, not scattered logic.
+
+Recommended helpers:
+- `_get_top_level_sections() -> list[tuple[str, wx.Window]]`
+- `_focus_section_by_index(index: int)`
+- `_cycle_section_focus()`
+
+Approved mapping:
+- 1 = Current conditions
+- 2 = Hourly / near-term
+- 3 = Daily forecast
+- 4 = Alerts
+- 5 = Event Center
+
+Add global accelerators in `app.py` for:
+- F6
+- Ctrl+1..Ctrl+5
+
+### Test-first slices
+
+1. RED: canonical section order returns expected widgets in expected order
+2. RED: hidden Event Center is omitted from visible traversal
+3. RED: Ctrl+5 reveals and focuses Event Center when hidden
+4. RED: F6 advances through visible sections in order
+
+### Important UI note
+
+To match the approved behavior cleanly, move Hourly Forecast above Daily Forecast in `_create_widgets()`.
+
+## Phase 3: Event capture wiring
+
+### Production changes
+
+Route user-facing spoken/event text into the Event Center.
+
+First-pass sources:
+- spoken alerts / notifications
+- spoken briefings / summaries generated by this work
+
+Possible integration points:
+- `MainWindow.set_status()` is not sufficient by itself and should not become the Event Center sink
+- add a dedicated `log_user_event(...)` / `log_spoken_event(...)` path on `MainWindow`
+- call it from places that already decide user-facing text
+
+For alert notifications, prefer logging the text composed for the user, not low-level event metadata.
+
+### Test-first slices
+
+1. RED: alert/event text passed through main-window event logging is appended in Event Center
+2. RED: plain reviewable text is stored even if sound/notifier delivery path is mocked
+
+## Phase 4: 90-minute mobility briefing
+
+### Production changes
+
+Add a new builder module, preferably under presentation/service layer, for example:
+- `src/accessiweather/services/mobility_briefing.py`
+  or
+- `src/accessiweather/display/presentation/mobility.py`
+
+Recommendation: keep generation logic out of `MainWindow` and out of `forecast.py` line-formatting code. Use a small helper that returns a concise string or `None`.
+
+Suggested API:
+- `build_mobility_briefing(weather_data: WeatherData, settings: AppSettings | None = None) -> str | None`
+
+Inputs to use in priority order:
+1. Pirate Weather minutely precipitation (`weather_data.minutely_precipitation`)
+2. Open-Meteo near-term/hourly fallback
+3. Visual Crossing hourly fallback
+
+First-pass output rules:
+- one concise sentence
+- next 90 minutes only
+- mention only meaningful mobility impacts:
+  - precip start/stop timing
+  - precip intensity shift
+  - gust increase
+  - visibility degradation or staying good
+  - thunder concern when meaningful
+
+Rendering integration:
+- prepend or insert the briefing at the top of `hourly_section_text`
+- also expose it separately on `ForecastPresentation` if helpful for reuse/testing
+
+Recommended small model extension:
+- add `mobility_briefing: str | None = None` to `ForecastPresentation`
+
+### Test-first slices
+
+1. RED: returns concise precip-start message from minutely precipitation data
+2. RED: omits irrelevant categories when conditions are stable
+3. RED: falls back to hourly wind/precip summary when minutely data absent
+4. RED: mentions visibility stability/degradation when materially relevant
+5. RED: limits scope to the next 90 minutes
+6. RED: hourly section text includes the mobility briefing ahead of generic hourly lines
+
+## Phase 5: Confidence wording cleanup
+
+### Current behavior
+
+`forecast.py` already appends:
+- `Forecast confidence: Medium. <rationale>.`
+
+### Production change
+
+Refine wording to approved explanation-first style without creating a separate diagnostics UI.
+
+Recommendation:
+- keep confidence in the daily section for now
+- convert internal `Medium` to user-facing `Moderate`
+- ensure rationale reads naturally as disagreement explanation
+
+Potential helper:
+- `format_confidence_line(confidence: ForecastConfidence) -> str`
+
+### Test-first slices
+
+1. RED: medium confidence renders as `Moderate`
+2. RED: disagreement rationale is preserved in plain language
+3. RED: confidence line stays concise and readable
+
+## Phase 6: Event Center capture for briefings
+
+### Production changes
+
+When a mobility briefing is actively spoken or surfaced as a user-facing summary, append it to the Event Center as:
+- `[time] Briefing: ...`
+
+### Test-first slices
+
+1. RED: a generated briefing can be logged to Event Center with `Briefing:` prefix
+2. RED: Event Center stores the same user-facing text used for review
+
+## Phase 7: Hazard-card hooks (deferred unless time remains)
+
+Do not implement full cards in the first coding pass unless earlier phases land cleanly with tests.
+
+If time remains, add only a tiny internal hook:
+- helper that detects whether a hazard callout should exist
+- no large UI surfacing yet
+
+## Test plan
+
+### Existing likely test targets to extend
+
+- `tests/test_main_window_forecast_sections.py`
+- `tests/test_main_window_announcer.py`
+- `tests/test_notification_event_manager.py`
+- `tests/test_hourly_forecast_presentation.py`
+- `tests/test_forecast_confidence_presentation.py`
+- `tests/test_all_locations_view.py`
+
+### New likely test files
+
+- `tests/test_main_window_event_center.py`
+- `tests/test_main_window_section_navigation.py`
+- `tests/test_mobility_briefing.py`
+
+## Recommended implementation order in code
+
+1. Add failing Event Center tests
+2. Implement Event Center helpers and toggle UI
+3. Add failing section-jump tests
+4. Implement F6 / Ctrl+1..Ctrl+5 navigation
+5. Add failing mobility briefing tests
+6. Implement mobility briefing builder
+7. Integrate briefing into forecast presentation
+8. Add failing confidence wording tests
+9. Refine confidence wording
+10. Wire briefing/event text into Event Center
+11. Run targeted tests, then broader relevant suite
+
+## Verification commands
+
+Start narrow during TDD:
+
+```bash
+pytest -q tests/test_main_window_event_center.py
+pytest -q tests/test_main_window_section_navigation.py
+pytest -q tests/test_mobility_briefing.py
+pytest -q tests/test_hourly_forecast_presentation.py
+pytest -q tests/test_forecast_confidence_presentation.py
+```
+
+Then run the touched broader set:
+
+```bash
+pytest -q \
+  tests/test_main_window_forecast_sections.py \
+  tests/test_main_window_announcer.py \
+  tests/test_notification_event_manager.py \
+  tests/test_hourly_forecast_presentation.py \
+  tests/test_forecast_confidence_presentation.py \
+  tests/test_all_locations_view.py
+```
+
+## Risks
+
+1. `MainWindow` already has a lot of responsibilities
+   - Mitigation: keep Event Center and section traversal behind small helper methods
+
+2. Shortcut logic split across `MainWindow` and `app.py`
+   - Mitigation: accelerators in `app.py`, destination resolution in `MainWindow`
+
+3. Mobility briefing could become verbose
+   - Mitigation: hard cap it to one concise sentence and 90-minute scope
+
+4. Forecast order mismatch between approved design and current UI
+   - Mitigation: reorder hourly above daily now so the keyboard model stays truthful
+
+5. Event Center could become a duplicate debug log
+   - Mitigation: only user-facing spoken/event text in first pass
+
+## Decision log
+
+- Proceed without Bright Data MCP for now; use curl and official docs directly
+- Keep implementation grounded in current client capabilities instead of building speculative new provider adapters first
+- Use TDD for each feature slice before production code changes

--- a/docs/superpowers/specs/2026-04-12-aw-polish-event-center-mobility-design.md
+++ b/docs/superpowers/specs/2026-04-12-aw-polish-event-center-mobility-design.md
@@ -1,0 +1,342 @@
+# AccessiWeather polish design: Event Center, section jumps, and near-term mobility briefing
+
+Date: 2026-04-12
+Project: AccessiWeather
+Status: Draft design approved in chat, written for review
+
+## Summary
+
+This design focuses AccessiWeather polish on presentation, prioritization, and reviewability rather than adding broad new feature surface. The first wave adds a PortkeyDrop-style, toggleable Event Center to the main window, plus stable section-jump keyboard navigation. The second wave adds one speech-first 90-minute mobility briefing that answers the practical question blind users often need most: whether it is a good time to leave now or shortly.
+
+The later waves add a short confidence/disagreement line and contextual hazard cards only when those signals are relevant. Documentation and contributor guidance are updated alongside the UI changes so visible labels, section order, and shortcut behavior stay aligned with the real application instead of drifting into stale docs.
+
+## Goals
+
+1. Ensure important spoken alerts and summaries are always reviewable after the fact.
+2. Make the main window faster to navigate by keyboard and screen reader.
+3. Provide one compact near-term mobility briefing covering the next 90 minutes.
+4. Surface confidence/disagreement and hazard context only when they materially help decision-making.
+5. Tighten docs so contributors and agents work from the app's actual UI model and real labels.
+
+## Non-goals
+
+1. Do not add a new standalone briefing window.
+2. Do not build a complex filtered log browser in the first pass.
+3. Do not expose raw model-comparison detail screens.
+4. Do not add persistent hazard panels that always occupy space even when irrelevant.
+5. Do not attempt a repo-wide documentation rewrite beyond the touched UI areas.
+
+## Current context
+
+The current codebase already contains useful groundwork:
+
+- AccessiWeather has notification-heavy recent work, increasing the value of a reviewable spoken/event history.
+- A history shortcut already exists, which suggests the app already accepts the idea of revisiting prior information.
+- Forecast confidence plumbing already exists in the weather client layer.
+- Display prioritization logic already includes themes tied to flood, fog, smoke, and visibility.
+- Open-Meteo, Pirate Weather, and Visual Crossing already expose much of the near-term weather data needed for a short mobility briefing.
+- Existing accessibility docs are partially outdated in architecture assumptions and do not yet serve as a precise canonical map of the real top-level UI model.
+
+## Canonical top-level section model
+
+This design introduces and documents one canonical section order for the main window. The visible labels and docs must match this order exactly.
+
+1. Current conditions
+2. Hourly / near-term
+3. Daily forecast
+4. Alerts
+5. Event Center
+
+This order is the basis for:
+
+- F6 section cycling
+- Ctrl+1 through Ctrl+5 direct jumps
+- visible UI ordering
+- docs and contributor guidance
+- screen reader expectations
+
+If the Event Center is hidden, it is removed from F6 traversal until shown again.
+
+## Feature 1: Reviewable Event Center
+
+### UX
+
+AccessiWeather gains a PortkeyDrop-style Event Center embedded in the main window. It is visible by default, but toggleable on and off by the user like PortkeyDrop's activity log panel.
+
+The first implementation uses a read-only multiline text control with plain timestamped lines appended at the bottom. This is intentionally simple and screen-reader-stable.
+
+### Day-one contents
+
+On first release, the Event Center records only:
+
+1. spoken alerts / notifications
+2. spoken summaries / briefings
+
+It does not yet attempt to record every internal state change, source swap, or refresh event. The goal is to preserve user-relevant spoken output, not to become a debug console.
+
+### Event entry format
+
+Event entries are plain text lines with timestamps, appended in chronological order. Example:
+
+[6:05 PM] Alert: Severe thunderstorm warning until 6:45 PM.
+[6:07 PM] Briefing: Dry for 35 minutes, then light rain likely; gusts increase after 6:30 PM; visibility stays good; thunder risk low.
+
+No grouping, filtering, category chips, or reverse-chronological ordering is required in the first pass.
+
+### Behavior rules
+
+- The Event Center is part of the normal main-window layout, not a separate dialog.
+- The panel can be shown or hidden by the user.
+- When visible, it participates in top-level navigation.
+- When hidden, F6 skips it.
+- Ctrl+5 should reveal and focus the Event Center if it is hidden.
+- Spoken alerts and spoken summaries should be written to the Event Center using the same user-facing text, or a very close reviewable equivalent.
+
+### Why this shape
+
+This follows the strongest PortkeyDrop lesson: spoken information should be reviewable without forcing users into a separate workflow. A simple embedded pane is lower risk and more discoverable than a dedicated history dialog.
+
+## Feature 2: Section-jump navigation
+
+### Keyboard model
+
+AccessiWeather adds two complementary top-level navigation mechanisms:
+
+1. F6 cycles through the visible top-level sections in on-screen order.
+2. Ctrl+1 through Ctrl+5 jump directly to top-level sections.
+
+Number mapping must follow the visible order exactly:
+
+- Ctrl+1: Current conditions
+- Ctrl+2: Hourly / near-term
+- Ctrl+3: Daily forecast
+- Ctrl+4: Alerts
+- Ctrl+5: Event Center
+
+### Focus behavior
+
+Each jump should move focus to a reliable control or focus target inside the destination section. If a section is represented by a composite region, the app should focus the section's primary readable widget, not a random nested control.
+
+The F6 cycle should always respect the real visible order, not an internal historical ordering.
+
+### Hidden Event Center behavior
+
+If the Event Center is hidden and the user presses Ctrl+5, the app should reveal the Event Center and move focus into it. This is better than announcing a dead destination because it keeps the shortcut meaningful and learnable.
+
+## Feature 3: 90-minute mobility briefing
+
+### Product goal
+
+The mobility briefing is the strongest user-facing improvement because it gives blind users the same practical departure-timing advantage that charts often give sighted users.
+
+The question it answers is not "what is all the weather data?" but "what matters for the next 90 minutes if I am deciding whether to leave now or soon?"
+
+### Placement
+
+The mobility briefing belongs in the Hourly / near-term area. It is not a separate window or mode.
+
+It should also be eligible to be spoken and written to the Event Center.
+
+### Output style
+
+The briefing should be one concise, speech-first summary. Example:
+
+"Dry for 35 minutes, then light rain likely; gusts increase after 6 PM; visibility stays good; thunder risk low."
+
+It should suppress irrelevant items rather than reading a rigid template.
+
+### Source fallback order
+
+For minute-level or sub-hourly generation, use this fallback order:
+
+1. Pirate Weather
+2. Open-Meteo
+3. Visual Crossing
+
+If minute-level or sub-hourly data is weak or unavailable, degrade gracefully to the best available near-term/hourly summary.
+
+### First-pass content scope
+
+The 90-minute mobility briefing should only mention items that directly affect near-term mobility:
+
+- precipitation start / stop timing
+- meaningful precipitation intensity changes
+- wind or gust worsening
+- visibility degradation or staying good
+- thunder risk when relevant
+
+It should not try to narrate every modeled field. Marine/coastal, flood, smoke, or fire specifics belong primarily to the later hazard-card phase unless they materially affect the 90-minute mobility message itself.
+
+### Briefing generation principles
+
+- Prefer one high-value sentence over a checklist.
+- Mention timing when known.
+- Mention worsening changes, not static values alone.
+- Omit categories that are steady and unimportant.
+- Preserve graceful degradation when only hourly or partial data is available.
+
+## Feature 4: Confidence / disagreement line
+
+### UX
+
+AccessiWeather adds a short, explanation-first confidence line near the relevant forecast summary. This should not be a separate model comparison view.
+
+Example output:
+
+- Confidence: High
+- Confidence: Moderate — precipitation timing differs between sources
+- Confidence: Low — sources disagree on rain timing and wind increase
+
+### Purpose
+
+The goal is to help users understand when the near-term forecast is straightforward versus when source disagreement makes it less certain. The line should explain the reason for lower confidence in plain language.
+
+### Scope
+
+This feature comes after Event Center, navigation, and the mobility briefing. It should reuse the existing confidence plumbing where possible instead of introducing a parallel scoring system.
+
+## Feature 5: Contextual hazard cards
+
+### UX
+
+Hazard cards appear only when relevant. They are not persistent clutter and should not duplicate the entire forecast.
+
+Initial hazard classes:
+
+- storm proximity / thunder concern
+- smoke / fire / air-quality visibility concern
+- flood / flash flood concern
+- marine / coastal concern
+
+### Content rules
+
+Each hazard card should answer:
+
+- what the risk is
+- why it matters now
+- what time window matters, if known
+
+### Priority
+
+Hazard cards come after:
+
+1. Event Center
+2. section-jump navigation
+3. mobility briefing
+4. confidence/disagreement line
+
+That keeps the early work focused on broadly useful presentation improvements before more conditional hazard surfacing.
+
+## Accessibility and interaction requirements
+
+1. The Event Center must be screen-reader readable as a standard multiline read-only text region.
+2. F6 and Ctrl+1 through Ctrl+5 must be documented with exact labels and exact section order.
+3. Docs must match visible UI labels and ordering exactly.
+4. Any new quick navigation or action labels touched during this work should be reviewed for user-facing clarity.
+5. The implementation should prefer stable, predictable focus targets over clever navigation logic.
+
+## Documentation requirements
+
+The design requires a canonical contributor-facing reference for the real top-level UI model that covers:
+
+- visible top-level section names
+- top-level section order
+- F6 cycle behavior
+- Ctrl+1 through Ctrl+5 destinations
+- Event Center behavior
+- what gets spoken and what gets logged
+
+The existing documentation should be updated only where needed to keep touched areas truthful. This is not a full-docs rewrite, but the touched docs must be made accurate.
+
+The docs cleanup should also include review of overly vague quick-action labels in the touched UI surfaces, since mismatched or unclear labels make both accessibility and contributor guidance worse.
+
+## Recommended implementation order
+
+1. Introduce a canonical top-level section model and documented order.
+2. Add the toggleable main-window Event Center pane.
+3. Route spoken alerts and spoken summaries into the Event Center.
+4. Add F6 visible-section cycling.
+5. Add Ctrl+1 through Ctrl+5 direct jumps using the canonical order.
+6. Add the 90-minute mobility briefing in the Hourly / near-term area.
+7. Add a short confidence/disagreement line near the relevant forecast summary.
+8. Add contextual hazard cards only when relevant.
+9. Update docs and contributor guidance for the touched areas as part of each phase, not all at the end.
+
+## Testing strategy
+
+### Event Center
+
+- Verify spoken alerts are appended to the Event Center.
+- Verify spoken summaries / briefings are appended to the Event Center.
+- Verify append order is chronological.
+- Verify toggle off hides the pane.
+- Verify toggle on restores it.
+- Verify Ctrl+5 reveals and focuses the Event Center when hidden.
+
+### Section navigation
+
+- Verify F6 cycles only through visible sections.
+- Verify F6 order matches on-screen order.
+- Verify Ctrl+1 through Ctrl+5 map to the documented sections exactly.
+- Verify the destination focus target is useful and screen-reader stable.
+
+### Mobility briefing
+
+- Verify the briefing appears in the near-term area.
+- Verify irrelevant categories are omitted.
+- Verify fallback order behaves as designed when minute/sub-hourly data is partial.
+- Verify the spoken briefing text is suitable for Event Center capture.
+
+### Confidence / disagreement
+
+- Verify high-confidence cases do not over-explain.
+- Verify disagreement cases mention the actual reason in plain language.
+- Verify placement is near the relevant summary rather than in an isolated diagnostics area.
+
+### Hazard cards
+
+- Verify cards appear only when relevant.
+- Verify they communicate risk, relevance, and timing.
+- Verify they do not duplicate the whole forecast.
+
+### Documentation
+
+- Verify docs match the visible labels and order exactly.
+- Verify shortcut docs match real runtime behavior.
+- Verify contributor guidance references the app's real UI model rather than outdated assumptions.
+
+## Risks and mitigations
+
+### Risk: Event Center becomes noisy
+Mitigation: day-one scope is limited to spoken alerts and spoken summaries only.
+
+### Risk: navigation shortcuts drift from actual UI order
+Mitigation: define one canonical section order and make shortcuts/docs derive from it.
+
+### Risk: mobility briefing becomes verbose or chart-like
+Mitigation: constrain it to the departure-timing question for the next 90 minutes.
+
+### Risk: confidence line becomes model trivia
+Mitigation: keep it explanation-first and user-facing, not diagnostic.
+
+### Risk: hazard surfacing adds clutter
+Mitigation: show hazard cards only when contextually relevant.
+
+## Open follow-up items intentionally deferred
+
+These are acknowledged but not required for the first implementation slice:
+
+- richer Event Center filtering and grouping
+- broader event capture beyond spoken alerts and summaries
+- deeper review of quick action labels outside the touched UI surfaces
+- more advanced hazard ranking or per-region hazard configuration
+
+## Recommendation
+
+Implement the work as a user-visible polish sequence anchored by a very small shared model:
+
+- one canonical top-level section order
+- one simple Event Center entry format
+- one near-term mobility briefing output shape
+
+That keeps the first pass practical, accessible, and easy to document while leaving room for later refinement without redoing the interaction model.

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -6,10 +6,12 @@ AccessiWeather is an accessible desktop weather application for Windows, macOS, 
 
 Instead of mixing everything into one long report, AccessiWeather separates weather into practical sections:
 
+- Location selector
 - Current Conditions
+- Hourly Forecast / near-term
 - Daily Forecast
-- Hourly Forecast
 - Weather Alerts
+- Event Center
 
 The app can also provide forecast discussions, air quality details, UV details, aviation weather, NOAA Weather Radio access, AI weather explanations, Weather Assistant chat, and optional notification sounds.
 
@@ -195,13 +197,39 @@ The main window is designed for quick keyboard and screen-reader use.
 
 The button row provides common actions without requiring the menu bar:
 
-- Add
-- Remove
-- Refresh
-- Explain
-- Discussion
+- Add Location
+- Remove Location
+- Refresh Weather
+- Explain Weather
+- Forecast Discussion
 - Settings
 - View Alert Details
+
+### Top-level navigation
+
+AccessiWeather supports two top-level navigation patterns in the main window:
+
+- F6 cycles through the visible top-level sections in order
+- Ctrl+1 through Ctrl+5 jump directly to the main forecast sections
+
+The current top-level order is:
+
+1. Location selector
+2. Current Conditions
+3. Hourly Forecast / near-term
+4. Daily Forecast
+5. Weather Alerts
+6. Event Center
+
+The direct-jump shortcuts map like this:
+
+- Ctrl+1: Current Conditions
+- Ctrl+2: Hourly Forecast / near-term
+- Ctrl+3: Daily Forecast
+- Ctrl+4: Weather Alerts
+- Ctrl+5: Event Center
+
+If the Event Center is hidden from the View menu, F6 skips it and Ctrl+5 does nothing until you show it again.
 
 ### Location selector
 
@@ -245,6 +273,24 @@ This is helpful if you need a quick answer before stepping outside and do not wa
 
 Leave this alone if you are planning for tomorrow or the weekend. In that case, the forecast sections are usually more useful.
 
+### Hourly Forecast / near-term
+
+This section shows the short-range hourly forecast. You can choose how many hours appear in Settings > Display.
+
+When AccessiWeather has enough useful near-term data, this section can begin with a one-sentence mobility briefing for roughly the next 90 minutes. The mobility briefing does not replace the hourly outlook summary. It appears above the hourly outlook when available.
+
+Use this when:
+
+- you need timing, not just a general day summary
+- you are deciding when to leave, when to return home, or when to fit in a trip outside
+- you want to know whether the coldest, windiest, wettest, or iciest part of the day lines up with your plans
+
+Hourly Forecast is usually the better choice for questions like "Will the rain start before my bus trip?" "Will the temperature still be above freezing at 7 PM?" or "Does the wind ease later tonight?"
+
+This is helpful if one part of the day is much different from another. It gives the timing that Daily Forecast intentionally smooths out.
+
+Leave this alone if you only need the big picture for the next several days. In that case, Daily Forecast is faster to read.
+
 ### Daily Forecast
 
 This section shows the multi-day forecast. The number of days depends on your Display settings and on what the source can provide.
@@ -259,23 +305,35 @@ Daily Forecast is usually the better choice for questions like "Which day looks 
 
 This is helpful if you do not want to read 24 or more hourly entries. It summarizes the larger pattern.
 
-Leave this alone if the exact timing matters, such as whether rain begins before 3 PM or whether winds ease after sunset. For those questions, use Hourly Forecast.
+Leave this alone if the exact timing matters, such as whether rain begins before 3 PM or whether winds ease after sunset. For those questions, use Hourly Forecast / near-term.
 
-### Hourly Forecast
+### Event Center
 
-This section shows the short-range hourly forecast. You can choose how many hours appear in Settings > Display.
+The Event Center is a reviewable text history of user-facing weather events and summaries.
 
-Use this when:
+On the current release, it is intended for:
 
-- you need timing, not just a general day summary
-- you are deciding when to leave, when to return home, or when to fit in a trip outside
-- you want to know whether the coldest, windiest, wettest, or iciest part of the day lines up with your plans
+- spoken or surfaced briefings
+- reviewable notification/event text
 
-Hourly Forecast is usually the better choice for questions like "Will the rain start before my bus trip?" "Will the temperature still be above freezing at 7 PM?" or "Does the wind ease later tonight?"
+Entries are appended as plain timestamped lines. Examples include:
 
-This is helpful if one part of the day is much different from another. It gives the timing that Daily Forecast intentionally smooths out.
+- brief mobility summaries
+- discussion-update summaries
+- other user-facing event text that AccessiWeather surfaces for review
 
-Leave this alone if you only need the big picture for the next several days. In that case, Daily Forecast is faster to read.
+The Event Center is part of the main window, not a separate dialog. It is visible by default and can be shown or hidden from View > Event Center.
+
+When it is visible:
+
+- F6 includes it in top-level cycling
+- Ctrl+5 jumps to it
+
+When it is hidden:
+
+- F6 skips it
+- Ctrl+5 does nothing
+- re-enable it from View > Event Center when you want it back
 
 ### Weather Alerts
 

--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -913,9 +913,15 @@ class AccessiWeatherApp(wx.App):
             (wx.ACCEL_CTRL, ord("L"), self._on_add_location_shortcut),
             (wx.ACCEL_CTRL, ord("D"), self._on_remove_location_shortcut),
             (wx.ACCEL_CTRL, ord("H"), self._on_history_shortcut),
+            (wx.ACCEL_CTRL, ord("1"), self._on_focus_current_conditions_shortcut),
+            (wx.ACCEL_CTRL, ord("2"), self._on_focus_hourly_shortcut),
+            (wx.ACCEL_CTRL, ord("3"), self._on_focus_daily_shortcut),
+            (wx.ACCEL_CTRL, ord("4"), self._on_focus_alerts_shortcut),
+            (wx.ACCEL_CTRL, ord("5"), self._on_focus_event_center_shortcut),
             (wx.ACCEL_CTRL, ord("S"), self._on_settings_shortcut),
             (wx.ACCEL_CTRL, ord("Q"), self._on_exit_shortcut),
             (wx.ACCEL_NORMAL, wx.WXK_F5, self._on_refresh_shortcut),
+            (wx.ACCEL_NORMAL, getattr(wx, "WXK_F6", wx.WXK_F5), self._on_cycle_sections_shortcut),
         ]
 
         # Create accelerator table
@@ -950,6 +956,36 @@ class AccessiWeatherApp(wx.App):
         """Handle Ctrl+H shortcut."""
         if self.main_window:
             self.main_window.on_view_history()
+
+    def _focus_section_shortcut(self, number: int) -> None:
+        """Delegate a numbered section-focus shortcut to the main window."""
+        if self.main_window:
+            self.main_window.focus_section_by_number(number)
+
+    def _on_focus_current_conditions_shortcut(self, event) -> None:
+        """Handle Ctrl+1 shortcut."""
+        self._focus_section_shortcut(1)
+
+    def _on_focus_hourly_shortcut(self, event) -> None:
+        """Handle Ctrl+2 shortcut."""
+        self._focus_section_shortcut(2)
+
+    def _on_focus_daily_shortcut(self, event) -> None:
+        """Handle Ctrl+3 shortcut."""
+        self._focus_section_shortcut(3)
+
+    def _on_focus_alerts_shortcut(self, event) -> None:
+        """Handle Ctrl+4 shortcut."""
+        self._focus_section_shortcut(4)
+
+    def _on_focus_event_center_shortcut(self, event) -> None:
+        """Handle Ctrl+5 shortcut."""
+        self._focus_section_shortcut(5)
+
+    def _on_cycle_sections_shortcut(self, event) -> None:
+        """Handle F6 shortcut."""
+        if self.main_window and hasattr(self.main_window, "cycle_section_focus"):
+            self.main_window.cycle_section_focus()
 
     def _on_settings_shortcut(self, event) -> None:
         """Handle Ctrl+S shortcut."""

--- a/src/accessiweather/display/presentation/forecast.py
+++ b/src/accessiweather/display/presentation/forecast.py
@@ -138,6 +138,7 @@ def build_forecast(
     settings: AppSettings | None = None,
     *,
     confidence: ForecastConfidence | None = None,
+    mobility_briefing: str | None = None,
 ) -> ForecastPresentation:
     """Create a structured forecast including optional hourly highlights."""
     title = f"Forecast for {location.name}"
@@ -322,6 +323,16 @@ def build_forecast(
         hours=hourly_hours,
         summary_line=hourly_summary_line,
     )
+    if mobility_briefing:
+        mobility_line = f"Mobility briefing: {mobility_briefing}"
+        if hourly_section_text:
+            hourly_section_text = hourly_section_text.replace(
+                "Hourly forecast:\n",
+                f"Hourly forecast:\n{mobility_line}\n",
+                1,
+            )
+        else:
+            hourly_section_text = f"Hourly forecast:\n{mobility_line}"
     fallback_sections = [daily_section_text]
     if hourly_section_text:
         fallback_sections.append(hourly_section_text)
@@ -345,6 +356,7 @@ def build_forecast(
         fallback_text=fallback_text,
         daily_section_text=daily_section_text,
         hourly_section_text=hourly_section_text,
+        mobility_briefing=mobility_briefing,
         confidence_label=confidence_label,
         summary=summary_line,
         impact_summary=forecast_impact,

--- a/src/accessiweather/display/presentation/forecast.py
+++ b/src/accessiweather/display/presentation/forecast.py
@@ -102,6 +102,20 @@ def _local_date(dt: datetime) -> date:
     return dt.date()
 
 
+def _format_confidence_level(confidence: ForecastConfidence) -> str:
+    """Return the user-facing confidence level label."""
+    if confidence.level.value == "Medium":
+        return "Moderate"
+    return confidence.level.value
+
+
+def _format_confidence_line(confidence: ForecastConfidence) -> str:
+    """Build a concise user-facing confidence explanation line."""
+    level_str = _format_confidence_level(confidence)
+    rationale = confidence.rationale.rstrip(".")
+    return f"Forecast confidence: {level_str}. {rationale}."
+
+
 def _select_periods_by_day_window(forecast: Forecast, configured_days: int) -> list[ForecastPeriod]:
     """Select periods within a strict calendar-day window when timestamps are available."""
     periods = forecast.periods or []
@@ -313,8 +327,8 @@ def build_forecast(
     # Append cross-source confidence summary when available
     confidence_label: str | None = None
     if confidence is not None:
-        level_str = confidence.level.value  # 'High', 'Medium', 'Low'
-        daily_lines.append(f"Forecast confidence: {level_str}. {confidence.rationale}.")
+        level_str = _format_confidence_level(confidence)
+        daily_lines.append(_format_confidence_line(confidence))
         confidence_label = f"Confidence: {level_str}"
 
     daily_section_text = "\n".join(daily_lines).rstrip()

--- a/src/accessiweather/display/weather_presenter.py
+++ b/src/accessiweather/display/weather_presenter.py
@@ -30,6 +30,7 @@ from ..models import (
     WeatherAlerts,
     WeatherData,
 )
+from ..services.mobility_briefing import build_mobility_briefing
 from ..units import resolve_display_unit_system, resolve_temperature_unit_preference
 from ..utils import TemperatureUnit, decode_taf_text
 from .presentation.environmental import AirQualityPresentation, build_air_quality_panel
@@ -107,6 +108,7 @@ class ForecastPresentation:
     fallback_text: str = ""
     daily_section_text: str = ""
     hourly_section_text: str = ""
+    mobility_briefing: str | None = None
     confidence_label: str | None = None
     summary: str | None = None
     impact_summary: ImpactSummary | None = None
@@ -237,6 +239,7 @@ class WeatherPresenter:
                 weather_data.location,
                 unit_pref,
                 confidence=weather_data.forecast_confidence,
+                mobility_briefing=build_mobility_briefing(weather_data),
             )
             if weather_data.forecast
             else None
@@ -312,12 +315,18 @@ class WeatherPresenter:
         location: Location,
         hourly_forecast: HourlyForecast | None = None,
         confidence: ForecastConfidence | None = None,
+        mobility_briefing: str | None = None,
     ) -> ForecastPresentation | None:
         if not forecast or not forecast.has_data():
             return None
         unit_pref, _unit_system = self._resolve_unit_preferences(location)
         return self._build_forecast(
-            forecast, hourly_forecast, location, unit_pref, confidence=confidence
+            forecast,
+            hourly_forecast,
+            location,
+            unit_pref,
+            confidence=confidence,
+            mobility_briefing=mobility_briefing,
         )
 
     def present_alerts(
@@ -369,6 +378,7 @@ class WeatherPresenter:
         location: Location,
         unit_pref: TemperatureUnit,
         confidence: ForecastConfidence | None = None,
+        mobility_briefing: str | None = None,
     ) -> ForecastPresentation:
         return build_forecast(
             forecast,
@@ -377,6 +387,7 @@ class WeatherPresenter:
             unit_pref,
             settings=self.settings,
             confidence=confidence,
+            mobility_briefing=mobility_briefing,
         )
 
     def _build_alerts(

--- a/src/accessiweather/services/mobility_briefing.py
+++ b/src/accessiweather/services/mobility_briefing.py
@@ -1,0 +1,201 @@
+"""Near-term mobility briefing helpers for AccessiWeather."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from ..models import WeatherData
+
+_ACTIONABLE_GUST_THRESHOLD_MPH = 25.0
+_VISIBILITY_CONCERN_THRESHOLD_MILES = 6.0
+_PRECIP_INTENSITY_THRESHOLD = 0.01
+
+
+def _coerce_utc(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def _infer_reference_time(weather_data: WeatherData) -> datetime | None:
+    candidate_times: list[datetime] = []
+
+    forecast = weather_data.minutely_precipitation
+    if forecast and forecast.points:
+        first_point_time = _coerce_utc(forecast.points[0].time)
+        if first_point_time is not None:
+            candidate_times.append(first_point_time)
+
+    hourly = weather_data.hourly_forecast
+    if hourly and hourly.periods:
+        first_period_time = _coerce_utc(hourly.periods[0].start_time)
+        if first_period_time is not None:
+            candidate_times.append(first_period_time)
+
+    if hourly and hourly.generated_at is not None:
+        generated_at = _coerce_utc(hourly.generated_at)
+        if generated_at is not None:
+            candidate_times.append(generated_at)
+
+    return min(candidate_times) if candidate_times else None
+
+
+def _normalize_reference_time(
+    reference_time: datetime | None, weather_data: WeatherData
+) -> datetime:
+    if reference_time is None:
+        inferred_reference_time = _infer_reference_time(weather_data)
+        if inferred_reference_time is not None:
+            return inferred_reference_time
+        return datetime.now(UTC)
+    if reference_time.tzinfo is None:
+        return reference_time.replace(tzinfo=UTC)
+    return reference_time.astimezone(UTC)
+
+
+def _first_precip_start_minutes(weather_data: WeatherData, now: datetime) -> int | None:
+    forecast = weather_data.minutely_precipitation
+    if not forecast or not forecast.points:
+        return None
+
+    for point in forecast.points:
+        point_time = point.time if point.time.tzinfo else point.time.replace(tzinfo=UTC)
+        delta = point_time.astimezone(UTC) - now
+        minutes = int(delta.total_seconds() // 60)
+        if minutes < 0 or minutes > 90:
+            continue
+        intensity = point.precipitation_intensity or 0.0
+        probability = point.precipitation_probability or 0.0
+        if intensity >= _PRECIP_INTENSITY_THRESHOLD or probability >= 0.5:
+            return minutes
+    return None
+
+
+def _gust_increase_phrase(weather_data: WeatherData, now: datetime) -> str | None:
+    hourly = weather_data.hourly_forecast
+    if not hourly or not hourly.periods:
+        return None
+
+    candidate_periods = []
+    for period in hourly.periods:
+        start = (
+            period.start_time if period.start_time.tzinfo else period.start_time.replace(tzinfo=UTC)
+        )
+        delta = start.astimezone(UTC) - now
+        if delta < timedelta(0) or delta > timedelta(minutes=90):
+            continue
+        candidate_periods.append((period, delta))
+
+    if not candidate_periods:
+        return None
+
+    first_gust = candidate_periods[0][0].wind_gust_mph or 0.0
+    max_period, max_delta = max(candidate_periods, key=lambda item: item[0].wind_gust_mph or 0.0)
+    max_gust = max_period.wind_gust_mph or 0.0
+    if max_gust < _ACTIONABLE_GUST_THRESHOLD_MPH:
+        return None
+    if max_gust <= first_gust + 5:
+        return None
+
+    minutes = int(max_delta.total_seconds() // 60)
+    if minutes <= 0:
+        return "gusts increase soon"
+    return f"gusts increase within {minutes} minutes"
+
+
+def _hourly_fallback_phrase(weather_data: WeatherData, now: datetime) -> str | None:
+    hourly = weather_data.hourly_forecast
+    if not hourly or not hourly.periods:
+        return None
+
+    candidate_periods = []
+    for period in hourly.periods:
+        start = (
+            period.start_time if period.start_time.tzinfo else period.start_time.replace(tzinfo=UTC)
+        )
+        delta = start.astimezone(UTC) - now
+        if delta < timedelta(0) or delta > timedelta(minutes=90):
+            continue
+        candidate_periods.append(period)
+
+    if not candidate_periods:
+        return None
+
+    for period in candidate_periods:
+        precip_prob = period.precipitation_probability or 0.0
+        if precip_prob >= 60 or (period.short_forecast and "rain" in period.short_forecast.lower()):
+            return period.short_forecast or "Rain likely"
+    return None
+
+
+def _visibility_phrase(weather_data: WeatherData, now: datetime) -> str | None:
+    hourly = weather_data.hourly_forecast
+    if hourly and hourly.periods:
+        candidate_visibilities = []
+        for period in hourly.periods:
+            start = (
+                period.start_time
+                if period.start_time.tzinfo
+                else period.start_time.replace(tzinfo=UTC)
+            )
+            delta = start.astimezone(UTC) - now
+            if delta < timedelta(0) or delta > timedelta(minutes=90):
+                continue
+            if period.visibility_miles is not None:
+                candidate_visibilities.append(period.visibility_miles)
+        if candidate_visibilities:
+            min_visibility = min(candidate_visibilities)
+            if min_visibility < _VISIBILITY_CONCERN_THRESHOLD_MILES:
+                return f"visibility may drop to around {min_visibility:.0f} miles"
+            return "visibility stays good"
+
+    current = weather_data.current
+    if (
+        current
+        and current.visibility_miles is not None
+        and current.visibility_miles >= _VISIBILITY_CONCERN_THRESHOLD_MILES
+    ):
+        return "visibility stays good"
+    return None
+
+
+def build_mobility_briefing(
+    weather_data: WeatherData,
+    *,
+    reference_time: datetime | None = None,
+) -> str | None:
+    """Build a concise next-90-minutes mobility briefing, if actionable."""
+    now = _normalize_reference_time(reference_time, weather_data)
+    phrases: list[str] = []
+
+    precip_start_minutes = _first_precip_start_minutes(weather_data, now)
+    if precip_start_minutes is not None:
+        if precip_start_minutes <= 0:
+            phrases.append("Rain is starting now")
+        else:
+            phrases.append(f"Dry for {precip_start_minutes} minutes, then rain likely")
+    else:
+        hourly_phrase = _hourly_fallback_phrase(weather_data, now)
+        if hourly_phrase is not None:
+            phrases.append(hourly_phrase)
+
+    gust_phrase = _gust_increase_phrase(weather_data, now)
+    if gust_phrase is not None:
+        phrases.append(gust_phrase)
+
+    visibility_phrase = _visibility_phrase(weather_data, now)
+    if visibility_phrase is not None and (phrases or visibility_phrase != "visibility stays good"):
+        phrases.append(visibility_phrase)
+
+    if not phrases:
+        return None
+
+    sentence = "; ".join(phrases).strip()
+    if not sentence:
+        return None
+    sentence = sentence[0].upper() + sentence[1:]
+    if not sentence.endswith("."):
+        sentence += "."
+    return sentence

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -8,6 +8,7 @@ widgets for optimal screen reader compatibility.
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 import wx
@@ -116,6 +117,14 @@ class MainWindow(SizedFrame):
         self.current_conditions.SetSizerProps(expand=True, proportion=1)
 
         # Forecast section
+        self._hourly_forecast_label = wx.StaticText(panel, label="Hourly Forecast:")
+        self.hourly_forecast_display = wx.TextCtrl(
+            panel,
+            style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH2,
+            name="Hourly weather forecast",
+        )
+        self.hourly_forecast_display.SetSizerProps(expand=True, proportion=1)
+
         self._daily_forecast_label = wx.StaticText(panel, label="Daily Forecast:")
         self.daily_forecast_display = wx.TextCtrl(
             panel,
@@ -124,14 +133,6 @@ class MainWindow(SizedFrame):
         )
         self.daily_forecast_display.SetSizerProps(expand=True, proportion=1)
         self.forecast_display = self.daily_forecast_display
-
-        self._hourly_forecast_label = wx.StaticText(panel, label="Hourly Forecast:")
-        self.hourly_forecast_display = wx.TextCtrl(
-            panel,
-            style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH2,
-            name="Hourly weather forecast",
-        )
-        self.hourly_forecast_display.SetSizerProps(expand=True, proportion=1)
 
         # Weather alerts section
         alerts_panel = SizedPanel(panel)
@@ -147,6 +148,16 @@ class MainWindow(SizedFrame):
 
         self.view_alert_button = wx.Button(alerts_panel, label="View Alert Details")
         self.view_alert_button.Disable()  # Disabled until alerts are available
+
+        # Event Center section
+        self._event_center_visible = True
+        self._event_center_label = wx.StaticText(panel, label="Event Center:")
+        self.event_center_display = wx.TextCtrl(
+            panel,
+            style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH2,
+            name="Event center",
+        )
+        self.event_center_display.SetSizerProps(expand=True, proportion=1)
 
         # Control buttons
         button_panel = SizedPanel(panel)
@@ -278,6 +289,13 @@ class MainWindow(SizedFrame):
         history_item = view_menu.Append(
             self._history_id, "Weather &History\tCtrl+H", "View weather history"
         )
+        self._toggle_event_center_id = wx.NewIdRef()
+        toggle_event_center_item = view_menu.AppendCheckItem(
+            self._toggle_event_center_id,
+            "Event &Center",
+            "Show or hide the Event Center",
+        )
+        toggle_event_center_item.Check(True)
         discussion_item = view_menu.Append(
             wx.ID_ANY, "Forecast &Discussion...", "View NWS Area Forecast Discussion"
         )
@@ -358,6 +376,9 @@ class MainWindow(SizedFrame):
         self.Bind(wx.EVT_MENU, lambda e: self.on_refresh(), refresh_item)
         self.Bind(wx.EVT_MENU, lambda e: self._on_explain_weather(), explain_item)
         self.Bind(wx.EVT_MENU, lambda e: self.on_view_history(), history_item)
+        self.Bind(
+            wx.EVT_MENU, lambda e: self.toggle_event_center(), id=self._toggle_event_center_id
+        )
         self.Bind(wx.EVT_MENU, lambda e: self._on_discussion(), discussion_item)
         self.Bind(wx.EVT_MENU, lambda e: self._on_aviation(), aviation_item)
         self.Bind(wx.EVT_MENU, lambda e: self._on_air_quality(), air_quality_item)
@@ -1181,6 +1202,11 @@ class MainWindow(SizedFrame):
                     presentation.forecast.hourly_section_text or "No hourly forecast available."
                 )
                 self._set_forecast_sections(daily_text, hourly_text)
+                if presentation.forecast.mobility_briefing:
+                    self.append_event_center_entry(
+                        presentation.forecast.mobility_briefing,
+                        category="Briefing",
+                    )
             else:
                 self._set_forecast_sections(
                     "No daily forecast available.", "No hourly forecast available."
@@ -1253,6 +1279,70 @@ class MainWindow(SizedFrame):
         """Update the daily and hourly forecast controls together."""
         self.daily_forecast_display.SetValue(daily_text)
         self.hourly_forecast_display.SetValue(hourly_text)
+
+    def append_event_center_entry(self, text: str, *, category: str | None = None) -> None:
+        """Append a timestamped reviewable line to the Event Center."""
+        if not text:
+            return
+        timestamp = datetime.now().strftime("%I:%M %p").lstrip("0")
+        prefix = f"{category}: " if category else ""
+        entry = f"[{timestamp}] {prefix}{text}\n"
+        self.event_center_display.AppendText(entry)
+
+    def toggle_event_center(self) -> None:
+        """Show or hide the Event Center section."""
+        visible = not getattr(self, "_event_center_visible", True)
+        self._event_center_visible = visible
+        self._event_center_label.Show(visible)
+        self.event_center_display.Show(visible)
+        self.Layout()
+
+    def focus_event_center(self) -> None:
+        """Reveal and focus the Event Center section."""
+        if not getattr(self, "_event_center_visible", True):
+            self._event_center_visible = True
+            self._event_center_label.Show(True)
+            self.event_center_display.Show(True)
+            self.Layout()
+        self.event_center_display.SetFocus()
+
+    def get_visible_top_level_sections(self) -> list[tuple[str, wx.Window]]:
+        """Return the canonical visible top-level weather sections in focus order."""
+        sections: list[tuple[str, wx.Window]] = [
+            ("Current conditions", self.current_conditions),
+            ("Hourly / near-term", self.hourly_forecast_display),
+            ("Daily forecast", self.daily_forecast_display),
+            ("Alerts", self.alerts_list),
+        ]
+        if getattr(self, "_event_center_visible", True):
+            sections.append(("Event Center", self.event_center_display))
+        return sections
+
+    def focus_section_by_number(self, number: int) -> None:
+        """Focus a canonical top-level section by its 1-based shortcut number."""
+        if number == 5:
+            self.focus_event_center()
+            return
+
+        sections = self.get_visible_top_level_sections()
+        index = number - 1
+        if 0 <= index < len(sections):
+            _label, widget = sections[index]
+            widget.SetFocus()
+
+    def cycle_section_focus(self) -> None:
+        """Move focus to the next visible top-level section, wrapping at the end."""
+        sections = self.get_visible_top_level_sections()
+        if not sections:
+            return
+
+        next_index = getattr(self, "_section_focus_index", -1) + 1
+        if next_index >= len(sections):
+            next_index = 0
+
+        self._section_focus_index = next_index
+        _label, widget = sections[next_index]
+        widget.SetFocus()
 
     def _set_forecast_sections_visible(self, visible: bool) -> None:
         """Show or hide the daily/hourly forecast labels and controls."""

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -1309,6 +1309,7 @@ class MainWindow(SizedFrame):
     def get_visible_top_level_sections(self) -> list[tuple[str, wx.Window]]:
         """Return the canonical visible top-level weather sections in focus order."""
         sections: list[tuple[str, wx.Window]] = [
+            ("Location", self.location_dropdown),
             ("Current conditions", self.current_conditions),
             ("Hourly / near-term", self.hourly_forecast_display),
             ("Daily forecast", self.daily_forecast_display),
@@ -1320,12 +1321,11 @@ class MainWindow(SizedFrame):
 
     def focus_section_by_number(self, number: int) -> None:
         """Focus a canonical top-level section by its 1-based shortcut number."""
-        if number == 5:
-            self.focus_event_center()
+        if number == 5 and not getattr(self, "_event_center_visible", True):
             return
 
         sections = self.get_visible_top_level_sections()
-        index = number - 1
+        index = len(sections) - 1 if number == 5 else number
         if 0 <= index < len(sections):
             _label, widget = sections[index]
             widget.SetFocus()

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -26,6 +26,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+QUICK_ACTION_LABELS = {
+    "add": "&Add Location",
+    "remove": "&Remove Location",
+    "refresh": "&Refresh Weather",
+    "explain": "&Explain Weather",
+    "discussion": "Forecast &Discussion",
+    "settings": "&Settings",
+}
+
 # Sentinel string used for the "All Locations" summary entry in the dropdown.
 ALL_LOCATIONS_SENTINEL = "All Locations"
 
@@ -164,12 +173,12 @@ class MainWindow(SizedFrame):
         button_panel.SetSizerType("horizontal")
         button_panel.SetSizerProps(expand=True)
 
-        self.add_button = wx.Button(button_panel, label="&Add")
-        self.remove_button = wx.Button(button_panel, label="Re&move")
-        self.refresh_button = wx.Button(button_panel, label="&Refresh")
-        self.explain_button = wx.Button(button_panel, label="&Explain")
-        self.discussion_button = wx.Button(button_panel, label="&Discussion")
-        self.settings_button = wx.Button(button_panel, label="&Settings")
+        self.add_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["add"])
+        self.remove_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["remove"])
+        self.refresh_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["refresh"])
+        self.explain_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["explain"])
+        self.discussion_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["discussion"])
+        self.settings_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["settings"])
 
         # Status bar — two fields: [0] main status, [1] stale/cached warning
         self.CreateStatusBar(2)

--- a/src/accessiweather/ui/main_window_notification_events.py
+++ b/src/accessiweather/ui/main_window_notification_events.py
@@ -23,6 +23,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _log_reviewable_event_text(window: MainWindow, title: str, message: str) -> None:
+    """Append reviewable user-facing event text to the Event Center when available."""
+    log_method = getattr(window, "append_event_center_entry", None)
+    if callable(log_method) and message:
+        log_method(message, category=title)
+
+
 def refresh_notification_events_async(window: MainWindow) -> None:
     """Run a lightweight event check without refreshing the full weather UI."""
     if window.app.is_updating:
@@ -187,6 +194,7 @@ def process_notification_events(window: MainWindow, weather_data) -> None:
 
         for event in events:
             try:
+                _log_reviewable_event_text(window, event.title, event.message)
                 logger.debug(
                     "[events] Sending %s notification: title=%r, sound_event=%r, play_sound=%s",
                     event.event_type,

--- a/tests/test_app_section_shortcuts.py
+++ b/tests/test_app_section_shortcuts.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def _make_app():
+    from accessiweather.app import AccessiWeatherApp
+
+    with patch.object(AccessiWeatherApp, "__init__", lambda self, *a, **kw: None):
+        app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+
+    app.main_window = MagicMock()
+    return app
+
+
+def test_ctrl_1_shortcut_focuses_current_conditions_section():
+    app = _make_app()
+
+    app._on_focus_current_conditions_shortcut(None)
+
+    app.main_window.focus_section_by_number.assert_called_once_with(1)
+
+
+def test_ctrl_5_shortcut_focuses_event_center_section():
+    app = _make_app()
+
+    app._on_focus_event_center_shortcut(None)
+
+    app.main_window.focus_section_by_number.assert_called_once_with(5)

--- a/tests/test_forecast_confidence_presentation.py
+++ b/tests/test_forecast_confidence_presentation.py
@@ -124,13 +124,13 @@ class TestBuildForecastHighConfidence:
 
 
 class TestBuildForecastMediumConfidence:
-    def test_confidence_label_is_confidence_medium(self):
+    def test_confidence_label_is_confidence_moderate(self):
         result = call_build(confidence=medium_confidence())
-        assert result.confidence_label == "Confidence: Medium"
+        assert result.confidence_label == "Confidence: Moderate"
 
-    def test_fallback_text_contains_forecast_confidence_medium(self):
+    def test_fallback_text_contains_forecast_confidence_moderate(self):
         result = call_build(confidence=medium_confidence())
-        assert "Forecast confidence: Medium" in result.fallback_text
+        assert "Forecast confidence: Moderate" in result.fallback_text
 
     def test_fallback_text_contains_single_source_rationale(self):
         result = call_build(confidence=medium_confidence())

--- a/tests/test_hourly_forecast_presentation.py
+++ b/tests/test_hourly_forecast_presentation.py
@@ -150,6 +150,44 @@ def test_build_forecast_formats_generated_time_in_location_timezone():
     assert f"Forecast generated: {expected_generated}" in result.daily_section_text
 
 
+def test_build_forecast_includes_mobility_briefing_at_top_of_hourly_section():
+    forecast = Forecast(
+        periods=[
+            ForecastPeriod(
+                name="Today",
+                temperature=70.0,
+                temperature_low=54.0,
+                temperature_unit="F",
+                short_forecast="Sunny",
+            )
+        ]
+    )
+    hourly = HourlyForecast(
+        periods=[
+            HourlyForecastPeriod(
+                start_time=datetime(2026, 3, 19, 12, tzinfo=UTC),
+                temperature=72.0,
+                temperature_unit="F",
+                short_forecast="Sunny",
+            )
+        ]
+    )
+
+    result = build_forecast(
+        forecast,
+        hourly,
+        Location(name="Testville", latitude=40.0, longitude=-75.0),
+        TemperatureUnit.FAHRENHEIT,
+        settings=AppSettings(hourly_forecast_hours=1),
+        mobility_briefing="Dry for 30 minutes, then rain likely.",
+    )
+
+    assert result.mobility_briefing == "Dry for 30 minutes, then rain likely."
+    assert result.hourly_section_text.startswith(
+        "Hourly forecast:\nMobility briefing: Dry for 30 minutes, then rain likely."
+    )
+
+
 def test_build_forecast_normalizes_hourly_timezone_label_from_offset_to_location_name():
     london_tz = ZoneInfo("Europe/London")
     forecast = Forecast(

--- a/tests/test_main_window_event_center.py
+++ b/tests/test_main_window_event_center.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+class _EventCenterCtrl:
+    def __init__(self):
+        self.chunks: list[str] = []
+        self.focused = False
+        self.shown = True
+
+    def AppendText(self, text: str) -> None:
+        self.chunks.append(text)
+
+    def SetFocus(self) -> None:
+        self.focused = True
+
+    def Show(self, visible: bool = True) -> None:
+        self.shown = visible
+
+
+class _WidgetStub:
+    def __init__(self):
+        self.shown = True
+
+    def Show(self, visible: bool = True) -> None:
+        self.shown = visible
+
+
+def _make_window():
+    from accessiweather.ui.main_window import MainWindow
+
+    with patch.object(MainWindow, "__init__", lambda self, *a, **kw: None):
+        win = MainWindow.__new__(MainWindow)
+
+    win.event_center_display = _EventCenterCtrl()
+    win._event_center_label = _WidgetStub()
+    win._event_center_visible = True
+    win.Layout = MagicMock()
+    return win
+
+
+def test_append_event_center_entry_adds_timestamped_line():
+    win = _make_window()
+
+    win.append_event_center_entry("Briefing: Dry for 30 minutes.")
+
+    output = "".join(win.event_center_display.chunks)
+    assert "Briefing: Dry for 30 minutes." in output
+    assert output.startswith("[")
+    assert "] " in output
+
+
+def test_toggle_event_center_hides_and_shows_widgets():
+    win = _make_window()
+
+    win.toggle_event_center()
+    assert win._event_center_visible is False
+    assert win._event_center_label.shown is False
+    assert win.event_center_display.shown is False
+
+    win.toggle_event_center()
+    assert win._event_center_visible is True
+    assert win._event_center_label.shown is True
+    assert win.event_center_display.shown is True
+
+
+def test_focus_event_center_reveals_hidden_panel_and_focuses_text_control():
+    win = _make_window()
+    win._event_center_visible = False
+    win._event_center_label.shown = False
+    win.event_center_display.shown = False
+
+    win.focus_event_center()
+
+    assert win._event_center_visible is True
+    assert win._event_center_label.shown is True
+    assert win.event_center_display.shown is True
+    assert win.event_center_display.focused is True

--- a/tests/test_main_window_forecast_sections.py
+++ b/tests/test_main_window_forecast_sections.py
@@ -36,6 +36,7 @@ def _make_window():
     win.hourly_forecast_display = MagicMock()
     win.refresh_button = MagicMock()
     win.set_status = MagicMock()
+    win.append_event_center_entry = MagicMock()
     win._update_alerts = MagicMock()
     win._process_notification_events = MagicMock()
     win._alert_lifecycle_labels = {}
@@ -53,6 +54,28 @@ def test_on_weather_data_received_sets_daily_and_hourly_forecast_sections():
 
     win.daily_forecast_display.SetValue.assert_called_once_with("Daily section")
     win.hourly_forecast_display.SetValue.assert_called_once_with("Hourly section")
+
+
+def test_on_weather_data_received_logs_mobility_briefing_to_event_center():
+    win = _make_window()
+    win.app.presenter.present.return_value.forecast = ForecastPresentation(
+        title="Forecast",
+        fallback_text="Combined forecast",
+        daily_section_text="Daily section",
+        hourly_section_text="Hourly section",
+        mobility_briefing="Dry for 30 minutes, then rain likely.",
+    )
+
+    weather_data = MagicMock()
+    weather_data.alerts = None
+    weather_data.alert_lifecycle_diff = None
+
+    win._on_weather_data_received(weather_data)
+
+    win.append_event_center_entry.assert_called_once_with(
+        "Dry for 30 minutes, then rain likely.",
+        category="Briefing",
+    )
 
 
 def test_set_forecast_sections_updates_both_controls():

--- a/tests/test_main_window_labels.py
+++ b/tests/test_main_window_labels.py
@@ -1,0 +1,12 @@
+from accessiweather.ui.main_window import QUICK_ACTION_LABELS
+
+
+def test_quick_action_labels_match_visible_ui_copy():
+    assert QUICK_ACTION_LABELS == {
+        "add": "&Add Location",
+        "remove": "&Remove Location",
+        "refresh": "&Refresh Weather",
+        "explain": "&Explain Weather",
+        "discussion": "Forecast &Discussion",
+        "settings": "&Settings",
+    }

--- a/tests/test_main_window_section_navigation.py
+++ b/tests/test_main_window_section_navigation.py
@@ -22,6 +22,7 @@ def _make_window():
     with patch.object(MainWindow, "__init__", lambda self, *a, **kw: None):
         win = MainWindow.__new__(MainWindow)
 
+    win.location_dropdown = _FocusableWidget("location")
     win.current_conditions = _FocusableWidget("current")
     win.hourly_forecast_display = _FocusableWidget("hourly")
     win.daily_forecast_display = _FocusableWidget("daily")
@@ -39,6 +40,7 @@ def test_get_visible_top_level_sections_returns_canonical_order():
     sections = win.get_visible_top_level_sections()
 
     assert [label for label, _widget in sections] == [
+        "Location",
         "Current conditions",
         "Hourly / near-term",
         "Daily forecast",
@@ -54,6 +56,7 @@ def test_get_visible_top_level_sections_skips_hidden_event_center():
     sections = win.get_visible_top_level_sections()
 
     assert [label for label, _widget in sections] == [
+        "Location",
         "Current conditions",
         "Hourly / near-term",
         "Daily forecast",
@@ -61,7 +64,7 @@ def test_get_visible_top_level_sections_skips_hidden_event_center():
     ]
 
 
-def test_focus_section_by_number_reveals_and_focuses_hidden_event_center():
+def test_focus_section_by_number_does_not_reveal_hidden_event_center():
     win = _make_window()
     win._event_center_visible = False
     win._event_center_label.shown = False
@@ -69,33 +72,33 @@ def test_focus_section_by_number_reveals_and_focuses_hidden_event_center():
 
     win.focus_section_by_number(5)
 
-    assert win._event_center_visible is True
-    assert win.event_center_display.shown is True
-    assert win.event_center_display.focused is True
+    assert win._event_center_visible is False
+    assert win.event_center_display.shown is False
+    assert win.event_center_display.focused is False
 
 
 def test_cycle_section_focus_advances_and_wraps_visible_sections():
     win = _make_window()
 
     win.cycle_section_focus()
+    assert win.location_dropdown.focused is True
+
+    win.location_dropdown.focused = False
+    win.cycle_section_focus()
     assert win.current_conditions.focused is True
 
     win.current_conditions.focused = False
+    win._section_focus_index = 5
     win.cycle_section_focus()
-    assert win.hourly_forecast_display.focused is True
-
-    win.hourly_forecast_display.focused = False
-    win._section_focus_index = 4
-    win.cycle_section_focus()
-    assert win.current_conditions.focused is True
+    assert win.location_dropdown.focused is True
 
 
 def test_cycle_section_focus_skips_hidden_event_center():
     win = _make_window()
     win._event_center_visible = False
-    win._section_focus_index = 3
+    win._section_focus_index = 4
 
     win.cycle_section_focus()
 
-    assert win.current_conditions.focused is True
+    assert win.location_dropdown.focused is True
     assert win.event_center_display.focused is False

--- a/tests/test_main_window_section_navigation.py
+++ b/tests/test_main_window_section_navigation.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+class _FocusableWidget:
+    def __init__(self, name: str):
+        self.name = name
+        self.focused = False
+        self.shown = True
+
+    def SetFocus(self) -> None:
+        self.focused = True
+
+    def Show(self, visible: bool = True) -> None:
+        self.shown = visible
+
+
+def _make_window():
+    from accessiweather.ui.main_window import MainWindow
+
+    with patch.object(MainWindow, "__init__", lambda self, *a, **kw: None):
+        win = MainWindow.__new__(MainWindow)
+
+    win.current_conditions = _FocusableWidget("current")
+    win.hourly_forecast_display = _FocusableWidget("hourly")
+    win.daily_forecast_display = _FocusableWidget("daily")
+    win.alerts_list = _FocusableWidget("alerts")
+    win.event_center_display = _FocusableWidget("event-center")
+    win._event_center_label = _FocusableWidget("event-label")
+    win._event_center_visible = True
+    win.Layout = MagicMock()
+    return win
+
+
+def test_get_visible_top_level_sections_returns_canonical_order():
+    win = _make_window()
+
+    sections = win.get_visible_top_level_sections()
+
+    assert [label for label, _widget in sections] == [
+        "Current conditions",
+        "Hourly / near-term",
+        "Daily forecast",
+        "Alerts",
+        "Event Center",
+    ]
+
+
+def test_get_visible_top_level_sections_skips_hidden_event_center():
+    win = _make_window()
+    win._event_center_visible = False
+
+    sections = win.get_visible_top_level_sections()
+
+    assert [label for label, _widget in sections] == [
+        "Current conditions",
+        "Hourly / near-term",
+        "Daily forecast",
+        "Alerts",
+    ]
+
+
+def test_focus_section_by_number_reveals_and_focuses_hidden_event_center():
+    win = _make_window()
+    win._event_center_visible = False
+    win._event_center_label.shown = False
+    win.event_center_display.shown = False
+
+    win.focus_section_by_number(5)
+
+    assert win._event_center_visible is True
+    assert win.event_center_display.shown is True
+    assert win.event_center_display.focused is True
+
+
+def test_cycle_section_focus_advances_and_wraps_visible_sections():
+    win = _make_window()
+
+    win.cycle_section_focus()
+    assert win.current_conditions.focused is True
+
+    win.current_conditions.focused = False
+    win.cycle_section_focus()
+    assert win.hourly_forecast_display.focused is True
+
+    win.hourly_forecast_display.focused = False
+    win._section_focus_index = 4
+    win.cycle_section_focus()
+    assert win.current_conditions.focused is True
+
+
+def test_cycle_section_focus_skips_hidden_event_center():
+    win = _make_window()
+    win._event_center_visible = False
+    win._section_focus_index = 3
+
+    win.cycle_section_focus()
+
+    assert win.current_conditions.focused is True
+    assert win.event_center_display.focused is False

--- a/tests/test_mobility_briefing.py
+++ b/tests/test_mobility_briefing.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from accessiweather.models import (
+    CurrentConditions,
+    HourlyForecast,
+    HourlyForecastPeriod,
+    Location,
+    MinutelyPrecipitationForecast,
+    MinutelyPrecipitationPoint,
+    WeatherData,
+)
+
+
+def _make_location() -> Location:
+    return Location(name="Testville", latitude=40.0, longitude=-75.0, timezone="UTC")
+
+
+def test_build_mobility_briefing_uses_minutely_precip_start_and_hourly_gusts():
+    from accessiweather.services.mobility_briefing import build_mobility_briefing
+
+    now = datetime(2026, 4, 12, 12, 0, tzinfo=UTC)
+    minutely = MinutelyPrecipitationForecast(
+        points=[
+            MinutelyPrecipitationPoint(time=now + timedelta(minutes=i), precipitation_intensity=0.0)
+            for i in range(30)
+        ]
+        + [
+            MinutelyPrecipitationPoint(
+                time=now + timedelta(minutes=i),
+                precipitation_intensity=0.08,
+                precipitation_type="rain",
+            )
+            for i in range(30, 91)
+        ]
+    )
+    hourly = HourlyForecast(
+        periods=[
+            HourlyForecastPeriod(
+                start_time=now,
+                short_forecast="Cloudy",
+                wind_speed="10 mph",
+                wind_gust_mph=15.0,
+                visibility_miles=10.0,
+            ),
+            HourlyForecastPeriod(
+                start_time=now + timedelta(hours=1),
+                short_forecast="Light Rain",
+                wind_speed="15 mph",
+                wind_gust_mph=28.0,
+                visibility_miles=8.0,
+            ),
+        ]
+    )
+    weather_data = WeatherData(
+        location=_make_location(),
+        current=CurrentConditions(visibility_miles=10.0),
+        hourly_forecast=hourly,
+        minutely_precipitation=minutely,
+    )
+
+    result = build_mobility_briefing(weather_data, reference_time=now)
+
+    assert result is not None
+    assert "Dry for 30 minutes" in result
+    assert "gusts increase" in result
+
+
+def test_build_mobility_briefing_falls_back_to_hourly_when_minutely_missing():
+    from accessiweather.services.mobility_briefing import build_mobility_briefing
+
+    now = datetime(2026, 4, 12, 12, 0, tzinfo=UTC)
+    hourly = HourlyForecast(
+        periods=[
+            HourlyForecastPeriod(
+                start_time=now,
+                short_forecast="Mostly Cloudy",
+                precipitation_probability=10.0,
+                wind_gust_mph=14.0,
+                visibility_miles=10.0,
+            ),
+            HourlyForecastPeriod(
+                start_time=now + timedelta(hours=1),
+                short_forecast="Rain Likely",
+                precipitation_probability=75.0,
+                wind_gust_mph=18.0,
+                visibility_miles=4.0,
+            ),
+        ]
+    )
+    weather_data = WeatherData(
+        location=_make_location(),
+        current=CurrentConditions(visibility_miles=10.0),
+        hourly_forecast=hourly,
+        minutely_precipitation=None,
+    )
+
+    result = build_mobility_briefing(weather_data, reference_time=now)
+
+    assert result is not None
+    assert "rain likely" in result.lower()
+    assert "visibility" in result.lower()
+
+
+def test_build_mobility_briefing_returns_none_when_no_near_term_signals_exist():
+    from accessiweather.services.mobility_briefing import build_mobility_briefing
+
+    now = datetime(2026, 4, 12, 12, 0, tzinfo=UTC)
+    hourly = HourlyForecast(
+        periods=[
+            HourlyForecastPeriod(
+                start_time=now,
+                short_forecast="Clear",
+                precipitation_probability=0.0,
+                wind_gust_mph=8.0,
+                visibility_miles=10.0,
+            ),
+            HourlyForecastPeriod(
+                start_time=now + timedelta(hours=1),
+                short_forecast="Clear",
+                precipitation_probability=0.0,
+                wind_gust_mph=9.0,
+                visibility_miles=10.0,
+            ),
+        ]
+    )
+    weather_data = WeatherData(
+        location=_make_location(),
+        current=CurrentConditions(visibility_miles=10.0),
+        hourly_forecast=hourly,
+    )
+
+    result = build_mobility_briefing(weather_data, reference_time=now)
+
+    assert result is None
+
+
+def test_build_mobility_briefing_infers_reference_time_from_forecast_timeline():
+    from accessiweather.services.mobility_briefing import build_mobility_briefing
+
+    now = datetime(2026, 4, 12, 12, 0, tzinfo=UTC)
+    weather_data = WeatherData(
+        location=_make_location(),
+        current=CurrentConditions(visibility_miles=10.0),
+        hourly_forecast=HourlyForecast(
+            periods=[
+                HourlyForecastPeriod(
+                    start_time=now,
+                    short_forecast="Cloudy",
+                    wind_gust_mph=15.0,
+                    visibility_miles=10.0,
+                ),
+                HourlyForecastPeriod(
+                    start_time=now + timedelta(hours=1),
+                    short_forecast="Light Rain",
+                    wind_gust_mph=28.0,
+                    visibility_miles=8.0,
+                ),
+            ]
+        ),
+        minutely_precipitation=MinutelyPrecipitationForecast(
+            points=[
+                MinutelyPrecipitationPoint(
+                    time=now + timedelta(minutes=i), precipitation_intensity=0.0
+                )
+                for i in range(20)
+            ]
+            + [
+                MinutelyPrecipitationPoint(
+                    time=now + timedelta(minutes=i),
+                    precipitation_intensity=0.08,
+                    precipitation_type="rain",
+                )
+                for i in range(20, 91)
+            ]
+        ),
+    )
+
+    result = build_mobility_briefing(weather_data)
+
+    assert result is not None
+    assert "Dry for 20 minutes" in result

--- a/tests/test_split_notification_timers.py
+++ b/tests/test_split_notification_timers.py
@@ -368,6 +368,7 @@ class TestNotificationEventHelpers:
         win.app.config_manager.config_dir = Path("/tmp/runtime-config")
         win._notification_event_manager = None
         win._fallback_notifier = None
+        win.append_event_center_entry = MagicMock()
         return win
 
     def test_get_notification_event_manager_caches_instance(self):
@@ -403,6 +404,8 @@ class TestNotificationEventHelpers:
         settings = MagicMock()
         settings.notify_discussion_update = True
         settings.notify_severe_risk_change = False
+        settings.notify_minutely_precipitation_start = False
+        settings.notify_minutely_precipitation_stop = False
         settings.sound_enabled = True
         win.app.config_manager.get_settings.return_value = settings
         location = MagicMock()
@@ -438,6 +441,44 @@ class TestNotificationEventHelpers:
             sound_event="discussion_update",
             play_sound=True,
             activation_arguments="accessiweather-toast:kind=discussion",
+        )
+        win.append_event_center_entry.assert_called_once_with(
+            "Summary",
+            category="Updated discussion",
+        )
+
+    def test_process_notification_events_logs_reviewable_text_when_notifier_returns_false(self):
+        win = self._make_window()
+        settings = MagicMock()
+        settings.notify_discussion_update = True
+        settings.notify_severe_risk_change = False
+        settings.notify_minutely_precipitation_start = False
+        settings.notify_minutely_precipitation_stop = False
+        settings.sound_enabled = True
+        win.app.config_manager.get_settings.return_value = settings
+        location = MagicMock()
+        location.name = "PHI"
+        win.app.config_manager.get_current_location.return_value = location
+        win.app.notifier = MagicMock()
+
+        event = MagicMock()
+        event.event_type = "discussion_update"
+        event.title = "Updated discussion"
+        event.message = "Summary"
+        event.sound_event = "discussion_update"
+        weather_data = MagicMock()
+
+        with patch(
+            "accessiweather.ui.main_window_notification_events.NotificationEventManager"
+        ) as manager_cls:
+            manager_cls.return_value.check_for_events.return_value = [event]
+            win.app.notifier.send_notification.return_value = False
+
+            win._process_notification_events(weather_data)
+
+        win.append_event_center_entry.assert_called_once_with(
+            "Summary",
+            category="Updated discussion",
         )
 
 

--- a/tests/test_weather_presenter_mobility_briefing.py
+++ b/tests/test_weather_presenter_mobility_briefing.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from accessiweather.display.weather_presenter import WeatherPresenter
+from accessiweather.models import (
+    AppSettings,
+    CurrentConditions,
+    Forecast,
+    ForecastPeriod,
+    HourlyForecast,
+    HourlyForecastPeriod,
+    Location,
+    MinutelyPrecipitationForecast,
+    MinutelyPrecipitationPoint,
+    WeatherData,
+)
+
+
+def test_weather_presenter_populates_forecast_mobility_briefing():
+    now = datetime(2026, 4, 12, 12, 0, tzinfo=UTC)
+    weather_data = WeatherData(
+        location=Location(name="Testville", latitude=40.0, longitude=-75.0, timezone="UTC"),
+        current=CurrentConditions(visibility_miles=10.0),
+        forecast=Forecast(
+            periods=[
+                ForecastPeriod(
+                    name="Today",
+                    temperature=70.0,
+                    temperature_low=54.0,
+                    temperature_unit="F",
+                    short_forecast="Cloudy",
+                )
+            ]
+        ),
+        hourly_forecast=HourlyForecast(
+            periods=[
+                HourlyForecastPeriod(
+                    start_time=now,
+                    short_forecast="Cloudy",
+                    wind_gust_mph=15.0,
+                    visibility_miles=10.0,
+                ),
+                HourlyForecastPeriod(
+                    start_time=now + timedelta(hours=1),
+                    short_forecast="Light Rain",
+                    wind_gust_mph=28.0,
+                    visibility_miles=8.0,
+                ),
+            ]
+        ),
+        minutely_precipitation=MinutelyPrecipitationForecast(
+            points=[
+                MinutelyPrecipitationPoint(
+                    time=now + timedelta(minutes=i), precipitation_intensity=0.0
+                )
+                for i in range(20)
+            ]
+            + [
+                MinutelyPrecipitationPoint(
+                    time=now + timedelta(minutes=i),
+                    precipitation_intensity=0.08,
+                    precipitation_type="rain",
+                )
+                for i in range(20, 91)
+            ]
+        ),
+    )
+
+    presenter = WeatherPresenter(AppSettings(hourly_forecast_hours=2))
+    presentation = presenter.present(weather_data)
+
+    assert presentation.forecast is not None
+    assert presentation.forecast.mobility_briefing is not None
+    assert "Dry for 20 minutes" in presentation.forecast.mobility_briefing
+    assert presentation.forecast.hourly_section_text.startswith(
+        "Hourly forecast:\nMobility briefing:"
+    )


### PR DESCRIPTION
## Summary
- add a toggleable Event Center to the main window as a reviewable text history for user-facing summaries and event text
- add canonical top-level navigation with F6 cycling and Ctrl+1..Ctrl+5 direct jumps
- add a 90-minute mobility briefing in the hourly / near-term section and log briefings to the Event Center
- refine forecast confidence wording so user-facing Medium becomes Moderate
- log reviewable notification/event text to the Event Center even when notifier delivery fails
- align the touched UI labels and docs with the real visible section order and shortcut behavior

## What shipped in this PR
- Event Center foundation in the main window
- View menu toggle for Event Center
- timestamped append-only Event Center entries
- canonical section order and focus targets
- F6 cycle behavior, including Location selector and hidden Event Center skip behavior
- Ctrl+1..Ctrl+5 direct section jumps
- hidden Event Center behavior where Ctrl+5 does nothing until the user re-enables View > Event Center
- Hourly / near-term placed above Daily Forecast to match navigation order
- 90-minute mobility briefing builder with forecast/presenter integration
- Event Center capture for briefings and reviewable notification/event text
- confidence wording cleanup for Moderate presentation
- clearer quick-action button labels in the main window
- user manual and contributor reference updates for navigation/Event Center behavior

## Follow-up work intentionally left out
- contextual hazard cards / hazard surfacing hooks
- broader documentation modernization outside the touched navigation/UI areas
- any future decision about suppressing the hourly outlook when a mobility briefing is present

## Test Plan
- `ruff format src/accessiweather/display/presentation/forecast.py src/accessiweather/ui/main_window.py src/accessiweather/ui/main_window_notification_events.py tests/test_forecast_confidence_presentation.py tests/test_main_window_labels.py tests/test_main_window_section_navigation.py tests/test_split_notification_timers.py`
- `ruff check src/accessiweather/display/presentation/forecast.py src/accessiweather/ui/main_window.py src/accessiweather/ui/main_window_notification_events.py tests/test_forecast_confidence_presentation.py tests/test_main_window_labels.py tests/test_main_window_section_navigation.py tests/test_split_notification_timers.py`
- `pytest -q tests/test_main_window_labels.py tests/test_main_window_section_navigation.py tests/test_app_section_shortcuts.py tests/test_main_window_forecast_sections.py tests/test_main_window_event_center.py tests/test_mobility_briefing.py tests/test_hourly_forecast_presentation.py tests/test_weather_presenter_mobility_briefing.py tests/test_forecast_confidence_presentation.py tests/test_split_notification_timers.py tests/test_main_window_announcer.py -n 0`

Result:
- ruff format/check passed
- 89 targeted tests passed locally
