### PR TITLE
feat(noaa-radio): let listeners widen nearby station search in radio dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **NOAA radio station count chooser** — the NOAA Weather Radio dialog now lets you pick how many nearby stations to load (10, 25, 50, 100, or All) without digging through the main Settings window
+
+### Fixed
+- **NOAA radio station count now sticks** — your nearby-station limit is saved with NOAA radio preferences and reused the next time you open the dialog, while preferred stream choices keep working as before
+
 ## [0.4.5] - 2026-03-26
 
 ### Added

--- a/src/accessiweather/noaa_radio/preferences.py
+++ b/src/accessiweather/noaa_radio/preferences.py
@@ -1,4 +1,4 @@
-"""User preferences for NOAA Weather Radio stream selection."""
+"""User preferences for NOAA Weather Radio stream selection and station limits."""
 
 from __future__ import annotations
 
@@ -7,10 +7,11 @@ import logging
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+DEFAULT_STATION_LIMIT = 10
 
 
 class RadioPreferences:
-    """Stores per-station preferred stream URLs in a JSON file."""
+    """Stores NOAA radio stream preferences and nearby-station limits in a JSON file."""
 
     def __init__(
         self,
@@ -19,6 +20,7 @@ class RadioPreferences:
     ) -> None:
         """Initialize with an optional canonical preferences file path."""
         self._prefs: dict[str, str] = {}
+        self._station_limit: int | None = DEFAULT_STATION_LIMIT
         if path is not None:
             self._path = Path(path)
         elif config_dir is not None:
@@ -31,7 +33,28 @@ class RadioPreferences:
         if self._path is None or not self._path.exists():
             return
         try:
-            self._prefs = json.loads(self._path.read_text(encoding="utf-8"))
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                logger.warning("Failed to load radio preferences: expected JSON object")
+                return
+
+            if "preferred_streams" in data or "station_limit" in data:
+                preferred_streams = data.get("preferred_streams", {})
+                if isinstance(preferred_streams, dict):
+                    self._prefs = {
+                        str(call_sign).upper(): url
+                        for call_sign, url in preferred_streams.items()
+                        if isinstance(url, str)
+                    }
+                station_limit = data.get("station_limit", DEFAULT_STATION_LIMIT)
+                self._station_limit = self._normalize_station_limit(station_limit)
+            else:
+                self._prefs = {
+                    str(call_sign).upper(): url
+                    for call_sign, url in data.items()
+                    if isinstance(url, str)
+                }
+                self._station_limit = DEFAULT_STATION_LIMIT
         except Exception as e:
             logger.warning(f"Failed to load radio preferences: {e}")
 
@@ -40,9 +63,23 @@ class RadioPreferences:
             return
         try:
             self._path.parent.mkdir(parents=True, exist_ok=True)
-            self._path.write_text(json.dumps(self._prefs, indent=2), encoding="utf-8")
+            payload = {
+                "preferred_streams": self._prefs,
+                "station_limit": self._station_limit,
+            }
+            self._path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         except Exception as e:
             logger.warning(f"Failed to save radio preferences: {e}")
+
+    def _normalize_station_limit(self, value: object) -> int | None:
+        """Return a validated station limit, defaulting invalid values to 10."""
+        if value is None:
+            return None
+        if isinstance(value, str) and value.lower() == "all":
+            return None
+        if isinstance(value, int) and value > 0:
+            return value
+        return DEFAULT_STATION_LIMIT
 
     def get_preferred_url(self, call_sign: str) -> str | None:
         """Get the preferred stream URL for a station, or None."""
@@ -65,3 +102,12 @@ class RadioPreferences:
         if preferred and preferred in urls:
             return [preferred] + [u for u in urls if u != preferred]
         return list(urls)
+
+    def get_station_limit(self) -> int | None:
+        """Return the preferred nearby-station limit, or None for all stations."""
+        return self._station_limit
+
+    def set_station_limit(self, limit: int | None) -> None:
+        """Set the preferred nearby-station limit."""
+        self._station_limit = self._normalize_station_limit(limit)
+        self._save()

