### PR TITLE
fix(ui): move Add/Remove Location back to bottom button row

### DIFF
--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -122,13 +122,6 @@ class MainWindow(SizedFrame):
         )
         self.location_dropdown.SetSizerProps(expand=True, proportion=1)
 
-        # Add / Remove live with the dropdown they operate on, not at the
-        # bottom with the global quick actions.  This groups related
-        # controls spatially and lets the bottom button row breathe
-        # (Refresh / Explain / Discussion / Settings).
-        self.add_button = wx.Button(location_panel, label=QUICK_ACTION_LABELS["add"])
-        self.remove_button = wx.Button(location_panel, label=QUICK_ACTION_LABELS["remove"])
-
         # Current conditions section
         wx.StaticText(panel, label="Current Conditions:")
         self.current_conditions = wx.TextCtrl(
@@ -194,6 +187,8 @@ class MainWindow(SizedFrame):
         button_panel.SetSizerType("horizontal")
         button_panel.SetSizerProps(expand=True)
 
+        self.add_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["add"])
+        self.remove_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["remove"])
         self.refresh_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["refresh"])
         self.explain_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["explain"])
         self.discussion_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["discussion"])


### PR DESCRIPTION
## Summary

Reverts the Add/Remove Location button placement from PR #600. Users reported that placing them on the location row interrupted the natural tab flow — screen reader users expect to tab from the location dropdown straight into the forecast content (Current Conditions → Hourly → Daily) without hitting action buttons first.

Moves both buttons back to the bottom button panel. Tab order is now:
**Location → Current Conditions → Hourly → Daily → Alerts → Recent Events → Add / Remove / Refresh / Explain Conditions / Forecast Discussion / Settings**

## Test plan

- [ ] CI passes
- [ ] Launch app and verify tab order flows from Location dropdown directly to Current Conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)