### PR TITLE
refactor(Notifications): unify WeatherNotifier on SafeDesktopNotifier

### DIFF
--- a/src/accessiweather/notifications/weather_notifier.py
+++ b/src/accessiweather/notifications/weather_notifier.py
@@ -24,7 +24,7 @@ from dateutil.parser import isoparse  # type: ignore # requires python-dateutil
 
 from accessiweather.paths import resolve_default_config_root
 
-from .toast_notifier import SafeToastNotifier
+from .toast_notifier import SafeDesktopNotifier
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ class WeatherNotifier:
             enable_persistence: Whether to enable persistent storage of alert state (default: True)
 
         """
-        self.toaster = SafeToastNotifier()
+        self.notifier = SafeDesktopNotifier(app_name="AccessiWeather")
         self.active_alerts: dict[str, dict[str, Any]] = {}
         self.enable_persistence = enable_persistence
 
@@ -96,11 +96,10 @@ class WeatherNotifier:
                 message = f"{alert_count} active weather {plural} in your area"
 
             # Show notification
-            self.toaster.show_toast(
+            self.notifier.send_notification(
                 title=title,
-                msg=message,
+                message=message,
                 timeout=10,
-                app_name="AccessiWeather",
             )
 
             logger.info(f"Displayed summary notification: {message}")
@@ -125,13 +124,10 @@ class WeatherNotifier:
             message = alert.get("headline", "Weather alert in your area")
 
             # Show notification
-            self.toaster.show_toast(
+            self.notifier.send_notification(
                 title=title,
-                # 'msg' parameter is mapped to 'message' in SafeToastNotifier
-                msg=message,
-                # 'timeout' instead of 'duration'
+                message=message,
                 timeout=10,
-                app_name="AccessiWeather",
             )
 
             if is_update:

--- a/tests/test_weather_notifier_unified_backend.py
+++ b/tests/test_weather_notifier_unified_backend.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+class TestWeatherNotifierUsesSafeDesktopNotifier:
+    def test_notify_alerts_uses_send_notification(self):
+        with patch(
+            "accessiweather.notifications.weather_notifier.SafeDesktopNotifier"
+        ) as notifier_cls:
+            notifier = notifier_cls.return_value
+            from accessiweather.notifications.weather_notifier import WeatherNotifier
+
+            weather_notifier = WeatherNotifier(enable_persistence=False)
+            weather_notifier.notify_alerts(alert_count=2, new_count=1, updated_count=1)
+
+        notifier.send_notification.assert_called_once_with(
+            title="Weather Alerts",
+            message="1 new alert, 1 updated alert in your area",
+            timeout=10,
+        )
+
+    def test_show_notification_uses_send_notification(self):
+        alert = {
+            "event": "Tornado Warning",
+            "headline": "Tornado warning in your area",
+        }
+
+        with patch(
+            "accessiweather.notifications.weather_notifier.SafeDesktopNotifier"
+        ) as notifier_cls:
+            notifier = notifier_cls.return_value
+            from accessiweather.notifications.weather_notifier import WeatherNotifier
+
+            weather_notifier = WeatherNotifier(enable_persistence=False)
+            weather_notifier.show_notification(alert, is_update=False)
+
+        notifier.send_notification.assert_called_once_with(
+            title="Weather Tornado Warning",
+            message="Tornado warning in your area",
+            timeout=10,
+        )


### PR DESCRIPTION
## Summary
- switch the remaining legacy `WeatherNotifier` notification calls over to `SafeDesktopNotifier`
- replace direct `SafeToastNotifier.show_toast()` use in that class with `send_notification()`
- add a regression test proving the legacy notifier path now uses the shared desktop notifier abstraction

## Why
The main desktop app notification flows were already unified on `SafeDesktopNotifier`, including:
- alert notifications
- lifecycle notifications
- discussion, severe-risk, and minutely-precip event notifications

This PR removes the remaining split path so production notification behavior is more consistent without changing the broader compatibility wrapper yet.

## Not included
- removing `SafeToastNotifier` entirely
- migrating the debug alert dialog fallback off the legacy wrapper
- broader notification cleanup beyond the remaining `WeatherNotifier` path

## Test Plan
- `ruff format src/accessiweather/notifications/weather_notifier.py tests/test_weather_notifier_unified_backend.py`
- `ruff check src/accessiweather/notifications/weather_notifier.py tests/test_weather_notifier_unified_backend.py`
- `pytest -q tests/test_weather_notifier_unified_backend.py tests/test_notification_test.py tests/test_split_notification_timers.py tests/test_toasted_windows_notifier.py -n 0`

Result:
- ruff format/check passed
- 69 tests passed locally
