### PR TITLE
[codex] add Help user manual entry and fix access keys

### DIFF
--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 QUICK_ACTION_LABELS = {
     "add": "&Add Location",
     "remove": "&Remove Location",
-    "refresh": "&Refresh Weather",
+    "refresh": "Re&fresh Weather",
     "explain": "&Explain Weather",
     "discussion": "Forecast &Discussion",
     "settings": "&Settings",
@@ -288,7 +288,7 @@ class MainWindow(SizedFrame):
 
         # View menu
         view_menu = wx.Menu()
-        refresh_item = view_menu.Append(wx.ID_REFRESH, "&Refresh\tF5", "Refresh weather data")
+        refresh_item = view_menu.Append(wx.ID_REFRESH, "Re&fresh\tF5", "Refresh weather data")
         view_menu.AppendSeparator()
         self._explain_id = wx.NewIdRef()
         explain_item = view_menu.Append(
@@ -329,7 +329,7 @@ class MainWindow(SizedFrame):
         view_menu.AppendSeparator()
         self._weather_chat_id = wx.NewIdRef()
         weather_chat_item = view_menu.Append(
-            self._weather_chat_id, "Weather &Assistant...\tCtrl+T", "Chat with AI weather assistant"
+            self._weather_chat_id, "Weather Assistan&t...\tCtrl+T", "Chat with AI weather assistant"
         )
         menu_bar.Append(view_menu, "&View")
 

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -17,6 +17,7 @@ from wx.lib.sized_controls import SizedFrame, SizedPanel
 from ..display.presentation.formatters import get_temperature_precision
 from ..screen_reader import ScreenReaderAnnouncer
 from ..units import resolve_temperature_unit_preference
+from ..user_manual import open_user_manual
 from ..utils.temperature_utils import format_temperature
 from . import main_window_notification_events
 
@@ -347,6 +348,11 @@ class MainWindow(SizedFrame):
             f"Check for &Updates ({channel.title()})...",
             "Check for application updates",
         )
+        user_manual_item = help_menu.Append(
+            wx.ID_ANY,
+            "User &Manual",
+            "Open the AccessiWeather user manual",
+        )
         self._debug_menu_items: dict[str, wx.MenuItem] = {}
         if getattr(self.app, "debug_mode", False):
             debug_menu = wx.Menu()
@@ -407,6 +413,7 @@ class MainWindow(SizedFrame):
         self.Bind(wx.EVT_MENU, lambda e: self._on_weather_chat(), weather_chat_item)
         self.Bind(wx.EVT_MENU, lambda e: self._on_soundpack_manager(), soundpack_item)
         self.Bind(wx.EVT_MENU, lambda e: self._on_check_updates(), self._check_updates_item)
+        self.Bind(wx.EVT_MENU, lambda e: self._on_open_user_manual(), user_manual_item)
         if self._debug_menu_items:
             self.Bind(
                 wx.EVT_MENU,
@@ -881,6 +888,17 @@ class MainWindow(SizedFrame):
         dialog = ReportIssueDialog(self)
         dialog.ShowModal()
         dialog.Destroy()
+
+    def _on_open_user_manual(self) -> None:
+        """Open the bundled user manual or fall back to the online manual."""
+        if open_user_manual():
+            return
+
+        wx.MessageBox(
+            "AccessiWeather could not open the user manual.",
+            "User Manual Unavailable",
+            wx.OK | wx.ICON_ERROR,
+        )
 
     def _on_about(self) -> None:
         """Show about dialog."""

--- a/src/accessiweather/user_manual.py
+++ b/src/accessiweather/user_manual.py
@@ -1,0 +1,58 @@
+"""User manual lookup and launching helpers."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import webbrowser
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+ONLINE_USER_MANUAL_URL = "https://github.com/Orinks/AccessiWeather/blob/main/docs/user_manual.md"
+
+
+def _find_project_root(start: Path) -> Path | None:
+    for parent in (start, *start.parents):
+        if (parent / "pyproject.toml").exists():
+            return parent
+    return None
+
+
+def get_bundled_user_manual_path() -> Path | None:
+    """Return the bundled/local user manual path when available."""
+    if getattr(sys, "frozen", False):
+        exe_dir = Path(sys.executable).resolve().parent
+        meipass_dir = Path(getattr(sys, "_MEIPASS", exe_dir))
+        candidates = [
+            meipass_dir / "accessiweather" / "docs" / "user_manual.md",
+            exe_dir / "accessiweather" / "docs" / "user_manual.md",
+        ]
+    else:
+        start = Path(__file__).resolve()
+        project_root = _find_project_root(start)
+        if project_root is None:
+            project_root = start.parents[2]
+        candidates = [project_root / "docs" / "user_manual.md"]
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def open_user_manual() -> bool:
+    """Open the local bundled user manual, falling back to the online manual."""
+    manual_path = get_bundled_user_manual_path()
+
+    if manual_path is not None:
+        try:
+            return bool(webbrowser.open(manual_path.resolve().as_uri()))
+        except Exception:
+            logger.exception("Failed to open local user manual at %s", manual_path)
+
+    try:
+        return bool(webbrowser.open(ONLINE_USER_MANUAL_URL))
+    except Exception:
+        logger.exception("Failed to open fallback online user manual")
+        return False

--- a/tests/test_main_window_labels.py
+++ b/tests/test_main_window_labels.py
@@ -5,8 +5,13 @@ def test_quick_action_labels_match_visible_ui_copy():
     assert QUICK_ACTION_LABELS == {
         "add": "&Add Location",
         "remove": "&Remove Location",
-        "refresh": "&Refresh Weather",
+        "refresh": "Re&fresh Weather",
         "explain": "&Explain Weather",
         "discussion": "Forecast &Discussion",
         "settings": "&Settings",
     }
+
+
+def test_quick_action_labels_use_unique_access_keys():
+    access_keys = [label[label.index("&") + 1].lower() for label in QUICK_ACTION_LABELS.values()]
+    assert len(access_keys) == len(set(access_keys))

--- a/tests/test_noaa_radio_menu_item.py
+++ b/tests/test_noaa_radio_menu_item.py
@@ -72,5 +72,5 @@ class TestNoaaRadioMenuItemSource:
     def test_menu_item_before_weather_assistant(self, source):
         """Test that NOAA Radio item appears before Weather Assistant."""
         noaa_pos = source.index("NOAA Weather &Radio")
-        chat_pos = source.index("Weather &Assistant")
+        chat_pos = source.index("Weather Assistan&t")
         assert noaa_pos < chat_pos

--- a/tests/test_user_manual.py
+++ b/tests/test_user_manual.py
@@ -82,7 +82,9 @@ def test_get_bundled_user_manual_path_uses_meipass_when_frozen(monkeypatch, tmp_
 
     monkeypatch.setattr(user_manual.sys, "frozen", True, raising=False)
     monkeypatch.setattr(user_manual.sys, "_MEIPASS", str(tmp_path), raising=False)
-    monkeypatch.setattr(user_manual.sys, "executable", str(tmp_path / "AccessiWeather.exe"), raising=False)
+    monkeypatch.setattr(
+        user_manual.sys, "executable", str(tmp_path / "AccessiWeather.exe"), raising=False
+    )
 
     assert user_manual.get_bundled_user_manual_path() == bundled_manual
 

--- a/tests/test_user_manual.py
+++ b/tests/test_user_manual.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import pathlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestUserManualSource:
+    @pytest.fixture
+    def source(self):
+        return pathlib.Path("src/accessiweather/ui/main_window.py").read_text()
+
+    def test_help_menu_item_exists(self, source):
+        assert "User &Manual" in source
+
+    def test_help_menu_item_binds_handler(self, source):
+        assert "_on_open_user_manual" in source
+
+    def test_help_menu_item_uses_expected_label(self, source):
+        assert '"User &Manual"' in source
+
+
+def test_on_open_user_manual_calls_helper_without_error_dialog():
+    from accessiweather.ui.main_window import MainWindow
+
+    with patch.object(MainWindow, "__init__", lambda self, *a, **kw: None):
+        win = MainWindow.__new__(MainWindow)
+
+    with (
+        patch("accessiweather.ui.main_window.open_user_manual", return_value=True) as open_mock,
+        patch("accessiweather.ui.main_window.wx.MessageBox", create=True) as message_box,
+    ):
+        MainWindow._on_open_user_manual(win)
+
+    open_mock.assert_called_once_with()
+    message_box.assert_not_called()
+
+
+def test_on_open_user_manual_shows_error_dialog_when_helper_fails():
+    from accessiweather.ui.main_window import MainWindow
+
+    with patch.object(MainWindow, "__init__", lambda self, *a, **kw: None):
+        win = MainWindow.__new__(MainWindow)
+
+    with (
+        patch("accessiweather.ui.main_window.open_user_manual", return_value=False) as open_mock,
+        patch("accessiweather.ui.main_window.wx.MessageBox", create=True) as message_box,
+    ):
+        MainWindow._on_open_user_manual(win)
+
+    open_mock.assert_called_once_with()
+    message_box.assert_called_once()
+
+
+def test_get_bundled_user_manual_path_prefers_dev_docs(monkeypatch, tmp_path):
+    project_root = tmp_path / "project"
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir(parents=True)
+    manual_path = docs_dir / "user_manual.md"
+    manual_path.write_text("manual", encoding="utf-8")
+
+    module_file = project_root / "src" / "accessiweather" / "user_manual.py"
+    module_file.parent.mkdir(parents=True)
+    module_file.write_text("# stub", encoding="utf-8")
+
+    from accessiweather import user_manual
+
+    monkeypatch.setattr(user_manual, "__file__", str(module_file))
+    monkeypatch.delattr(user_manual.sys, "frozen", raising=False)
+    monkeypatch.delattr(user_manual.sys, "_MEIPASS", raising=False)
+
+    assert user_manual.get_bundled_user_manual_path() == manual_path
+
+
+def test_get_bundled_user_manual_path_uses_meipass_when_frozen(monkeypatch, tmp_path):
+    bundled_manual = tmp_path / "accessiweather" / "docs" / "user_manual.md"
+    bundled_manual.parent.mkdir(parents=True)
+    bundled_manual.write_text("manual", encoding="utf-8")
+
+    from accessiweather import user_manual
+
+    monkeypatch.setattr(user_manual.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(user_manual.sys, "_MEIPASS", str(tmp_path), raising=False)
+    monkeypatch.setattr(user_manual.sys, "executable", str(tmp_path / "AccessiWeather.exe"), raising=False)
+
+    assert user_manual.get_bundled_user_manual_path() == bundled_manual
+
+
+def test_open_user_manual_opens_local_file_before_web_fallback(monkeypatch, tmp_path):
+    manual_path = tmp_path / "user_manual.md"
+    manual_path.write_text("manual", encoding="utf-8")
+
+    from accessiweather import user_manual
+
+    opened_urls: list[str] = []
+    monkeypatch.setattr(user_manual, "get_bundled_user_manual_path", lambda: manual_path)
+    monkeypatch.setattr(user_manual.webbrowser, "open", lambda url: opened_urls.append(url) or True)
+
+    assert user_manual.open_user_manual() is True
+    assert opened_urls == [manual_path.resolve().as_uri()]
+
+
+def test_open_user_manual_falls_back_to_online_manual(monkeypatch):
+    from accessiweather import user_manual
+
+    opened_urls: list[str] = []
+    monkeypatch.setattr(user_manual, "get_bundled_user_manual_path", lambda: None)
+    monkeypatch.setattr(user_manual.webbrowser, "open", lambda url: opened_urls.append(url) or True)
+
+    assert user_manual.open_user_manual() is True
+    assert opened_urls == [user_manual.ONLINE_USER_MANUAL_URL]
+
+
+def test_open_user_manual_returns_false_when_both_local_and_fallback_fail(monkeypatch, tmp_path):
+    manual_path = tmp_path / "user_manual.md"
+    manual_path.write_text("manual", encoding="utf-8")
+
+    from accessiweather import user_manual
+
+    open_mock = MagicMock(side_effect=[RuntimeError("local failed"), RuntimeError("web failed")])
+    monkeypatch.setattr(user_manual, "get_bundled_user_manual_path", lambda: manual_path)
+    monkeypatch.setattr(user_manual.webbrowser, "open", open_mock)
+
+    assert user_manual.open_user_manual() is False
+    assert open_mock.call_count == 2


### PR DESCRIPTION
## What changed
- add a `Help -> User Manual` action in the wx main window
- wire the action through the shared `user_manual` helper so the app opens a local manual first and falls back to the online manual
- add focused tests for the helper and the new menu handler
- resolve duplicate wx access-key mnemonics in the main window labels and View menu without changing the existing `Ctrl+...` accelerators

## Why
The interrupted user-manual work had already introduced the helper and tests, but the Help menu entry was not wired into the wx UI. While finishing that path, duplicate `Alt+` access keys in the same window/menu were also surfaced and cleaned up so keyboard navigation is less ambiguous.

## Impact
- users can now open the AccessiWeather user manual directly from the Help menu
- if the bundled manual is unavailable, the app falls back to the online manual instead of failing silently
- main-window access keys no longer collide for `Refresh`/`Radio`, `Aviation`/`Assistant`, or `Remove`/`Refresh`

## Root cause
The manual-opening helper existed as untracked work but had never been connected to the wx Help menu. Separately, several labels in the same UI context reused the same mnemonic marker (`&`), producing duplicate `Alt+` access keys.

## Validation
- `./.venv/bin/pytest -q tests/test_user_manual.py`
- `./.venv/bin/pytest -q tests/test_main_window_labels.py tests/test_noaa_radio_menu_item.py tests/test_user_manual.py`
- `./.venv/bin/ruff check src/accessiweather/ui/main_window.py src/accessiweather/user_manual.py tests/test_main_window_labels.py tests/test_noaa_radio_menu_item.py tests/test_user_manual.py`
- `./.venv/bin/pyright src/accessiweather/user_manual.py`

## Notes
- `src/accessiweather/ui/main_window.py` still has unrelated pre-existing pyright issues outside the scope of this PR.