--- a/src/accessiweather/noaa_radio/station_db.py
+++ b/src/accessiweather/noaa_radio/station_db.py
@@ -253,11 +253,13 @@ class StationDatabase:
         state_upper = state.upper()
         return [s for s in self._stations if s.state.upper() == state_upper]
 
-    def find_nearest(self, lat: float, lon: float, limit: int = 5) -> list[StationResult]:
-        """Return the *limit* nearest stations sorted by distance ascending."""
+    def find_nearest(self, lat: float, lon: float, limit: int | None = 5) -> list[StationResult]:
+        """Return the nearest stations sorted by distance ascending."""
         results = [
             StationResult(station=s, distance_km=_haversine(lat, lon, s.lat, s.lon))
             for s in self._stations
         ]
         results.sort(key=lambda r: r.distance_km)
+        if limit is None:
+            return results
         return results[:limit]

--- a/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
+++ b/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
@@ -16,7 +16,7 @@ from accessiweather.noaa_radio import (
     StreamURLProvider,
 )
 from accessiweather.noaa_radio.player import RadioPlayer
-from accessiweather.noaa_radio.preferences import RadioPreferences
+from accessiweather.noaa_radio.preferences import DEFAULT_STATION_LIMIT, RadioPreferences
 from accessiweather.noaa_radio.weatherindex_client import WeatherIndexClient
 from accessiweather.noaa_radio.wxradio_client import WxRadioClient
 
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 SUPPRESSION_TTL_SECONDS = 1800
+STATION_LIMIT_PRESETS: tuple[int | None, ...] = (10, 25, 50, 100, None)
+STATION_LIMIT_LABELS: tuple[str, ...] = ("10", "25", "50", "100", "All")
 
 # Module-level cache for clients to leverage HTTP caching across dialog opens
 _wxradio_client: WxRadioClient | None = None
@@ -144,6 +146,16 @@ class NOAARadioDialog(wx.Dialog):
         self._station_choice.Bind(wx.EVT_CHAR_HOOK, self._on_choice_key)
         sizer.Add(self._station_choice, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 10)
 
