### PR TITLE
feat(ui): add precipitation timeline view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - **NOAA radio station count chooser** — the NOAA Weather Radio dialog now lets you pick how many nearby stations to load (10, 25, 50, 100, or All) without digging through the main Settings window
+- **Precipitation timeline dialog** — View > Precipitation Timeline now opens a dedicated Pirate Weather minutely precipitation timeline with a quick summary and minute-by-minute plain-text breakdown
 
 ### Fixed
 - **NOAA radio station count now sticks** — your nearby-station limit is saved with NOAA radio preferences and reused the next time you open the dialog, while preferred stream choices keep working as before

--- a/src/accessiweather/ui/dialogs/__init__.py
+++ b/src/accessiweather/ui/dialogs/__init__.py
@@ -9,6 +9,7 @@ from .explanation_dialog import show_explanation_dialog
 from .location_dialog import show_add_location_dialog
 from .nationwide_discussion_dialog import show_nationwide_discussion_dialog
 from .noaa_radio_dialog import NOAARadioDialog, show_noaa_radio_dialog
+from .precipitation_timeline_dialog import show_precipitation_timeline_dialog
 from .settings_dialog import show_settings_dialog
 from .soundpack_manager_dialog import show_soundpack_manager_dialog
 from .soundpack_wizard_dialog import SoundPackWizardDialog
@@ -32,6 +33,7 @@ __all__ = [
     "show_weather_history_dialog",
     "NOAARadioDialog",
     "show_noaa_radio_dialog",
+    "show_precipitation_timeline_dialog",
     "SoundPackWizardDialog",
 ]
 
