### PR TITLE
feat(ui): add preference for location buttons near dropdown

### DIFF
--- a/src/accessiweather/models/config.py
+++ b/src/accessiweather/models/config.py
@@ -172,6 +172,9 @@ class AppSettings:
     show_timezone_suffix: bool = False
     # Alert dialog display style
     alert_display_style: str = "separate"  # "separate" | "combined"
+    # Place Add/Edit/Remove Location buttons on the location row instead of the
+    # bottom button panel.  Takes effect on app restart.
+    location_buttons_on_top: bool = False
     # Date format preset for rendered dates
     date_format: str = "iso"  # "iso" | "us_short" | "us_long" | "eu"
     # Taskbar icon text options

--- a/src/accessiweather/models/config.py
+++ b/src/accessiweather/models/config.py
@@ -502,6 +502,7 @@ class AppSettings:
             "time_format_12hour": self.time_format_12hour,
             "show_timezone_suffix": self.show_timezone_suffix,
             "alert_display_style": self.alert_display_style,
+            "location_buttons_on_top": self.location_buttons_on_top,
             "date_format": self.date_format,
             "taskbar_icon_text_enabled": self.taskbar_icon_text_enabled,
             "taskbar_icon_dynamic_enabled": self.taskbar_icon_dynamic_enabled,
@@ -601,6 +602,7 @@ class AppSettings:
             time_format_12hour=cls._as_bool(data.get("time_format_12hour"), True),
             show_timezone_suffix=cls._as_bool(data.get("show_timezone_suffix"), False),
             alert_display_style=data.get("alert_display_style", "separate"),
+            location_buttons_on_top=cls._as_bool(data.get("location_buttons_on_top"), False),
             date_format=data.get("date_format", "iso"),
             taskbar_icon_text_enabled=cls._as_bool(data.get("taskbar_icon_text_enabled"), False),
             taskbar_icon_dynamic_enabled=cls._as_bool(

--- a/src/accessiweather/ui/dialogs/settings_tabs/display.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/display.py
@@ -249,6 +249,27 @@ class DisplayTab:
             lambda parent: wx.Choice(parent, choices=_ALERT_DISPLAY_CHOICES),
         )
 
+        layout_section = self.dialog.create_section(
+            panel,
+            sizer,
+            "Main window layout",
+            "Adjust where the main window places location-management buttons. "
+            "Changes take effect after you restart AccessiWeather.",
+        )
+        controls["location_buttons_on_top"] = wx.CheckBox(
+            panel,
+            label=(
+                "Show Add, Edit, and Remove Location buttons next to the "
+                "location dropdown (restart required)"
+            ),
+        )
+        layout_section.Add(
+            controls["location_buttons_on_top"],
+            0,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
+            10,
+        )
+
         panel.SetSizer(sizer)
         self.dialog.notebook.AddPage(panel, page_label)
         return panel
@@ -299,6 +320,10 @@ class DisplayTab:
         alert_display = getattr(settings, "alert_display_style", "separate")
         controls["alert_display_style"].SetSelection(_ALERT_DISPLAY_MAP.get(alert_display, 0))
 
+        controls["location_buttons_on_top"].SetValue(
+            getattr(settings, "location_buttons_on_top", False)
+        )
+
     def save(self) -> dict:
         """Return Display tab settings as a dict."""
         controls = self.dialog._controls
@@ -326,6 +351,7 @@ class DisplayTab:
             "alert_display_style": _ALERT_DISPLAY_VALUES[
                 controls["alert_display_style"].GetSelection()
             ],
+            "location_buttons_on_top": controls["location_buttons_on_top"].GetValue(),
         }
 
     def get_selected_temperature_unit(self) -> str:
@@ -356,6 +382,10 @@ class DisplayTab:
             "verbosity_level": "Verbosity level",
             "severe_weather_override": "Automatically prioritize severe weather details",
             "alert_display_style": "Alert display style",
+            "location_buttons_on_top": (
+                "Show Add, Edit, and Remove Location buttons next to the "
+                "location dropdown (restart required)"
+            ),
         }
         for key, name in names.items():
             controls[key].SetName(name)

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -124,6 +124,20 @@ class MainWindow(SizedFrame):
         )
         self.location_dropdown.SetSizerProps(expand=True, proportion=1)
 
+        # Optional: place Add/Edit/Remove on the location row instead of the
+        # bottom button panel.  Grouped spatially with the dropdown they act on,
+        # at the cost of inserting buttons between the dropdown and the forecast
+        # content in the tab order.
+        location_buttons_on_top = getattr(
+            self.app.config_manager.get_settings(),
+            "location_buttons_on_top",
+            False,
+        )
+        if location_buttons_on_top:
+            self.add_button = wx.Button(location_panel, label=QUICK_ACTION_LABELS["add"])
+            self.edit_button = wx.Button(location_panel, label=QUICK_ACTION_LABELS["edit"])
+            self.remove_button = wx.Button(location_panel, label=QUICK_ACTION_LABELS["remove"])
+
         # Current conditions section
         wx.StaticText(panel, label="Current Conditions:")
         self.current_conditions = wx.TextCtrl(
@@ -189,9 +203,10 @@ class MainWindow(SizedFrame):
         button_panel.SetSizerType("horizontal")
         button_panel.SetSizerProps(expand=True)
 
-        self.add_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["add"])
-        self.edit_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["edit"])
-        self.remove_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["remove"])
+        if not location_buttons_on_top:
+            self.add_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["add"])
+            self.edit_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["edit"])
+            self.remove_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["remove"])
         self.refresh_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["refresh"])
         self.explain_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["explain"])
         self.discussion_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["discussion"])


### PR DESCRIPTION
## Summary

Reintroduces the pre-#606 placement (Add/Edit/Remove Location on the location row) as an opt-in setting. Default stays at the current bottom button row, so nothing changes for existing users.

## Why

We've had conflicting feedback:
- One user prefers buttons at the bottom so tabbing from the location dropdown goes straight into Current Conditions -> Hourly -> Daily with no buttons interrupting the flow (the win #606 restored).
- Another user prefers the buttons grouped spatially with the dropdown they operate on.

Both are reasonable. A preference satisfies both, and hotkeys (Ctrl+L / Ctrl+D / Location menu) continue to work regardless.

## What changed

- New setting \`location_buttons_on_top\` (default \`False\`) on \`AppSettings\`.
- \`MainWindow._create_widgets\` conditionally constructs Add/Edit/Remove on either \`location_panel\` or \`button_panel\` based on the setting.
- New **Main window layout** section on the Display settings tab with a checkbox and a restart-required note.

The setting is restart-gated deliberately — live sizer reordering in wx is fiddly and this is a rarely-flipped preference.

## Test plan

- [ ] CI passes
- [ ] Default behavior unchanged: Location -> forecasts with no buttons in the tab order between them
- [ ] Toggle setting on, restart: Add/Edit/Remove appear on the location row; bottom row has Refresh / Explain / Discussion / Settings only
- [ ] All three buttons still invoke the correct handlers (Ctrl+L / Ctrl+D hotkeys and Location menu also still work)