### PR TITLE
feat(alerts): combined alert view + configurable date format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 - **Edit Location** — a new "Edit Location" button and menu item in the Location menu let you toggle Marine Mode on existing locations without having to remove and re-add them
 - **NOAA radio station count chooser** — the NOAA Weather Radio dialog now lets you pick how many nearby stations to load (10, 25, 50, 100, or All) without digging through the main Settings window
 - **Precipitation timeline dialog** — View > Precipitation Timeline now opens a dedicated Pirate Weather minutely precipitation timeline with a quick summary and minute-by-minute plain-text breakdown
+- **Single combined alert view** — pick "Single combined view" in Settings > Display > Alert display to read the whole alert (headline, description, instruction, Issued, and Expires) in one scrollable edit box with a Close button. The original separate-fields layout is still the default
+- **Configurable date format** — choose how dates are shown: ISO (2026-04-18), US short (04/18/2026), US long (April 18, 2026), or EU (18/04/2026). Applies to timestamps in the new combined alert view for now
 
 ### Fixed
 - **NOAA radio station count now sticks** — your nearby-station limit is saved with NOAA radio preferences and reused the next time you open the dialog, while preferred stream choices keep working as before

--- a/docs/plans/2026-04-18-combined-alert-view-design.md
+++ b/docs/plans/2026-04-18-combined-alert-view-design.md
@@ -1,0 +1,165 @@
+# Combined Alert View + Configurable Date Format — Design
+
+**Date:** 2026-04-18
+**Status:** Approved, ready for implementation
+**Scope:** Add an opt-in "single combined view" mode for the Alert dialog, plus a new app-wide `date_format` preset used (for now) only by the new view.
+
+---
+
+## Problem
+
+The Alert dialog currently presents alert content in four separate read-only `wx.TextCtrl` fields: Subject, Alert Info (severity/urgency/certainty), Details, Instructions. Some users prefer to read the entire alert as one block of text — roughly how NWS issues it — with a single close button.
+
+Separately, there is no user-facing date format preference. The existing `time_format_12hour` bool covers time style but not date style.
+
+## Goals
+
+1. Let users pick between the current "separate fields" layout (default) and a new "single combined view" layout via a Settings preference.
+2. Introduce a new `date_format` preset setting (`iso` / `us_short` / `us_long` / `eu`).
+3. Use the new date format in the combined view's `Issued:` / `Expires:` lines.
+4. Land a shared `format_date` / `format_datetime` helper in `display/presentation/formatters.py` so future call sites can adopt it without duplication.
+
+## Non-goals
+
+- No in-dialog toggle button — Settings preference only.
+- No mass rollout of the new date format to other presenters in this PR. Other call sites opt in later.
+- No new severity/urgency/certainty surfacing in the combined view (matches the user-supplied example).
+
+## Decisions
+
+| Decision | Choice | Why |
+|----------|--------|-----|
+| Mode toggle | Settings preference (`wx.Choice`) | Consistent with other settings; one-time choice |
+| Date format scope | New setting, wired into combined view only for now | Small, focused PR; helper ready for later adoption |
+| Date format UI | `wx.Choice` with 4 presets | Matches existing setting conventions (no RadioBox) |
+| Date format helper | New in `formatters.py` | Central module already exists |
+| Settings injection into dialog | Explicit argument | Testable without globals |
+| Severity/urgency/certainty | Omitted from combined view | Matches example; user-approved |
+| Issued/Expires | Included in combined view | User-requested; skipped on missing or unparseable |
+
+---
+
+## Section 1 — Settings
+
+**Model** — `src/accessiweather/models/config.py`, `AppSettings`:
+
+```python
+alert_display_style: str = "separate"   # "separate" | "combined"
+date_format: str = "iso"                # "iso" | "us_short" | "us_long" | "eu"
+```
+
+Both added to `to_dict()` and `from_dict()`. `from_dict` falls back to the defaults on unknown strings so a hand-edited JSON file cannot crash startup.
+
+**Settings UI** — `src/accessiweather/ui/dialogs/settings_tabs/display.py`:
+
+Two new `wx.StaticText` + `wx.Choice` pairs (matching existing conventions; no RadioBox):
+
+- **Alert display style:** `Separate fields (default)` / `Single combined view`
+- **Date format:** `ISO (2026-04-18)` / `US short (04/18/2026)` / `US long (April 18, 2026)` / `EU (18/04/2026)`
+
+Accessible-label pairing comes from the adjacent `wx.StaticText`. Values load/save via the existing populate/collect pattern used by `time_format_12hour`.
+
+## Section 2 — Formatter helpers
+
+`src/accessiweather/display/presentation/formatters.py`:
+
+```python
+_DATE_FORMATS = {
+    "iso":      "%Y-%m-%d",
+    "us_short": "%m/%d/%Y",
+    "us_long":  "%B %d, %Y",
+    "eu":       "%d/%m/%Y",
+}
+
+def format_date(dt: datetime | None, style: str) -> str:
+    if dt is None:
+        return ""
+    return dt.strftime(_DATE_FORMATS.get(style, _DATE_FORMATS["iso"]))
+
+def format_datetime(dt: datetime | None, date_style: str, time_12hour: bool) -> str:
+    if dt is None:
+        return ""
+    date_part = format_date(dt, date_style)
+    time_fmt = "%I:%M %p" if time_12hour else "%H:%M"
+    time_part = dt.strftime(time_fmt).lstrip("0")
+    return f"{date_part} {time_part}"
+```
+
+Pure functions. Caller passes already-known settings strings. Unknown style keys fall back to ISO silently. `None` → `""`. String-to-`datetime` parsing is the caller's responsibility.
+
+## Section 3 — Alert dialog
+
+`src/accessiweather/ui/dialogs/alert_dialog.py`:
+
+**Signature change:** `show_alert_dialog(parent, alert, settings=None)` and `AlertDialog(parent, alert, settings=None)`. Updates the one existing caller (main window) to pass settings. `None` falls back to defaults.
+
+**Dispatch** in `_create_ui`:
+
+```python
+if self.settings and self.settings.alert_display_style == "combined":
+    self._create_combined_ui(panel, main_sizer)
+else:
+    self._create_separate_ui(panel, main_sizer)   # existing code, extracted
+```
+
+**Combined UI** — one `wx.StaticText` labelled `"Alert:"`, one multiline read-only `wx.TextCtrl` filling the panel, one `Close` button. TextCtrl gets initial focus. Escape/close behavior unchanged.
+
+**Text assembly** — `@staticmethod _build_combined_text(alert, settings) -> str`:
+
+```
+{headline or event}
+
+{description verbatim}
+
+{instruction, if present}
+
+Issued: {format_datetime(sent, date_format, time_12hour)}
+Expires: {format_datetime(expires, date_format, time_12hour)}
+```
+
+- Blank lines separate blocks.
+- Missing fields are omitted entirely.
+- `sent` / `expires` parsed with `datetime.fromisoformat()`; on failure, the line is skipped, no exception.
+
+**Separate UI** — current `_create_ui` body moved verbatim into `_create_separate_ui`. No behavior change for existing users.
+
+## Section 4 — Testing (TDD)
+
+Red-green-refactor, four files, in this order:
+
+1. **`tests/test_formatters_date.py`** — pure.
+   - Each preset renders expected string for fixed datetime.
+   - Unknown style → ISO fallback.
+   - `None` → `""`.
+   - `format_datetime` 12h vs 24h.
+   - Hypothesis over datetimes × style keys: no crashes.
+
+2. **`tests/test_config_alert_display.py`** — settings round-trip.
+   - Defaults correct.
+   - `to_dict` / `from_dict` round-trip.
+   - Bogus values fall back to defaults.
+
+3. **`tests/test_alert_dialog_combined_text.py`** — pure string assembly.
+   - All fields → expected block order.
+   - Missing instruction → block absent, no stray blanks.
+   - Missing expires → line absent, Issued still present.
+   - Unparseable ISO string → line skipped, no exception.
+   - `us_long` + 12h → `"Issued: April 18, 2026 2:05 PM"`.
+
+4. **`tests/test_alert_dialog_dispatch.py`** — wx dispatch.
+   - `"combined"` → `combined_ctrl` attribute, no `subject_ctrl`.
+   - `"separate"` / `None` → opposite.
+   - Matches existing wx test fixture patterns.
+
+**Verification:**
+- `pytest -n auto`
+- `ruff check --fix . && ruff format .`
+- `pyright`
+- Launch the app (`uv run accessiweather`) and eyeball both modes.
+
+---
+
+## Rollout / future work
+
+- `format_date` / `format_datetime` are available for other presenters; they opt in as they're touched.
+- If users later want a custom strftime string, add a fifth preset key `"custom"` with a paired text field — additive, non-breaking.