@@ -46,6 +48,7 @@ _LAZY_IMPORTS = {
     "show_nationwide_discussion_dialog": ".nationwide_discussion_dialog",
     "NOAARadioDialog": ".noaa_radio_dialog",
     "show_noaa_radio_dialog": ".noaa_radio_dialog",
+    "show_precipitation_timeline_dialog": ".precipitation_timeline_dialog",
     "show_settings_dialog": ".settings_dialog",
     "show_soundpack_manager_dialog": ".soundpack_manager_dialog",
     "SoundPackWizardDialog": ".soundpack_wizard_dialog",

--- a/src/accessiweather/ui/dialogs/precipitation_timeline_dialog.py
+++ b/src/accessiweather/ui/dialogs/precipitation_timeline_dialog.py
@@ -1,0 +1,225 @@
+"""Pirate Weather minutely precipitation timeline dialog."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import wx
+
+from ...notifications.minutely_precipitation import is_wet, precipitation_type_label
+
+if TYPE_CHECKING:
+    from ...app import AccessiWeatherApp
+    from ...models import MinutelyPrecipitationForecast, MinutelyPrecipitationPoint
+
+logger = logging.getLogger(__name__)
+
+
+def has_precipitation_timeline_data(weather_data) -> bool:
+    """Return True when minutely precipitation data is available."""
+    forecast = getattr(weather_data, "minutely_precipitation", None)
+    if forecast is None:
+        return False
+
+    has_data = getattr(forecast, "has_data", None)
+    if callable(has_data):
+        return bool(has_data())
+
+    return bool(getattr(forecast, "points", None))
+
+
+def show_precipitation_timeline_dialog(parent, app: AccessiWeatherApp) -> None:
+    """Show the minutely precipitation timeline dialog."""
+    try:
+        config_manager = getattr(app, "config_manager", None)
+        location = config_manager.get_current_location() if config_manager else None
+        if not location:
+            wx.MessageBox(
+                "Please select a location first.",
+                "No Location Selected",
+                wx.OK | wx.ICON_WARNING,
+            )
+            return
+
+        weather_data = getattr(app, "current_weather_data", None)
+        forecast = getattr(weather_data, "minutely_precipitation", None)
+        if forecast is None or not has_precipitation_timeline_data(weather_data):
+            wx.MessageBox(
+                "Minutely precipitation data is not available for this location yet.",
+                "No Precipitation Timeline Available",
+                wx.OK | wx.ICON_INFORMATION,
+            )
+            return
+
+        dlg = PrecipitationTimelineDialog(
+            parent,
+            location_name=location.name,
+            forecast=forecast,
+            timezone_name=getattr(location, "timezone", None),
+        )
+        dlg.ShowModal()
+        dlg.Destroy()
+    except Exception as exc:
+        logger.error("Failed to show precipitation timeline dialog: %s", exc)
+        wx.MessageBox(
+            f"Failed to open precipitation timeline: {exc}",
+            "Error",
+            wx.OK | wx.ICON_ERROR,
+        )
+
+
+def build_precipitation_timeline_text(
+    forecast: MinutelyPrecipitationForecast,
+    timezone_name: str | None = None,
+) -> str:
+    """Build a plain-text minute-by-minute timeline."""
+    zone = _resolve_zone(timezone_name)
+    zone_label = zone.key if zone else "forecast time"
+
+    header = [
+        "Offset  Time      Conditions",
+        "------  --------  ----------",
+    ]
+
+    lines = [
+        _format_timeline_line(index, point, zone)
+        for index, point in enumerate(getattr(forecast, "points", []))
+    ]
+    if not lines:
+        lines = ["No minutely precipitation data available."]
+
+    return f"Times shown in {zone_label}.\n\n" + "\n".join(header + lines)
+
+
+class PrecipitationTimelineDialog(wx.Dialog):
+    """Dialog for Pirate Weather minutely precipitation guidance."""
+
+    def __init__(
+        self,
+        parent,
+        *,
+        location_name: str,
+        forecast: MinutelyPrecipitationForecast,
+        timezone_name: str | None = None,
+    ) -> None:
+        """Initialize the precipitation timeline dialog."""
+        super().__init__(
+            parent,
+            title=f"Precipitation Timeline - {location_name}",
+            size=(720, 540),
+            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
+        )
+
+        self.location_name = location_name
+        self.forecast = forecast
+        self.timezone_name = timezone_name
+
+        self._create_ui()
+        self._setup_accessibility()
+        self.Bind(wx.EVT_CHAR_HOOK, self._on_char_hook)
+
+    def _create_ui(self) -> None:
+        panel = wx.Panel(self)
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+
+        header = wx.StaticText(panel, label=f"Precipitation Timeline for {self.location_name}")
+        header.SetFont(header.GetFont().Bold().Scaled(1.2))
+        main_sizer.Add(header, 0, wx.ALL, 15)
+
+        description = wx.StaticText(
+            panel,
+            label=(
+                "Pirate Weather minutely guidance for the next hour. "
+                "Summary first, followed by a plain-text timeline."
+            ),
+        )
+        description.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
+        description.Wrap(650)
+        main_sizer.Add(description, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 15)
+
+        summary_header = wx.StaticText(panel, label="Summary")
+        summary_header.SetFont(summary_header.GetFont().Bold().Scaled(1.05))
+        main_sizer.Add(summary_header, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 15)
+
+        summary_text = (self.forecast.summary or "No summary available.").strip()
+        self.summary_label = wx.StaticText(panel, label=summary_text)
+        self.summary_label.Wrap(650)
+        main_sizer.Add(self.summary_label, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 15)
+
+        timeline_header = wx.StaticText(panel, label="Minute-by-minute timeline")
+        timeline_header.SetFont(timeline_header.GetFont().Bold().Scaled(1.05))
+        main_sizer.Add(timeline_header, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 15)
+
+        timeline_text = build_precipitation_timeline_text(self.forecast, self.timezone_name)
+        self.timeline_display = wx.TextCtrl(
+            panel,
+            value=timeline_text,
+            style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH2,
+        )
+        self.timeline_display.SetFont(
+            wx.Font(10, wx.FONTFAMILY_TELETYPE, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL)
+        )
+        main_sizer.Add(self.timeline_display, 1, wx.EXPAND | wx.LEFT | wx.RIGHT, 15)
+
+        button_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        button_sizer.AddStretchSpacer()
+        close_btn = wx.Button(panel, wx.ID_CLOSE, "Close")
+        close_btn.Bind(wx.EVT_BUTTON, self._on_close)
+        button_sizer.Add(close_btn, 0)
+        main_sizer.Add(button_sizer, 0, wx.EXPAND | wx.ALL, 15)
+
+        panel.SetSizer(main_sizer)
+        self.timeline_display.SetFocus()
+
+    def _setup_accessibility(self) -> None:
+        """Set accessible names for key controls."""
+        self.summary_label.SetName("Precipitation summary")
+        self.timeline_display.SetName("Precipitation timeline text")
+
+    def _on_char_hook(self, event: wx.KeyEvent) -> None:
+        """Close the dialog when Escape is pressed."""
+        if event.GetKeyCode() == wx.WXK_ESCAPE:
+            self._on_close(event)
+            return
+        event.Skip()
+
+    def _on_close(self, event) -> None:
+        """Handle close button press."""
+        self.EndModal(wx.ID_CLOSE)
+
+
+def _format_timeline_line(
+    minute_offset: int,
+    point: MinutelyPrecipitationPoint,
+    zone: ZoneInfo | None,
+) -> str:
+    offset_label = "Now" if minute_offset == 0 else f"+{minute_offset:02d}m"
+    point_time = point.time.astimezone(zone) if zone else point.time
+    time_label = point_time.strftime("%I:%M %p").lstrip("0")
+    return f"{offset_label:<6}  {time_label:<8}  {_format_point_conditions(point)}"
+
+
+def _format_point_conditions(point: MinutelyPrecipitationPoint) -> str:
+    details = [precipitation_type_label(point.precipitation_type)] if is_wet(point) else ["Dry"]
+
+    probability = getattr(point, "precipitation_probability", None)
+    if probability is not None and probability > 0:
+        details.append(f"{round(probability * 100):.0f}% chance")
+
+    intensity = getattr(point, "precipitation_intensity", None)
+    if intensity is not None and intensity > 0:
+        details.append(f"{intensity:.3f} in/hr")
+
+    return " | ".join(details)
+
+
+def _resolve_zone(timezone_name: str | None) -> ZoneInfo | None:
+    if not timezone_name:
+        return None
+    try:
+        return ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError:
+        logger.debug("Unknown timezone for precipitation timeline: %s", timezone_name)
+        return None

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -298,6 +298,12 @@ class MainWindow(SizedFrame):
         history_item = view_menu.Append(
             self._history_id, "Weather &History\tCtrl+H", "View weather history"
         )
+        self._precipitation_timeline_id = wx.NewIdRef()
+        self._precipitation_timeline_item = view_menu.Append(
+            self._precipitation_timeline_id,
+            "Precipitation &Timeline...",
+            "View Pirate Weather minute-by-minute precipitation guidance",
+        )
         self._toggle_event_center_id = wx.NewIdRef()
         toggle_event_center_item = view_menu.AppendCheckItem(
             self._toggle_event_center_id,
@@ -386,6 +392,11 @@ class MainWindow(SizedFrame):
         self.Bind(wx.EVT_MENU, lambda e: self._on_explain_weather(), explain_item)
         self.Bind(wx.EVT_MENU, lambda e: self.on_view_history(), history_item)
         self.Bind(
+            wx.EVT_MENU,
+            lambda e: self._on_precipitation_timeline(),
+            id=self._precipitation_timeline_id,
+        )
+        self.Bind(
             wx.EVT_MENU, lambda e: self.toggle_event_center(), id=self._toggle_event_center_id
         )
         self.Bind(wx.EVT_MENU, lambda e: self._on_discussion(), discussion_item)
@@ -419,6 +430,7 @@ class MainWindow(SizedFrame):
             )
         self.Bind(wx.EVT_MENU, lambda e: self._on_report_issue(), report_issue_item)
         self.Bind(wx.EVT_MENU, lambda e: self._on_about(), about_item)
+        MainWindow._update_precipitation_timeline_menu_state(self)
 
     def _on_location_changed(self, event) -> None:
         """Handle location selection change with debounce for rapid switching."""
@@ -433,6 +445,7 @@ class MainWindow(SizedFrame):
         # --- All Locations special case ---
         if selected == ALL_LOCATIONS_SENTINEL:
             self._all_locations_active = True
+            MainWindow._update_precipitation_timeline_menu_state(self)
             # Increment generation to invalidate any in-flight fetches for the previous location
             self._fetch_generation += 1
             # Use CallAfter so the summary renders after any already-queued wx.CallAfter
@@ -556,6 +569,12 @@ class MainWindow(SizedFrame):
         from .dialogs import show_weather_history_dialog
 
         show_weather_history_dialog(self, self.app)
+
+    def _on_precipitation_timeline(self) -> None:
+        """View Pirate Weather minutely precipitation guidance."""
+        from .dialogs import show_precipitation_timeline_dialog
+
+        show_precipitation_timeline_dialog(self, self.app)
 
     def _on_explain_weather(self) -> None:
         """Get AI explanation of current weather."""
@@ -1178,6 +1197,7 @@ class MainWindow(SizedFrame):
             return
         try:
             self.app.current_weather_data = weather_data
+            MainWindow._update_precipitation_timeline_menu_state(self, weather_data)
 
             # Use presenter to create formatted presentation
             presentation = self.app.presenter.present(weather_data)
@@ -1487,6 +1507,7 @@ class MainWindow(SizedFrame):
             self._set_forecast_sections("", "")
             self.alerts_list.Clear()
             self.view_alert_button.Disable()
+            MainWindow._update_precipitation_timeline_menu_state(self)
             return
 
         lines: list[str] = ["All Locations Summary", ""]
@@ -1557,6 +1578,7 @@ class MainWindow(SizedFrame):
         self.app.update_tray_tooltip(tray_data, tray_loc_name)
 
         self.stale_warning_label.SetLabel("")
+        MainWindow._update_precipitation_timeline_menu_state(self)
 
         # Ensure the refresh button stays enabled in this view.
         self.app.is_updating = False
@@ -1667,6 +1689,29 @@ class MainWindow(SizedFrame):
         logger.info(f"Status: {message}")
         if message:
             self._announcer.announce(message)
+
+    def _update_precipitation_timeline_menu_state(self, weather_data=None) -> None:
+        """Enable the precipitation timeline menu item when minutely data is available."""
+        menu_item = getattr(self, "_precipitation_timeline_item", None)
+        if menu_item is None:
+            return
+
+        is_enabled = False
+        if not getattr(self, "_all_locations_active", False):
+            data = (
+                weather_data
+                if weather_data is not None
+                else getattr(self.app, "current_weather_data", None)
+            )
+            forecast = getattr(data, "minutely_precipitation", None)
+            if forecast is not None:
+                has_data = getattr(forecast, "has_data", None)
+                if callable(has_data):
+                    is_enabled = bool(has_data())
+                else:
+                    is_enabled = bool(getattr(forecast, "points", None))
+
+        menu_item.Enable(is_enabled)
 
     def _get_notification_event_manager(self):
         """Get or create the notification event manager for AFD/severe risk notifications."""

--- a/tests/test_main_window_precipitation_timeline.py
+++ b/tests/test_main_window_precipitation_timeline.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+from accessiweather.models import MinutelyPrecipitationForecast, MinutelyPrecipitationPoint
+
+
+class _MenuItemStub:
+    def __init__(self) -> None:
+        self.enabled: bool | None = None
+        self.calls: list[bool] = []
+
+    def Enable(self, value: bool) -> None:
+        self.enabled = value
+        self.calls.append(value)
+
+
+def _make_forecast() -> MinutelyPrecipitationForecast:
+    return MinutelyPrecipitationForecast(
+        summary="Rain",
+        points=[
+            MinutelyPrecipitationPoint(
+                time=datetime(2026, 1, 1, 15, 4, tzinfo=UTC),
+                precipitation_intensity=0.1,
+                precipitation_type="rain",
+            )
+        ],
+    )
+
+
+def _make_window(current_weather_data=None, *, all_locations: bool = False):
+    from accessiweather.ui.main_window import MainWindow
+
+    with patch.object(MainWindow, "__init__", lambda self, *args, **kwargs: None):
+        win = MainWindow.__new__(MainWindow)
+
+    mutable_win = cast(Any, win)
+    mutable_win.app = SimpleNamespace(current_weather_data=current_weather_data)
+    mutable_win._all_locations_active = all_locations
+    mutable_win._precipitation_timeline_item = _MenuItemStub()
+    return win
+
+
+def test_view_menu_source_includes_precipitation_timeline_item():
+    source = Path("src/accessiweather/ui/main_window.py").read_text()
+
+    assert "Precipitation &Timeline..." in source
+    assert "_precipitation_timeline_id" in source
+    assert "_on_precipitation_timeline" in source
+
+
+def test_menu_item_enabled_when_minutely_precipitation_exists():
+    win = _make_window(SimpleNamespace(minutely_precipitation=_make_forecast()))
+
+    win._update_precipitation_timeline_menu_state()
+
+    assert win._precipitation_timeline_item.enabled is True
+
+
+def test_menu_item_disabled_without_minutely_precipitation():
+    win = _make_window(SimpleNamespace(minutely_precipitation=None))
+
+    win._update_precipitation_timeline_menu_state()
+
+    assert win._precipitation_timeline_item.enabled is False
+
+
+def test_menu_item_disabled_in_all_locations_view():
+    win = _make_window(SimpleNamespace(minutely_precipitation=_make_forecast()), all_locations=True)
+
+    win._update_precipitation_timeline_menu_state()
+
+    assert win._precipitation_timeline_item.enabled is False
+
+
+def test_precipitation_timeline_handler_opens_dialog():
+    from accessiweather.ui.main_window import MainWindow
+
+    with patch.object(MainWindow, "__init__", lambda self, *args, **kwargs: None):
+        win = MainWindow.__new__(MainWindow)
+
+    cast(Any, win).app = MagicMock()
+
+    with patch("accessiweather.ui.dialogs.show_precipitation_timeline_dialog") as show_dialog:
+        win._on_precipitation_timeline()
+
+    show_dialog.assert_called_once_with(win, win.app)

--- a/tests/test_precipitation_timeline_dialog.py
+++ b/tests/test_precipitation_timeline_dialog.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from accessiweather.models import MinutelyPrecipitationForecast, MinutelyPrecipitationPoint
+from accessiweather.ui.dialogs.precipitation_timeline_dialog import (
+    build_precipitation_timeline_text,
+    has_precipitation_timeline_data,
+    show_precipitation_timeline_dialog,
+)
+
+
+def _make_forecast() -> MinutelyPrecipitationForecast:
+    start = datetime(2026, 1, 1, 15, 4, tzinfo=UTC)
+    return MinutelyPrecipitationForecast(
+        summary="Light rain starting soon.",
+        points=[
+            MinutelyPrecipitationPoint(time=start, precipitation_intensity=0.0),
+            MinutelyPrecipitationPoint(
+                time=start + timedelta(minutes=1),
+                precipitation_intensity=0.12,
+                precipitation_probability=0.6,
+                precipitation_type="rain",
+            ),
+            MinutelyPrecipitationPoint(
+                time=start + timedelta(minutes=2),
+                precipitation_intensity=0.03,
+                precipitation_probability=0.3,
+                precipitation_type="rain",
+            ),
+        ],
+    )
+
+
+def test_has_precipitation_timeline_data_requires_minutely_points():
+    assert has_precipitation_timeline_data(SimpleNamespace(minutely_precipitation=_make_forecast()))
+    assert not has_precipitation_timeline_data(SimpleNamespace(minutely_precipitation=None))
+    assert not has_precipitation_timeline_data(
+        SimpleNamespace(minutely_precipitation=MinutelyPrecipitationForecast(points=[]))
+    )
+
+
+def test_build_precipitation_timeline_text_returns_plain_text_timeline():
+    text = build_precipitation_timeline_text(_make_forecast())
+
+    assert "Times shown in forecast time." in text
+    assert "Offset  Time      Conditions" in text
+    assert "Now" in text
+    assert "+01m" in text
+    assert "3:04 PM" in text
+    assert "Rain | 60% chance | 0.120 in/hr" in text
+
+
+def test_show_precipitation_timeline_dialog_warns_when_minutely_data_missing():
+    app = MagicMock()
+    app.config_manager.get_current_location.return_value = SimpleNamespace(name="Test City")
+    app.current_weather_data = SimpleNamespace(minutely_precipitation=None)
+
+    with patch(
+        "accessiweather.ui.dialogs.precipitation_timeline_dialog.wx.MessageBox",
+        create=True,
+    ) as message_box:
+        show_precipitation_timeline_dialog(MagicMock(), app)
+
+    message_box.assert_called_once()
+    assert "Minutely precipitation data is not available" in message_box.call_args.args[0]
+
+
+def test_show_precipitation_timeline_dialog_creates_modal_dialog():
+    app = MagicMock()
+    app.config_manager.get_current_location.return_value = SimpleNamespace(
+        name="Test City",
+        timezone="America/New_York",
+    )
+    app.current_weather_data = SimpleNamespace(minutely_precipitation=_make_forecast())
+
+    created: dict[str, object] = {}
+
+    class _FakeDialog:
+        def __init__(self, parent, *, location_name, forecast, timezone_name=None):
+            created["parent"] = parent
+            created["location_name"] = location_name
+            created["forecast"] = forecast
+            created["timezone_name"] = timezone_name
+            created["shown"] = False
+            created["destroyed"] = False
+
+        def ShowModal(self):
+            created["shown"] = True
+
+        def Destroy(self):
+            created["destroyed"] = True
+
+    with patch(
+        "accessiweather.ui.dialogs.precipitation_timeline_dialog.PrecipitationTimelineDialog",
+        _FakeDialog,
+    ):
+        show_precipitation_timeline_dialog(MagicMock(), app)
+
+    assert created["location_name"] == "Test City"
+    assert created["forecast"] is app.current_weather_data.minutely_precipitation
+    assert created["timezone_name"] == "America/New_York"
+    assert created["shown"] is True
+    assert created["destroyed"] is True


### PR DESCRIPTION
## Summary

- add **View > Precipitation Timeline...** for Pirate Weather minutely precipitation data
- show a dedicated dialog with a short summary plus a plain-text minute-by-minute timeline
- keep the menu item disabled unless the current single-location weather payload includes minutely precipitation data
- leave Current Conditions unchanged instead of adding more minutely detail to the main readout

## Why

This follows the updated direction after closing PR #570. A separate timeline view keeps minutely precipitation guidance easy to review without cluttering Current Conditions, and gives users a clearer way to inspect the underlying data when checking notification behavior.

## Testing

- [x] `./.venv/bin/ruff check src/accessiweather/ui/main_window.py src/accessiweather/ui/dialogs/__init__.py src/accessiweather/ui/dialogs/precipitation_timeline_dialog.py tests/test_main_window_precipitation_timeline.py tests/test_precipitation_timeline_dialog.py`
- [x] `./.venv/bin/pytest tests/test_precipitation_timeline_dialog.py tests/test_main_window_precipitation_timeline.py -q`
