### PR TITLE
fix(updates): make auto-update scheduler resilient to sleep/wake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - **NOAA radio station count now sticks** — your nearby-station limit is saved with NOAA radio preferences and reused the next time you open the dialog, while preferred stream choices keep working as before
+- **Automatic update checks now fire on long-running sessions** — the 24-hour update check used a single long wxTimer that could silently skip its tick after the computer slept or hibernated, so users who left the app open had to check manually. The scheduler now polls every 15 minutes and uses wall-clock elapsed time, so checks run on schedule even across sleep/wake cycles
 
 ## [0.4.5] - 2026-03-26
 

--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -140,6 +140,8 @@ class AccessiWeatherApp(wx.App):
         # Background update
         self._update_timer: wx.Timer | None = None
         self._auto_update_check_timer: wx.Timer | None = None
+        self._auto_update_interval_seconds: int = 24 * 3600
+        self._last_update_check_at: float | None = None
         self._activation_handoff_timer: wx.Timer | None = None
         self._startup_update_check_deferred: bool = False
         self.is_updating: bool = False
@@ -1076,6 +1078,14 @@ class AccessiWeatherApp(wx.App):
 
             channel = getattr(settings, "update_channel", "stable")
 
+            # Mark that a check was initiated now so the periodic scheduler
+            # doesn't also fire during/right after this one. Use wall-clock-
+            # inclusive monotonic time so sleep/wake cycles are accounted for.
+            import time as _time
+
+            self._last_update_check_at = _time.monotonic()
+            logger.info("Auto-update check starting (channel=%s)", channel)
+
             def do_check():
                 import asyncio
 
@@ -1134,7 +1144,7 @@ class AccessiWeatherApp(wx.App):
 
                         wx.CallAfter(show_update_notification)
                     else:
-                        logger.debug("No updates available")
+                        logger.info("Auto-update check: no updates available")
 
                 except Exception as e:
                     logger.warning(f"Startup update check failed: {e}")

--- a/src/accessiweather/app_timer_manager.py
+++ b/src/accessiweather/app_timer_manager.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import time
 from typing import TYPE_CHECKING
 
 import wx
@@ -17,6 +18,11 @@ if TYPE_CHECKING:
     from .app import AccessiWeatherApp
 
 logger = logging.getLogger(__name__)
+
+# How often the scheduler wakes to check if an update check is due.
+# Short enough that a 24h check fires within ~15 minutes of being due even after
+# laptop sleep/wake; long enough to avoid overhead.
+AUTO_UPDATE_POLL_INTERVAL_MS = 15 * 60 * 1000
 
 
 def stop_auto_update_checks(app: AccessiWeatherApp) -> None:
@@ -38,7 +44,7 @@ def stop_auto_update_checks(app: AccessiWeatherApp) -> None:
 
 
 def start_auto_update_checks(app: AccessiWeatherApp) -> None:
-    """Start periodic automatic update checks based on user settings."""
+    """Start a short-interval scheduler that runs an update check when due."""
     try:
         settings = app.config_manager.get_settings()
         auto_enabled = bool(getattr(settings, "auto_update_enabled", True))
@@ -47,28 +53,58 @@ def start_auto_update_checks(app: AccessiWeatherApp) -> None:
         stop_auto_update_checks(app)
 
         if not auto_enabled:
-            logger.debug("Automatic update checks disabled")
+            logger.info("Auto-update scheduler: disabled via settings")
             return
 
         interval_hours = max(1, int(getattr(settings, "update_check_interval_hours", 24)))
-        interval_ms = interval_hours * 60 * 60 * 1000
+        app._auto_update_interval_seconds = interval_hours * 3600
+
+        # Seed the "last check" timestamp so the first periodic tick isn't
+        # immediately treated as overdue. The startup update check runs
+        # separately via _check_for_updates_after_startup_guidance().
+        if getattr(app, "_last_update_check_at", None) is None:
+            app._last_update_check_at = time.monotonic()
 
         timer = wx.Timer(app)
         app.Bind(wx.EVT_TIMER, app._on_auto_update_check_timer, timer)
