### PR TITLE
feat(locations): add Edit Location dialog for Marine Mode toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Edit Location** — a new "Edit Location" button and menu item in the Location menu let you toggle Marine Mode on existing locations without having to remove and re-add them
 - **NOAA radio station count chooser** — the NOAA Weather Radio dialog now lets you pick how many nearby stations to load (10, 25, 50, 100, or All) without digging through the main Settings window
 - **Precipitation timeline dialog** — View > Precipitation Timeline now opens a dedicated Pirate Weather minutely precipitation timeline with a quick summary and minute-by-minute plain-text breakdown
 

--- a/src/accessiweather/config/config_manager.py
+++ b/src/accessiweather/config/config_manager.py
@@ -296,6 +296,10 @@ class ConfigManager:
             marine_mode=marine_mode,
         )
 
+    def update_location_marine_mode(self, name: str, marine_mode: bool) -> bool:
+        """Update marine_mode on an existing location."""
+        return self._locations.update_location_marine_mode(name, marine_mode)
+
     def remove_location(self, name: str) -> bool:
         """Remove a location."""
         return self._locations.remove_location(name)

--- a/src/accessiweather/config/locations.py
+++ b/src/accessiweather/config/locations.py
@@ -56,6 +56,19 @@ class LocationOperations:
         self.logger.info(f"Added location: {name} ({latitude}, {longitude})")
         return self._manager.save_config()
 
+    def update_location_marine_mode(self, name: str, marine_mode: bool) -> bool:
+        """Update marine_mode on an existing location and persist it."""
+        config = self._manager.get_config()
+
+        for location in config.locations:
+            if location.name == name:
+                location.marine_mode = marine_mode
+                self.logger.info(f"Set marine_mode={marine_mode} on location: {name}")
+                return self._manager.save_config()
+
+        self.logger.warning(f"Location {name} not found")
+        return False
+
     def remove_location(self, name: str) -> bool:
         """Remove a location by name."""
         config = self._manager.get_config()

--- a/src/accessiweather/ui/dialogs/__init__.py
+++ b/src/accessiweather/ui/dialogs/__init__.py
@@ -6,7 +6,7 @@ from .alerts_summary_dialog import show_alerts_summary_dialog
 from .aviation_dialog import show_aviation_dialog
 from .discussion_dialog import show_discussion_dialog
 from .explanation_dialog import show_explanation_dialog
-from .location_dialog import show_add_location_dialog
+from .location_dialog import show_add_location_dialog, show_edit_location_dialog
 from .nationwide_discussion_dialog import show_nationwide_discussion_dialog
 from .noaa_radio_dialog import NOAARadioDialog, show_noaa_radio_dialog
 from .precipitation_timeline_dialog import show_precipitation_timeline_dialog
