### PR TITLE
fix(ui): main window UX polish — sizing, title, status, grouping

### DIFF
--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -122,6 +122,13 @@ class MainWindow(SizedFrame):
         )
         self.location_dropdown.SetSizerProps(expand=True, proportion=1)
 
+        # Add / Remove live with the dropdown they operate on, not at the
+        # bottom with the global quick actions.  This groups related
+        # controls spatially and lets the bottom button row breathe
+        # (Refresh / Explain / Discussion / Settings).
+        self.add_button = wx.Button(location_panel, label=QUICK_ACTION_LABELS["add"])
+        self.remove_button = wx.Button(location_panel, label=QUICK_ACTION_LABELS["remove"])
+
         # Current conditions section
         wx.StaticText(panel, label="Current Conditions:")
         self.current_conditions = wx.TextCtrl(
@@ -187,8 +194,6 @@ class MainWindow(SizedFrame):
         button_panel.SetSizerType("horizontal")
         button_panel.SetSizerProps(expand=True)
 
-        self.add_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["add"])
-        self.remove_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["remove"])
         self.refresh_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["refresh"])
         self.explain_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["explain"])
         self.discussion_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["discussion"])

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -94,8 +94,13 @@ class MainWindow(SizedFrame):
         self._bind_events()
         self._setup_escape_accelerator()
 
-        # Set initial window size
-        self.SetSize((800, 600))
+        # Set initial window size.  The main window stacks five multi-line text
+        # sections (current conditions, hourly, daily, alerts, event center) plus
+        # the location row and button row; 600px of height caused every section
+        # to clip its content.  Minimum size keeps the layout usable if the
+        # window is resized down.
+        self.SetSize((900, 820))
+        self.SetMinSize((800, 700))
 
         # Populate initial data
         self._populate_locations()

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -31,7 +31,7 @@ QUICK_ACTION_LABELS = {
     "add": "&Add Location",
     "remove": "&Remove Location",
     "refresh": "Re&fresh Weather",
-    "explain": "&Explain Weather",
+    "explain": "Explain &Conditions",
     "discussion": "Forecast &Discussion",
     "settings": "&Settings",
 }

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -164,14 +164,22 @@ class MainWindow(SizedFrame):
         self.view_alert_button = wx.Button(alerts_panel, label="View Alert Details")
         self.view_alert_button.Disable()  # Disabled until alerts are available
 
-        # Event Center section
+        # Event Center section — displayed as "Recent Events" so users
+        # immediately understand it's a reviewable log of recent notifications
+        # and app events, not a live feed.
         self._event_center_visible = True
-        self._event_center_label = wx.StaticText(panel, label="Event Center:")
+        self._event_center_label = wx.StaticText(panel, label="Recent Events:")
+        self._event_center_tooltip_text = (
+            "Reviewable log of recent weather notifications, AFD updates, "
+            "forecast briefings, and other in-app events."
+        )
+        self._event_center_label.SetToolTip(self._event_center_tooltip_text)
         self.event_center_display = wx.TextCtrl(
             panel,
             style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH2,
-            name="Event center",
+            name="Recent events",
         )
+        self.event_center_display.SetToolTip(self._event_center_tooltip_text)
         self.event_center_display.SetSizerProps(expand=True, proportion=1)
 
         # Control buttons

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -269,10 +269,26 @@ class MainWindow(SizedFrame):
             if current and current.name in all_names:
                 idx = all_names.index(current.name)
                 self.location_dropdown.SetSelection(idx)
+                self._update_title_for_location(current.name)
             else:
                 self.location_dropdown.SetSelection(0)
+                self._update_title_for_location(ALL_LOCATIONS_SENTINEL)
         except Exception as e:
             logger.error(f"Failed to populate locations: {e}")
+
+    def _update_title_for_location(self, location_name: str | None) -> None:
+        """
+        Set the window title to include the active location.
+
+        The title is used by the taskbar, screen readers on window focus,
+        and Alt+Tab, so surfacing the active location there gives users
+        orientation without needing to read the location dropdown.
+        """
+        base = "AccessiWeather"
+        if location_name and location_name != ALL_LOCATIONS_SENTINEL:
+            self.SetTitle(f"{base} \u2014 {location_name}")
+        else:
+            self.SetTitle(base)
 
     def _create_menu_bar(self) -> None:
         """Create the application menu bar."""
@@ -465,6 +481,7 @@ class MainWindow(SizedFrame):
         # --- All Locations special case ---
         if selected == ALL_LOCATIONS_SENTINEL:
             self._all_locations_active = True
+            self._update_title_for_location(ALL_LOCATIONS_SENTINEL)
             MainWindow._update_precipitation_timeline_menu_state(self)
             # Increment generation to invalidate any in-flight fetches for the previous location
             self._fetch_generation += 1
@@ -480,6 +497,7 @@ class MainWindow(SizedFrame):
         self._all_locations_alerts_data = []
         self._last_single_location_name = selected
         self._set_forecast_sections_visible(True)
+        self._update_title_for_location(selected)
 
         self._set_current_location(selected)
 

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -1333,6 +1333,11 @@ class MainWindow(SizedFrame):
             # Process notification events (AFD updates, severe risk changes)
             self._process_notification_events(weather_data)
 
+            # Surface the refresh time in the status bar so users have a
+            # passive indicator of data freshness without needing to re-read
+            # any panels.  Silent (no screen-reader announcement).
+            self._set_last_updated_status()
+
             # Play data_updated sound on successful weather data refresh
             try:
                 settings = self.app.config_manager.get_settings()