-        timer.Start(interval_ms)
+        timer.Start(AUTO_UPDATE_POLL_INTERVAL_MS)
         app._auto_update_check_timer = timer
 
         logger.info(
-            "Automatic update checks scheduled every %s hour(s)",
+            "Auto-update scheduler: checks every %sh (polled every %dmin, "
+            "resilient to system sleep/wake)",
             interval_hours,
+            AUTO_UPDATE_POLL_INTERVAL_MS // 60000,
         )
     except Exception as e:
         logger.warning(f"Failed to start automatic update checks: {e}")
 
 
 def on_auto_update_check_timer(app: AccessiWeatherApp, event) -> None:
-    """Run an automatic update check on timer ticks."""
-    app._check_for_updates_on_startup()
+    """Poll handler: run an update check if the configured interval has elapsed."""
+    try:
+        interval_seconds = int(getattr(app, "_auto_update_interval_seconds", 24 * 3600))
+        last = getattr(app, "_last_update_check_at", None)
+        now = time.monotonic()
+
+        elapsed = float("inf") if last is None else now - last
+
+        if elapsed < interval_seconds:
+            logger.debug(
+                "Auto-update tick: %ds elapsed of %ds — not due",
+                int(elapsed),
+                interval_seconds,
+            )
+            return
+
+        logger.info(
+            "Auto-update tick: %s elapsed (threshold %ds) — running check",
+            f"{int(elapsed)}s" if elapsed != float("inf") else "no prior check",
+            interval_seconds,
+        )
+        app._check_for_updates_on_startup()
+    except Exception as e:
+        logger.warning(f"Auto-update tick failed: {e}")
 
 
 def stop_background_updates(app: AccessiWeatherApp) -> None:

--- a/tests/test_app_auto_update_checks.py
+++ b/tests/test_app_auto_update_checks.py
@@ -77,6 +77,8 @@ def test_initialize_components_delegates_to_initialization_module():
 
 
 def test_start_auto_update_checks_uses_configured_interval(monkeypatch):
+    from accessiweather.app_timer_manager import AUTO_UPDATE_POLL_INTERVAL_MS
+
     app = AccessiWeatherApp.__new__(AccessiWeatherApp)
     app.config_manager = MagicMock()
     app.config_manager.get_settings.return_value = SimpleNamespace(
@@ -84,6 +86,7 @@ def test_start_auto_update_checks_uses_configured_interval(monkeypatch):
         update_check_interval_hours=6,
     )
     app._auto_update_check_timer = None
+    app._last_update_check_at = None
     app._force_wizard = False
     app.Bind = MagicMock()
     app.Unbind = MagicMock()
@@ -96,8 +99,11 @@ def test_start_auto_update_checks_uses_configured_interval(monkeypatch):
 
     timer_factory.assert_called_once_with(app)
     app.Bind.assert_called_once_with(wx.EVT_TIMER, app._on_auto_update_check_timer, timer)
-    timer.Start.assert_called_once_with(6 * 60 * 60 * 1000)
+    # Poll interval is short (15 min); "6 hours" is the due threshold.
+    timer.Start.assert_called_once_with(AUTO_UPDATE_POLL_INTERVAL_MS)
+    assert app._auto_update_interval_seconds == 6 * 3600
     assert app._auto_update_check_timer is timer
+    assert app._last_update_check_at is not None  # seeded
 
 
 def test_start_auto_update_checks_replaces_existing_timer_and_honors_disabled():
@@ -121,6 +127,8 @@ def test_start_auto_update_checks_replaces_existing_timer_and_honors_disabled():
 
 
 def test_start_auto_update_checks_reconfigures_existing_enabled_timer(monkeypatch):