+        station_limit_label = wx.StaticText(panel, label="Nearby station count:")
+        sizer.Add(station_limit_label, 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
+
+        self._station_limit_choice = wx.Choice(panel, choices=list(STATION_LIMIT_LABELS))
+        self._station_limit_choice.SetSelection(
+            self._get_station_limit_choice_index(self._prefs.get_station_limit())
+        )
+        self._station_limit_choice.Bind(wx.EVT_CHOICE, self._on_station_limit_changed)
+        sizer.Add(self._station_limit_choice, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 10)
+
         self._show_unavailable_checkbox = wx.CheckBox(
             panel,
             label="Show unavailable stations",
@@ -211,21 +223,26 @@ class NOAARadioDialog(wx.Dialog):
         self._station_choice.Set(["Loading stations..."])
         self._set_status("Finding nearest stations...")
         show_unavailable = self._show_unavailable_enabled()
+        station_limit = self._get_selected_station_limit()
 
         # Run station loading in background thread
         thread = threading.Thread(
             target=self._load_stations_worker,
-            args=(show_unavailable,),
+            args=(show_unavailable, station_limit),
             daemon=True,
         )
         thread.start()
 
-    def _load_stations_worker(self, show_unavailable: bool = False) -> None:
+    def _load_stations_worker(
+        self,
+        show_unavailable: bool = False,
+        station_limit: int | None = DEFAULT_STATION_LIMIT,
+    ) -> None:
         """Worker method that loads stations in background thread."""
         try:
             db = StationDatabase()
-            results = db.find_nearest(self._lat, self._lon, limit=25)
-            nearby = [r.station for r in results][:10]
+            results = db.find_nearest(self._lat, self._lon, limit=station_limit)
+            nearby = [r.station for r in results]
             entries = self._station_availability.build_entries(
                 nearby,
                 show_unavailable=show_unavailable,
@@ -472,6 +489,12 @@ class NOAARadioDialog(wx.Dialog):
         """Reload stations when the unavailable-station filter changes."""
         self._load_stations_async()
 
+    def _on_station_limit_changed(self, event: wx.CommandEvent) -> None:
+        """Persist and apply a new nearby-station limit."""
+        self._prefs.set_station_limit(self._get_selected_station_limit())
+        self._load_stations_async()
+        event.Skip()
+
     def _on_station_changed(self, event: wx.CommandEvent) -> None:
         """Update button label when the user picks a different station."""
         self._update_play_btn_label()
@@ -522,6 +545,24 @@ class NOAARadioDialog(wx.Dialog):
         """Return the current state of the unavailable-station filter."""
         checkbox = getattr(self, "_show_unavailable_checkbox", None)
         return bool(checkbox.GetValue()) if checkbox is not None else False
+
+    def _get_selected_station_limit(self) -> int | None:
+        """Return the chosen nearby-station limit, or None for all stations."""
+        choice = getattr(self, "_station_limit_choice", None)
+        if choice is None:
+            return self._prefs.get_station_limit()
+
+        selection = choice.GetSelection()
+        if selection == wx.NOT_FOUND or selection >= len(STATION_LIMIT_PRESETS):
+            return self._prefs.get_station_limit()
+        return STATION_LIMIT_PRESETS[selection]
+
+    def _get_station_limit_choice_index(self, limit: int | None) -> int:
+        """Return the choice index matching the saved nearby-station limit."""
+        try:
+            return STATION_LIMIT_PRESETS.index(limit)
+        except ValueError:
+            return STATION_LIMIT_PRESETS.index(DEFAULT_STATION_LIMIT)
 
     def _mark_current_station_unavailable(self, reason: str = "all_streams_failed") -> None:
         """Suppress the current station after all playback options fail."""

--- a/tests/test_noaa_radio.py
+++ b/tests/test_noaa_radio.py
@@ -1,10 +1,11 @@
 """Tests for NOAA Weather Radio modules."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 from accessiweather.noaa_radio import Station, StationDatabase, StreamURLProvider
 from accessiweather.noaa_radio.player import RadioPlayer
-from accessiweather.noaa_radio.preferences import RadioPreferences
+from accessiweather.noaa_radio.preferences import DEFAULT_STATION_LIMIT, RadioPreferences
 
 # ---------------------------------------------------------------------------
 # Station / StationDatabase tests
@@ -36,6 +37,17 @@ class TestStationDatabase:
         db = StationDatabase()
         results = db.find_nearest(40.0, -74.0, limit=3)
         assert len(results) == 3
+
+    def test_find_nearest_all_returns_every_station(self):
+        stations = [
+            Station("A", 162.4, "One", 40.0, -74.0, "NY"),
+            Station("B", 162.4, "Two", 41.0, -75.0, "PA"),
+        ]
+        db = StationDatabase(stations)
+
+        results = db.find_nearest(40.0, -74.0, limit=None)
+
+        assert [result.station.call_sign for result in results] == ["A", "B"]
 
     def test_get_stations_by_state(self):
         stations = [
@@ -211,6 +223,38 @@ class TestRadioPreferences:
         prefs = RadioPreferences(config_dir=tmp_path)
         prefs.set_preferred_url("test1", "http://stream.com")
         assert prefs.get_preferred_url("TEST1") == "http://stream.com"
+
+    def test_station_limit_defaults_to_ten(self, tmp_path):
+        prefs = RadioPreferences(config_dir=tmp_path)
+
+        assert prefs.get_station_limit() == DEFAULT_STATION_LIMIT
+
+    def test_station_limit_persists_across_reload(self, tmp_path):
+        prefs = RadioPreferences(config_dir=tmp_path)
+        prefs.set_preferred_url("TEST1", "http://stream.com")
+        prefs.set_station_limit(50)
+
+        reloaded = RadioPreferences(config_dir=tmp_path)
+
+        assert reloaded.get_preferred_url("TEST1") == "http://stream.com"
+        assert reloaded.get_station_limit() == 50
+
+    def test_station_limit_all_persists_as_none(self, tmp_path):
+        prefs = RadioPreferences(config_dir=tmp_path)
+        prefs.set_station_limit(None)
+
+        reloaded = RadioPreferences(config_dir=tmp_path)
+
+        assert reloaded.get_station_limit() is None
+
+    def test_legacy_preferences_default_station_limit_to_ten(self, tmp_path):
+        prefs_file = tmp_path / "noaa_radio_prefs.json"
+        prefs_file.write_text(json.dumps({"WXJ76": "http://stream.com"}), encoding="utf-8")
+
+        prefs = RadioPreferences(config_dir=tmp_path)
+
+        assert prefs.get_preferred_url("WXJ76") == "http://stream.com"
+        assert prefs.get_station_limit() == DEFAULT_STATION_LIMIT
 
 
 class TestRadioPreferencesEdgeCases:

--- a/tests/test_noaa_radio_dialog.py
+++ b/tests/test_noaa_radio_dialog.py
@@ -149,6 +149,8 @@ def _make_dialog_instance(module):
     dlg._url_provider = MagicMock()
     dlg._station_choice = MagicMock()
     dlg._station_choice.GetSelection.return_value = 0
+    dlg._station_limit_choice = MagicMock()
+    dlg._station_limit_choice.GetSelection.return_value = 0
     dlg._play_stop_btn = MagicMock()
     dlg._volume_slider = MagicMock()
     dlg._volume_slider.GetValue.return_value = 100
@@ -397,6 +399,8 @@ class TestUnavailableStations:
         dlg._on_volume_change = MagicMock()
         dlg._on_close = MagicMock()
         dlg._on_show_unavailable_changed = MagicMock()
+        dlg._prefs = MagicMock()
+        dlg._prefs.get_station_limit.return_value = 10
 
         noaa_dialog_module.NOAARadioDialog._init_ui(dlg)
 
@@ -405,6 +409,28 @@ class TestUnavailableStations:
             noaa_dialog_module.wx.CheckBox.call_args.kwargs["label"] == "Show unavailable stations"
         )
 
+    def test_station_limit_choice_is_created(self, noaa_dialog_module):
+        dlg = object.__new__(noaa_dialog_module.NOAARadioDialog)
+        dlg.Bind = MagicMock()
+        dlg._on_health_check = MagicMock()
+        dlg._on_station_changed = MagicMock()
+        dlg._on_choice_key = MagicMock()
+        dlg._on_play_stop = MagicMock()
+        dlg._on_next_stream = MagicMock()
+        dlg._on_set_preferred = MagicMock()
+        dlg._on_volume_change = MagicMock()
+        dlg._on_close = MagicMock()
+        dlg._on_show_unavailable_changed = MagicMock()
+        dlg._on_station_limit_changed = MagicMock()
+        dlg._prefs = MagicMock()
+        dlg._prefs.get_station_limit.return_value = 25
+
+        noaa_dialog_module.NOAARadioDialog._init_ui(dlg)
+
+        assert noaa_dialog_module.wx.Choice.call_count == 2
+        station_limit_choice = noaa_dialog_module.wx.Choice.call_args_list[1]
+        assert station_limit_choice.kwargs["choices"] == ["10", "25", "50", "100", "All"]
+
     def test_show_unavailable_toggle_refreshes_station_list(self, noaa_dialog_module):
         dlg = _make_dialog_instance(noaa_dialog_module)
         dlg._load_stations_async = MagicMock()
@@ -412,6 +438,18 @@ class TestUnavailableStations:
         dlg._on_show_unavailable_changed(MagicMock())
 
         dlg._load_stations_async.assert_called_once()
+
+    def test_station_limit_toggle_persists_and_refreshes_station_list(self, noaa_dialog_module):
+        dlg = _make_dialog_instance(noaa_dialog_module)
+        dlg._station_limit_choice.GetSelection.return_value = 2
+        dlg._load_stations_async = MagicMock()
+        event = MagicMock()
+
+        dlg._on_station_limit_changed(event)
+
+        dlg._prefs.set_station_limit.assert_called_once_with(50)
+        dlg._load_stations_async.assert_called_once()
+        event.Skip.assert_called_once()
 
     def test_on_stations_loaded_sets_no_available_status_when_empty(self, noaa_dialog_module):
         dlg = _make_dialog_instance(noaa_dialog_module)

--- a/tests/test_noaa_radio_dialog_integration.py
+++ b/tests/test_noaa_radio_dialog_integration.py
@@ -135,6 +135,8 @@ def _make_dialog(module):
     dlg._url_provider = MagicMock()
     dlg._station_choice = MagicMock()
     dlg._station_choice.GetSelection.return_value = 0
+    dlg._station_limit_choice = MagicMock()
+    dlg._station_limit_choice.GetSelection.return_value = 0
     dlg._play_stop_btn = MagicMock()
     dlg._volume_slider = MagicMock()
     dlg._volume_slider.GetValue.return_value = 100
@@ -284,11 +286,41 @@ class TestLoadStations:
             mock_db_cls.return_value.find_nearest.return_value = results
             dlg._load_stations_worker()
 
-        mock_db_cls.return_value.find_nearest.assert_called_once()
+        mock_db_cls.return_value.find_nearest.assert_called_once_with(40.7, -74.0, limit=10)
         dlg._station_availability.build_entries.assert_called_once_with(
             test_stations,
             show_unavailable=False,
         )
+
+    def test_load_stations_uses_selected_station_limit(self, noaa_dialog_module):
+        dlg = _make_dialog(noaa_dialog_module)
+        dlg._station_choice = MagicMock()
+        entry = MagicMock()
+        entry.station = Station("TEST1", 162.55, "Test City 1", 40.0, -74.0, "NY")
+        entry.label = "TEST1 - Test City 1 (162.55 MHz)"
+        dlg._station_availability.build_entries.return_value = [entry]
+        results = [StationResult(station=entry.station, distance_km=0.0)]
+
+        with patch("accessiweather.ui.dialogs.noaa_radio_dialog.StationDatabase") as mock_db_cls:
+            mock_db_cls.return_value.find_nearest.return_value = results
+            dlg._load_stations_worker(station_limit=100)
+
+        mock_db_cls.return_value.find_nearest.assert_called_once_with(40.7, -74.0, limit=100)
+
+    def test_load_stations_all_uses_unbounded_lookup(self, noaa_dialog_module):
+        dlg = _make_dialog(noaa_dialog_module)
+        dlg._station_choice = MagicMock()
+        entry = MagicMock()
+        entry.station = Station("TEST1", 162.55, "Test City 1", 40.0, -74.0, "NY")
+        entry.label = "TEST1 - Test City 1 (162.55 MHz)"
+        dlg._station_availability.build_entries.return_value = [entry]
+        results = [StationResult(station=entry.station, distance_km=0.0)]
+
+        with patch("accessiweather.ui.dialogs.noaa_radio_dialog.StationDatabase") as mock_db_cls:
+            mock_db_cls.return_value.find_nearest.return_value = results
+            dlg._load_stations_worker(station_limit=None)
+
+        mock_db_cls.return_value.find_nearest.assert_called_once_with(40.7, -74.0, limit=None)
 
     def test_load_stations_error_sets_status(self, noaa_dialog_module):
         """Test _load_stations_worker handles database errors gracefully."""


### PR DESCRIPTION
## Summary
- add a persisted nearby-station limit preference for NOAA Weather Radio
- expose station-count presets in the NOAA Weather Radio dialog flow: 10, 25, 50, 100, All
- apply the selected limit when loading nearby stations while preserving existing preferred stream behavior

## Testing
- ./.venv/bin/python -m pytest -q tests/test_noaa_radio.py tests/test_noaa_radio_dialog.py tests/test_noaa_radio_dialog_integration.py