### PR TITLE
chore(deps-dev): update vcrpy requirement from >=6.0.0 to >=8.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
     "pytest-recording>=0.13.0",
     "pytest-rerunfailures>=12.0",
     "hypothesis>=6.0.0",
-    "vcrpy>=6.0.0",
+    "vcrpy>=8.1.1",
     "ruff>=0.15.10",
     "mypy>=1.0.0",
     "pyright",


### PR DESCRIPTION
Supersedes #597, which got stuck with a stale GitHub-side head ref after the other Dependabot merges.\n\nThis lands the same dependency update cleanly on top of current main.