+    from accessiweather.app_timer_manager import AUTO_UPDATE_POLL_INTERVAL_MS
+
     app = AccessiWeatherApp.__new__(AccessiWeatherApp)
     app.config_manager = MagicMock()
     app.config_manager.get_settings.return_value = SimpleNamespace(
@@ -134,6 +142,7 @@ def test_start_auto_update_checks_reconfigures_existing_enabled_timer(monkeypatc
     monkeypatch.setattr(wx, "Timer", timer_factory)
 
     app._auto_update_check_timer = old_timer
+    app._last_update_check_at = None
     app._force_wizard = False
     app.Bind = MagicMock()
     app.Unbind = MagicMock()
@@ -143,13 +152,43 @@ def test_start_auto_update_checks_reconfigures_existing_enabled_timer(monkeypatc
     old_timer.Stop.assert_called_once()
     app.Unbind.assert_called_once_with(wx.EVT_TIMER, source=old_timer)
     app.Bind.assert_called_once_with(wx.EVT_TIMER, app._on_auto_update_check_timer, new_timer)
-    new_timer.Start.assert_called_once_with(12 * 60 * 60 * 1000)
+    new_timer.Start.assert_called_once_with(AUTO_UPDATE_POLL_INTERVAL_MS)
+    assert app._auto_update_interval_seconds == 12 * 3600
     assert app._auto_update_check_timer is new_timer
 
 
-def test_on_auto_update_check_timer_invokes_update_check():
+def test_on_auto_update_check_timer_skips_when_not_due():
+    import time as _time
+
     app = AccessiWeatherApp.__new__(AccessiWeatherApp)
     app._check_for_updates_on_startup = MagicMock()
+    app._auto_update_interval_seconds = 24 * 3600
+    app._last_update_check_at = _time.monotonic()  # just checked
+
+    app._on_auto_update_check_timer(event=MagicMock())
+
+    app._check_for_updates_on_startup.assert_not_called()
+
+
+def test_on_auto_update_check_timer_runs_when_due():
+    import time as _time
+
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    app._check_for_updates_on_startup = MagicMock()
+    app._auto_update_interval_seconds = 24 * 3600
+    # Pretend last check was 25 hours ago.
+    app._last_update_check_at = _time.monotonic() - (25 * 3600)
+
+    app._on_auto_update_check_timer(event=MagicMock())
+
+    app._check_for_updates_on_startup.assert_called_once()
+
+
+def test_on_auto_update_check_timer_runs_when_never_checked():
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    app._check_for_updates_on_startup = MagicMock()
+    app._auto_update_interval_seconds = 24 * 3600
+    app._last_update_check_at = None
 
     app._on_auto_update_check_timer(event=MagicMock())
 


### PR DESCRIPTION
## Summary
- The 24h auto-update check used a single long `wx.Timer`; on Windows that tick can be dropped after sleep/hibernate, so users who left the app running had to check manually
- Switch to a 15-minute poll that compares `time.monotonic()` against `_last_update_check_at` and runs the check only when the configured interval has actually elapsed — survives sleep/wake because `GetTickCount64` counts suspended time
- Promote "auto-update check starting" and "no updates available" to INFO so a user who can produce a log can confirm the scheduler fires

## Root cause
`app_timer_manager.start_auto_update_checks` started a `wx.Timer(app)` with an 86,400,000 ms interval. wxMSW's timer is backed by Win32 `SetTimer`/`WM_TIMER`, which is not guaranteed to deliver a pending tick across system suspend/resume. Combined with the previous DEBUG-only "no updates available" log, there was no way to tell whether the timer had ever fired. Verified in isolation that the wx pattern itself works — the failure mode is specific to long intervals crossing sleep.

## Changes
- `src/accessiweather/app_timer_manager.py`: new `AUTO_UPDATE_POLL_INTERVAL_MS = 15 min`. `start_auto_update_checks` seeds `_last_update_check_at` and starts the short poll. `on_auto_update_check_timer` computes elapsed time and only dispatches the real check when due. Clear INFO/DEBUG logging on each tick.
- `src/accessiweather/app.py`: `__init__` initializes `_auto_update_interval_seconds` / `_last_update_check_at`. `_check_for_updates_on_startup` stamps the timestamp at dispatch time and logs at INFO. "No updates available" promoted from DEBUG to INFO.
- `CHANGELOG.md`: user-facing entry under `[Unreleased] → Fixed`.
- `tests/test_app_auto_update_checks.py`: existing interval assertions updated to reflect the new poll + threshold split; three new tests cover due-logic (skip-when-not-due, run-when-due, run-when-never-checked).

## Test plan
- [x] `uv run pytest tests/test_app_auto_update_checks.py tests/test_split_update_timers.py -n 0` — 20 passed
- [x] `uv run ruff check` + `ruff format --check` on changed files — clean
- [ ] Manual: run a frozen build for 24h+ across a sleep cycle and confirm the INFO-level "Auto-update check starting" log appears after wake
- [ ] Manual: change `update_check_interval_hours` in Settings and confirm the scheduler respects the new value without restart (handled via existing `refresh_runtime_settings` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)