@@ -19,6 +19,7 @@ from .weather_history_dialog import show_weather_history_dialog
 
 __all__ = [
     "show_add_location_dialog",
+    "show_edit_location_dialog",
     "show_air_quality_dialog",
     "show_alert_dialog",
     "show_alerts_summary_dialog",
@@ -45,6 +46,7 @@ _LAZY_IMPORTS = {
     "show_discussion_dialog": ".discussion_dialog",
     "show_explanation_dialog": ".explanation_dialog",
     "show_add_location_dialog": ".location_dialog",
+    "show_edit_location_dialog": ".location_dialog",
     "show_nationwide_discussion_dialog": ".nationwide_discussion_dialog",
     "NOAARadioDialog": ".noaa_radio_dialog",
     "show_noaa_radio_dialog": ".noaa_radio_dialog",

--- a/src/accessiweather/ui/dialogs/location_dialog.py
+++ b/src/accessiweather/ui/dialogs/location_dialog.py
@@ -49,6 +49,81 @@ def show_add_location_dialog(parent, app: AccessiWeatherApp) -> str | None:
         return None
 
 
+def show_edit_location_dialog(parent, app: AccessiWeatherApp, location) -> bool | None:
+    """
+    Show a small edit dialog for an existing location.
+
+    Currently edits the per-location ``marine_mode`` flag only. Returns the new
+    value on OK, or ``None`` if the user cancelled.
+    """
+    try:
+        dlg = EditLocationDialog(parent, location)
+        result = dlg.ShowModal()
+
+        if result == wx.ID_OK:
+            new_value = dlg.get_marine_mode()
+            dlg.Destroy()
+            return new_value
+
+        dlg.Destroy()
+        return None
+
+    except Exception as e:
+        logger.error(f"Failed to show edit location dialog: {e}")
+        wx.MessageBox(
+            f"Failed to open edit location dialog: {e}",
+            "Error",
+            wx.OK | wx.ICON_ERROR,
+        )
+        return None
+
+
+class EditLocationDialog(wx.Dialog):
+    """Small dialog for editing an existing location's marine-mode flag."""
+
+    def __init__(self, parent, location):
+        """Initialize with the location being edited."""
+        super().__init__(
+            parent,
+            title=f"Edit Location: {location.name}",
+            size=(420, 200),
+            style=wx.DEFAULT_DIALOG_STYLE,
+        )
+        self._location = location
+
+        panel = wx.Panel(self)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+
+        name_label = wx.StaticText(panel, label=f"Location: {location.name}")
+        sizer.Add(name_label, 0, wx.ALL, 10)
+
+        self.marine_checkbox = wx.CheckBox(
+            panel,
+            label="Enable Marine Mode for this location (coastal essentials only)",
+        )
+        self.marine_checkbox.SetValue(bool(getattr(location, "marine_mode", False)))
+        self.marine_checkbox.SetToolTip(
+            "Adds nearby NWS marine zone summary, wind and wave highlights, and marine advisories."
+        )
+        self.marine_checkbox.SetName("Enable Marine Mode for this location")
+        sizer.Add(self.marine_checkbox, 0, wx.ALL | wx.EXPAND, 10)
+
+        button_sizer = wx.StdDialogButtonSizer()
+        ok_button = wx.Button(panel, wx.ID_OK, "&Save")
+        cancel_button = wx.Button(panel, wx.ID_CANCEL, "Cancel")
+        button_sizer.AddButton(ok_button)
+        button_sizer.AddButton(cancel_button)
+        button_sizer.Realize()
+        sizer.Add(button_sizer, 0, wx.ALL | wx.ALIGN_RIGHT, 10)
+
+        panel.SetSizer(sizer)
+        ok_button.SetDefault()
+
+    def get_marine_mode(self) -> bool:
+        """Return the marine_mode value chosen in the dialog."""
+        return self.marine_checkbox.GetValue()
+
+
 class AddLocationDialog(wx.Dialog):
     """Dialog for adding a new location with search functionality."""
 

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -20,6 +20,7 @@ from ..units import resolve_temperature_unit_preference
 from ..user_manual import open_user_manual
 from ..utils.temperature_utils import format_temperature
 from . import main_window_notification_events
+from .dialogs.location_dialog import show_edit_location_dialog
 
 if TYPE_CHECKING:
     from ..app import AccessiWeatherApp
@@ -29,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 QUICK_ACTION_LABELS = {
     "add": "&Add Location",
+    "edit": "&Edit Location",
     "remove": "&Remove Location",
     "refresh": "Re&fresh Weather",
     "explain": "Explain &Conditions",
@@ -188,6 +190,7 @@ class MainWindow(SizedFrame):
         button_panel.SetSizerProps(expand=True)
 
         self.add_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["add"])
+        self.edit_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["edit"])
         self.remove_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["remove"])
         self.refresh_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["refresh"])
         self.explain_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["explain"])
@@ -211,6 +214,7 @@ class MainWindow(SizedFrame):
 
         # Buttons
         self.add_button.Bind(wx.EVT_BUTTON, lambda e: self.on_add_location())
+        self.edit_button.Bind(wx.EVT_BUTTON, lambda e: self.on_edit_location())
         self.remove_button.Bind(wx.EVT_BUTTON, lambda e: self.on_remove_location())
         self.refresh_button.Bind(wx.EVT_BUTTON, lambda e: self.on_refresh())
         self.explain_button.Bind(wx.EVT_BUTTON, lambda e: self._on_explain_weather())
