### PR TITLE
fix(startup): make Windows startup check target-aware

### DIFF
--- a/src/accessiweather/services/startup_utils.py
+++ b/src/accessiweather/services/startup_utils.py
@@ -171,10 +171,55 @@ class StartupManager:
     def _is_windows_startup_enabled(self) -> bool:
         try:
             shortcut_path = self._get_windows_startup_shortcut()
-            return shortcut_path.exists()
+            if not shortcut_path.exists():
+                return False
+
+            actual = self._read_windows_shortcut(shortcut_path)
+            if actual is None:
+                return False
+            actual_target, actual_args = actual
+
+            expected_target, expected_args_list = self._get_launch_command()
+            expected_args = (
+                subprocess.list2cmdline(expected_args_list) if expected_args_list else ""
+            )
+
+            return (
+                os.path.normcase(os.path.normpath(actual_target))
+                == os.path.normcase(os.path.normpath(str(expected_target)))
+                and actual_args.strip() == expected_args.strip()
+            )
         except (PermissionError, FileNotFoundError, OSError) as exc:
             logger.error("Failed checking Windows startup status: %s", exc)
             return False
+
+    def _read_windows_shortcut(self, shortcut_path: Path) -> tuple[str, str] | None:
+        """Return ``(target_path, arguments)`` of a ``.lnk`` file or None on failure."""
+        shortcut_str = self._escape_powershell_single_quotes(str(shortcut_path))
+        script = (
+            "$shell = New-Object -COMObject WScript.Shell;"
+            f"$shortcut = $shell.CreateShortcut('{shortcut_str}');"
+            "Write-Output $shortcut.TargetPath;"
+            "Write-Output $shortcut.Arguments;"
+        )
+        commands = [
+            ["powershell.exe", "-NoProfile", "-Command", script],
+            ["pwsh", "-NoProfile", "-Command", script],
+        ]
+        for command in commands:
+            try:
+                result = subprocess.run(command, check=True, capture_output=True)
+            except FileNotFoundError:
+                continue
+            except subprocess.CalledProcessError as exc:
+                stderr = exc.stderr.decode("utf-8", errors="ignore") if exc.stderr else ""
+                logger.warning("Failed reading shortcut via PowerShell: %s", stderr)
+                return None
+            output = result.stdout.decode("utf-8", errors="ignore").splitlines()
+            target = output[0].strip() if output else ""
+            args = output[1].strip() if len(output) > 1 else ""
+            return target, args
+        return None
 
     def _escape_powershell_single_quotes(self, value: str) -> str:
         return value.replace("'", "''")