@@ -1738,6 +1743,19 @@ class MainWindow(SizedFrame):
         logger.info(f"Status: {message}")
         if message:
             self._announcer.announce(message)
+
+    def _set_last_updated_status(self, when: datetime | None = None) -> None:
+        """
+        Write 'Last updated HH:MM' to the main status field silently.
+
+        Unlike set_status(), this does not invoke the screen-reader
+        announcer — refresh success is already conveyed by the
+        data_updated sound and a re-announcement on every refresh would
+        be noisy.  The timestamp is formatted in the user's local time
+        using 12-hour format to match Event Center entries.
+        """
+        stamp = (when or datetime.now()).strftime("%I:%M %p").lstrip("0")
+        self.GetStatusBar().SetStatusText(f"Last updated {stamp}", 0)
 
     def _update_precipitation_timeline_menu_state(self, weather_data=None) -> None:
         """Enable the precipitation timeline menu item when minutely data is available."""

--- a/tests/test_all_locations_view.py
+++ b/tests/test_all_locations_view.py
@@ -56,6 +56,7 @@ def _make_window():
     win._fetch_all_locations_data = MagicMock(return_value=MagicMock())
     win._fetch_weather_data = MagicMock(return_value=MagicMock())
     win._set_current_location = MagicMock()
+    win._update_title_for_location = MagicMock()
 
     # Delegate the real implementations we want to test.
     win.set_status = MainWindow.set_status.__get__(win, MainWindow)

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -259,6 +259,7 @@ class TestMainWindowLocationSwitchAlertCheck:
         win._all_locations_alerts_data = []
         win._set_current_location = MagicMock()
         win._set_forecast_sections_visible = MagicMock()
+        win._update_title_for_location = MagicMock()
         win._on_weather_data_received = MagicMock()
         win.refresh_notification_events_async = MagicMock()
         win.Bind = MagicMock()

--- a/tests/test_main_window_labels.py
+++ b/tests/test_main_window_labels.py
@@ -6,7 +6,7 @@ def test_quick_action_labels_match_visible_ui_copy():
         "add": "&Add Location",
         "remove": "&Remove Location",
         "refresh": "Re&fresh Weather",
-        "explain": "&Explain Weather",
+        "explain": "Explain &Conditions",
         "discussion": "Forecast &Discussion",
         "settings": "&Settings",
     }

--- a/tests/test_main_window_sounds.py
+++ b/tests/test_main_window_sounds.py
@@ -60,6 +60,7 @@ class TestMainWindowDataUpdatedSound:
         win._set_forecast_sections = MagicMock()
         win._update_alerts = MagicMock()
         win._process_notification_events = MagicMock()
+        win._set_last_updated_status = MagicMock()
         win._alert_lifecycle_labels = {}
         # Stub presenter so the method doesn't blow up on presentation logic
         presentation = MagicMock()
@@ -194,6 +195,7 @@ class TestMainWindowFetchErrorSound:
         win._set_forecast_sections = MagicMock()
         win._update_alerts = MagicMock()
         win._process_notification_events = MagicMock()
+        win._set_last_updated_status = MagicMock()
         win._alert_lifecycle_labels = {}
         presentation = MagicMock()
         presentation.current_conditions = MagicMock()


### PR DESCRIPTION
## Summary

A set of small, independent UX fixes to the main window, each in its own commit so they can be reverted piecewise if needed. Branched from `dev`; 8 commits.

- **Window sizing** — enlarge default to 900x820 with a 800x700 minimum so forecast sections stop clipping
- **Title includes active location** — `AccessiWeather - Lumberton, New Jersey` for real locations, plain `AccessiWeather` for the All Locations summary
- **Last updated timestamp** — `Last updated H:MM AM/PM` written silently (no SR announcement) to the main status bar field on each successful refresh
- **Event Center -> Recent Events** — clearer on-screen label + tooltip describing what the section contains. Internal identifiers unchanged
- **Explain Weather -> Explain Conditions** — button rename (access key `C`, still unique); menu text left as `&Explain Weather` to avoid an access-key conflict with `Event &Center` in the View menu
- **Add/Remove Location moved** — now live on the Location row next to the dropdown they operate on; bottom button row is now purely global actions (Refresh / Explain Conditions / Forecast Discussion / Settings)
- **Test stub updates** — `_make_window` harnesses in `test_all_locations_view.py`, `test_coverage_gaps.py`, and `test_main_window_sounds.py` now mock the two new helpers (`_update_title_for_location`, `_set_last_updated_status`) so they don't reach real wx on an uninitialised `MainWindow`

An earlier attempt to collapse the empty Weather Alerts section was tried and reverted after local testing showed the SizedPanel announced as just "panel" under NVDA when its focusable children were hidden. The alerts section stays as it was — always-visible empty ListBox + disabled View Alert Details button.

## Test plan

- [x] Full test suite locally: 3419 pass. 7 failures exist on Windows locally but are all Windows-specific paths (toast identity, keyring auto-import, WinRT notifier) — verified the same 7 fail against `origin/dev`'s `src/` unchanged, so they are pre-existing and do not run on the Ubuntu CI matrix
- [x] Launched the app, visually verified all six fixes in the UI
- [x] Status bar shows `Last updated 11:25 AM` after first refresh
- [x] Window title updates to include location on launch and on dropdown changes
- [ ] Verify CI (Ubuntu Py 3.12 + 3.13) passes on this PR