--- a/docs/plans/2026-04-18-combined-alert-view-plan.md
+++ b/docs/plans/2026-04-18-combined-alert-view-plan.md
@@ -1,0 +1,857 @@
+# Combined Alert View + Date Format — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an opt-in "single combined view" mode for the Alert dialog plus a new `date_format` preset setting (wired only into the new combined view for now).
+
+**Architecture:** Two new fields on `AppSettings` (`alert_display_style`, `date_format`), two new `wx.Choice` controls on the Display settings tab, two new pure helpers in `display/presentation/formatters.py`, and a branched UI in `AlertDialog` (separate = current layout, combined = one TextCtrl). Settings are injected into the dialog for testability.
+
+**Tech Stack:** Python 3.10+, wxPython, pytest + Hypothesis. Run the app with `uv run accessiweather` (NOT `briefcase dev` — the worktree CLAUDE.md is stale).
+
+**Design doc:** [docs/plans/2026-04-18-combined-alert-view-design.md](2026-04-18-combined-alert-view-design.md)
+
+**Ground truth already verified in the codebase:**
+- `WeatherAlert.sent` and `WeatherAlert.expires` are already `datetime | None` — no ISO parsing needed in the dialog.
+- Existing `time_format_12hour: bool` in `AppSettings` is what the new `format_datetime` helper pairs with.
+- `show_alert_dialog` is called from 3 sites: `app.py:51`, `main_window.py:1558`, `main_window.py:1570`. Settings are reachable via `self.app.config_manager.get_settings()` at the UI call sites.
+
+---
+
+## Task 1: Formatter helpers + unit tests
+
+**Files:**
+- Create: `tests/test_formatters_date.py`
+- Modify: `src/accessiweather/display/presentation/formatters.py` (add near top, after existing imports)
+
+### Step 1.1: Write failing tests
+
+Create `tests/test_formatters_date.py`:
+
+```python
+"""Tests for date/datetime format helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from hypothesis import given, strategies as st
+
+from accessiweather.display.presentation.formatters import (
+    format_date,
+    format_datetime,
+)
+
+
+FIXED_DT = datetime(2026, 4, 18, 14, 5)  # 2:05 PM / 14:05
+
+
+class TestFormatDate:
+    @pytest.mark.parametrize(
+        "style, expected",
+        [
+            ("iso", "2026-04-18"),
+            ("us_short", "04/18/2026"),
+            ("us_long", "April 18, 2026"),
+            ("eu", "18/04/2026"),
+        ],
+    )
+    def test_each_preset(self, style: str, expected: str) -> None:
+        assert format_date(FIXED_DT, style) == expected
+
+    def test_unknown_style_falls_back_to_iso(self) -> None:
+        assert format_date(FIXED_DT, "not-a-real-style") == "2026-04-18"
+
+    def test_none_returns_empty_string(self) -> None:
+        assert format_date(None, "iso") == ""
+
+    @given(
+        st.datetimes(
+            min_value=datetime(1900, 1, 1),
+            max_value=datetime(2100, 12, 31),
+        ),
+        st.sampled_from(["iso", "us_short", "us_long", "eu", "bogus"]),
+    )
+    def test_never_crashes(self, dt: datetime, style: str) -> None:
+        result = format_date(dt, style)
+        assert isinstance(result, str)
+        assert result  # non-empty for any real datetime
+
+
+class TestFormatDatetime:
+    def test_us_long_12hour(self) -> None:
+        assert format_datetime(FIXED_DT, "us_long", True) == "April 18, 2026 2:05 PM"
+
+    def test_iso_24hour(self) -> None:
+        assert format_datetime(FIXED_DT, "iso", False) == "2026-04-18 14:05"
+
+    def test_us_short_24hour(self) -> None:
+        assert format_datetime(FIXED_DT, "us_short", False) == "04/18/2026 14:05"
+
+    def test_morning_12hour_strips_leading_zero(self) -> None:
+        morning = datetime(2026, 4, 18, 9, 7)
+        assert format_datetime(morning, "iso", True) == "2026-04-18 9:07 AM"
+
+    def test_none_returns_empty_string(self) -> None:
+        assert format_datetime(None, "iso", True) == ""
+```
+
+### Step 1.2: Run test — verify red
+
+Run:
+```
+cd .worktrees/combined-alert-view
+uv run pytest tests/test_formatters_date.py -n 0 -v
+```
+Expected: collection error / ImportError (`format_date` / `format_datetime` don't exist yet).
+
+### Step 1.3: Add helpers to formatters.py
+
+In `src/accessiweather/display/presentation/formatters.py`, immediately after the existing imports (after line 18), add:
+
+```python
+_DATE_FORMATS = {
+    "iso": "%Y-%m-%d",
+    "us_short": "%m/%d/%Y",
+    "us_long": "%B %d, %Y",
+    "eu": "%d/%m/%Y",
+}
+
+
+def format_date(dt: datetime | None, style: str) -> str:
+    """Format a date using a preset style key; unknown keys fall back to ISO."""
+    if dt is None:
+        return ""
+    fmt = _DATE_FORMATS.get(style, _DATE_FORMATS["iso"])
+    return dt.strftime(fmt)
+
+
+def format_datetime(dt: datetime | None, date_style: str, time_12hour: bool) -> str:
+    """Format a full datetime as "<date> <time>"; 12h output strips leading zero."""
+    if dt is None:
+        return ""
+    date_part = format_date(dt, date_style)
+    time_fmt = "%I:%M %p" if time_12hour else "%H:%M"
+    time_part = dt.strftime(time_fmt).lstrip("0")
+    return f"{date_part} {time_part}"
+```
+
+### Step 1.4: Run test — verify green
+
+Run:
+```
+uv run pytest tests/test_formatters_date.py -n 0 -v
+```
+Expected: all tests pass.
+
+### Step 1.5: Commit
+
+```
+git add tests/test_formatters_date.py src/accessiweather/display/presentation/formatters.py
+git commit -m "feat(formatters): add format_date and format_datetime helpers"
+```
+
+---
+
+## Task 2: Settings model — new fields
+
+**Files:**
+- Modify: `src/accessiweather/models/config.py` (add fields + serialization)
+- Create: `tests/test_config_alert_display.py`
+
+### Step 2.1: Write failing tests
+
+Create `tests/test_config_alert_display.py`:
+
+```python
+"""Tests for alert display + date format settings round-trip."""
+
+from __future__ import annotations
+
+from accessiweather.models.config import AppSettings
+
+
+class TestDefaults:
+    def test_alert_display_style_defaults_to_separate(self) -> None:
+        assert AppSettings().alert_display_style == "separate"
+
+    def test_date_format_defaults_to_iso(self) -> None:
+        assert AppSettings().date_format == "iso"
+
+
+class TestRoundTrip:
+    def test_to_dict_includes_new_fields(self) -> None:
+        data = AppSettings().to_dict()
+        assert data["alert_display_style"] == "separate"
+        assert data["date_format"] == "iso"
+
+    def test_from_dict_preserves_valid_values(self) -> None:
+        settings = AppSettings.from_dict(
+            {"alert_display_style": "combined", "date_format": "us_long"}
+        )
+        assert settings.alert_display_style == "combined"
+        assert settings.date_format == "us_long"
+
+    def test_from_dict_falls_back_on_bogus_alert_display_style(self) -> None:
+        settings = AppSettings.from_dict({"alert_display_style": "bogus"})
+        assert settings.alert_display_style == "separate"
+
+    def test_from_dict_falls_back_on_bogus_date_format(self) -> None:
+        settings = AppSettings.from_dict({"date_format": "not-a-format"})
+        assert settings.date_format == "iso"
+```
+
+### Step 2.2: Run test — verify red
+
+```
+uv run pytest tests/test_config_alert_display.py -n 0 -v
+```
+Expected: `AttributeError: 'AppSettings' object has no attribute 'alert_display_style'`.
+
+### Step 2.3: Implement
+
+In `src/accessiweather/models/config.py`:
+
+1. Add to the `_PERSISTED_FIELD_NAMES` set (around line 80, alongside `time_format_12hour`):
+
+```python
+"alert_display_style",
+"date_format",
+```
+
+2. Add fields to the `AppSettings` dataclass, near the existing `time_format_12hour` line (currently line 169). After `show_timezone_suffix`:
+
+```python
+# Alert dialog display style
+alert_display_style: str = "separate"  # "separate" | "combined"
+# Date format preset for rendered dates
+date_format: str = "iso"  # "iso" | "us_short" | "us_long" | "eu"
+```
+
+3. In `to_dict()` (around line 483), add alongside `time_format_12hour`:
+
+```python
+"alert_display_style": self.alert_display_style,
+"date_format": self.date_format,
+```
+
+4. In `from_dict()` (around line 580), use defensive fallback. Add a helper near the top of `from_dict` (if there isn't already one for enum-like strings) OR use inline validation:
+
+```python
+_VALID_ALERT_STYLES = {"separate", "combined"}
+_VALID_DATE_FORMATS = {"iso", "us_short", "us_long", "eu"}
+
+def _enum_or_default(value, valid: set[str], default: str) -> str:
+    return value if isinstance(value, str) and value in valid else default
+```
+
+Place module constants/helper near the top of the module (after imports). Then in `from_dict`:
+
+```python
+alert_display_style=_enum_or_default(
+    data.get("alert_display_style"), _VALID_ALERT_STYLES, "separate"
+),
+date_format=_enum_or_default(
+    data.get("date_format"), _VALID_DATE_FORMATS, "iso"
+),
+```
+
+**Important:** check the surrounding style of other `from_dict` entries before placing — if they use `cls._as_bool` / `cls._as_int` helpers inside the class, match that pattern instead of a module-level helper. Read `config.py:560-600` to confirm the convention and match it.
+
+### Step 2.4: Run test — verify green
+
+```
+uv run pytest tests/test_config_alert_display.py -n 0 -v
+```
+Expected: all 6 tests pass.
+
+### Step 2.5: Regression check on existing settings tests
+
+```
+uv run pytest tests/test_settings_operations.py -n 0 -q
+```
+Expected: still 38 passing.
+
+### Step 2.6: Commit
+
+```
+git add tests/test_config_alert_display.py src/accessiweather/models/config.py
+git commit -m "feat(config): add alert_display_style and date_format settings"
+```
+
+---
+
+## Task 3: Alert dialog — extract existing UI, accept settings
+
+This task refactors without changing behavior, so it lands **before** adding the combined mode. Pure mechanical extraction.
+
+**Files:**
+- Modify: `src/accessiweather/ui/dialogs/alert_dialog.py`
+- Modify: `src/accessiweather/app.py:47-51`
+- Modify: `src/accessiweather/ui/main_window.py:1558` and `:1570`
+
+### Step 3.1: Add settings parameter, extract separate UI
+
+In `src/accessiweather/ui/dialogs/alert_dialog.py`:
+
+1. Change signature of `show_alert_dialog`:
+```python
+def show_alert_dialog(parent, alert, settings=None) -> None:
+    ...
+    dlg = AlertDialog(parent_ctrl, alert, settings)
+```
+
+2. Change `AlertDialog.__init__` to accept `settings=None` and store `self.settings = settings`.
+
+3. Rename current `_create_ui` body to `_create_separate_ui(self, panel, main_sizer)`. Change the method so it receives `panel` and `main_sizer` rather than creating them. Keep all existing logic — close button, focus, etc. — inside it.
+
+4. New `_create_ui`:
+```python
+def _create_ui(self):
+    panel = wx.Panel(self)
+    main_sizer = wx.BoxSizer(wx.VERTICAL)
+    self._create_separate_ui(panel, main_sizer)
+    panel.SetSizer(main_sizer)
+```
+
+(Leaves a minimal shim that the combined path will piggyback on in Task 4.)
+
+### Step 3.2: Update call sites
+
+- `src/accessiweather/app.py:47-51`:
+```python
+def show_alert_dialog(parent, alert, settings=None) -> None:
+    from .ui.dialogs import show_alert_dialog as _show_alert_dialog
+    _show_alert_dialog(parent, alert, settings)
+```
+At `app.py:282`, pass `self.config_manager.get_settings()`:
+```python
+show_alert_dialog(self.main_window, alerts[0], self.config_manager.get_settings())
+```
+
+- `src/accessiweather/ui/main_window.py:1558` and `:1570`: replace both `show_alert_dialog(self, alert)` with:
+```python
+show_alert_dialog(self, alert, self.app.config_manager.get_settings())
+```
+
+### Step 3.3: Regression check
+
+```
+uv run pytest tests/ -n 0 -q -k "alert or settings"
+```
+Expected: existing alert-related and settings-related tests still pass. No behavior change yet.
+
+### Step 3.4: Commit
+
+```
+git add src/accessiweather/ui/dialogs/alert_dialog.py src/accessiweather/app.py src/accessiweather/ui/main_window.py
+git commit -m "refactor(alert-dialog): accept settings and extract separate-mode UI"
+```
+
+---
+
+## Task 4: Combined text builder (pure string)
+
+**Files:**
+- Modify: `src/accessiweather/ui/dialogs/alert_dialog.py` (add static method)
+- Create: `tests/test_alert_dialog_combined_text.py`
+
+### Step 4.1: Write failing tests
+
+Create `tests/test_alert_dialog_combined_text.py`:
+
+```python
+"""Tests for AlertDialog._build_combined_text (pure string assembly)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+
+from accessiweather.models.config import AppSettings
+from accessiweather.ui.dialogs.alert_dialog import AlertDialog
+
+
+def _alert(**kwargs):
+    defaults = {
+        "headline": None,
+        "event": None,
+        "description": None,
+        "instruction": None,
+        "sent": None,
+        "expires": None,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _settings(**kwargs):
+    return AppSettings(**kwargs)
+
+
+class TestBuildCombinedText:
+    def test_all_fields_present_in_order(self) -> None:
+        alert = _alert(
+            headline="FROST ADVISORY IN EFFECT FROM 2 AM TO 10 AM",
+            description="WHAT...Frost.\nWHERE...Michigan.",
+            instruction="Protect tender plants.",
+            sent=datetime(2026, 4, 18, 14, 10),
+            expires=datetime(2026, 4, 18, 22, 15),
+        )
+        text = AlertDialog._build_combined_text(alert, _settings())
+
+        # Order: headline, blank, description, blank, instruction, blank, issued, expires
+        headline_i = text.index("FROST ADVISORY")
+        desc_i = text.index("WHAT...Frost")
+        instr_i = text.index("Protect tender plants")
+        issued_i = text.index("Issued:")
+        expires_i = text.index("Expires:")
+        assert headline_i < desc_i < instr_i < issued_i < expires_i
+
+    def test_falls_back_to_event_when_no_headline(self) -> None:
+        alert = _alert(event="Frost Advisory")
+        text = AlertDialog._build_combined_text(alert, _settings())
+        assert text.startswith("Frost Advisory")
+
+    def test_missing_instruction_omitted(self) -> None:
+        alert = _alert(
+            headline="H", description="D",
+            sent=datetime(2026, 4, 18, 14, 10),
+            expires=datetime(2026, 4, 18, 22, 15),
+        )
+        text = AlertDialog._build_combined_text(alert, _settings())
+        assert "Issued:" in text
+        # No stray "None" or blank-block collapses expected
+        assert "None" not in text
+
+    def test_missing_expires_line_absent(self) -> None:
+        alert = _alert(
+            headline="H",
+            sent=datetime(2026, 4, 18, 14, 10),
+        )
+        text = AlertDialog._build_combined_text(alert, _settings())
+        assert "Issued:" in text
+        assert "Expires:" not in text
+
+    def test_missing_sent_line_absent(self) -> None:
+        alert = _alert(headline="H", expires=datetime(2026, 4, 18, 22, 15))
+        text = AlertDialog._build_combined_text(alert, _settings())
+        assert "Issued:" not in text
+        assert "Expires:" in text
+
+    def test_date_format_and_12hour_applied(self) -> None:
+        alert = _alert(
+            headline="H", sent=datetime(2026, 4, 18, 14, 5),
+        )
+        settings = _settings(date_format="us_long", time_format_12hour=True)
+        text = AlertDialog._build_combined_text(alert, settings)
+        assert "Issued: April 18, 2026 2:05 PM" in text
+
+    def test_empty_description_does_not_add_blank_block(self) -> None:
+        alert = _alert(headline="H")
+        text = AlertDialog._build_combined_text(alert, _settings())
+        # No triple-newlines
+        assert "\n\n\n" not in text
+
+    def test_fallback_headline_when_nothing_given(self) -> None:
+        alert = _alert()
+        text = AlertDialog._build_combined_text(alert, _settings())
+        assert text.startswith("Weather Alert")
+```
+
+### Step 4.2: Run test — verify red
+
+```
+uv run pytest tests/test_alert_dialog_combined_text.py -n 0 -v
+```
+Expected: `AttributeError: type object 'AlertDialog' has no attribute '_build_combined_text'`.
+
+### Step 4.3: Implement the builder
+
+In `src/accessiweather/ui/dialogs/alert_dialog.py`, add inside the `AlertDialog` class:
+
+```python
+@staticmethod
+def _build_combined_text(alert, settings) -> str:
+    """Assemble the combined-view text block. Pure function; settings is AppSettings-like."""
+    from ...display.presentation.formatters import format_datetime
+
+    date_style = getattr(settings, "date_format", "iso")
+    time_12h = getattr(settings, "time_format_12hour", True)
+
+    blocks: list[str] = []
+
+    headline = (
+        getattr(alert, "headline", None)
+        or getattr(alert, "event", None)
+        or "Weather Alert"
+    )
+    blocks.append(headline)
+
+    description = getattr(alert, "description", None)
+    if description:
+        blocks.append(description)
+
+    instruction = getattr(alert, "instruction", None)
+    if instruction:
+        blocks.append(instruction)
+
+    times: list[str] = []
+    sent = getattr(alert, "sent", None)
+    if sent is not None:
+        times.append(f"Issued: {format_datetime(sent, date_style, time_12h)}")
+    expires = getattr(alert, "expires", None)
+    if expires is not None:
+        times.append(f"Expires: {format_datetime(expires, date_style, time_12h)}")
+    if times:
+        blocks.append("\n".join(times))
+
+    return "\n\n".join(blocks)
+```
+
+### Step 4.4: Run test — verify green
+
+```
+uv run pytest tests/test_alert_dialog_combined_text.py -n 0 -v
+```
+Expected: all 8 tests pass.
+
+### Step 4.5: Commit
+
+```
+git add tests/test_alert_dialog_combined_text.py src/accessiweather/ui/dialogs/alert_dialog.py
+git commit -m "feat(alert-dialog): add combined-view text builder"
+```
+
+---
+
+## Task 5: Wire combined-mode UI into the dialog
+
+**Files:**
+- Modify: `src/accessiweather/ui/dialogs/alert_dialog.py`
+- Create: `tests/test_alert_dialog_dispatch.py`
+
+### Step 5.1: Write failing tests
+
+Create `tests/test_alert_dialog_dispatch.py`:
+
+```python
+"""Tests for AlertDialog mode dispatch and control creation."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+import wx
+
+from accessiweather.models.config import AppSettings
+from accessiweather.ui.dialogs.alert_dialog import AlertDialog
+
+
+@pytest.fixture(scope="module")
+def wx_app():
+    app = wx.App()
+    yield app
+    app.Destroy()
+
+
+def _alert():
+    return SimpleNamespace(
+        title="t", description="D", severity="Moderate", urgency="Expected",
+        certainty="Likely", event="Frost Advisory", headline="H",
+        instruction="I", areas=[], references=[],
+        sent=datetime(2026, 4, 18, 14, 10),
+        expires=datetime(2026, 4, 18, 22, 15),
+    )
+
+
+class TestDispatch:
+    def test_separate_mode_creates_subject_ctrl(self, wx_app):
+        settings = AppSettings(alert_display_style="separate")
+        dlg = AlertDialog(None, _alert(), settings)
+        try:
+            assert hasattr(dlg, "subject_ctrl")
+            assert not hasattr(dlg, "combined_ctrl")
+        finally:
+            dlg.Destroy()
+
+    def test_combined_mode_creates_combined_ctrl(self, wx_app):
+        settings = AppSettings(alert_display_style="combined")
+        dlg = AlertDialog(None, _alert(), settings)
+        try:
+            assert hasattr(dlg, "combined_ctrl")
+            assert not hasattr(dlg, "subject_ctrl")
+        finally:
+            dlg.Destroy()
+
+    def test_none_settings_defaults_to_separate(self, wx_app):
+        dlg = AlertDialog(None, _alert(), None)
+        try:
+            assert hasattr(dlg, "subject_ctrl")
+            assert not hasattr(dlg, "combined_ctrl")
+        finally:
+            dlg.Destroy()
+
+    def test_combined_mode_textctrl_contains_headline(self, wx_app):
+        settings = AppSettings(alert_display_style="combined")
+        dlg = AlertDialog(None, _alert(), settings)
+        try:
+            assert "H" in dlg.combined_ctrl.GetValue()
+            assert "Issued:" in dlg.combined_ctrl.GetValue()
+        finally:
+            dlg.Destroy()
+```
+
+### Step 5.2: Run — verify red
+
+```
+uv run pytest tests/test_alert_dialog_dispatch.py -n 0 -v
+```
+Expected: the combined-mode test fails (`combined_ctrl` missing).
+
+### Step 5.3: Implement `_create_combined_ui` + dispatch
+
+In `src/accessiweather/ui/dialogs/alert_dialog.py`, modify `_create_ui` to dispatch:
+
+```python
+def _create_ui(self):
+    panel = wx.Panel(self)
+    main_sizer = wx.BoxSizer(wx.VERTICAL)
+
+    style = getattr(self.settings, "alert_display_style", "separate") if self.settings else "separate"
+    if style == "combined":
+        self._create_combined_ui(panel, main_sizer)
+    else:
+        self._create_separate_ui(panel, main_sizer)
+
+    panel.SetSizer(main_sizer)
+```
+
+Add `_create_combined_ui`:
+
+```python
+def _create_combined_ui(self, panel, main_sizer):
+    """Create a single TextCtrl containing the full alert, with a Close button."""
+    label = wx.StaticText(panel, label="Alert:")
+    label.SetFont(label.GetFont().Bold())
+    main_sizer.Add(label, 0, wx.LEFT | wx.RIGHT | wx.TOP, 15)
+
+    text = self._build_combined_text(self.alert, self.settings)
+    self.combined_ctrl = wx.TextCtrl(
+        panel,
+        value=text,
+        style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH2,
+    )
+    main_sizer.Add(
+        self.combined_ctrl, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 15
+    )
+
+    button_sizer = wx.BoxSizer(wx.HORIZONTAL)
+    button_sizer.AddStretchSpacer()
+    close_btn = wx.Button(panel, wx.ID_CLOSE, "Close")
+    close_btn.Bind(wx.EVT_BUTTON, self._on_close)
+    button_sizer.Add(close_btn, 0)
+    main_sizer.Add(button_sizer, 0, wx.EXPAND | wx.ALL, 15)
+
+    self.combined_ctrl.SetFocus()
+```
+
+Update `_setup_accessibility` to also name the combined control when present (per the user's rule, SetName alone is not sufficient — but the adjacent `"Alert:"` StaticText provides the screen-reader label; SetName is a harmless additional hint):
+
+```python
+def _setup_accessibility(self):
+    if hasattr(self, "subject_ctrl"):
+        self.subject_ctrl.SetName("Subject with alert headline")
+    if hasattr(self, "info_ctrl"):
+        self.info_ctrl.SetName("Alert information with severity, urgency, and certainty")
+    if hasattr(self, "details_ctrl"):
+        self.details_ctrl.SetName("Alert details")
+    if hasattr(self, "instr_ctrl"):
+        self.instr_ctrl.SetName("Instructions")
+    if hasattr(self, "combined_ctrl"):
+        self.combined_ctrl.SetName("Full alert text")
+```
+
+### Step 5.4: Run — verify green
+
+```
+uv run pytest tests/test_alert_dialog_dispatch.py tests/test_alert_dialog_combined_text.py -n 0 -v
+```
+Expected: all pass.
+
+### Step 5.5: Commit
+
+```
+git add tests/test_alert_dialog_dispatch.py src/accessiweather/ui/dialogs/alert_dialog.py
+git commit -m "feat(alert-dialog): add combined display mode"
+```
+
+---
+
+## Task 6: Settings UI — add the two Choices
+
+**Files:**
+- Modify: `src/accessiweather/ui/dialogs/settings_tabs/display.py`
+
+No new test file — the existing pattern (`_TIME_MODE_MAP` etc.) is mature; we follow it exactly. Settings round-trip is already covered by Task 2.
+
+### Step 6.1: Add the preset maps
+
+At the top of `display.py` near the other `_*_MAP` / `_*_VALUES` constants, add:
+
+```python
+_ALERT_DISPLAY_MAP = {"separate": 0, "combined": 1}
+_ALERT_DISPLAY_VALUES = ["separate", "combined"]
+_ALERT_DISPLAY_CHOICES = ["Separate fields (default)", "Single combined view"]
+
+_DATE_FORMAT_MAP = {"iso": 0, "us_short": 1, "us_long": 2, "eu": 3}
+_DATE_FORMAT_VALUES = ["iso", "us_short", "us_long", "eu"]
+_DATE_FORMAT_CHOICES = [
+    "ISO (2026-04-18)",
+    "US short (04/18/2026)",
+    "US long (April 18, 2026)",
+    "EU (18/04/2026)",
+]
+```
+
+### Step 6.2: Add the two controls
+
+Inside `build()` (the method that creates controls), after the `time_format_12hour` block (around line 179 — i.e. after the CheckBox's `time_section.Add`), add a **Date format** row in the same `time_section`:
+
+```python
+controls["date_format"] = self.dialog.add_labeled_control_row(
+    panel,
+    time_section,
+    "Date format:",
+    lambda parent: wx.Choice(parent, choices=_DATE_FORMAT_CHOICES),
+)
+```
+
+Create the alert display style in an appropriate section — NOT the `time_section`. Look for an "Alerts" section in the file; if none exists, add the control to the end of the existing `time_section` is acceptable but semantically it belongs with alert-related settings. Before placing, grep the file for existing sections and choose the one that best fits. If unsure, add a new small section near the end of the Display tab:
+
+```python
+alert_display_section = self.dialog.create_section(
+    panel,
+    sizer,
+    "Alert display",
+    "Choose how weather alerts are shown when you open one.",
+)
+controls["alert_display_style"] = self.dialog.add_labeled_control_row(
+    panel,
+    alert_display_section,
+    "Alert display style:",
+    lambda parent: wx.Choice(parent, choices=_ALERT_DISPLAY_CHOICES),
+)
+```
+
+### Step 6.3: Load in `load()`
+
+In `load()` (around line 255, near `time_format_12hour`), add:
+
+```python
+date_format = getattr(settings, "date_format", "iso")
+controls["date_format"].SetSelection(_DATE_FORMAT_MAP.get(date_format, 0))
+
+alert_display = getattr(settings, "alert_display_style", "separate")
+controls["alert_display_style"].SetSelection(_ALERT_DISPLAY_MAP.get(alert_display, 0))
+```
+
+### Step 6.4: Save in `save()`
+
+In `save()`'s dict (around line 285), add:
+
+```python
+"date_format": _DATE_FORMAT_VALUES[controls["date_format"].GetSelection()],
+"alert_display_style": _ALERT_DISPLAY_VALUES[controls["alert_display_style"].GetSelection()],
+```
+
+### Step 6.5: Accessibility names
+
+In `setup_accessibility()` (around line 300), add to the `names` dict:
+
+```python
+"date_format": "Date format",
+"alert_display_style": "Alert display style",
+```
+
+### Step 6.6: Run broader regression
+
+```
+uv run pytest tests/ -n 0 -q -k "settings or config or alert"
+```
+Expected: all related tests pass.
+
+### Step 6.7: Commit
+
+```
+git add src/accessiweather/ui/dialogs/settings_tabs/display.py
+git commit -m "feat(settings): add Alert display style and Date format controls"
+```
+
+---
+
+## Task 7: Changelog + full regression + manual eyeball
+
+### Step 7.1: Add CHANGELOG entry
+
+Edit `CHANGELOG.md`, add under the current Unreleased / upcoming section (match the existing style — conversational, user-focused, no hedging):
+
+```markdown
+- New alert display option: pick **Single combined view** in Settings → Display to read the whole alert — headline, details, instructions, and timestamps — in one scrollable edit box with a Close button. The original separate-fields layout stays the default.
+- You can now choose how dates are shown: **ISO (2026-04-18)**, **US short (04/18/2026)**, **US long (April 18, 2026)**, or **EU (18/04/2026)**. Applies to timestamps in the new combined alert view for now.
+```
+
+### Step 7.2: Full test run
+
+```
+uv run pytest -n auto -q --tb=short
+```
+Expected: all tests pass. If anything unrelated fails, investigate — do **not** mark the task complete until green.
+
+### Step 7.3: Lint + type check
+
+```
+uv run ruff check --fix .
+uv run ruff format .
+uv run pyright 2>&1 | tail -30
+```
+Expected: clean. Fix anything reported.
+
+### Step 7.4: Manual eyeball
+
+**Note to executing engineer:** per the user's standing rule, do **not** kill/relaunch the AccessiWeather process yourself. Ask the user to launch `uv run accessiweather` and verify manually:
+- Open Settings → Display → confirm both new controls render with expected labels and choices.
+- Pick `Single combined view`, save, open an active alert: confirm single TextCtrl with headline / description / instruction / Issued / Expires and a Close button. Escape closes.
+- Switch back to `Separate fields`: confirm original four-field layout is restored.
+- Toggle date format presets: confirm the Issued/Expires lines reformat correctly.
+
+If you cannot test the UI yourself, say so explicitly rather than claiming success (per project CLAUDE.md).
+
+### Step 7.5: Commit + final summary
+
+```
+git add CHANGELOG.md
+git commit -m "docs(changelog): combined alert view and date format"
+```
+
+If lint/format/pyright made any changes in step 7.3:
+
+```
+git add -u
+git commit -m "chore: apply ruff/pyright fixes"
+```
+
+---
+
+## Done checklist
+
+- [ ] Task 1: formatter helpers + tests committed
+- [ ] Task 2: settings fields + tests committed
+- [ ] Task 3: dialog accepts settings, call sites updated
+- [ ] Task 4: `_build_combined_text` + tests committed
+- [ ] Task 5: combined-mode UI + dispatch + tests committed
+- [ ] Task 6: settings UI controls committed
+- [ ] Task 7: changelog + full pytest/ruff/pyright green + user eyeballed both modes
+- [ ] Worktree ready for PR against `dev`

--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -275,7 +275,7 @@ class AccessiWeatherApp(wx.App):
 
     def _show_immediate_alert_popup(self, alerts) -> None:
         """Show the opted-in in-app alert popup without restoring the main window."""
-        if self.main_window is None or not alerts:
+        if self.main_window is None or self.config_manager is None or not alerts:
             return
 
         if len(alerts) == 1:

--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -44,11 +44,11 @@ if not logging.getLogger().handlers:
 logger = logging.getLogger(__name__)
 
 
-def show_alert_dialog(parent, alert) -> None:
+def show_alert_dialog(parent, alert, settings=None) -> None:
     """Lazy wrapper for the single-alert details dialog."""
     from .ui.dialogs import show_alert_dialog as _show_alert_dialog
 
-    _show_alert_dialog(parent, alert)
+    _show_alert_dialog(parent, alert, settings)
 
 
 def show_alerts_summary_dialog(parent, alerts) -> None:
@@ -279,7 +279,7 @@ class AccessiWeatherApp(wx.App):
             return
 
         if len(alerts) == 1:
-            show_alert_dialog(self.main_window, alerts[0])
+            show_alert_dialog(self.main_window, alerts[0], self.config_manager.get_settings())
             return
 
         show_alerts_summary_dialog(self.main_window, alerts)

--- a/src/accessiweather/display/presentation/formatters.py
+++ b/src/accessiweather/display/presentation/formatters.py
@@ -17,6 +17,31 @@ from ...utils import (
     format_wind_speed,
 )
 
+_DATE_FORMATS = {
+    "iso": "%Y-%m-%d",
+    "us_short": "%m/%d/%Y",
+    "us_long": "%B %d, %Y",
+    "eu": "%d/%m/%Y",
+}
+
+
+def format_date(dt: datetime | None, style: str) -> str:
+    """Format a date using a preset style key; unknown keys fall back to ISO."""
+    if dt is None:
+        return ""
+    fmt = _DATE_FORMATS.get(style, _DATE_FORMATS["iso"])
+    return dt.strftime(fmt)
+
+
+def format_datetime(dt: datetime | None, date_style: str, time_12hour: bool) -> str:
+    """Format a full datetime as "<date> <time>"; 12h output strips leading zero."""
+    if dt is None:
+        return ""
+    date_part = format_date(dt, date_style)
+    time_fmt = "%I:%M %p" if time_12hour else "%H:%M"
+    time_part = dt.strftime(time_fmt).lstrip("0")
+    return f"{date_part} {time_part}"
+
 
 def format_temperature_pair(
     temp_f: float | None,

--- a/src/accessiweather/display/presentation/formatters.py
+++ b/src/accessiweather/display/presentation/formatters.py
@@ -39,7 +39,9 @@ def format_datetime(dt: datetime | None, date_style: str, time_12hour: bool) -> 
         return ""
     date_part = format_date(dt, date_style)
     time_fmt = "%I:%M %p" if time_12hour else "%H:%M"
-    time_part = dt.strftime(time_fmt).lstrip("0")
+    time_part = dt.strftime(time_fmt)
+    if time_12hour:
+        time_part = time_part.lstrip("0")
     return f"{date_part} {time_part}"
 
 

--- a/src/accessiweather/models/config.py
+++ b/src/accessiweather/models/config.py
@@ -88,6 +88,8 @@ NON_CRITICAL_SETTINGS: set[str] = {
     "time_display_mode",
     "time_format_12hour",
     "show_timezone_suffix",
+    "alert_display_style",
+    "date_format",
     "taskbar_icon_text_enabled",
     "taskbar_icon_dynamic_enabled",
     "taskbar_icon_text_format",
@@ -168,6 +170,10 @@ class AppSettings:
     time_display_mode: str = "local"
     time_format_12hour: bool = True
     show_timezone_suffix: bool = False
+    # Alert dialog display style
+    alert_display_style: str = "separate"  # "separate" | "combined"
+    # Date format preset for rendered dates
+    date_format: str = "iso"  # "iso" | "us_short" | "us_long" | "eu"
     # Taskbar icon text options
     taskbar_icon_text_enabled: bool = False
     taskbar_icon_dynamic_enabled: bool = True
@@ -387,6 +393,16 @@ class AppSettings:
             if value not in valid_budgets:
                 setattr(self, setting_name, "max_coverage")
 
+        elif setting_name == "alert_display_style":
+            valid_styles = {"separate", "combined"}
+            if value not in valid_styles:
+                setattr(self, setting_name, "separate")
+
+        elif setting_name == "date_format":
+            valid_formats = {"iso", "us_short", "us_long", "eu"}
+            if value not in valid_formats:
+                setattr(self, setting_name, "iso")
+
         elif setting_name in {
             "source_priority_us",
             "source_priority_international",
@@ -482,6 +498,8 @@ class AppSettings:
             "time_display_mode": self.time_display_mode,
             "time_format_12hour": self.time_format_12hour,
             "show_timezone_suffix": self.show_timezone_suffix,
+            "alert_display_style": self.alert_display_style,
+            "date_format": self.date_format,
             "taskbar_icon_text_enabled": self.taskbar_icon_text_enabled,
             "taskbar_icon_dynamic_enabled": self.taskbar_icon_dynamic_enabled,
             "taskbar_icon_text_format": self.taskbar_icon_text_format,
@@ -579,6 +597,8 @@ class AppSettings:
             time_display_mode=data.get("time_display_mode", "local"),
             time_format_12hour=cls._as_bool(data.get("time_format_12hour"), True),
             show_timezone_suffix=cls._as_bool(data.get("show_timezone_suffix"), False),
+            alert_display_style=data.get("alert_display_style", "separate"),
+            date_format=data.get("date_format", "iso"),
             taskbar_icon_text_enabled=cls._as_bool(data.get("taskbar_icon_text_enabled"), False),
             taskbar_icon_dynamic_enabled=cls._as_bool(
                 data.get("taskbar_icon_dynamic_enabled"), True
@@ -630,6 +650,8 @@ class AppSettings:
             show_impact_summaries=cls._as_bool(data.get("show_impact_summaries"), False),
         )
         settings.validate_on_access("auto_mode_api_budget")
+        settings.validate_on_access("alert_display_style")
+        settings.validate_on_access("date_format")
         return settings
 
     def to_alert_settings(self):

--- a/src/accessiweather/ui/dialogs/alert_dialog.py
+++ b/src/accessiweather/ui/dialogs/alert_dialog.py
@@ -73,6 +73,7 @@ class AlertDialog(wx.Dialog):
         main_sizer = wx.BoxSizer(wx.VERTICAL)
         self._create_separate_ui(panel, main_sizer)
         panel.SetSizer(main_sizer)
+        self._focus_target.SetFocus()
 
     def _create_separate_ui(self, panel, main_sizer):
         """Build the classic separate-field UI into the provided panel/sizer."""
@@ -145,7 +146,7 @@ class AlertDialog(wx.Dialog):
         main_sizer.Add(button_sizer, 0, wx.EXPAND | wx.ALL, 15)
 
         # Set initial focus to subject field
-        self.subject_ctrl.SetFocus()
+        self._focus_target = self.subject_ctrl
 
     def _build_subject_text(self) -> str:
         """

--- a/src/accessiweather/ui/dialogs/alert_dialog.py
+++ b/src/accessiweather/ui/dialogs/alert_dialog.py
@@ -73,9 +73,42 @@ class AlertDialog(wx.Dialog):
         """Create the dialog UI, dispatching to separate or combined mode."""
         panel = wx.Panel(self)
         main_sizer = wx.BoxSizer(wx.VERTICAL)
-        self._create_separate_ui(panel, main_sizer)
+
+        style = (
+            getattr(self.settings, "alert_display_style", "separate")
+            if self.settings is not None
+            else "separate"
+        )
+        if style == "combined":
+            self._create_combined_ui(panel, main_sizer)
+        else:
+            self._create_separate_ui(panel, main_sizer)
+
         panel.SetSizer(main_sizer)
         self._focus_target.SetFocus()
+
+    def _create_combined_ui(self, panel, main_sizer):
+        """Create a single TextCtrl containing the full alert, with a Close button."""
+        label = wx.StaticText(panel, label="Alert:")
+        label.SetFont(label.GetFont().Bold())
+        main_sizer.Add(label, 0, wx.LEFT | wx.RIGHT | wx.TOP, 15)
+
+        text = self._build_combined_text(self.alert, self.settings)
+        self.combined_ctrl = wx.TextCtrl(
+            panel,
+            value=text,
+            style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH2,
+        )
+        main_sizer.Add(self.combined_ctrl, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 15)
+
+        button_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        button_sizer.AddStretchSpacer()
+        close_btn = wx.Button(panel, wx.ID_CLOSE, "Close")
+        close_btn.Bind(wx.EVT_BUTTON, self._on_close)
+        button_sizer.Add(close_btn, 0)
+        main_sizer.Add(button_sizer, 0, wx.EXPAND | wx.ALL, 15)
+
+        self._focus_target = self.combined_ctrl
 
     def _create_separate_ui(self, panel, main_sizer):
         """Build the classic separate-field UI into the provided panel/sizer."""
@@ -225,7 +258,8 @@ class AlertDialog(wx.Dialog):
 
     def _setup_accessibility(self):
         """Set up accessibility labels for screen readers."""
-        self.subject_ctrl.SetName("Subject with alert headline")
+        if hasattr(self, "subject_ctrl"):
+            self.subject_ctrl.SetName("Subject with alert headline")
 
         if hasattr(self, "info_ctrl"):
             self.info_ctrl.SetName("Alert information with severity, urgency, and certainty")
@@ -235,6 +269,9 @@ class AlertDialog(wx.Dialog):
 
         if hasattr(self, "instr_ctrl"):
             self.instr_ctrl.SetName("Instructions")
+
+        if hasattr(self, "combined_ctrl"):
+            self.combined_ctrl.SetName("Full alert text")
 
     def _on_key(self, event):
         """Handle key press - close dialog on Escape."""

--- a/src/accessiweather/ui/dialogs/alert_dialog.py
+++ b/src/accessiweather/ui/dialogs/alert_dialog.py
@@ -13,19 +13,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def show_alert_dialog(parent, alert) -> None:
+def show_alert_dialog(parent, alert, settings=None) -> None:
     """
     Show the alert details dialog.
 
     Args:
         parent: Parent window
         alert: Weather alert object
+        settings: Optional application settings (for combined-mode dispatch)
 
     """
     try:
         parent_ctrl = parent
 
-        dlg = AlertDialog(parent_ctrl, alert)
+        dlg = AlertDialog(parent_ctrl, alert, settings)
         dlg.ShowModal()
         dlg.Destroy()
 
@@ -41,13 +42,14 @@ def show_alert_dialog(parent, alert) -> None:
 class AlertDialog(wx.Dialog):
     """Dialog for displaying weather alert details."""
 
-    def __init__(self, parent, alert):
+    def __init__(self, parent, alert, settings=None):
         """
         Initialize the alert dialog.
 
         Args:
             parent: Parent window
             alert: Weather alert object
+            settings: Optional application settings (for combined-mode dispatch)
 
         """
         event = getattr(alert, "event", "Weather Alert")
@@ -59,16 +61,21 @@ class AlertDialog(wx.Dialog):
         )
 
         self.alert = alert
+        self.settings = settings
 
         self._create_ui()
         self._setup_accessibility()
         self.Bind(wx.EVT_CHAR_HOOK, self._on_key)
 
     def _create_ui(self):
-        """Create the dialog UI with accessible text controls."""
+        """Create the dialog UI, dispatching to separate or combined mode."""
         panel = wx.Panel(self)
         main_sizer = wx.BoxSizer(wx.VERTICAL)
+        self._create_separate_ui(panel, main_sizer)
+        panel.SetSizer(main_sizer)
 
+    def _create_separate_ui(self, panel, main_sizer):
+        """Build the classic separate-field UI into the provided panel/sizer."""
         # Subject field (headline + times) - gets initial focus
         subject_text = self._build_subject_text()
         subject_label = wx.StaticText(panel, label="Subject:")
@@ -136,8 +143,6 @@ class AlertDialog(wx.Dialog):
         button_sizer.Add(close_btn, 0)
 
         main_sizer.Add(button_sizer, 0, wx.EXPAND | wx.ALL, 15)
-
-        panel.SetSizer(main_sizer)
 
         # Set initial focus to subject field
         self.subject_ctrl.SetFocus()

--- a/src/accessiweather/ui/dialogs/alert_dialog.py
+++ b/src/accessiweather/ui/dialogs/alert_dialog.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 
 import wx
 
+from ...display.presentation.formatters import format_datetime
+
 if TYPE_CHECKING:
     pass
 
@@ -170,8 +172,6 @@ class AlertDialog(wx.Dialog):
     @staticmethod
     def _build_combined_text(alert, settings) -> str:
         """Assemble the combined-view text block. Pure function; settings is AppSettings-like."""
-        from ...display.presentation.formatters import format_datetime
-
         date_style = getattr(settings, "date_format", "iso")
         time_12h = getattr(settings, "time_format_12hour", True)
 

--- a/src/accessiweather/ui/dialogs/alert_dialog.py
+++ b/src/accessiweather/ui/dialogs/alert_dialog.py
@@ -167,6 +167,41 @@ class AlertDialog(wx.Dialog):
             return event
         return "Weather Alert"
 
+    @staticmethod
+    def _build_combined_text(alert, settings) -> str:
+        """Assemble the combined-view text block. Pure function; settings is AppSettings-like."""
+        from ...display.presentation.formatters import format_datetime
+
+        date_style = getattr(settings, "date_format", "iso")
+        time_12h = getattr(settings, "time_format_12hour", True)
+
+        blocks: list[str] = []
+
+        headline = (
+            getattr(alert, "headline", None) or getattr(alert, "event", None) or "Weather Alert"
+        )
+        blocks.append(headline)
+
+        description = getattr(alert, "description", None)
+        if description:
+            blocks.append(description)
+
+        instruction = getattr(alert, "instruction", None)
+        if instruction:
+            blocks.append(instruction)
+
+        times: list[str] = []
+        sent = getattr(alert, "sent", None)
+        if sent is not None:
+            times.append(f"Issued: {format_datetime(sent, date_style, time_12h)}")
+        expires = getattr(alert, "expires", None)
+        if expires is not None:
+            times.append(f"Expires: {format_datetime(expires, date_style, time_12h)}")
+        if times:
+            blocks.append("\n".join(times))
+
+        return "\n\n".join(blocks)
+
     def _build_info_text(self) -> str:
         """
         Build the alert info text with severity, urgency, and certainty.

--- a/src/accessiweather/ui/dialogs/settings_tabs/display.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/display.py
@@ -18,6 +18,18 @@ _TIME_MODE_VALUES = ["local", "utc", "both"]
 _TIME_MODE_MAP = {"local": 0, "utc": 1, "both": 2}
 _VERBOSITY_VALUES = ["minimal", "standard", "detailed"]
 _VERBOSITY_MAP = {"minimal": 0, "standard": 1, "detailed": 2}
+_ALERT_DISPLAY_MAP = {"separate": 0, "combined": 1}
+_ALERT_DISPLAY_VALUES = ["separate", "combined"]
+_ALERT_DISPLAY_CHOICES = ["Separate fields (default)", "Single combined view"]
+
+_DATE_FORMAT_MAP = {"iso": 0, "us_short": 1, "us_long": 2, "eu": 3}
+_DATE_FORMAT_VALUES = ["iso", "us_short", "us_long", "eu"]
+_DATE_FORMAT_CHOICES = [
+    "ISO (2026-04-18)",
+    "US short (04/18/2026)",
+    "US long (April 18, 2026)",
+    "EU (18/04/2026)",
+]
 
 
 class DisplayTab:
@@ -187,6 +199,12 @@ class DisplayTab:
             wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
             10,
         )
+        controls["date_format"] = self.dialog.add_labeled_control_row(
+            panel,
+            time_section,
+            "Date format:",
+            lambda parent: wx.Choice(parent, choices=_DATE_FORMAT_CHOICES),
+        )
 
         priority_section = self.dialog.create_section(
             panel,
@@ -216,6 +234,19 @@ class DisplayTab:
             0,
             wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
             10,
+        )
+
+        alert_display_section = self.dialog.create_section(
+            panel,
+            sizer,
+            "Alert display",
+            "Choose how weather alerts are shown when you open one.",
+        )
+        controls["alert_display_style"] = self.dialog.add_labeled_control_row(
+            panel,
+            alert_display_section,
+            "Alert display style:",
+            lambda parent: wx.Choice(parent, choices=_ALERT_DISPLAY_CHOICES),
         )
 
         panel.SetSizer(sizer)
@@ -255,12 +286,18 @@ class DisplayTab:
         controls["time_format_12hour"].SetValue(getattr(settings, "time_format_12hour", True))
         controls["show_timezone_suffix"].SetValue(getattr(settings, "show_timezone_suffix", False))
 
+        date_format = getattr(settings, "date_format", "iso")
+        controls["date_format"].SetSelection(_DATE_FORMAT_MAP.get(date_format, 0))
+
         verbosity = getattr(settings, "verbosity_level", "standard")
         controls["verbosity_level"].SetSelection(_VERBOSITY_MAP.get(verbosity, 1))
 
         controls["severe_weather_override"].SetValue(
             getattr(settings, "severe_weather_override", True)
         )
+
+        alert_display = getattr(settings, "alert_display_style", "separate")
+        controls["alert_display_style"].SetSelection(_ALERT_DISPLAY_MAP.get(alert_display, 0))
 
     def save(self) -> dict:
         """Return Display tab settings as a dict."""
@@ -283,8 +320,12 @@ class DisplayTab:
             "time_display_mode": _TIME_MODE_VALUES[controls["time_display_mode"].GetSelection()],
             "time_format_12hour": controls["time_format_12hour"].GetValue(),
             "show_timezone_suffix": controls["show_timezone_suffix"].GetValue(),
+            "date_format": _DATE_FORMAT_VALUES[controls["date_format"].GetSelection()],
             "verbosity_level": _VERBOSITY_VALUES[controls["verbosity_level"].GetSelection()],
             "severe_weather_override": controls["severe_weather_override"].GetValue(),
+            "alert_display_style": _ALERT_DISPLAY_VALUES[
+                controls["alert_display_style"].GetSelection()
+            ],
         }
 
     def get_selected_temperature_unit(self) -> str:
@@ -311,8 +352,10 @@ class DisplayTab:
             "time_display_mode": "Time display mode",
             "time_format_12hour": "Use 12-hour time format",
             "show_timezone_suffix": "Show timezone abbreviations",
+            "date_format": "Date format",
             "verbosity_level": "Verbosity level",
             "severe_weather_override": "Automatically prioritize severe weather details",
+            "alert_display_style": "Alert display style",
         }
         for key, name in names.items():
             controls[key].SetName(name)

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -1555,7 +1555,7 @@ class MainWindow(SizedFrame):
                 _loc_name, alert = data[alert_index]
                 from .dialogs import show_alert_dialog
 
-                show_alert_dialog(self, alert)
+                show_alert_dialog(self, alert, self.app.config_manager.get_settings())
             return
 
         if not self.app.current_weather_data or not self.app.current_weather_data.alerts:
@@ -1567,7 +1567,7 @@ class MainWindow(SizedFrame):
             alert = active[alert_index]
             from .dialogs import show_alert_dialog
 
-            show_alert_dialog(self, alert)
+            show_alert_dialog(self, alert, self.app.config_manager.get_settings())
 
     def _show_all_locations_summary(self) -> None:
         """

--- a/tests/test_alert_dialog_combined_text.py
+++ b/tests/test_alert_dialog_combined_text.py
@@ -92,3 +92,32 @@ class TestBuildCombinedText:
         alert = _alert()
         text = AlertDialog._build_combined_text(alert, _settings())
         assert text.startswith("Weather Alert")
+
+    def test_empty_string_description_and_instruction_omitted(self) -> None:
+        alert = _alert(headline="H", description="", instruction="")
+        text = AlertDialog._build_combined_text(alert, _settings())
+        assert text == "H"
+
+    def test_exact_output_for_full_alert(self) -> None:
+        alert = _alert(
+            headline="Frost Advisory",
+            description="Frost overnight.",
+            instruction="Cover plants.",
+            sent=datetime(2026, 4, 18, 14, 0),
+            expires=datetime(2026, 4, 18, 22, 0),
+        )
+        settings = _settings(date_format="iso", time_format_12hour=False)
+        expected = (
+            "Frost Advisory\n\n"
+            "Frost overnight.\n\n"
+            "Cover plants.\n\n"
+            "Issued: 2026-04-18 14:00\n"
+            "Expires: 2026-04-18 22:00"
+        )
+        assert AlertDialog._build_combined_text(alert, settings) == expected
+
+    def test_settings_none_uses_default_formats(self) -> None:
+        alert = _alert(headline="H", sent=datetime(2026, 4, 18, 14, 5))
+        text = AlertDialog._build_combined_text(alert, None)
+        # Default settings: date_format="iso", time_format_12hour=True -> "Issued: 2026-04-18 2:05 PM"
+        assert "Issued: 2026-04-18 2:05 PM" in text

--- a/tests/test_alert_dialog_combined_text.py
+++ b/tests/test_alert_dialog_combined_text.py
@@ -1,0 +1,94 @@
+"""Tests for AlertDialog._build_combined_text (pure string assembly)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+
+from accessiweather.models.config import AppSettings
+from accessiweather.ui.dialogs.alert_dialog import AlertDialog
+
+
+def _alert(**kwargs):
+    defaults = {
+        "headline": None,
+        "event": None,
+        "description": None,
+        "instruction": None,
+        "sent": None,
+        "expires": None,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _settings(**kwargs):
+    return AppSettings(**kwargs)
+
+
+class TestBuildCombinedText:
+    def test_all_fields_present_in_order(self) -> None:
+        alert = _alert(
+            headline="FROST ADVISORY IN EFFECT FROM 2 AM TO 10 AM",
+            description="WHAT...Frost.\nWHERE...Michigan.",
+            instruction="Protect tender plants.",
+            sent=datetime(2026, 4, 18, 14, 10),
+            expires=datetime(2026, 4, 18, 22, 15),
+        )
+        text = AlertDialog._build_combined_text(alert, _settings())
+        headline_i = text.index("FROST ADVISORY")
+        desc_i = text.index("WHAT...Frost")
+        instr_i = text.index("Protect tender plants")
+        issued_i = text.index("Issued:")
+        expires_i = text.index("Expires:")
+        assert headline_i < desc_i < instr_i < issued_i < expires_i
+
+    def test_falls_back_to_event_when_no_headline(self) -> None:
+        alert = _alert(event="Frost Advisory")
+        text = AlertDialog._build_combined_text(alert, _settings())
+        assert text.startswith("Frost Advisory")
+
+    def test_missing_instruction_omitted(self) -> None:
+        alert = _alert(
+            headline="H",
+            description="D",
+            sent=datetime(2026, 4, 18, 14, 10),
+            expires=datetime(2026, 4, 18, 22, 15),
+        )
+        text = AlertDialog._build_combined_text(alert, _settings())
+        assert "Issued:" in text
+        assert "None" not in text
+
+    def test_missing_expires_line_absent(self) -> None:
+        alert = _alert(
+            headline="H",
+            sent=datetime(2026, 4, 18, 14, 10),
+        )
+        text = AlertDialog._build_combined_text(alert, _settings())
+        assert "Issued:" in text
+        assert "Expires:" not in text
+
+    def test_missing_sent_line_absent(self) -> None:
+        alert = _alert(headline="H", expires=datetime(2026, 4, 18, 22, 15))
+        text = AlertDialog._build_combined_text(alert, _settings())
+        assert "Issued:" not in text
+        assert "Expires:" in text
+
+    def test_date_format_and_12hour_applied(self) -> None:
+        alert = _alert(
+            headline="H",
+            sent=datetime(2026, 4, 18, 14, 5),
+        )
+        settings = _settings(date_format="us_long", time_format_12hour=True)
+        text = AlertDialog._build_combined_text(alert, settings)
+        assert "Issued: April 18, 2026 2:05 PM" in text
+
+    def test_empty_description_does_not_add_blank_block(self) -> None:
+        alert = _alert(headline="H")
+        text = AlertDialog._build_combined_text(alert, _settings())
+        assert "\n\n\n" not in text
+
+    def test_fallback_headline_when_nothing_given(self) -> None:
+        alert = _alert()
+        text = AlertDialog._build_combined_text(alert, _settings())
+        assert text.startswith("Weather Alert")

--- a/tests/test_alert_dialog_dispatch.py
+++ b/tests/test_alert_dialog_dispatch.py
@@ -14,9 +14,17 @@ from accessiweather.ui.dialogs.alert_dialog import AlertDialog
 
 @pytest.fixture(scope="module")
 def wx_app():
-    app = wx.App()
+    app = wx.GetApp() or wx.App()
     yield app
-    app.Destroy()
+
+
+@pytest.fixture
+def hidden_parent(wx_app):
+    """Hidden wx.Frame used as parent so test dialogs never appear on screen."""
+    frame = wx.Frame(None)
+    frame.Hide()
+    yield frame
+    frame.Destroy()
 
 
 def _alert():
@@ -37,35 +45,35 @@ def _alert():
 
 
 class TestDispatch:
-    def test_separate_mode_creates_subject_ctrl(self, wx_app):
+    def test_separate_mode_creates_subject_ctrl(self, hidden_parent):
         settings = AppSettings(alert_display_style="separate")
-        dlg = AlertDialog(None, _alert(), settings)
+        dlg = AlertDialog(hidden_parent, _alert(), settings)
         try:
             assert hasattr(dlg, "subject_ctrl")
             assert not hasattr(dlg, "combined_ctrl")
         finally:
             dlg.Destroy()
 
-    def test_combined_mode_creates_combined_ctrl(self, wx_app):
+    def test_combined_mode_creates_combined_ctrl(self, hidden_parent):
         settings = AppSettings(alert_display_style="combined")
-        dlg = AlertDialog(None, _alert(), settings)
+        dlg = AlertDialog(hidden_parent, _alert(), settings)
         try:
             assert hasattr(dlg, "combined_ctrl")
             assert not hasattr(dlg, "subject_ctrl")
         finally:
             dlg.Destroy()
 
-    def test_none_settings_defaults_to_separate(self, wx_app):
-        dlg = AlertDialog(None, _alert(), None)
+    def test_none_settings_defaults_to_separate(self, hidden_parent):
+        dlg = AlertDialog(hidden_parent, _alert(), None)
         try:
             assert hasattr(dlg, "subject_ctrl")
             assert not hasattr(dlg, "combined_ctrl")
         finally:
             dlg.Destroy()
 
-    def test_combined_mode_textctrl_contains_headline(self, wx_app):
+    def test_combined_mode_textctrl_contains_headline(self, hidden_parent):
         settings = AppSettings(alert_display_style="combined")
-        dlg = AlertDialog(None, _alert(), settings)
+        dlg = AlertDialog(hidden_parent, _alert(), settings)
         try:
             assert "H" in dlg.combined_ctrl.GetValue()
             assert "Issued:" in dlg.combined_ctrl.GetValue()

--- a/tests/test_alert_dialog_dispatch.py
+++ b/tests/test_alert_dialog_dispatch.py
@@ -1,0 +1,73 @@
+"""Tests for AlertDialog mode dispatch and control creation."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+import wx
+
+from accessiweather.models.config import AppSettings
+from accessiweather.ui.dialogs.alert_dialog import AlertDialog
+
+
+@pytest.fixture(scope="module")
+def wx_app():
+    app = wx.App()
+    yield app
+    app.Destroy()
+
+
+def _alert():
+    return SimpleNamespace(
+        title="t",
+        description="D",
+        severity="Moderate",
+        urgency="Expected",
+        certainty="Likely",
+        event="Frost Advisory",
+        headline="H",
+        instruction="I",
+        areas=[],
+        references=[],
+        sent=datetime(2026, 4, 18, 14, 10),
+        expires=datetime(2026, 4, 18, 22, 15),
+    )
+
+
+class TestDispatch:
+    def test_separate_mode_creates_subject_ctrl(self, wx_app):
+        settings = AppSettings(alert_display_style="separate")
+        dlg = AlertDialog(None, _alert(), settings)
+        try:
+            assert hasattr(dlg, "subject_ctrl")
+            assert not hasattr(dlg, "combined_ctrl")
+        finally:
+            dlg.Destroy()
+
+    def test_combined_mode_creates_combined_ctrl(self, wx_app):
+        settings = AppSettings(alert_display_style="combined")
+        dlg = AlertDialog(None, _alert(), settings)
+        try:
+            assert hasattr(dlg, "combined_ctrl")
+            assert not hasattr(dlg, "subject_ctrl")
+        finally:
+            dlg.Destroy()
+
+    def test_none_settings_defaults_to_separate(self, wx_app):
+        dlg = AlertDialog(None, _alert(), None)
+        try:
+            assert hasattr(dlg, "subject_ctrl")
+            assert not hasattr(dlg, "combined_ctrl")
+        finally:
+            dlg.Destroy()
+
+    def test_combined_mode_textctrl_contains_headline(self, wx_app):
+        settings = AppSettings(alert_display_style="combined")
+        dlg = AlertDialog(None, _alert(), settings)
+        try:
+            assert "H" in dlg.combined_ctrl.GetValue()
+            assert "Issued:" in dlg.combined_ctrl.GetValue()
+        finally:
+            dlg.Destroy()

--- a/tests/test_all_locations_view.py
+++ b/tests/test_all_locations_view.py
@@ -366,7 +366,9 @@ class TestShowAlertDetailsAllLocations:
 
         with patch("accessiweather.ui.dialogs.show_alert_dialog") as mock_dialog:
             MainWindow._show_alert_details(win, 0)
-            mock_dialog.assert_called_once_with(win, alert)
+            mock_dialog.assert_called_once_with(
+                win, alert, win.app.config_manager.get_settings.return_value
+            )
 
     def test_out_of_range_index_does_nothing(self):
         """An out-of-range alert index in All Locations mode silently returns."""

--- a/tests/test_app_immediate_alert_popups.py
+++ b/tests/test_app_immediate_alert_popups.py
@@ -97,6 +97,7 @@ def test_show_immediate_alert_popup_uses_existing_single_alert_dialog() -> None:
 def test_show_immediate_alert_popup_uses_combined_dialog_for_multiple_alerts() -> None:
     app = AccessiWeatherApp.__new__(AccessiWeatherApp)
     app.main_window = MagicMock()
+    app.config_manager = MagicMock()
     app.tray_icon = SimpleNamespace(show_main_window=MagicMock())
     alerts = [_AlertStub("alpha"), _AlertStub("beta")]
 
@@ -113,6 +114,7 @@ def test_show_immediate_alert_popup_uses_combined_dialog_for_multiple_alerts() -
 def test_show_immediate_alert_popup_does_not_restore_main_window() -> None:
     app = AccessiWeatherApp.__new__(AccessiWeatherApp)
     app.main_window = MagicMock()
+    app.config_manager = MagicMock()
     app.tray_icon = SimpleNamespace(show_main_window=MagicMock())
     alerts = [_AlertStub("alpha"), _AlertStub("beta")]
 
@@ -138,6 +140,7 @@ def test_show_immediate_alert_popup_ignores_missing_window_or_empty_alerts(
 ) -> None:
     app = AccessiWeatherApp.__new__(AccessiWeatherApp)
     app.main_window = main_window
+    app.config_manager = MagicMock()
 
     with (
         patch("accessiweather.app.show_alert_dialog") as mock_show_alert_dialog,

--- a/tests/test_app_immediate_alert_popups.py
+++ b/tests/test_app_immediate_alert_popups.py
@@ -37,7 +37,7 @@ def test_show_alert_dialog_lazy_wrapper_forwards_to_dialog_module() -> None:
     with patch.dict(sys.modules, {"accessiweather.ui.dialogs": dialogs_module}):
         show_alert_dialog(parent, alert)
 
-    mock_show_single.assert_called_once_with(parent, alert)
+    mock_show_single.assert_called_once_with(parent, alert, None)
 
 
 def test_show_alerts_summary_dialog_lazy_wrapper_forwards_to_dialog_module() -> None:
@@ -78,6 +78,7 @@ def test_queue_immediate_alert_popup_skips_empty_alert_list() -> None:
 def test_show_immediate_alert_popup_uses_existing_single_alert_dialog() -> None:
     app = AccessiWeatherApp.__new__(AccessiWeatherApp)
     app.main_window = MagicMock()
+    app.config_manager = MagicMock()
     app.tray_icon = SimpleNamespace(show_main_window=MagicMock())
     alert = _AlertStub("alpha")
 
@@ -87,7 +88,9 @@ def test_show_immediate_alert_popup_uses_existing_single_alert_dialog() -> None:
     ):
         app._show_immediate_alert_popup([alert])
 
-    mock_show_alert_dialog.assert_called_once_with(app.main_window, alert)
+    mock_show_alert_dialog.assert_called_once_with(
+        app.main_window, alert, app.config_manager.get_settings.return_value
+    )
     mock_show_summary_dialog.assert_not_called()
 
 

--- a/tests/test_config_alert_display.py
+++ b/tests/test_config_alert_display.py
@@ -1,0 +1,35 @@
+"""Tests for alert display + date format settings round-trip."""
+
+from __future__ import annotations
+
+from accessiweather.models.config import AppSettings
+
+
+class TestDefaults:
+    def test_alert_display_style_defaults_to_separate(self) -> None:
+        assert AppSettings().alert_display_style == "separate"
+
+    def test_date_format_defaults_to_iso(self) -> None:
+        assert AppSettings().date_format == "iso"
+
+
+class TestRoundTrip:
+    def test_to_dict_includes_new_fields(self) -> None:
+        data = AppSettings().to_dict()
+        assert data["alert_display_style"] == "separate"
+        assert data["date_format"] == "iso"
+
+    def test_from_dict_preserves_valid_values(self) -> None:
+        settings = AppSettings.from_dict(
+            {"alert_display_style": "combined", "date_format": "us_long"}
+        )
+        assert settings.alert_display_style == "combined"
+        assert settings.date_format == "us_long"
+
+    def test_from_dict_falls_back_on_bogus_alert_display_style(self) -> None:
+        settings = AppSettings.from_dict({"alert_display_style": "bogus"})
+        assert settings.alert_display_style == "separate"
+
+    def test_from_dict_falls_back_on_bogus_date_format(self) -> None:
+        settings = AppSettings.from_dict({"date_format": "not-a-format"})
+        assert settings.date_format == "iso"

--- a/tests/test_config_alert_display.py
+++ b/tests/test_config_alert_display.py
@@ -33,3 +33,19 @@ class TestRoundTrip:
     def test_from_dict_falls_back_on_bogus_date_format(self) -> None:
         settings = AppSettings.from_dict({"date_format": "not-a-format"})
         assert settings.date_format == "iso"
+
+    def test_from_dict_empty_dict_uses_defaults(self) -> None:
+        settings = AppSettings.from_dict({})
+        assert settings.alert_display_style == "separate"
+        assert settings.date_format == "iso"
+
+    def test_from_dict_non_string_values_fall_back(self) -> None:
+        settings = AppSettings.from_dict({"alert_display_style": None, "date_format": 42})
+        assert settings.alert_display_style == "separate"
+        assert settings.date_format == "iso"
+
+    def test_full_round_trip_preserves_combined_and_us_long(self) -> None:
+        original = AppSettings(alert_display_style="combined", date_format="us_long")
+        restored = AppSettings.from_dict(original.to_dict())
+        assert restored.alert_display_style == "combined"
+        assert restored.date_format == "us_long"

--- a/tests/test_formatters_date.py
+++ b/tests/test_formatters_date.py
@@ -1,0 +1,68 @@
+"""Tests for date/datetime format helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from hypothesis import (
+    given,
+    strategies as st,
+)
+
+from accessiweather.display.presentation.formatters import (
+    format_date,
+    format_datetime,
+)
+
+FIXED_DT = datetime(2026, 4, 18, 14, 5)  # 2:05 PM / 14:05
+
+
+class TestFormatDate:
+    @pytest.mark.parametrize(
+        "style, expected",
+        [
+            ("iso", "2026-04-18"),
+            ("us_short", "04/18/2026"),
+            ("us_long", "April 18, 2026"),
+            ("eu", "18/04/2026"),
+        ],
+    )
+    def test_each_preset(self, style: str, expected: str) -> None:
+        assert format_date(FIXED_DT, style) == expected
+
+    def test_unknown_style_falls_back_to_iso(self) -> None:
+        assert format_date(FIXED_DT, "not-a-real-style") == "2026-04-18"
+
+    def test_none_returns_empty_string(self) -> None:
+        assert format_date(None, "iso") == ""
+
+    @given(
+        st.datetimes(
+            min_value=datetime(1900, 1, 1),
+            max_value=datetime(2100, 12, 31),
+        ),
+        st.sampled_from(["iso", "us_short", "us_long", "eu", "bogus"]),
+    )
+    def test_never_crashes(self, dt: datetime, style: str) -> None:
+        result = format_date(dt, style)
+        assert isinstance(result, str)
+        assert result  # non-empty for any real datetime
+
+
+class TestFormatDatetime:
+    def test_us_long_12hour(self) -> None:
+        assert format_datetime(FIXED_DT, "us_long", True) == "April 18, 2026 2:05 PM"
+
+    def test_iso_24hour(self) -> None:
+        assert format_datetime(FIXED_DT, "iso", False) == "2026-04-18 14:05"
+
+    def test_us_short_24hour(self) -> None:
+        assert format_datetime(FIXED_DT, "us_short", False) == "04/18/2026 14:05"
+
+    def test_morning_12hour_strips_leading_zero(self) -> None:
+        morning = datetime(2026, 4, 18, 9, 7)
+        assert format_datetime(morning, "iso", True) == "2026-04-18 9:07 AM"
+
+    def test_none_returns_empty_string(self) -> None:
+        assert format_datetime(None, "iso", True) == ""

--- a/tests/test_formatters_date.py
+++ b/tests/test_formatters_date.py
@@ -74,3 +74,21 @@ class TestFormatDatetime:
     def test_midnight_24hour_not_corrupted(self) -> None:
         midnight = datetime(2026, 4, 18, 0, 0)
         assert format_datetime(midnight, "iso", False) == "2026-04-18 00:00"
+
+    def test_midnight_12hour(self) -> None:
+        midnight = datetime(2026, 4, 18, 0, 0)
+        assert format_datetime(midnight, "iso", True) == "2026-04-18 12:00 AM"
+
+    def test_noon_12hour(self) -> None:
+        noon = datetime(2026, 4, 18, 12, 0)
+        assert format_datetime(noon, "iso", True) == "2026-04-18 12:00 PM"
+
+    def test_double_digit_hour_12hour(self) -> None:
+        ten_am = datetime(2026, 4, 18, 10, 5)
+        assert format_datetime(ten_am, "iso", True) == "2026-04-18 10:05 AM"
+
+    def test_tz_aware_datetime_formats_without_tz_info(self) -> None:
+        from datetime import timezone
+
+        aware = datetime(2026, 4, 18, 14, 5, tzinfo=timezone.utc)
+        assert format_datetime(aware, "iso", False) == "2026-04-18 14:05"

--- a/tests/test_formatters_date.py
+++ b/tests/test_formatters_date.py
@@ -66,3 +66,11 @@ class TestFormatDatetime:
 
     def test_none_returns_empty_string(self) -> None:
         assert format_datetime(None, "iso", True) == ""
+
+    def test_morning_24hour_keeps_leading_zero(self) -> None:
+        morning = datetime(2026, 4, 18, 9, 7)
+        assert format_datetime(morning, "iso", False) == "2026-04-18 09:07"
+
+    def test_midnight_24hour_not_corrupted(self) -> None:
+        midnight = datetime(2026, 4, 18, 0, 0)
+        assert format_datetime(midnight, "iso", False) == "2026-04-18 00:00"


### PR DESCRIPTION
## Summary

- New **Alert display style** setting: pick "Single combined view" to read the whole alert — headline, description, instructions, Issued/Expires timestamps — in one scrollable edit box with a Close button. The original separate-fields layout stays the default.
- New **Date format** setting: ISO (2026-04-18), US short (04/18/2026), US long (April 18, 2026), or EU (18/04/2026). Applied to the combined view's Issued/Expires lines for now; the shared `format_date` / `format_datetime` helpers land in `display/presentation/formatters.py` so other call sites can opt in later.
- TDD throughout: 40+ new tests covering formatter edge cases (leading-zero handling across 12h/24h, tz-aware datetimes), settings round-trip and fallback, combined-text assembly (block ordering, missing fields, exact-string format), and dialog dispatch.

Design and plan documents live under `docs/plans/2026-04-18-combined-alert-view-*.md`.

## Verification

- [x] `uv run pytest -n auto` — **3578 passed, 7 pre-existing failures** on `origin/dev` (Windows toast / portable API-key plumbing, unrelated).
- [x] `uv run ruff check .` — clean.
- [x] `uv run ruff format .` — no reformats needed.
- [x] `uv run pyright` — zero errors in new/changed code.

## Test plan

- [ ] Launch: `uv run accessiweather`
- [ ] Open Settings → Display — confirm **Date format:** Choice in Time display section, and a new **Alert display** section at the bottom with **Alert display style:** Choice.
- [ ] Pick "Single combined view", save, open an active alert — confirm single TextCtrl shows headline + description + instruction + Issued + Expires, Close button works, Escape closes.
- [ ] Switch back to "Separate fields", save — confirm the original four-field layout is restored.
- [ ] Toggle each date format preset, reopen an alert — confirm Issued/Expires lines reformat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)