--- a/tests/test_startup_manager_windows_target_aware.py
+++ b/tests/test_startup_manager_windows_target_aware.py
@@ -1,0 +1,112 @@
+"""
+Windows startup enablement must compare the shortcut's target, not just existence.
+
+Previously `_is_windows_startup_enabled` returned True whenever any
+`accessiweather.lnk` existed in the Startup folder — even one pointing at a
+different install (e.g. a dev venv or an older path). That made
+`apply_startup_setting` a no-op when it should have overwritten the shortcut
+to point at the current executable, matching the macOS/Linux behavior.
+
+These tests pin the new semantics: True only when the shortcut targets the
+same executable and arguments as `_get_launch_command()` returns now.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from accessiweather.services.startup_utils import StartupManager
+
+
+@pytest.fixture
+def manager(tmp_path, monkeypatch):
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    platform_detector = MagicMock()
+    platform_info = MagicMock()
+    platform_info.platform = "windows"
+    platform_info.app_directory = Path("accessiweather")
+    platform_detector.get_platform_info.return_value = platform_info
+    return StartupManager(platform_detector=platform_detector)
+
+
+def _shortcut_path(manager: StartupManager) -> Path:
+    return manager._get_windows_startup_shortcut()
+
+
+def test_disabled_when_shortcut_missing(manager):
+    assert manager._is_windows_startup_enabled() is False
+
+
+def test_enabled_when_shortcut_targets_current_launch_command(manager, monkeypatch):
+    expected_target = Path("C:/Program Files/AccessiWeather/AccessiWeather.exe")
+    expected_args: list[str] = []
+    monkeypatch.setattr(manager, "_get_launch_command", lambda: (expected_target, expected_args))
+    monkeypatch.setattr(
+        manager,
+        "_read_windows_shortcut",
+        lambda _path: (str(expected_target), ""),
+    )
+    _shortcut_path(manager).touch()
+
+    assert manager._is_windows_startup_enabled() is True
+
+
+def test_disabled_when_shortcut_targets_different_executable(manager, monkeypatch):
+    """
+    A stale .lnk pointing at a different install must be treated as disabled.
+
+    This is the dev-venv vs. installed-exe case: user's dev session created a
+    shortcut pointing at the venv python; running the installed .exe must see
+    the shortcut as out-of-date and overwrite it.
+    """
+    monkeypatch.setattr(
+        manager,
+        "_get_launch_command",
+        lambda: (Path("C:/Program Files/AccessiWeather/AccessiWeather.exe"), []),
+    )
+    monkeypatch.setattr(
+        manager,
+        "_read_windows_shortcut",
+        lambda _path: (
+            "C:/Users/joshu/accessiweather/.venv/Scripts/python.exe",
+            "-m accessiweather",
+        ),
+    )
+    _shortcut_path(manager).touch()
+
+    assert manager._is_windows_startup_enabled() is False
+
+
+def test_enabled_when_shortcut_targets_python_with_matching_args(manager, monkeypatch):
+    """Source-run case: python.exe + `-m accessiweather` args must match."""
+    monkeypatch.setattr(
+        manager,
+        "_get_launch_command",
+        lambda: (Path("C:/venv/Scripts/python.exe"), ["-m", "accessiweather"]),
+    )
+    monkeypatch.setattr(
+        manager,
+        "_read_windows_shortcut",
+        lambda _path: ("C:/venv/Scripts/python.exe", "-m accessiweather"),
+    )
+    _shortcut_path(manager).touch()
+
+    assert manager._is_windows_startup_enabled() is True
+
+
+def test_disabled_when_shortcut_target_unreadable(manager, monkeypatch):
+    """
+    Unreadable .lnk (corrupt/PowerShell-missing) is treated as not-enabled.
+
+    Safer to overwrite than to leave a potentially broken shortcut in place.
+    """
+    monkeypatch.setattr(
+        manager, "_get_launch_command", lambda: (Path("C:/app/AccessiWeather.exe"), [])
+    )
+    monkeypatch.setattr(manager, "_read_windows_shortcut", lambda _path: None)
+    _shortcut_path(manager).touch()
+
+    assert manager._is_windows_startup_enabled() is False


### PR DESCRIPTION
## Summary

Follow-up to #604. `_is_windows_startup_enabled` in [startup_utils.py:171](src/accessiweather/services/startup_utils.py:171) only checked whether `accessiweather.lnk` exists in the Startup folder — it didn't verify what the shortcut pointed at. So if a dev-venv run left a shortcut behind, the installed build would see it as "already enabled", `apply_startup_setting` would no-op, and the stale venv-targeted shortcut would silently keep winning at reboot.

This PR makes the check target-aware, matching macOS ([startup_utils.py:298](src/accessiweather/services/startup_utils.py:298)) and Linux ([startup_utils.py:373](src/accessiweather/services/startup_utils.py:373)), which already compared target + arguments.

## What changed

- New `_read_windows_shortcut(path)` helper reads `TargetPath` and `Arguments` from a `.lnk` via `WScript.Shell` (same PowerShell pattern used by `_create_windows_shortcut`). Returns `None` on failure.
- `_is_windows_startup_enabled` now: (1) checks existence, (2) reads the shortcut, (3) compares target (case-insensitive, normalized via `os.path.normpath`/`normcase`) and arguments against `_get_launch_command()`. Returns True only when both match.
- Unreadable / corrupt shortcuts are treated as not-enabled so `apply_startup_setting` will overwrite them — safer than leaving a broken shortcut.

## Why this matters tonight

Without this, users with both a dev venv and an installed nightly (like Orin's setup) end up with whichever variant launched first winning the Startup-folder shortcut permanently, even after running the other. With this, whichever variant is currently launching will overwrite a stale shortcut from the other.

## Test plan

- [x] 5 new tests in `tests/test_startup_manager_windows_target_aware.py` — TDD'd, confirmed RED (4 of 5 failing against pre-change code, 1 was already correct for the missing-shortcut case). All green after.
  - Disabled when shortcut missing
  - Enabled when target + args match `_get_launch_command()`
  - **Disabled when shortcut targets a different executable** (the dev-venv vs. installed-exe case)
  - Enabled when shortcut targets python with matching `-m accessiweather` args (source-run case)
  - Disabled when shortcut is unreadable
- [ ] Manual verification: with a venv-targeted `accessiweather.lnk` in `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup`, run the installed nightly build → verify `accessiweather.lnk` gets overwritten to point at the installed `.exe` within the ~150ms deferred sync window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)