### PR TITLE
fix(notifications): stop alert renotification every ~10 min in auto mode

### DIFF
--- a/src/accessiweather/weather_client_base.py
+++ b/src/accessiweather/weather_client_base.py
@@ -536,6 +536,13 @@ class WeatherClient:
                         location
                     )
 
+            # In auto mode the full refresh stores AlertAggregator.aggregate_alerts(...)
+            # output in _previous_alerts. The lightweight poll must produce the same
+            # canonical shape or the two paths will alternate and diff_alerts will fire
+            # phantom "new"/"updated" notifications every refresh cycle.
+            if self.data_source == "auto" and weather_data.alerts is not None:
+                weather_data.alerts = AlertAggregator().aggregate_alerts(weather_data.alerts, None)
+
             loc_key = self._location_key(location)
             previous_alerts = self._previous_alerts.get(loc_key)
             if self.data_source in ("auto", "nws"):

--- a/tests/test_alert_lifecycle_pipeline.py
+++ b/tests/test_alert_lifecycle_pipeline.py
@@ -227,3 +227,149 @@ class TestWeatherDataAlertLifecycleField:
         diff = AlertLifecycleDiff()
         wd.alert_lifecycle_diff = diff
         assert wd.alert_lifecycle_diff is diff
+
+
+# ---------------------------------------------------------------------------
+# Auto-mode lightweight poll must aggregate duplicates so the diff against
+# the full-refresh snapshot (which stores MERGED alerts) doesn't see phantom
+# updates every 10 minutes.
+# ---------------------------------------------------------------------------
+
+
+class TestLightweightPollMatchesFullRefreshAggregation:
+    """
+    Regression tests for renotification caused by raw/merged alternation.
+
+    Full refresh (auto mode) stores ``AlertAggregator.aggregate_alerts(...)``
+    output in ``_previous_alerts``. The lightweight poll used to store RAW
+    NWS alerts, so the cache alternated between merged and raw on every
+    refresh cycle. That caused ``diff_alerts`` to fire phantom "updated"
+    notifications every ``update_interval_minutes`` even when nothing changed.
+    """
+
+    @pytest.fixture
+    def auto_client(self) -> WeatherClient:
+        settings = AppSettings(enable_alerts=True)
+        client = WeatherClient(settings=settings)
+        client.data_source = "auto"
+        return client
+
+    @pytest.mark.asyncio
+    async def test_no_phantom_updates_when_full_refresh_merged_same_alerts(
+        self, auto_client, us_location
+    ):
+        """Priming the cache with merged alerts must not trigger updates on poll."""
+        from accessiweather.weather_client_alerts import AlertAggregator
+
+        # Two overlapping NWS alerts (same event, overlapping areas) that
+        # the full refresh's AlertAggregator will merge into a single alert
+        # with the longer description.
+        raw = WeatherAlerts(
+            alerts=[
+                WeatherAlert(
+                    id="nws-urn-alert-a",
+                    title="Winter Storm Warning",
+                    event="Winter Storm Warning",
+                    description="Short description.",
+                    severity="Severe",
+                    urgency="Expected",
+                    headline="Winter Storm Warning in effect",
+                    instruction="Take precautions.",
+                    areas=["County X"],
+                    source="NWS",
+                ),
+                WeatherAlert(
+                    id="nws-urn-alert-b",
+                    title="Winter Storm Warning",
+                    event="Winter Storm Warning",
+                    description="A much longer and more detailed description text.",
+                    severity="Severe",
+                    urgency="Expected",
+                    headline="Winter Storm Warning in effect",
+                    instruction="Take precautions.",
+                    areas=["County X", "County Y"],
+                    source="NWS",
+                ),
+            ]
+        )
+        merged = AlertAggregator().aggregate_alerts(raw, None)
+        assert len(merged.alerts) == 1, "sanity: overlapping NWS alerts must merge"
+
+        # Simulate the post-full-refresh cache state: merged alerts stored.
+        loc_key = auto_client._location_key(us_location)
+        auto_client._previous_alerts[loc_key] = merged
+
+        # Simulate lightweight poll: mock NWS to return the same raw alerts.
+        auto_client._get_nws_discussion_only = AsyncMock(return_value=("AFD text", None))
+        auto_client._get_nws_alerts = AsyncMock(return_value=raw)
+        auto_client._fetch_nws_cancel_references = AsyncMock(return_value=set())
+
+        weather_data = await auto_client.get_notification_event_data(us_location)
+
+        diff = weather_data.alert_lifecycle_diff
+        assert diff is not None
+        # No phantom new/updated alerts: the lightweight poll must see the
+        # same canonical alert shape that the full refresh stored.
+        assert diff.new_alerts == []
+        assert diff.updated_alerts == []
+        assert diff.escalated_alerts == []
+        assert diff.extended_alerts == []
+        assert diff.has_changes is False, (
+            f"Phantom change detected: {diff.summary!r}. "
+            "Lightweight poll must aggregate the same way full refresh does."
+        )
+
+    @pytest.mark.asyncio
+    async def test_cached_previous_alerts_match_full_refresh_shape(self, auto_client, us_location):
+        """
+        After a lightweight poll, _previous_alerts must hold the aggregated form.
+
+        If the lightweight poll stored raw alerts, the next full refresh would
+        diff merged-vs-raw and fire spurious updates. Store the aggregated
+        form so both paths round-trip to the same snapshot.
+        """
+        from accessiweather.weather_client_alerts import AlertAggregator
+
+        raw = WeatherAlerts(
+            alerts=[
+                WeatherAlert(
+                    id="nws-urn-alert-a",
+                    title="Flood Warning",
+                    event="Flood Warning",
+                    description="Short.",
+                    severity="Severe",
+                    urgency="Expected",
+                    areas=["County X"],
+                    source="NWS",
+                ),
+                WeatherAlert(
+                    id="nws-urn-alert-b",
+                    title="Flood Warning",
+                    event="Flood Warning",
+                    description="Longer description with more detail.",
+                    severity="Severe",
+                    urgency="Expected",
+                    areas=["County X"],
+                    source="NWS",
+                ),
+            ]
+        )
+        expected_merged = AlertAggregator().aggregate_alerts(raw, None)
+
+        auto_client._get_nws_discussion_only = AsyncMock(return_value=(None, None))
+        auto_client._get_nws_alerts = AsyncMock(return_value=raw)
+        auto_client._fetch_nws_cancel_references = AsyncMock(return_value=set())
+
+        await auto_client.get_notification_event_data(us_location)
+
+        loc_key = auto_client._location_key(us_location)
+        cached = auto_client._previous_alerts[loc_key]
+        cached_ids = sorted(a.get_unique_id() for a in cached.alerts)
+        expected_ids = sorted(a.get_unique_id() for a in expected_merged.alerts)
+        assert cached_ids == expected_ids, (
+            "Lightweight poll must store aggregated alerts so the next full "
+            "refresh diff doesn't fire spurious updates."
+        )
+        cached_hashes = sorted(a.get_content_hash() for a in cached.alerts)
+        expected_hashes = sorted(a.get_content_hash() for a in expected_merged.alerts)
+        assert cached_hashes == expected_hashes