@@ -308,6 +312,12 @@ class MainWindow(SizedFrame):
         self._add_location_id = wx.NewIdRef()
         add_item = location_menu.Append(
             self._add_location_id, "&Add Location\tCtrl+L", "Add a new location"
+        )
+        self._edit_location_id = wx.NewIdRef()
+        edit_item = location_menu.Append(
+            self._edit_location_id,
+            "&Edit Location...",
+            "Edit the selected location (e.g. enable Marine Mode)",
         )
         self._remove_location_id = wx.NewIdRef()
         remove_item = location_menu.Append(
@@ -422,6 +432,7 @@ class MainWindow(SizedFrame):
         self.Bind(wx.EVT_MENU, lambda e: self.on_settings(), settings_item)
         self.Bind(wx.EVT_MENU, lambda e: self.app.request_exit(), exit_item)
         self.Bind(wx.EVT_MENU, lambda e: self.on_add_location(), add_item)
+        self.Bind(wx.EVT_MENU, lambda e: self.on_edit_location(), edit_item)
         self.Bind(wx.EVT_MENU, lambda e: self.on_remove_location(), remove_item)
         self.Bind(wx.EVT_MENU, lambda e: self.on_refresh(), refresh_item)
         self.Bind(wx.EVT_MENU, lambda e: self._on_explain_weather(), explain_item)
@@ -544,6 +555,31 @@ class MainWindow(SizedFrame):
                     self.location_dropdown.SetSelection(idx)
                     self._set_current_location(new_name)
             self.refresh_weather_async()
+
+    def on_edit_location(self) -> None:
+        """Handle edit location button click — currently edits marine_mode."""
+        selected = self.location_dropdown.GetStringSelection()
+        if not selected or selected == ALL_LOCATIONS_SENTINEL:
+            wx.MessageBox(
+                "Please select a specific location to edit.",
+                "No Location Selected",
+                wx.OK | wx.ICON_WARNING,
+            )
+            return
+
+        location = next(
+            (loc for loc in self.app.config_manager.get_all_locations() if loc.name == selected),
+            None,
+        )
+        if location is None:
+            return
+
+        new_marine_mode = show_edit_location_dialog(self, self.app, location)
+        if new_marine_mode is None:
+            return
+
+        self.app.config_manager.update_location_marine_mode(selected, new_marine_mode)
+        self.refresh_weather_async(force_refresh=True)
 
     def on_remove_location(self) -> None:
         """Handle remove location button click."""

--- a/tests/gui/test_alerts_list_activation.py
+++ b/tests/gui/test_alerts_list_activation.py
@@ -32,6 +32,7 @@ class TestAlertsListActivation:
         win.Bind = MagicMock()
         win.location_dropdown = MagicMock()
         win.add_button = MagicMock()
+        win.edit_button = MagicMock()
         win.remove_button = MagicMock()
         win.refresh_button = MagicMock()
         win.explain_button = MagicMock()

--- a/tests/test_all_locations_view.py
+++ b/tests/test_all_locations_view.py
@@ -416,6 +416,72 @@ class TestRemoveLocationGuard:
 
 
 # ---------------------------------------------------------------------------
+# on_edit_location — per-location marine-mode toggle
+# ---------------------------------------------------------------------------
+
+
+class TestEditLocation:
+    def test_edit_location_blocks_all_locations_sentinel(self):
+        import accessiweather.ui.main_window as mw_module
+        from accessiweather.ui.main_window import ALL_LOCATIONS_SENTINEL, MainWindow
+
+        win = _make_window()
+        win.location_dropdown.GetStringSelection.return_value = ALL_LOCATIONS_SENTINEL
+
+        mock_wx = MagicMock()
+        with patch.object(mw_module, "wx", mock_wx):
+            MainWindow.on_edit_location(win)
+            mock_wx.MessageBox.assert_called_once()
+            win.app.config_manager.update_location_marine_mode.assert_not_called()
+
+    def test_edit_location_empty_selection_blocked(self):
+        import accessiweather.ui.main_window as mw_module
+        from accessiweather.ui.main_window import MainWindow
+
+        win = _make_window()
+        win.location_dropdown.GetStringSelection.return_value = ""
+
+        mock_wx = MagicMock()
+        with patch.object(mw_module, "wx", mock_wx):
+            MainWindow.on_edit_location(win)
+            mock_wx.MessageBox.assert_called_once()
+            win.app.config_manager.update_location_marine_mode.assert_not_called()
+
+    def test_edit_location_applies_marine_mode_from_dialog(self):
+        import accessiweather.ui.main_window as mw_module
+        from accessiweather.ui.main_window import MainWindow
+
+        win = _make_window()
+        win.location_dropdown.GetStringSelection.return_value = "Annapolis"
+        annapolis = _make_location("Annapolis")
+        annapolis.marine_mode = False
+        win.app.config_manager.get_all_locations.return_value = [annapolis]
+
+        with patch.object(mw_module, "show_edit_location_dialog", return_value=True) as mock_dialog:
+            MainWindow.on_edit_location(win)
+
+        mock_dialog.assert_called_once()
+        win.app.config_manager.update_location_marine_mode.assert_called_once_with(
+            "Annapolis", True
+        )
+
+    def test_edit_location_does_nothing_on_cancel(self):
+        import accessiweather.ui.main_window as mw_module
+        from accessiweather.ui.main_window import MainWindow
+
+        win = _make_window()
+        win.location_dropdown.GetStringSelection.return_value = "Annapolis"
+        annapolis = _make_location("Annapolis")
+        annapolis.marine_mode = False
+        win.app.config_manager.get_all_locations.return_value = [annapolis]
+
+        with patch.object(mw_module, "show_edit_location_dialog", return_value=None):
+            MainWindow.on_edit_location(win)
+
+        win.app.config_manager.update_location_marine_mode.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # refresh_weather_async — All Locations mode
 # ---------------------------------------------------------------------------
 

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -155,6 +155,26 @@ class TestConfigManager:
         manager.add_location("Test", 40.0, -74.0)
         assert manager.has_locations() is True
 
+    def test_update_location_marine_mode_toggles_flag(self, manager):
+        """update_location_marine_mode flips marine_mode and persists it."""
+        manager.add_location("Annapolis", 38.9784, -76.4922)
+
+        result = manager.update_location_marine_mode("Annapolis", True)
+        assert result is True
+
+        stored = next(loc for loc in manager.get_all_locations() if loc.name == "Annapolis")
+        assert stored.marine_mode is True
+
+        # Persists across a fresh manager instance.
+        manager2 = ConfigManager(manager.app, config_dir=manager.config_dir)
+        manager2.load_config()
+        reloaded = next(loc for loc in manager2.get_all_locations() if loc.name == "Annapolis")
+        assert reloaded.marine_mode is True
+
+    def test_update_location_marine_mode_nonexistent_returns_false(self, manager):
+        """Updating marine_mode on an unknown location returns False."""
+        assert manager.update_location_marine_mode("Nowhere", True) is False
+
     def test_update_settings(self, manager):
         """Test updating settings."""
         manager.load_config()

--- a/tests/test_main_window_labels.py
+++ b/tests/test_main_window_labels.py
@@ -4,6 +4,7 @@ from accessiweather.ui.main_window import QUICK_ACTION_LABELS
 def test_quick_action_labels_match_visible_ui_copy():
     assert QUICK_ACTION_LABELS == {
         "add": "&Add Location",
+        "edit": "&Edit Location",
         "remove": "&Remove Location",
         "refresh": "Re&fresh Weather",
         "explain": "Explain &Conditions",


### PR DESCRIPTION
## Summary
- Adds a per-location edit flow so existing users can enable Marine Mode on locations they already saved, without deleting and re-adding them.
- Surfaces an **Edit Location** button in the bottom action row and an **Edit Location...** entry in the Location menu.
- The dialog itself is intentionally minimal right now: it shows the location name and exposes a single checkbox — *Enable Marine Mode for this location*. Scope kept tight; more fields (rename, re-geocode) can land when needed.

## Changes
- `LocationOperations.update_location_marine_mode` + `ConfigManager.update_location_marine_mode` — persist the flag on an existing location; returns `False` for unknown names.
- `EditLocationDialog` + `show_edit_location_dialog` helper in `location_dialog.py`.
- `MainWindow.on_edit_location` wired to a new button and menu item; guards the *All Locations* sentinel and empty selection.
- CHANGELOG entry.

## Test plan
- [x] `pytest tests/test_config_manager.py -k update_location_marine_mode` — round-trip persistence + nonexistent-location guard.
- [x] `pytest tests/test_all_locations_view.py::TestEditLocation` — four handler cases: All Locations guard, empty guard, dialog OK applies update, dialog cancel does nothing.
- [ ] Manual: select a coastal US location → Edit Location → tick Marine Mode → Save → verify marine section appears in forecast and marine alerts (if any) appear in the alert list.

Built via TDD (red → green per case); the two wx dialog classes are trivial wrappers verified by hand since they require a live wxPython backend.