### PR DESCRIPTION
## Summary
- Run `AlertAggregator.aggregate_alerts(...)` inside `get_notification_event_data` when `data_source == \"auto\"` so the lightweight 60s poll stores the same canonical alert shape as the full refresh.
- Add two regression tests in `test_alert_lifecycle_pipeline.py` covering the raw-vs-merged alternation that caused phantom \"updated\"/\"new\" notifications.

## Root cause
Full refresh stored `AlertAggregator` output in `_previous_alerts`; the lightweight poll stored **raw** alerts. The cache alternated between merged and raw each cycle, so `diff_alerts` + `AlertManager.process_alerts` saw phantom NEW/UPDATED entries every ~10 min for alerts that never changed — user-visible as \"alert notification every X minutes, despite the alert not changing status.\"

Only triggers when auto mode has multiple overlapping NWS alerts (same event, overlapping areas, onset within 60m) that the aggregator merges — e.g., the same Winter Storm Warning covering multiple neighboring zones.

## Fix
Match the full refresh behavior: run the aggregator in the lightweight poll path too when in auto mode. Single-source modes (nws/visualcrossing/pirateweather) don't use the aggregator in either path, so no alternation exists there and no change is needed.

## Test plan
- [x] Added `TestLightweightPollMatchesFullRefreshAggregation` — 2 tests confirmed failing pre-fix, passing post-fix
- [x] `pytest tests/test_alert_lifecycle_pipeline.py tests/test_alert_lifecycle.py tests/test_alert_manager.py tests/test_alert_aggregator.py tests/test_alert_notification_system.py tests/test_nws_afd_notification.py tests/test_split_notification_timers.py tests/test_auto_mode_api_budget.py` — 209 passed
- [x] `pytest -k \"weather_client or notification or alert\"` — 713 passed
- [ ] Monitor in a nightly build: confirm no recurring \"updated\" toasts for stable NWS alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)