### PR TITLE
feat(zones): PR 1 Phase A — NWS zone metadata on saved locations

### DIFF
--- a/docs/brainstorms/2026-04-20-nws-text-products-registry-requirements.md
+++ b/docs/brainstorms/2026-04-20-nws-text-products-registry-requirements.md
@@ -1,0 +1,124 @@
+---
+date: 2026-04-20
+topic: nws-text-products-registry
+---
+
+# Forecast Products Dialog (AFD + HWO + SPS)
+
+> **Phase 0 dependency:** This feature bundles in one PR with [Zone Metadata Enrichment](2026-04-20-zone-metadata-enrichment-requirements.md). Phase 0 captures `cwa_office` per saved location; this feature is the first user-visible consumer. Together they form **PR 1**.
+
+## Problem Frame
+
+AccessiWeather's screen-reader-first users get forecaster reasoning today only via the per-location **Discussion dialog** (Area Forecast Discussion, hereafter **AFD**) — one text product, one dialog. Two other per-WFO text products that are equally screen-reader-friendly are invisible to the app:
+
+- **HWO (Hazardous Weather Outlook)** — daily 7-day hazard horizon from the local WFO. Structured probability grid of hazard categories (Day 1 specific hazards for today; Days 2-7 probabilistic outlook). Distinct from AFD: AFD is discursive forecaster reasoning; HWO is structured probable hazards up to a week ahead that don't yet warrant watches/warnings.
+- **SPS (Special Weather Statement)** — ad-hoc text advisories below warning/watch threshold. SPS products fall into two populations, verified against live NWS API data:
+  - **Event-style SPS** (hail, dense fog, radar-indicated hazards): issued as both `/products/types/SPS` AND CAP alerts on `/alerts/active`. Users already see these via the existing alert stream; the alert's `description` field contains the core meteorological content.
+  - **Informational SPS** (fire-weather statements, pollen, multi-zone advisory text, coordination statements): issued as `/products/types/SPS` but NOT as CAP alerts. Example verified: WFO PHI issued a 2000-char fire-weather SPS on 2026-04-16 that never appeared in `/alerts/active`. **These are completely invisible to AccessiWeather users today.**
+
+This feature brings all three products into a tabbed per-location **Forecast Products dialog**. Event-style SPS continue to notify through the existing alert pipeline (no duplication); the tab is the reference surface for both SPS populations. Informational SPS become visible for the first time.
+
+Additionally, the existing AFD dialog's "Plain Language Summary" (AI tl;dr via OpenRouter at [ai_explainer.py](src/accessiweather/ai_explainer.py), consumed by [ui/dialogs/discussion_dialog.py](src/accessiweather/ui/dialogs/discussion_dialog.py)) is reused across all three tabs.
+
+## Requirements
+
+**Data layer**
+- R1. Fetch, parse, and cache three NWS text products per saved US location using the `cwa_office` field populated by Phase 0:
+  - AFD via `/products/types/AFD/locations/{cwa_office}` — existing async implementation at [weather_client_nws.py:769](src/accessiweather/weather_client_nws.py) (`get_nws_discussion`) already extracts `issuanceTime` for the background-refresh path. Extend this async fetcher (generalize or add siblings — see Outstanding Questions). The sync wrapper at [alerts_and_products.py:150](src/accessiweather/api_client/alerts_and_products.py) is NOT the target — it lacks issuance-time extraction.
+  - HWO via `/products/types/HWO/locations/{cwa_office}` (new).
+  - SPS via `/products/types/SPS/locations/{cwa_office}` (new). Multiple concurrent SPS products may exist; show all in the tab as numbered entries sorted newest-first.
+- R2. Cache TTLs: AFD 1h, HWO 2h, SPS 15min. Cache keyed per `(product_type, cwa_office)`. Planning picks cache layer (extend [cache.py](src/accessiweather/cache.py) with per-key TTL or new per-product cache). `NationalDiscussionService` in [services/national_discussion_service.py](src/accessiweather/services/national_discussion_service.py) does NOT generalize (sync, single-TTL, location-agnostic).
+- R3. Background-fetch all three products for **all saved US locations** during the app's existing weather refresh cycle. Enables SPS/HWO notifications across the user's full location set; pre-warms the dialog for instant open. Failure isolation: each `(product_type, location)` fetch runs independently; one failure never cascades to another.
+- R4. Fetch is skipped for non-US locations (per Phase 0's `_is_us_location` check in [display/presentation/forecast.py:40-50](src/accessiweather/display/presentation/forecast.py)) and for US locations where `cwa_office` is still null (Phase 0 hasn't populated yet — self-heals on next refresh).
+
+**UI — Forecast Products dialog**
+- R5. Rename the existing main-window "Discussion" button to **"Forecast Products"** (updating the menu item label, accessibility-announced label, and `QUICK_ACTION_LABELS` key). The existing Nationwide-dialog branch at [main_window.py:675-686](src/accessiweather/ui/main_window.py) remains unchanged — only the per-location AFD branch's entry point is renamed. Extract a reusable `ForecastProductPanel` wx component (TextCtrl + AI summary button + model info label + issuance-time label); host three instances inside a `wx.Notebook` in the renamed dialog.
+- R6. Each tab contains:
+  - A single `wx.TextCtrl` (read-only, multi-line, scrollable) showing the **raw product text** as issued by the WFO. No section parsing — wxPython lacks a semantic heading widget that screen readers navigate as HTML `<h2>`. Users read linearly (Say-All) or use arrow/page keys.
+  - A **"Plain Language Summary"** button invoking the AI summary flow. `ai_explainer.explain_afd` has an AFD-specific system prompt — planning decides between (a) parallel `explain_hwo` / `explain_sps` methods or (b) refactoring to a generic `explain_text_product(product_type, text, location_name, style)` with a prompt lookup table. Existing `custom_system_prompt` / `custom_instructions` settings apply to all three product types.
+  - An issuance-time label: `"Issued: {time}"` converted to the user's OS timezone via `datetime.astimezone()`.
+  - For SPS specifically, if multiple products are active: a `wx.Choice` above the TextCtrl lists each product by issuance time / headline; selecting one updates the TextCtrl.
+- R7. Tab content states (wx.Notebook does NOT support per-tab disable on Windows — `EnableTab` is AuiNotebook-only; states are communicated via content panel text, not tab label):
+  - All three tabs always visible and selectable.
+  - **SPS empty (common case, `@graph` is `[]`):** panel displays "No Special Weather Statements currently active for {cwa_office}."
+  - **HWO empty (uncommon for active US WFOs; may indicate API failure):** panel displays "Hazardous Weather Outlook not currently available for {cwa_office}." (See Outstanding Questions for distinguishing empty vs. error.)
+  - **AFD empty (rare):** panel displays "Area Forecast Discussion not currently available for {cwa_office}."
+  - **Fetch failed (API error):** panel displays "Failed to fetch — try again." with a retry button.
+  - **`cwa_office` null for selected location:** all three panels display "NWS text products will populate after the next weather refresh."
+  - Initial focus on dialog open: AFD tab's TextCtrl. On tab switch: focus moves to the selected tab's TextCtrl.
+- R8. Non-US locations: the main-window **"Forecast Products" button is `Disable()`d**. Adjacent `wx.StaticText` below the button reads "NWS products are US-only" (per project memory: accessible labels come from adjacent StaticText, not `SetName` or tooltip). The StaticText is only shown when the selected location is non-US.
+
+**Notifications**
+- R9. The existing AFD update notification (via [notifications/notification_event_manager.py](src/accessiweather/notifications/notification_event_manager.py), gated by `notify_discussion_update`) is preserved: content, notification logic, issuance-time tracking, and AI summary behavior are all unchanged. Only the entry-point label rename (R5) is a user-visible AFD-related change.
+- R10. Two new notification streams with per-stream Settings toggles in [ui/dialogs/settings_tabs/notifications.py](src/accessiweather/ui/dialogs/settings_tabs/notifications.py):
+  - `notify_hwo_update` — fires when HWO content changes between fetches. **Default ON** (HWO is distinct from AFD: structured 7-day hazard grid vs. discursive reasoning; daily cadence is an acknowledged tradeoff).
+  - `notify_sps_issued` — fires when a new SPS product appears that does NOT have a corresponding active Special Weather Statement alert on `/alerts/active` (deduping against the alerts pipeline). **Default ON** (the value is Case B — informational SPS that never reach the alerts feed). Dedupe rule: at SPS fetch time, if an active alert exists with `event == "Special Weather Statement"` AND its zones/affected area intersect the SPS product's scope, suppress the notification; the alert pipeline already surfaces it.
+  - Settings section intro text must be updated — currently reads "These are optional updates beyond standard alerts and are off unless you turn them on," which would be factually wrong with both defaults ON. New text spells out the asymmetric behavior.
+  - Cold-start / first-fetch policy: the first time we see content for a product type on a location, store the baseline silently — do NOT notify. Matches existing AFD pattern at `notification_event_manager.py:427-435`. Covers app first install, long absence, newly added locations.
+  - A conservative per-stream rate limit (suggested: 30 min per product type per location) prevents storms after prolonged absence. The existing alert rate-limiter applies to alerts only, not product-update events — planning sets the exact per-stream value.
+  - `NotificationState` gains `last_hwo_issuance_time`, `last_hwo_text`, `last_sps_issuance_time`, `last_sps_product_id` fields — additive, backward-compatible via defensive `.get()`. The [runtime_state.py](src/accessiweather/runtime_state.py) translation layer (`_runtime_section_to_legacy_shape` / `_legacy_shape_to_runtime_section`) and `_DEFAULT_RUNTIME_STATE` gain parallel `hwo` and `sps` sub-sections. No `schema_version` bump.
+- R11. Notification content follows existing `format_accessible_message` pattern.
+  - **SPS notifications** source the headline from the NWS product metadata `headline` field when present, falling back to the first non-empty line of `productText` when `headline` is null. Body format: `"{headline} — {cwa_office}"`. 160-character budget (Windows toast constraint); truncate with ellipsis.
+  - **HWO update notifications** use the existing `summarize_discussion_change` pattern adapted for HWO's structured grid if feasible, else generic "Hazardous Weather Outlook updated for {cwa_office} — tap to view."
+
+## Success Criteria
+
+- A US user opens Forecast Products and sees three tabs pre-populated with the latest AFD, HWO, and (if any) active SPS products for their location's CWA office. No perceptible load time on open.
+- A user receives a desktop notification when their WFO issues an informational SPS that is NOT in the alerts feed (verified against the Case B example: a fire-weather SPS that appears on `/products/types/SPS` but not `/alerts/active`).
+- A user does NOT receive duplicate notifications when their WFO issues an event-style SPS that IS also in the alerts feed — the alert pipeline handles it, the Registry dedupes.
+- An SPS tab with no active advisories displays "No Special Weather Statements currently active for {cwa_office}" — users understand nothing is active, not that the feature is broken.
+- AFD content, notification, issuance-time tracking, and AI summary behavior are unchanged; only the entry-point button/menu label is renamed.
+- A non-US user sees the main-window Forecast Products button as `Disable()`d with an adjacent StaticText "NWS products are US-only" announced by screen readers.
+- After closing the app for 18 hours and reopening, the user sees no notification storm — first-fetch baseline stores silently; only genuinely unseen changes fire within the rate-limit window.
+- AI "Plain Language Summary" works on any of the three tabs, translating meteorology jargon into plain English.
+
+## Scope Boundaries
+
+- **Section-parsing / heading-navigation for AFD is NOT in scope.** Raw-blob reading is the default; wxPython doesn't have semantic heading widgets equivalent to HTML `<h2>` navigable via screen-reader H-key.
+- **No additional NWS products beyond AFD / HWO / SPS.** Marine text products (CWF, NSH), aviation products, climate summaries are scope for future features (Marine & Water Context, ideation #7).
+- **No changes to the Nationwide discussion view.** The `_on_discussion` branch that routes to `NationwideDiscussionDialog` when location name is "Nationwide" is unaffected.
+- **No new AI features beyond reusing existing tl;dr on all three tabs.** Per-product prompt routing (parallel methods or generic refactor) is the only `ai_explainer.py` change.
+- **Zone metadata beyond `cwa_office` is not consumed.** `county_zone_id`, `fire_zone_id`, `radar_station`, `timezone` captured by Phase 0 are plumbing for other features.
+- **No "View full statement" deep-link from alert details.** Verified that SPS alert `description` fields contain the meteorological content already; deep-linking to `productText` for event-style SPS adds little value. Users who want more context use the SPS tab in the dialog.
+- **No caching of AI summaries beyond existing in-memory cache.** The `explain_afd` cache behavior applies to the generalized explainer.
+
+## Key Decisions
+
+- **All three products in one tabbed dialog, bundled with Phase 0 as PR 1** — original product instinct. Event-style SPS continue through alerts (no duplication); the tab is reference + discovery for informational (Case B) SPS that would otherwise be invisible.
+- **SPS notification dedupes against alerts** — prevents double-notification for Case A SPS while preserving the novel-capability value for Case B. Planning verifies the dedupe check is cheap enough to run per SPS fetch.
+- **HWO notification Default ON, SPS notification Default ON** — both deliver distinct value not present today: HWO's 7-day hazard horizon, SPS Case B's informational advisories.
+- **Background-fetch all three for all saved US locations** — enables notifications across the user's full location set; pre-warms the dialog.
+- **Content panel empty-states instead of disabled tabs** — wx.Notebook doesn't support per-tab disable on Windows.
+- **Non-US button disabled with adjacent StaticText reason** — project's accessibility pattern is adjacent StaticText for accessible labels, not tooltip or `SetName`.
+- **Extract ForecastProductPanel component, host in wx.Notebook** — avoids state triplication in the existing DiscussionDialog's single-instance AI summary wiring.
+- **Raw-blob reading, no heading navigation** — wx desktop apps don't expose StaticText as semantic headings to screen readers the way HTML does.
+- **Issuance-time in user OS timezone** — users plan in their own timezone; station-local adds cognitive load without benefit.
+- **First-fetch baseline storage (no notify)** — prevents notification storms on fresh install, new locations, post-absence reopen.
+
+## Dependencies / Assumptions
+
+- **Phase 0 Zone Metadata Enrichment** populates `cwa_office` on saved US `Location` records. This Registry is the first user-visible consumer.
+- NWS `/products/types/{TYPE}/locations/{CWA}` endpoint shape stable across AFD, HWO, SPS — same `@graph[0].id` → `products/{id}.productText` + `issuanceTime` pattern already used by `get_nws_discussion` at [weather_client_nws.py:769](src/accessiweather/weather_client_nws.py) and verified against live PHI endpoint.
+- `/alerts/active?event=Special Weather Statement` returns alerts that, when matched against SPS products by zone/area, reliably identify the Case A subset. Verified SPS products without alerts (Case B: fire-weather) and SPS alerts without matching product listings both exist.
+- `NotificationEventManager` state persistence extends backward-compatibly via defensive `.get()` — proven pattern for `last_discussion_issuance_time` at `notification_event_manager.py:208-222`.
+- `_DEFAULT_RUNTIME_STATE` in [runtime_state.py:14-37](src/accessiweather/runtime_state.py) gains `hwo` and `sps` sub-sections under `notification_events`; `_runtime_section_to_legacy_shape` and `_legacy_shape_to_runtime_section` (lines 297-340) are updated in parallel. No `schema_version` bump.
+- OpenRouter integration at `ai_explainer.py` can be refactored to a generic `explain_text_product` OR extended with parallel methods; either is feasible per the feasibility review.
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R1][Technical] Whether to add `get_nws_hwo` / `get_nws_sps` paired with existing `get_nws_discussion`, OR generalize into `get_nws_text_product(product_type, cwa_office)`. The async path at [weather_client_nws.py:769](src/accessiweather/weather_client_nws.py) is the target.
+- [Affects R2][Technical] Cache layer choice — extend `cache.py` with per-key TTL support OR build a new per-product cache.
+- [Affects R3][Technical] Integration point for per-location-set background fetch — `_fetch_weather_data` at [main_window.py:1108](src/accessiweather/ui/main_window.py) (active location only) vs. [app_timer_manager.py](src/accessiweather/app_timer_manager.py) (all locations) vs. extending `_pre_warm_other_locations` at `main_window.py:1182`.
+- [Affects R6][Technical] AI explainer refactor — add parallel methods OR generic `explain_text_product(product_type, ...)`. Confirm behavior with user-set `custom_system_prompt` / `custom_instructions`.
+- [Affects R6][Technical] SPS multi-product `wx.Choice` widget — confirm screen-reader announcement behavior when the selected product changes.
+- [Affects R7][Technical] wx.Notebook focus management — `SetFocus()` via `wx.CallAfter` pattern replicated per-tab.
+- [Affects R10][Technical] SPS alert-dedupe check — compare SPS product zones against active alerts' `affectedZones`. Planning validates the match is reliable (zone codes should align since both come from NWS) and measures performance cost per fetch.
+- [Affects R10][Technical] Per-stream rate limit exact value (suggested 30 min per product type per location).
+- [Affects R7][UX] HWO empty-state copy — if observed fetch-success rate approaches 100% for active US WFOs, consider splitting "not yet issued today" vs. "fetch failed" states.
+- [Affects R11][UX] HWO update-notification diffing — `summarize_discussion_change` was designed for AFD narrative; applying to HWO's structured grid may produce low-quality summaries. Planning evaluates and falls back to generic wording if needed.
+- [Affects R11][UX] SPS expiration — when an active SPS disappears from `@graph`, fire a silent "cleared" state change (no notification) matching the existing discussion-cleared pattern.
+
+## Next Steps
+-> `/ce:plan` for the bundled **PR 1**: Phase 0 Zone Metadata Enrichment + Forecast Products Dialog (AFD + HWO + SPS).

--- a/docs/brainstorms/2026-04-20-zone-metadata-enrichment-requirements.md
+++ b/docs/brainstorms/2026-04-20-zone-metadata-enrichment-requirements.md
@@ -1,0 +1,92 @@
+---
+date: 2026-04-20
+topic: zone-metadata-enrichment
+---
+
+# Zone Metadata Enrichment Service (Phase 0 data layer)
+
+> **Status:** This document is scoped as **Phase 0** of the [Forecast Products Dialog (AFD + HWO + SPS)](2026-04-20-nws-text-products-registry-requirements.md) feature, ships as **PR 1** bundled with it. PR 1 delivers: zone enrichment on save, lazy drift correction, alert-path zone reuse, and the tabbed Forecast Products dialog that is the first user-visible consumer of `cwa_office`.
+
+## Problem Frame
+
+AccessiWeather resolves NWS zone identifiers (forecast zone, CWA office, county) from latitude/longitude on every weather refresh via the NWS `/points` endpoint. The resolved IDs are used by `weather_client_nws.py` for alert fetching and then discarded — `cwa` and `forecastZone` are stripped by `_transform_point_data` in [api/nws/point_location.py:86-141](src/accessiweather/api/nws/point_location.py), and `fireWeatherZone`, `county`, `radarStation`, `timeZone` are extracted but only used transiently. This prevents any per-location feature from starting from a known CWA office, marine zone, or county zone without re-resolving from coordinates.
+
+Enriching each saved location with its NWS zone metadata at save-time (with lazy backfill and opportunistic drift correction) removes that friction and makes the Text Products Registry (AFD / HWO / SPS) a straightforward consumer on top.
+
+## Requirements
+
+Throughout this document: `forecast_zone_id`, `cwa_office`, `county_zone_id`, `fire_zone_id`, `radar_station`, `timezone` refer to the persisted fields on the `Location` record. `forecastZone`, `cwa`, `county`, `fireWeatherZone`, `radarStation`, `timeZone` refer to the raw field names in the NWS `/points` API response.
+
+**Data capture**
+- R1. On save of a new location where the location is US (per existing `country_code == "US"` / continental-Alaska-Hawaii bbox detection in [display/presentation/forecast.py:40-50](src/accessiweather/display/presentation/forecast.py)), fetch NWS `/points` once and persist the full set of zone-metadata fields on the `Location` record: `forecast_zone_id` (from `forecastZone`), `cwa_office` (from `cwa`), `county_zone_id` (from `county`), `fire_zone_id` (from `fireWeatherZone`), `radar_station` (from `radarStation`), `timezone` (from `timeZone`). All fields are `Optional[str]`, default `None`.
+- R2. For non-US locations, do not attempt NWS zone resolution. Persisted zone fields remain null.
+- R3. If the `/points` call fails at save-time, save the location immediately with zone fields null. Never block the save or prompt the user. The error is logged at debug level only.
+
+**Backfill and drift correction**
+- R4. On each successful `/points` response during weather refresh, compare each freshly returned field against its stored counterpart. If a stored field is null, populate it. If a stored field differs from a non-null fresh value, overwrite silently and persist the config. **Never overwrite a populated stored value with null** (treat null/missing fresh values as "no update"). **If the `/points` call itself raises an exception, skip the drift check for that cycle; retry on the next refresh.**
+- R5. Locations saved before this feature shipped get their zone fields populated opportunistically via R4 the first time their weather is refreshed. No explicit migration step.
+
+**Consumption**
+- R6. Alert fetching in `weather_client_nws.py` uses stored zone values when present, skipping the redundant per-refresh zone resolution path. Specifically:
+  - `alert_radius_type="county"` (default) path uses stored `county_zone_id` when present.
+  - `alert_radius_type="zone"` path uses stored `forecast_zone_id` when present.
+  - Either path falls back to the existing `/points`-derived resolution when the stored value is null.
+- R7. The [Forecast Products Dialog (AFD + HWO + SPS)](2026-04-20-nws-text-products-registry-requirements.md) bundled in PR 1 uses stored `cwa_office` for all three product lookups. Future features (Marine & Water Context #7, fire-weather products, etc.) can rely on the corresponding stored fields being populated for any US saved location that has been refreshed at least once.
+
+**User visibility**
+- R8. The Edit Location dialog ([ui/dialogs/location_dialog.py:81-125](src/accessiweather/ui/dialogs/location_dialog.py)) gains a read-only informational section displaying the stored `forecast_zone_id` and `cwa_office` with label-prefixed format using `wx.StaticText`:
+  - `Forecast Zone: NCZ027`
+  - `NWS Office: RAH`
+  - (Other captured fields — county, fire zone, radar station, timezone — are NOT surfaced in this release; they're plumbing for downstream features.)
+  - Pattern matches the existing name-label at line 97. No refresh button; no editability. The dialog's fixed `size=(420, 200)` at line 89 must be resized or switched to a Fit-based sizer to accommodate the added rows.
+- R9. Null-state display:
+  - **Non-US location** (R2 path): the two zone rows are hidden entirely — showing them with a "Not applicable" message would be noise in the common international case.
+  - **US location, zone fields null** (R3 failed or pre-feature save not yet refreshed): displays "Forecast Zone: Not yet resolved — will populate after next weather refresh" / "NWS Office: Not yet resolved — ...".
+  - **US location, one of two fields populated** (rare partial response): display the populated value; display the other field with the US-null message above.
+
+## Success Criteria
+
+- A saved US location that has been refreshed at least once has non-null `forecast_zone_id`, `cwa_office`, `county_zone_id`, `fire_zone_id`, `radar_station`, `timezone` in the persisted JSON config (excepting genuine NWS coverage gaps).
+- Alert fetch under the default `alert_radius_type="county"` no longer re-resolves the county zone from lat/lon for locations with stored values.
+- The NWS Text Products Registry consumes `cwa_office` directly at fetch time; its planning doc needs no zone-resolution scope.
+- Edit Location dialog announces the cached forecast zone and CWA office via screen reader as label-prefixed values.
+- A boundary change (simulated by editing stored values in config and re-opening) is silently corrected on the next weather refresh — user sees the updated values in Edit Location without any manual action.
+- No new user-facing failure modes introduced: save works on flaky networks, save works for non-US locations, save works for coordinates with genuine NWS coverage gaps.
+
+## Scope Boundaries
+
+- **Marine Mode auto-activation is NOT included.** The Marine Mode checkbox in Edit Location remains a manual user toggle. Marine zone ID isn't among the captured fields in this release — that's deferred to the Marine & Water Context Module (ideation #7), which will extend capture when it lands. (Rationale: marine zone requires a separate NWS call today; adding it would expand scope beyond the `/points`-already-fetched pass.)
+- **Single-hash alert bug is NOT addressed here.** Per [docs/alert_audit_report.md](docs/alert_audit_report.md) that bug is about severity-history tracking (deque), not zone-based keying. Coordinate separately.
+- **Boundary polygon storage and travel-mode "you crossed into a different zone" detection are NOT in scope.**
+- **No manual "Refresh zone data" button.** Opportunistic validation on refresh handles drift.
+- **No config schema version bump.** Defensive `.get()` with null defaults matches the existing pattern in `AppConfig.to_dict` / `AppSettings.from_dict`.
+- **Fields beyond forecast zone + CWA office are NOT surfaced in the UI in this release.** They're captured but hidden until a downstream feature uses them. Surfacing can be added incrementally.
+
+## Key Decisions
+
+- **Bundle with Forecast Products Dialog (AFD + HWO + SPS) as PR 1** — Phase 0 alone has limited user-visible value (alert-path zone reuse reduces API load, but is invisible). The full Forecast Products dialog is the first real consumer and makes drift correction end-to-end testable. One shipping moment.
+- **Broaden capture to all six `/points`-returned fields** — marginal cost is near zero since `/points` is already fetched and the fields are already parsed. Amortizes across current (AFD + HWO + SPS) and future (Marine Context, fire-weather products) consumers.
+- **Save without zones, retry lazily** — never block the user on `/points` availability. Self-healing and network-tolerant.
+- **Opportunistic validation over TTL or startup scan** — reuse the `/points` call already happening every refresh. Zero extra API cost; drift corrects when the user next refreshes that location.
+- **Label-prefixed raw IDs in UI** — "Forecast Zone: NCZ027" gives screen-reader users honest, copy-pasteable support context without the scope of fetching human-readable zone names.
+- **Expose only forecast zone + CWA office in UI for this release** — remaining fields are plumbing; surfacing them would add dialog rows with no current user value.
+- **Extend existing `Location` dataclass rather than introduce a side cache** — zones are per-location metadata, not cache. Single source of truth.
+
+## Dependencies / Assumptions
+
+- Assumes the NWS `/points` response field names (`forecastZone`, `cwa`, `county`, `fireWeatherZone`, `radarStation`, `timeZone`) remain stable. All six are already exposed by the generated API client at [weather_gov_api_client/models/point.py](src/accessiweather/weather_gov_api_client/models/point.py).
+- Assumes `Location` dataclass in [models/weather.py:124-141](src/accessiweather/models/weather.py) can gain six optional fields without breaking the existing config round-trip (consistent with how `country_code` and `marine_mode` were added — defensive `.get()` with null defaults in `AppConfig.to_dict` / `from_dict`).
+- The Text Products Registry brainstorm/plan is a direct sibling of this work and will share the same PR.
+
+## Outstanding Questions
+
+### Deferred to Planning
+- [Affects R1/R4][Technical] `api/nws/point_location.py:86-141` currently strips `cwa` and `forecastZone` from the transformed point response — only `county`, `fireWeatherZone`, `timeZone`, `radarStation` pass through. The transform must be extended to include all six zone fields, OR the new enrichment path must read from the raw point response directly. Planning picks the cleaner integration.
+- [Affects R6][Technical] Exact integration point — whether to short-circuit in `weather_client_nws.py` at the alert-fetch callers (lines 873-941) or push the stored-value preference into `point_location.py`. The county-path (873-890) and zone-path (915-941) have different shapes; planning resolves.
+- [Affects R4][Technical] Whether the opportunistic persist-on-drift should fire synchronously during the weather refresh or be queued. `LocationOperations.update_location_marine_mode` at [config/locations.py:59-70](src/accessiweather/config/locations.py) is the closest template (synchronous `save_config()`). Also: thread-safety of `save_config` from the refresh thread needs verification.
+- [Affects R8][Technical] `EditLocationDialog` fixed `size=(420, 200)` at [ui/dialogs/location_dialog.py:89](src/accessiweather/ui/dialogs/location_dialog.py) will clip content with two added rows. Resize or switch to Fit-based sizer.
+- [Affects R8][Design] Announcement order of the two fields, tab-order position relative to the marine-mode checkbox, and whether to group under a `wx.StaticBox` with a section heading like "NWS Zone Information". Small UX decisions resolvable during planning.
+- [Affects R8][Design] Whether an already-open Edit Location dialog should reflect drift-corrected values live or read only from the snapshot taken at dialog open. Minor edge case; default to snapshot-at-open unless planning surfaces a user-visible problem.
+
+## Next Steps
+-> `/ce:plan` for the combined **PR 1**: Phase 0 Zone Metadata Enrichment + Forecast Products Dialog (AFD + HWO + SPS). The plan treats Phase 0 as the data layer and the Forecast Products dialog as the first user-visible consumer.

--- a/docs/ideation/2026-04-20-api-endpoints-ideation.md
+++ b/docs/ideation/2026-04-20-api-endpoints-ideation.md
@@ -1,0 +1,109 @@
+---
+date: 2026-04-20
+topic: api-endpoints
+focus: underutilized endpoints across NWS, Open-Meteo, Pirate Weather, Visual Crossing
+---
+
+# Ideation: Underutilized Weather API Endpoints
+
+## Codebase Context
+
+AccessiWeather is a wxPython, text-first accessible weather app. Sources integrated: NWS, Open-Meteo, Pirate Weather (in-flight), Visual Crossing, AVWX. Text-over-graphics rule; graceful degradation when a source lacks a category; 5-min TTL cache keyed by location+conditions. Flagship in-flight feature: 90-minute mobility briefing using Pirate Weather minutely.
+
+**Currently utilized endpoints:**
+- NWS: `/points`, `/gridpoints` forecast + hourly, `/stations/observations`, `/alerts/active` (point + zone + state)
+- Open-Meteo: `/forecast` (current/daily/hourly), `/geocoding`, `/archive` (only for history dialog)
+- Pirate Weather: `/forecast` (current + daily + hourly unified); `minutely` block parsed but UI ignores; `flags` metadata ignored
+- Visual Crossing: `/timeline`, air quality parsed but not displayed, `/history` method exists but UI gap
+- AVWX: METAR/TAF
+
+**Underutilized/unused endpoints:**
+Pirate Weather `minutely`, Pirate Weather `flags`, VC AQI (parsed, no UI), VC `/history`, VC `/timelineBatch`, VC events API, VC stations API, Open-Meteo Archive (minimal use), Open-Meteo Marine, Open-Meteo Air Quality, Open-Meteo Pollen, Open-Meteo Ensemble, Open-Meteo Flood, Open-Meteo Solar Radiation / Evapotranspiration, NWS AFD / HWO / SPS text products, NWS marine text forecasts (CWF/NSH/OFF), NWS `/zones`, NWS `/products` catalog, NHC off-season products.
+
+**Established constraints (from past learnings):**
+- Text-over-graphics rule: no standalone radar/charts
+- Graceful degradation: skip category when source lacks data
+- Alert prerequisite work required before adding new alert types (single-hash state bug, hour-boundary rate-limit burst per `docs/alert_audit_report.md`)
+- Pirate Weather fallback order: PW → Open-Meteo → VC
+- Non-goals: model-comparison UI, raw diagnostic view, always-on hazard panels
+
+## Ranked Ideas
+
+### 1. NWS Text Products Registry (AFD + HWO + SPS)
+**Description:** One fetcher+parser framework over NWS `/products` normalizing Area Forecast Discussion, Hazardous Weather Outlook, and Special Weather Statements into a common `TextProduct` dataclass. Surfaces forecaster narrative inline (auto-summary of AFD "KEY MESSAGES"/"SHORT TERM"), 7-day HWO horizon, and SPS quiet channel for non-warning advisories.
+**Rationale:** Text-native products are accessibility gold — the nationwide forecast integration proved the pattern. Three high-value products, one pipeline. Each future product type becomes ~20 lines.
+**Downsides:** Requires CWA office resolution per location (cheap with zone enrichment). Product text is jargon-heavy without an AI summary pass.
+**Confidence:** 85%
+**Complexity:** Medium
+**Status:** Explored (brainstorm 2026-04-20 → `docs/brainstorms/2026-04-20-nws-text-products-registry-requirements.md`; bundles with #6 as PR 1)
+
+### 2. Pirate Weather Minutely Nowcast
+**Description:** Wire the already-parsed `minutely` block into a `PrecipNowcast` service powering (a) a passive text banner ("Light rain starting in 12 min, lasting ~20 min") and (b) opt-in threshold notification. Distinct from the in-flight 90-min mobility briefing — the low-effort always-on equivalent.
+**Rationale:** Data parsed and thrown away today. Text equivalent to the radar loop we refuse to draw. Zero new API cost.
+**Downsides:** Pirate Weather API key required; graceful degradation when absent.
+**Confidence:** 90%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 3. Climatology Baseline — "Is This Normal?" Layer
+**Description:** A `ClimatologyBaseline` service wrapping Open-Meteo Archive that, for any (location, date, metric), returns percentile, 30-year normal, record high/low, and sigma anomaly. Unlocks: inline "unusual for this date" tags on current conditions and forecast days, real data in the history dialog, seasonal context enrichment for AI explanations, "first freeze of the season" pattern alerts.
+**Rationale:** Archive currently used only for one-off history comparison — wire once, unlock five features. Answers the question sighted users absorb passively ("is 92°F hot for April?") that blind users must currently leave the app to ask.
+**Downsides:** History feature doc explicitly flagged caching as future work — baseline aggregation needs its own cache strategy (30-day TTL, keyed by location+date).
+**Confidence:** 80%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 4. Environmental Exposure Index (AQI + Pollen + UV)
+**Description:** Unified `ExposureProfile` combining Open-Meteo Air Quality + Open-Meteo Pollen + Open-Meteo Solar/UV + Visual Crossing AQI (already parsed, no UI today) into a per-hour composite. Three modes: inline daily briefing line, threshold-only notifications ("tree pollen spiked from low to high"), and a configurable personal sensitivity profile.
+**Rationale:** Three unused endpoints plus a clear user audience — allergy/asthma/COPD users who have high overlap with accessibility needs. Text summary is the right ergonomic for this audience, not a chart.
+**Downsides:** Roadmap already lists AQ/pollen alerting — notification mode requires the alerts prerequisite work (single-hash bug, hour-boundary burst) before shipping.
+**Confidence:** 85%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 5. Ensemble Confidence Layer
+**Description:** Fetch Open-Meteo Ensemble for every forecast view; compute member spread; attach optional confidence suffix to hourly/daily cells ("68°F, high confidence" / "chance 40%, models disagree"). Surface as a single line in AI explanations and mobility briefing — not as a comparison UI.
+**Rationale:** The April 2026 mobility briefing design explicitly scopes a "confidence/disagreement line" as a deferred enhancement. This builds that primitive cleanly. Respects the "no model-comparison UI" non-goal.
+**Downsides:** Ensemble endpoint heavier than standard forecast; add targeted caching. Only Open-Meteo provides ensembles — graceful degradation when other sources primary.
+**Confidence:** 70%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 6. Zone Metadata Enrichment Service
+**Description:** At save-time, call NWS `/zones` once per location and persist: forecast zone ID, county FIPS, fire zone, marine zone, CWA office, timezone. All subsequent product/alert lookups use zone IDs directly.
+**Rationale:** Quiet plumbing with disproportionate downstream dividend: zone-scoped alert keying (helps fix the single-hash alert bug), correct office routing for #1's AFD/HWO/SPS fetches, auto-activation of marine mode from water zones, county-boundary awareness. Prerequisite or co-requisite for #1 and #7.
+**Downsides:** Low user-visibility on its own — value realized only through dependent features. Must handle US-only gracefully (skip for international Open-Meteo locations).
+**Confidence:** 80%
+**Complexity:** Low
+**Status:** Explored (brainstorm 2026-04-20)
+
+### 7. Marine & Water Context Module
+**Description:** Unified `WaterContext` combining Open-Meteo Marine (wave height, period, swell direction, sea surface temp), NWS marine text forecasts (CWF/NSH/OFF), Open-Meteo Flood (`river_discharge` vs. climatology), and year-round NHC products. Auto-activates when zone enrichment detects coastal or near-river location; manual opt-in otherwise.
+**Rationale:** Open-Meteo Marine has no wrapper at all. NWS marine text forecasts are text-native. Four unused endpoints into one gated module with graceful hiding when irrelevant.
+**Downsides:** Discoverability — inland non-flood users should never see this. Depends on zone enrichment (#6) for clean auto-activation.
+**Confidence:** 70%
+**Complexity:** Medium-High
+**Status:** Unexplored
+
+## Rejection Summary
+
+| # | Idea | Reason Rejected |
+|---|------|-----------------|
+| 1 | "What Changed Since Last Check" delta briefing | Presentation layer on cached data — not an endpoint-leverage play |
+| 2 | "Dictate a Location" freeform lookup | UX reshape; uses already-integrated endpoint |
+| 3 | Auto-retire stale locations | Not endpoint-related; trivial local housekeeping |
+| 4 | Unified WeatherStation abstraction | Abstraction-first; no concrete user win; tech debt, not a feature |
+| 5 | Source Provenance pipeline (PW `flags`) | Invisible plumbing — user asked for user-facing value |
+| 6 | Event-Based Historical Recall (VC events API) | Misgrounded — VC events API targets real-estate monitoring, not weather history |
+| 7 | Global Travel Briefing Mode | Large scope; positioning reframe more than endpoint play |
+| 8 | "Best Window" Task Planner (solar+ET) | Bold but speculative user value; better as brainstorm after a building block lands |
+| 9 | "Safe to run an errand?" confidence query | Duplicates survivor #5 (Ensemble Confidence Layer) |
+| 10 | Solar-Commute "sun in your eyes" line | Clever but niche; merge into #4 later |
+| 11 | Proactive Pattern Alerts | Depends on alerts prerequisite work + climatology baseline (#3) |
+| 12 | Batch Pre-Fetch Orchestrator | Infrastructure; not a feature v1 survivors depend on |
+| — | Merged duplicates | AFD digest/auto-summary, HWO horizon, SPS channel → #1; minute-zero banner, proactive precip ping, next-60-minutes → #2; same-day-last-year, "unusual for this date" → #3; allergen briefing, auto-detected allergy days, AQI-when-bad, breathing index → #4; forecaster confidence briefing → #5; marine zone briefing, marine-mode auto-activation, silent flood-watch → #7 |
+
+## Session Log
+- 2026-04-20: Initial ideation — 41 generated across 4 frames (user pain, inversion/automation, reframing, leverage/compounding), 7 survived.
+- 2026-04-20: Brainstormed #6 (Zone Metadata Enrichment) → `docs/brainstorms/2026-04-20-zone-metadata-enrichment-requirements.md`.
+- 2026-04-20: Brainstormed #1 (NWS Text Products Registry) → `docs/brainstorms/2026-04-20-nws-text-products-registry-requirements.md`. Bundled with #6 as PR 1. Mid-brainstorm discovery via live NWS API probe: SPS products fall into two populations (Case A issued as alerts, Case B informational-only); Case B is the unmet need and belongs in the dialog's SPS tab. An interim split (separate SPS alert-details doc) was briefly written and discarded after verification showed the alert `description` already covers Case A content.

--- a/docs/plans/2026-04-20-forecast-products-pr1-plan.md
+++ b/docs/plans/2026-04-20-forecast-products-pr1-plan.md
@@ -1,0 +1,749 @@
+---
+title: "PR 1: Zone Metadata Enrichment + Forecast Products Dialog (AFD + HWO + SPS)"
+type: feat
+status: active
+date: 2026-04-20
+origin:
+  - docs/brainstorms/2026-04-20-zone-metadata-enrichment-requirements.md
+  - docs/brainstorms/2026-04-20-nws-text-products-registry-requirements.md
+ideation: docs/ideation/2026-04-20-api-endpoints-ideation.md
+---
+
+# PR 1: Zone Metadata Enrichment + Forecast Products Dialog (AFD + HWO + SPS)
+
+## Overview
+
+PR 1 is one bundled shipping moment delivering two tightly-coupled changes:
+
+- **Phase A — Zone Metadata Enrichment** (data layer): saved `Location` records gain six NWS zone fields captured at save-time from `/points`, lazily drift-corrected on each weather refresh, and reused by the alert-fetch path. Fields: `forecast_zone_id`, `cwa_office`, `county_zone_id`, `fire_zone_id`, `radar_station`, `timezone`. Edit Location exposes two of them read-only; the rest are plumbing.
+- **Phase B — Forecast Products Dialog** (first visible consumer): the existing per-location "Discussion" button becomes "Forecast Products", opening a three-tabbed dialog with AFD, HWO, and SPS. Background fetch across all saved US locations pre-warms the dialog and drives two new notification streams (HWO updates, informational SPS) with alert-dedupe against the existing alert pipeline.
+
+Phase A on its own is invisible; Phase B is the feature. Bundling makes drift correction testable end-to-end and gives us one release cycle, one user-visible changelog entry.
+
+## Problem Frame
+
+Screen-reader-first users get forecaster reasoning today only via the single-product Discussion dialog (AFD). Two equally text-friendly per-WFO products are completely missing:
+
+- **HWO**: structured 7-day hazard horizon, updated roughly daily.
+- **SPS**: ad-hoc advisories. Live-API verification confirmed two populations — event-style SPS (hail, dense fog) already appear on `/alerts/active` and users see them today; **informational SPS** (fire-weather, pollen, coordination statements) appear on `/products/types/SPS` but never on `/alerts/active` and are invisible to AccessiWeather users. Verified example: WFO PHI issued a 2000-char fire-weather SPS on 2026-04-16 that never reached the alerts feed.
+
+Separately, NWS zone identifiers (`cwa`, `forecastZone`, etc.) are resolved from lat/lon on every refresh and immediately discarded — `_transform_point_data` at `src/accessiweather/api/nws/point_location.py:86-141` explicitly strips `cwa` and `forecastZone`. Any per-location feature that needs the CWA office (like Forecast Products) has to re-derive it by parsing URLs out of grid data. Persisting zone metadata on the `Location` record removes this friction and unlocks both PR 1 and downstream features (Marine Context, fire-weather products, climatology).
+
+## Requirements Trace
+
+Phase A (Zone Enrichment):
+- **A-R1.** On save of a new US location, fetch `/points` once and persist six `Optional[str]` zone fields on the `Location` record.
+- **A-R2.** Non-US locations never attempt NWS zone resolution; fields stay null.
+- **A-R3.** `/points` failure at save-time never blocks the save; fields stay null, debug-logged.
+- **A-R4.** Each successful refresh-time `/points` response drift-corrects stored fields: null → populate; differing non-null → overwrite; missing/null fresh value → no update. Persisted via main-thread bounce.
+- **A-R5.** Locations saved before this feature populate opportunistically via A-R4; no migration step.
+- **A-R6.** Alert fetch uses stored `county_zone_id` / `forecast_zone_id` when present; falls back to fresh resolution when null.
+- **A-R7.** Forecast Products Dialog consumes stored `cwa_office` (no extra resolution).
+- **A-R8.** Edit Location dialog gains a read-only "NWS Zone Information" section showing `forecast_zone_id` and `cwa_office`.
+- **A-R9.** Null/non-US states in Edit Location render without noise per spec.
+
+Phase B (Forecast Products):
+- **B-R1.** Fetch, parse, and cache AFD / HWO / SPS per saved US location with populated `cwa_office` via a generalized `get_nws_text_product(product_type, cwa_office)` async fetcher.
+- **B-R2.** Per-product TTLs via the existing `Cache` layer: AFD 3600s, HWO 7200s, SPS 900s. Keys: `nws_text_product:{product_type}:{cwa_office}`.
+- **B-R3.** Background-fetch all three products for every saved US location during the existing refresh cycle; failure isolation per `(product_type, location)`.
+- **B-R4.** Skip fetch for non-US locations and US locations where `cwa_office` is still null (self-heals after next refresh).
+- **B-R5.** Rename per-location "Discussion" → "Forecast Products" (button, menu, `QUICK_ACTION_LABELS`). Nationwide branch unchanged.
+- **B-R6.** Dialog is a `wx.Notebook` hosting three `ForecastProductPanel` instances. Per-tab: raw-product `wx.TextCtrl`, AI "Plain Language Summary" button (hidden-until-clicked per existing design), issuance-time `wx.StaticText`, SPS `wx.Choice` for multi-product selection.
+- **B-R7.** Empty-state and error-state copy rendered in content panels (tabs always visible; `wx.Notebook` lacks per-tab disable on Windows).
+- **B-R8.** Non-US locations: main-window "Forecast Products" button `Disable()`d with adjacent `wx.StaticText` "NWS products are US-only".
+- **B-R9.** Existing AFD notification (content, logic, cold-start baseline) unchanged.
+- **B-R10.** Two new notification streams: `notify_hwo_update` (default ON), `notify_sps_issued` (default ON). SPS dedupes against `/alerts/active` by zone intersection.
+- **B-R11.** Notification content: SPS uses `headline` with `productText` fallback; HWO attempts `summarize_discussion_change` and falls back to generic copy.
+
+## Scope Boundaries
+
+- Raw-blob reading only — no semantic heading navigation for AFD; wxPython doesn't expose `StaticText` as HTML-`<h2>`-equivalent to screen readers.
+- No NWS products beyond AFD / HWO / SPS (marine CWF/NSH/OFF, aviation, climate → future features).
+- No changes to Nationwide discussion view; the `"Nationwide"` branch of `_on_discussion` is untouched.
+- No AI features beyond reusing existing tl;dr per-tab.
+- Zone metadata beyond `cwa_office` (county, fire, radar, timezone) is captured but not surfaced in UI this release.
+- No "View full statement" deep-link from alert details (SPS alert `description` already carries the content).
+- No marine-mode auto-activation (deferred to Marine & Water Context Module).
+- Single-hash alert state bug (`docs/alert_audit_report.md` §3) and hour-boundary rate-limit burst (§7) are NOT fixed here; coordinated separately. PR 1 follows the §7 guidance by using a sliding-window rate limit for new product streams, not a calendar-hour counter.
+- No config `schema_version` bump; defensive `.get()` with defaults matches the existing `country_code` / `marine_mode` precedent.
+- No manual "Refresh zone data" button.
+
+### Deferred to Separate Tasks
+
+- `ConfigManager.save_config` in-process locking (research flagged it has no lock; PR 1 mitigates via `wx.CallAfter` main-thread bounce): track as follow-up issue.
+- Marine zone ID capture: deferred until the Marine & Water Context Module lands; it requires an additional NWS call outside the `/points`-already-fetched pass.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Location model**: `src/accessiweather/models/weather.py:124-141`. Field-addition precedent: `country_code`, `marine_mode`.
+- **Config round-trip**: `src/accessiweather/models/config.py:700-745`. Pattern: conditional spread on serialize, defensive `.get()` on deserialize.
+- **LocationOperations template**: `src/accessiweather/config/locations.py:59-70` (`update_location_marine_mode` is the lazy-update analogue).
+- **Point transform pinch-point**: `src/accessiweather/api/nws/point_location.py:86-141`. `_transform_point_data` strips `cwa`, `forecastZone`, `gridId` — must be extended, or a sibling method added.
+- **NWS async fetcher**: `src/accessiweather/weather_client_nws.py:769-844` (`get_nws_discussion`). Shape to generalize.
+- **Alert callers using `/points`**: `src/accessiweather/weather_client_nws.py:873-941` (county path, zone path).
+- **Cache**: `src/accessiweather/cache.py:46-165`. `Cache.set(key, value, ttl=N)` already supports per-key TTL; no new cache class needed. `WeatherAlert` cache at `:422-455` drops `affectedZones` (bad for SPS dedupe — extend additively).
+- **NationalDiscussionService**: `src/accessiweather/services/national_discussion_service.py:55-85`. Single-TTL, location-agnostic — NOT generalizable for multi-location AFD/HWO/SPS. Untouched.
+- **Timer infrastructure**: `src/accessiweather/app_timer_manager.py:121-158` (two timers — full refresh + lightweight event-check). Product notifications piggyback on the existing notification-event path; no third timer.
+- **Multi-location pre-warm**: `src/accessiweather/ui/main_window.py:1273-1290` (`_pre_warm_other_locations`). Extend to also fetch the three products per US location with populated `cwa_office`.
+- **Active-location fetch**: `src/accessiweather/ui/main_window.py:1108-1186` (`_fetch_weather_data`). Add product fetch + notification check after weather-data success.
+- **Main-window entry point**: `src/accessiweather/ui/main_window.py:674-686` (`_on_discussion`). Non-Nationwide branch becomes `_on_forecast_products`; Nationwide branch unchanged.
+- **Labels registry**: `src/accessiweather/ui/main_window.py:31-40` (`QUICK_ACTION_LABELS`). Single-line rename propagates.
+- **Notifications state & cold-start**: `src/accessiweather/notifications/notification_event_manager.py:182-222` (`NotificationState`), `:404-455` (`_check_discussion_update` cold-start pattern), `:427-435` (first-fetch baseline silent store).
+- **Runtime state**: `src/accessiweather/runtime_state.py:14-37` (`_DEFAULT_RUNTIME_STATE`), `:297-340` (section converters). All three must be updated in parallel or state round-trips silently drop fields.
+- **AI explainer**: `src/accessiweather/ai_explainer.py:746-941` (`explain_afd`). Does NOT cache results today (`explain_weather` does, pattern at `:741`). Refactor introduces caching.
+- **Existing dialog template**: `src/accessiweather/ui/dialogs/discussion_dialog.py`. Shape to adapt — per-tab mirrors its content area; AI visibility follows `docs/superpowers/specs/2026-04-08-discussion-dialog-ai-visibility-design.md` (hidden until Explain clicked; Explain/Regenerate mutually exclusive; error fills the AI box rather than hiding it).
+- **Nationwide notebook precedent**: `docs/nationwide_discussions.md` — nested `wx.Notebook` with per-tab `wx.TextCtrl(style=wx.TE_MULTILINE | wx.TE_READONLY | wx.HSCROLL)`.
+- **Edit Location dialog**: `src/accessiweather/ui/dialogs/location_dialog.py:81-125`. Fixed `size=(420, 200)` at `:89` — must switch to Fit-based or content clips.
+- **Settings notifications tab**: `src/accessiweather/ui/dialogs/settings_tabs/notifications.py:110-125` (existing `notify_discussion_update` section). New toggles mirror that shape; intro copy must be rewritten (two defaults become ON).
+- **US detection**: `src/accessiweather/display/presentation/forecast.py:40-51` (`_is_us_location`).
+- **Test conventions**: `tests/conftest.py:19-100` — wx stub via `_WxStubBase`; no Toga backend despite stale CLAUDE.md text. Flat `tests/test_*.py`; `tests/gui/` for GUI-specific. Pattern mock: `test_dialog_accessibility.py`.
+
+### Institutional Learnings
+
+- **Hour-boundary rate-limit burst** (`docs/alert_audit_report.md` §7): calendar-hour reset causes bursts at the top of the hour. PR 1's per-stream rate limit uses a sliding window (timestamp comparison), not calendar buckets.
+- **Single-hash alert state** (`docs/alert_audit_report.md` §3): don't reduce SPS dedupe to a single-value hash; keep the richer `last_sps_product_ids` collection shape.
+- **AFD cold-start pattern** (`notification_event_manager.py:427-435`): first-fetch stores baseline silently via defensive `.get()`. Reused verbatim for HWO and SPS.
+- **Runtime-state parallel update rule**: every new `notification_events` sub-key must appear in `_DEFAULT_RUNTIME_STATE` **and** both section converters (`_runtime_section_to_legacy_shape`, `_legacy_shape_to_runtime_section`) or round-trips silently drop data.
+- **Location additive-field precedent**: `country_code`, `marine_mode` were added without `schema_version` bumps; PR 1 follows identically for six new Optional[str] fields.
+- **Accessibility pattern**: adjacent `wx.StaticText` is what screen readers announce. `SetName()` is ignored. Use descriptive widget-level `label=` strings plus adjacent StaticText for context.
+
+### External References
+
+Not used. Repo patterns are thick; brainstorms were already grounded in live-API probes (PHI fire-weather SPS). External research would add no practical value.
+
+## Key Technical Decisions
+
+- **Bundle Phase A + Phase B as PR 1** — Phase A alone has no visible value; bundling gives drift correction an end-to-end testable consumer and one release cycle.
+- **Extend `_transform_point_data` to expose all six zone fields** (not a parallel raw-response path) — single source of truth; cleaner integration; reuses existing URL-extraction helpers at `point_location.py:145-205`.
+- **Alert-path integration at the call-site** (`weather_client_nws.py:873-941`), not inside `point_location.py` — county and zone paths are different shapes; call-site branching is clearer than wrapping the helper.
+- **Drift persistence via `wx.CallAfter` bounce to main thread** — `ConfigManager.save_config` has no in-process lock (research finding); the main-thread bounce is the simplest correct fix for PR 1. A proper `threading.Lock` on `ConfigManager` is deferred to a separate task.
+- **Edit Location dialog: switch to Fit-based sizer with `SetMinSize((420, -1))`** — fixed `size=(420, 200)` clips with added rows. Fit-based protects future row additions.
+- **Zone info grouped in `wx.StaticBox` "NWS Zone Information"**, placed after marine-mode checkbox, before OK/Cancel. Non-focusable StaticText rows, skipped by Tab.
+- **Edit-Location drift reflection: snapshot-at-open** — live mutation of an open dialog risks focus/accessibility regressions for no observable win.
+- **Generalize to `get_nws_text_product(product_type, cwa_office)`** in `weather_client_nws.py`; keep `get_nws_discussion` as a thin wrapper for call-site backward compat — the three endpoints share shape, parallel methods would triplicate code.
+- **Reuse existing `Cache` with per-key TTL** (keys `nws_text_product:{product_type}:{cwa_office}`) — no new cache class; `Cache.set(..., ttl=N)` already supports this.
+- **Background fetch: extend `_pre_warm_other_locations` for non-active locations and add a product-fetch step to `_fetch_weather_data` for the active location** — piggybacks on the existing multi-location iteration; `app_timer_manager.py` stays product-agnostic.
+- **AI explainer: add `explain_text_product(product_text, product_type, location_name, ...)` with a prompt lookup table**; make `explain_afd` a thin wrapper. Add per-product result caching keyed `(product_type, location_name, text_hash, style)` with 5-minute TTL — matches the `explain_weather` cache. Fixes the incidental `explain_afd` no-cache regression.
+- **`ForecastProductPanel` is a reusable `wx.Panel`** taking `(product_type, fetch_callable, notification_state_reader)`; `ForecastProductsDialog` hosts three instances in `wx.Notebook`.
+- **SPS multi-product `wx.Choice`** above the TextCtrl; hidden via `Sizer.Show(False) + Layout()` when only one SPS is active.
+- **Tab-switch focus: `EVT_NOTEBOOK_PAGE_CHANGED` handler + `wx.CallAfter(panel.product_textctrl.SetFocus)`**. Dialog open: `wx.CallAfter` on AFD tab's TextCtrl after `Show()`.
+- **SPS dedupe**: at SPS fetch time, read currently-cached NWS alerts for the location, filter `event == "Special Weather Statement"`, compare zone intersections. To enable this, `WeatherAlert` serializer at `cache.py:422-455` gains an additive `affected_zones: list[str]` field (backward-compatible, populated from `alert_geocode.py`). Fallback if intersection data missing: substring match on `headline`. Performance: O(products × alerts × zones), realistically < 5 × 10 × 20 — trivial per fetch.
+- **Per-stream rate limit: 30 minutes per `(product_type, location)`** using sliding-window timestamp compare (NOT calendar-hour; avoids the §7 burst pattern). Implemented as `last_notified_at: dict[(product_type, location_id), datetime]` on `NotificationEventManager` — ephemeral, not persisted to runtime state.
+- **HWO empty vs error states**: 200 + empty `@graph` → "Hazardous Weather Outlook not currently available for {cwa_office}."; exception/non-200 → "Failed to fetch — try again." with retry button.
+- **HWO diffing**: attempt `summarize_discussion_change` first; fall back to generic "Hazardous Weather Outlook updated for {cwa_office} — tap to view." when the summary is empty or below a length heuristic.
+- **SPS silent expiration**: when a previously-seen SPS product ID disappears from `@graph`, remove it from `NotificationState.last_sps_product_ids` with no notification. Matches the existing discussion-cleared pattern.
+- **No `schema_version` bump anywhere** — every new field (6 Location, ~4 NotificationState, 2 runtime-state sub-sections, `WeatherAlert.affected_zones`) uses defensive `.get()` with null/default.
+
+## Open Questions
+
+### Resolved During Planning
+
+All planning-deferred questions from both brainstorms are resolved above under **Key Technical Decisions**.
+
+### Deferred to Implementation
+
+- Exact `length-heuristic` threshold for HWO summarizer fallback — tune during implementation by running `summarize_discussion_change` against a couple of live HWO products.
+- Exact intro-text wording for the Settings notifications section — writer's call during implementation; constraint: must accurately reflect "HWO + SPS default ON; others default OFF".
+- `ForecastProductPanel` minimum size tuning — pick once the three panels are visible together in the Notebook on Windows; may need `SetMinSize` adjustments.
+- Exact copy of the "Plain Language Summary" prompts for HWO and SPS — iterate against a handful of live products to get meteorology-jargon translation quality right.
+- Whether to extend `_is_us_location` bboxes to include Puerto Rico / territories — if NWS `/points` returns valid data there, the enrichment path can stay as-is; confirm at implementation.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```text
+                                   ┌────────────────────────────────────┐
+                                   │  Saved Location (JSON config)      │
+                                   │  + forecast_zone_id, cwa_office,   │
+                                   │    county_zone_id, fire_zone_id,   │
+                                   │    radar_station, timezone         │
+                                   └────────────┬───────────────────────┘
+                                                │  (read on every fetch)
+         ┌──────────────────────────────────────┼──────────────────────────────────────┐
+         │                                      │                                      │
+         ▼                                      ▼                                      ▼
+  Alert fetch (reuses               Forecast Products background fetch         Edit Location dialog
+  county/forecast zone IDs,         (active loc + pre-warm others)             (shows forecast_zone_id,
+   skips redundant /points)                     │                               cwa_office read-only)
+                                                ▼
+                             get_nws_text_product(product_type, cwa_office)
+                             ┌─────────────┬─────────────┬─────────────┐
+                             │   AFD       │   HWO       │   SPS       │
+                             │  TTL 3600s  │  TTL 7200s  │  TTL 900s   │
+                             └─────┬───────┴──────┬──────┴──────┬──────┘
+                                   │              │             │
+                 ┌─────────────────┼──────────────┼─────────────┤
+                 │                 │              │             │
+                 ▼                 ▼              ▼             ▼
+   ForecastProductsDialog    AFD notify     HWO notify     SPS notify
+     (wx.Notebook:           (unchanged)    (diff +         (new ID +
+      AFD | HWO | SPS)                       rate limit     alert-dedupe +
+         │                                   30 min)         rate limit 30 min)
+         ▼
+   ForecastProductPanel × 3
+     - raw TextCtrl (readonly, multi-line)
+     - wx.Choice (SPS multi-product only)
+     - "Issued:" StaticText
+     - "Plain Language Summary" (hidden AI)
+```
+
+Key seams:
+- Zone enrichment writes on save; drift-corrects on refresh; reads everywhere.
+- `get_nws_text_product` is the one async fetcher; `get_nws_discussion` becomes a thin wrapper.
+- Notification dedupe lives at SPS fetch time, not at alert arrival.
+
+## Implementation Units
+
+- [ ] **Unit 1: Location model + config round-trip + point-transform exposure**
+
+  **Goal:** Data surface for zone metadata — model fields, JSON round-trip, and getting the six fields out of `/points` in the first place.
+
+  **Requirements:** A-R1, A-R2, A-R3 (data-shape pieces).
+
+  **Dependencies:** None.
+
+  **Files:**
+  - Modify: `src/accessiweather/models/weather.py` (add six `Optional[str]` zone fields to `Location`)
+  - Modify: `src/accessiweather/models/config.py` (`AppConfig.to_dict`/`from_dict` round-trip — conditional spread on serialize, defensive `.get()` on deserialize, matching `country_code` precedent)
+  - Modify: `src/accessiweather/api/nws/point_location.py` (extend `_transform_point_data` ~86-141 to include `cwa`, `forecastZone`, `gridId` alongside existing `county`, `fireWeatherZone`, `timeZone`, `radarStation`)
+  - Test: `tests/test_models_config_location_zones.py` (new)
+
+  **Approach:**
+  - Field naming mirrors existing snake_case: `forecast_zone_id`, `cwa_office`, `county_zone_id`, `fire_zone_id`, `radar_station`, `timezone`. All default `None`.
+  - Serializer omits a field when its value is null (conditional-spread pattern at `config.py:700-745`).
+  - `_transform_point_data` change is additive — existing keys continue; new keys appear.
+
+  **Patterns to follow:**
+  - `country_code`, `marine_mode` additions to `Location` (locate via git blame on `weather.py`).
+  - Conditional-spread serialize + `.get()` deserialize at `models/config.py:700-745`.
+
+  **Test scenarios:**
+  - Happy path: `Location` with all six fields populated round-trips through JSON identically.
+  - Happy path: `Location` with all six fields null round-trips without producing null keys in the JSON.
+  - Happy path: legacy JSON without the six fields deserializes, yields all-null zone fields on the `Location`.
+  - Happy path: `_transform_point_data` returns `cwa`, `forecastZone`, `gridId` alongside existing fields given a realistic point-endpoint response fixture.
+  - Edge case: partial population (only `cwa_office` populated) round-trips without emitting null keys for the rest.
+
+  **Verification:**
+  - `Location` can carry zone metadata through save/load.
+  - `_transform_point_data` no longer strips the fields PR 1 needs.
+  - No existing tests regress.
+
+- [ ] **Unit 2: Zone enrichment on save**
+
+  **Goal:** First-time population of zone fields when a user adds a US location.
+
+  **Requirements:** A-R1, A-R2, A-R3.
+
+  **Dependencies:** Unit 1.
+
+  **Files:**
+  - Modify: `src/accessiweather/config/locations.py` (extend `add_location` path to trigger enrichment for US locations)
+  - Create: `src/accessiweather/services/zone_enrichment_service.py` (new; orchestrates `/points` fetch + mapping to Location fields)
+  - Test: `tests/test_zone_enrichment_service.py` (new)
+
+  **Approach:**
+  - `ZoneEnrichmentService.enrich_location(location) -> Location` returns a new `Location` with fields populated (or unchanged on failure/non-US).
+  - Call the existing point-location helper rather than raw HTTP — reuses transform + caching.
+  - Non-US bypass via `_is_us_location(location)` at `src/accessiweather/display/presentation/forecast.py:40-51`.
+  - On network exception or non-200: return `location` unchanged, debug-log.
+  - `LocationOperations.add_location` calls the service before persisting; if enrichment returned populated fields they're saved; otherwise the location saves with zone fields null.
+
+  **Patterns to follow:**
+  - `LocationOperations.update_location_marine_mode` at `src/accessiweather/config/locations.py:59-70` — mutate-then-persist.
+  - `src/accessiweather/services/national_discussion_service.py` for service-module shape.
+
+  **Test scenarios:**
+  - Happy path: adding a US location with a working `/points` call persists all six fields.
+  - Happy path: adding a non-US location never calls `/points`; zone fields stay null.
+  - Error path: `/points` raises `httpx.HTTPError` → location still saves; fields null; debug log emitted.
+  - Error path: `/points` returns non-200 → location still saves; fields null.
+  - Edge case: `/points` returns 200 with some zone fields missing from payload → populated fields saved; absent fields stay null.
+  - Edge case: save flow never prompts the user or blocks on `/points` (assert no modal dialog spawned during failure).
+
+  **Verification:**
+  - Adding any US location yields a `Location` record with six zone fields populated (when `/points` succeeds).
+  - Adding a non-US location or saving during a `/points` outage still succeeds.
+
+- [ ] **Unit 3: Opportunistic drift correction on refresh**
+
+  **Goal:** Lazy backfill + boundary-change self-healing during the regular weather refresh.
+
+  **Requirements:** A-R4, A-R5.
+
+  **Dependencies:** Unit 1.
+
+  **Files:**
+  - Modify: `src/accessiweather/weather_client_nws.py` (after each successful `/points` response in the refresh path, invoke drift-correction hook)
+  - Modify: `src/accessiweather/config/locations.py` (new `LocationOperations.update_zone_metadata(location_id, fields_dict)`)
+  - Modify: `src/accessiweather/services/zone_enrichment_service.py` (from Unit 2: add `diff_and_update(location, fresh_point_data) -> dict[str, str] | None`)
+  - Test: `tests/test_zone_enrichment_drift.py` (new)
+
+  **Approach:**
+  - Diff rule: for each of the six fields, if stored is null and fresh is non-null → populate. If both non-null and they differ → overwrite. If fresh is null/missing → no update (never overwrite populated with null).
+  - If `/points` call itself raises, skip drift this cycle; retry on next refresh (A-R4 explicit).
+  - Persistence: call `LocationOperations.update_zone_metadata(...)` via `wx.CallAfter` from the refresh thread. This avoids racing with user-initiated `save_config` calls on the main thread. `ConfigManager.save_config` has no in-process lock (research finding) — `wx.CallAfter` is the smallest correct fix.
+
+  **Execution note:** Write tests for the diff rule first; getting "never overwrite populated with null" wrong is the subtle bug this unit exists to prevent.
+
+  **Patterns to follow:**
+  - `update_location_marine_mode` at `src/accessiweather/config/locations.py:59-70` for mutate-then-persist.
+  - `wx.CallAfter` usage in `src/accessiweather/notifications/notification_event_manager.py` for thread bounce.
+
+  **Test scenarios:**
+  - Happy path: stored field null + fresh non-null → diff returns that field; update persists it.
+  - Happy path: stored and fresh both non-null and equal → no update, no persist.
+  - Happy path: stored and fresh both non-null and differ → diff returns the changed field; update overwrites.
+  - Edge case: stored non-null + fresh null/missing → diff returns empty; stored value preserved.
+  - Edge case: stored all six null + fresh all six present (legacy location first refresh) → all six populated in one call.
+  - Error path: `/points` raises → drift-correction skipped silently; no crash; retry on next cycle.
+  - Integration: drift write from the refresh thread is funneled via `wx.CallAfter` to the main thread (mock `wx.CallAfter`; assert it's invoked with the persist callable).
+
+  **Verification:**
+  - Simulating a stored `cwa_office = "PHI"` with `/points` returning `cwa = "OKX"` causes stored value to flip to "OKX" on next refresh.
+  - Simulating `/points` omitting `cwa` does NOT null out a populated stored `cwa_office`.
+  - No crashes from concurrent refresh cycles.
+
+- [ ] **Unit 4: Alert-path stored-zone reuse**
+
+  **Goal:** Skip redundant `/points` resolution in the alert-fetch path when stored zones are present.
+
+  **Requirements:** A-R6.
+
+  **Dependencies:** Units 1 and 3 (so stored values are populated in practice).
+
+  **Files:**
+  - Modify: `src/accessiweather/weather_client_nws.py` (county path ~873-890, zone path ~915-941)
+  - Test: `tests/test_weather_client_nws_alerts_zone_reuse.py` (new)
+
+  **Approach:**
+  - `alert_radius_type="county"` path: prefer `location.county_zone_id` when present; else fall back to fresh resolution.
+  - `alert_radius_type="zone"` path: prefer `location.forecast_zone_id` when present; else fall back.
+  - No change to alert response shape; the only diff is whether we made an extra `/points` roundtrip.
+
+  **Patterns to follow:**
+  - Existing caller structure at `weather_client_nws.py:873-941`.
+
+  **Test scenarios:**
+  - Happy path (county): stored `county_zone_id` present → alerts fetched with that zone; no `/points` call.
+  - Happy path (zone): stored `forecast_zone_id` present → alerts fetched with that zone; no `/points` call.
+  - Happy path (fallback): stored fields null → existing `/points` resolution runs.
+  - Error path: stored zone ID present but NWS returns 404 for that zone → surfaces as alert-fetch error; no silent downgrade (consistent with today's behavior on bad zones).
+  - Integration: after first successful refresh, the second refresh's alert fetch makes one fewer HTTP call than the first (verify via mock assertion).
+
+  **Verification:**
+  - Measure API calls per refresh before/after: drops by one per refresh once zones are populated.
+  - Default `alert_radius_type="county"` stops re-resolving from lat/lon on populated locations.
+
+- [ ] **Unit 5: Edit Location dialog — "NWS Zone Information" section + Fit-based sizing**
+
+  **Goal:** User-visible read-only surface for `forecast_zone_id` and `cwa_office`.
+
+  **Requirements:** A-R8, A-R9.
+
+  **Dependencies:** Unit 1.
+
+  **Files:**
+  - Modify: `src/accessiweather/ui/dialogs/location_dialog.py` (~81-125)
+  - Test: `tests/gui/test_location_dialog_zone_info.py` (new)
+
+  **Approach:**
+  - Add a `wx.StaticBox` labeled "NWS Zone Information" below the marine-mode checkbox, above OK/Cancel.
+  - Inside: two `wx.StaticText` rows, label-prefixed: "Forecast Zone: NCZ027", "NWS Office: RAH".
+  - Null/non-US state rules (from A-R9):
+    - Non-US: entire StaticBox `Show(False)` — hidden.
+    - US + both fields null: both rows show "Not yet resolved — will populate after next weather refresh".
+    - US + partial (one field populated): show populated value in that row; null message in the other.
+  - Remove fixed `size=(420, 200)` at `:89`; call `self.Fit()` after sizer population. Add `self.SetMinSize((420, -1))` to preserve baseline width.
+  - Tab order: Name → Marine Mode → OK → Cancel. StaticText rows are skipped by Tab (non-focusable).
+  - Snapshot-at-open: values read from the Location passed to the constructor; no live binding.
+
+  **Patterns to follow:**
+  - Existing `EditLocationDialog` sizer/label style.
+  - wxPython accessibility rule: adjacent `wx.StaticText` announces to screen readers; label prefix IS the accessible label.
+
+  **Test scenarios:**
+  - Happy path (US populated): both zone rows render with "Forecast Zone: NCZ027" and "NWS Office: RAH".
+  - Happy path (non-US): StaticBox not shown — querying `IsShown()` returns False.
+  - Edge case (US null): both rows show the "Not yet resolved" message.
+  - Edge case (US partial): one row shows value; the other shows "Not yet resolved".
+  - Edge case (sizing): dialog fits content without clipping after adding rows (assert `GetSize()` height exceeds original 200).
+  - Accessibility: each StaticText's `GetLabel()` returns the label-prefixed string (the accessible announcement).
+
+  **Verification:**
+  - Dialog opens for US and non-US locations without truncation.
+  - Screen reader reads the forecast zone and CWA office when focus lands near the StaticBox.
+
+- [ ] **Unit 6: Generalized `get_nws_text_product` fetcher + `ForecastProductService`**
+
+  **Goal:** One async fetcher for AFD/HWO/SPS + a service that caches results per `(product_type, cwa_office)` with per-type TTLs.
+
+  **Requirements:** B-R1, B-R2, B-R4.
+
+  **Dependencies:** Unit 1 (needs `cwa_office` persisted).
+
+  **Files:**
+  - Modify: `src/accessiweather/weather_client_nws.py` (add `get_nws_text_product(product_type: Literal["AFD","HWO","SPS"], cwa_office: str) -> TextProduct | list[TextProduct] | None`; refactor `get_nws_discussion` to call it internally for AFD)
+  - Create: `src/accessiweather/services/forecast_product_service.py` (new; `ForecastProductService.get(product_type, location) -> TextProduct | list[TextProduct] | None` with cache read-through)
+  - Create: `src/accessiweather/models/text_product.py` (new `TextProduct` dataclass: `product_type`, `product_id`, `cwa_office`, `issuance_time`, `product_text`, `headline: str | None`)
+  - Test: `tests/test_weather_client_nws_text_product.py` (new)
+  - Test: `tests/test_forecast_product_service.py` (new)
+
+  **Approach:**
+  - Endpoint: `products/types/{product_type}/locations/{cwa_office}`; response shape per research: `@graph[]` with `id`, each fetched via `products/{id}` for `productText` + `issuanceTime`.
+  - AFD and HWO: always take the first (newest) product from `@graph`. Return a single `TextProduct` or `None` if `@graph` empty.
+  - SPS: return ALL entries from `@graph` sorted newest-first (multiple concurrent SPSs common).
+  - TTLs via `Cache.set(..., ttl=...)`: AFD 3600, HWO 7200, SPS 900.
+  - Cache keys: `nws_text_product:{product_type}:{cwa_office}`.
+  - Skip fetch when `cwa_office` is None or `_is_us_location` returns False.
+  - Error handling: network / non-200 raises `TextProductFetchError` (new sentinel) — caller distinguishes from "empty `@graph`" (returns `None` / `[]`).
+
+  **Execution note:** Start with failing tests for the generic fetcher covering both single-product (AFD/HWO) and multi-product (SPS) shapes.
+
+  **Patterns to follow:**
+  - `get_nws_discussion` at `src/accessiweather/weather_client_nws.py:769-844` for async + `issuanceTime` extraction.
+  - `src/accessiweather/cache.py` for per-key TTL usage.
+  - `src/accessiweather/services/national_discussion_service.py` for service-module shape (untouched, not generalized).
+
+  **Test scenarios:**
+  - Happy path: AFD fetch returns one `TextProduct` with `issuance_time`, `product_text`, `headline`.
+  - Happy path: HWO fetch returns one `TextProduct`.
+  - Happy path: SPS fetch with three active products returns a list of three `TextProduct` sorted newest-first.
+  - Happy path: SPS fetch with empty `@graph` returns empty list (not error).
+  - Edge case: AFD fetch with empty `@graph` returns None.
+  - Edge case: `cwa_office = None` → returns None without making HTTP calls.
+  - Error path: HTTP 500 raises `TextProductFetchError`.
+  - Error path: timeout raises `TextProductFetchError`.
+  - Integration: repeated calls within the TTL window hit cache (assert single HTTP call).
+  - Integration: per-type TTL — AFD still cached at t+30min; SPS refetches at t+16min.
+
+  **Verification:**
+  - Three live product types fetch with distinct TTLs through one code path.
+  - `get_nws_discussion` call-sites continue to work (thin wrapper preserves signature).
+
+- [ ] **Unit 7: AI `explain_text_product` generalization + per-product cache**
+
+  **Goal:** Reuse the existing tl;dr across all three tabs; fix the incidental `explain_afd` no-cache gap.
+
+  **Requirements:** B-R6 (AI button per tab).
+
+  **Dependencies:** Unit 6 (receives `TextProduct`).
+
+  **Files:**
+  - Modify: `src/accessiweather/ai_explainer.py` (add `explain_text_product(product_text, product_type, location_name, style, preserve_markdown)`; refactor `explain_afd` to a thin wrapper; add result cache)
+  - Test: `tests/test_ai_explainer_text_product.py` (new)
+
+  **Approach:**
+  - Prompt lookup table at module level: `_SYSTEM_PROMPTS: dict[str, str]` keyed by product type. AFD prompt preserved verbatim to keep existing behavior untouched. HWO and SPS prompts mirror the AFD shape (objective bullets) with domain-specific phrasing.
+  - Caching: match `explain_weather`'s pattern at `ai_explainer.py:741` — cache key `(product_type, location_name, hash(product_text), style)` with 300s TTL on `self.cache`.
+  - Custom prompt / custom instructions (`AppSettings.custom_system_prompt`, `custom_instructions`) apply to all three product types (append as today).
+
+  **Patterns to follow:**
+  - `explain_weather` at `ai_explainer.py:741` for cache shape.
+  - `explain_afd` at `:746-941` for prompt structure.
+
+  **Test scenarios:**
+  - Happy path (AFD): `explain_text_product(product_type="AFD", ...)` returns a result whose prompt matches the current AFD prompt byte-for-byte.
+  - Happy path (HWO): returns result using the HWO system prompt.
+  - Happy path (SPS): returns result using the SPS system prompt.
+  - Happy path (cache): repeated call with same inputs returns `cached=True` and does NOT call the LLM.
+  - Happy path (custom prompt): `AppSettings.custom_system_prompt` set → it replaces the product-specific system prompt (or appends per existing rule); assert final prompt contains custom text.
+  - Edge case: `explain_afd` wrapper still returns the expected `ExplanationResult`.
+  - Error path: LLM error propagates as today (no silent fallback).
+
+  **Verification:**
+  - AFD tab's "Plain Language Summary" behaves identically to today.
+  - HWO and SPS tabs produce sensible plain-language summaries against live products.
+
+- [ ] **Unit 8: `ForecastProductPanel` + `ForecastProductsDialog` + main-window rename + non-US button state**
+
+  **Goal:** The user-visible dialog and its entry point, wired and accessible.
+
+  **Requirements:** B-R5, B-R6, B-R7, B-R8, B-R9 (AFD unchanged).
+
+  **Dependencies:** Unit 6 (data), Unit 7 (AI).
+
+  **Files:**
+  - Create: `src/accessiweather/ui/dialogs/forecast_product_panel.py` (new reusable `wx.Panel` subclass)
+  - Create: `src/accessiweather/ui/dialogs/forecast_products_dialog.py` (new `wx.Dialog` hosting `wx.Notebook`)
+  - Modify: `src/accessiweather/ui/main_window.py` (`QUICK_ACTION_LABELS` at ~37; `_on_discussion` non-Nationwide branch at 674-686 renamed/routed to `_on_forecast_products`; add adjacent `wx.StaticText` "NWS products are US-only" below the Forecast Products button, shown only when non-US selection)
+  - Modify: `src/accessiweather/ui/main_window.py` (existing test-notification menu at ~415 — update label if it references "Discussion" in a user-visible way)
+  - Test: `tests/gui/test_forecast_product_panel.py` (new)
+  - Test: `tests/gui/test_forecast_products_dialog.py` (new)
+
+  **Approach:**
+  - `ForecastProductPanel.__init__(parent, product_type, product_loader, ai_explainer)`:
+    - Header `wx.StaticText` (product full name — "Area Forecast Discussion", etc.)
+    - Optional `wx.Choice` for SPS multi-product (hidden via `Sizer.Show(False) + Layout()` when only one SPS or non-SPS).
+    - `wx.TextCtrl(style=wx.TE_MULTILINE | wx.TE_READONLY | wx.HSCROLL)` for raw product text.
+    - `wx.StaticText` "Issued: {local time}".
+    - "Plain Language Summary" `wx.Button` — hidden-until-clicked design per `docs/superpowers/specs/2026-04-08-discussion-dialog-ai-visibility-design.md`.
+    - Hidden AI result TextCtrl + model-info StaticText + Regenerate button; shown after first Explain click.
+    - Retry button when fetch failed.
+  - Empty/error state strings embedded in the content panel (not tab label) per B-R7.
+  - `ForecastProductsDialog`:
+    - `wx.Dialog` with `wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER`.
+    - `wx.Notebook` with three `ForecastProductPanel` instances: AFD, HWO, SPS.
+    - `EVT_NOTEBOOK_PAGE_CHANGED` → `wx.CallAfter(panel.product_textctrl.SetFocus)`.
+    - Dialog open: `wx.CallAfter` focus on AFD tab's TextCtrl after `Show()`.
+    - ESC closes via `EVT_CHAR_HOOK` (match existing DiscussionDialog).
+  - Main window:
+    - `QUICK_ACTION_LABELS["discussion"] = "Forecast &Products"` at `main_window.py:37`.
+    - `_on_discussion` keeps Nationwide branch; non-Nationwide branch routes to `_on_forecast_products` which opens `ForecastProductsDialog`.
+    - Adjacent `wx.StaticText` labeled "NWS products are US-only" positioned below the Forecast Products button, `Show(False)` by default, `Show(True)` when a non-US location is selected; button `Disable()` in the same state transition.
+
+  **Execution note:** Write accessibility assertions first — each button and TextCtrl must have its announce string verified before wiring behavior.
+
+  **Patterns to follow:**
+  - `src/accessiweather/ui/dialogs/discussion_dialog.py` for dialog shape, AI visibility pattern at lines 283-394.
+  - `docs/nationwide_discussions.md` for nested `wx.Notebook` precedent.
+  - Accessibility: adjacent `wx.StaticText` for context; descriptive `label=` strings on buttons; do NOT rely on `SetName()`.
+
+  **Test scenarios:**
+  - Happy path: dialog opens with three tabs; AFD tab focused; TextCtrl has latest AFD text.
+  - Happy path: tab switch to HWO moves focus to HWO TextCtrl.
+  - Happy path (SPS multi): three SPS products → `wx.Choice` visible with three entries; selecting another swaps TextCtrl content.
+  - Happy path (SPS single): one SPS product → `wx.Choice` hidden.
+  - Edge case: SPS empty → panel displays "No Special Weather Statements currently active for {cwa_office}".
+  - Edge case: HWO 200 + empty `@graph` → "Hazardous Weather Outlook not currently available for {cwa_office}".
+  - Error path: HWO fetch raised → "Failed to fetch Hazardous Weather Outlook — try again." with retry button; retry click re-invokes loader.
+  - Edge case: `cwa_office` null for selected location → all three panels show "NWS text products will populate after the next weather refresh."
+  - Happy path (non-US button): selecting a non-US location → Forecast Products button `Disable()`d; adjacent StaticText "NWS products are US-only" shown.
+  - Happy path (renames): `QUICK_ACTION_LABELS["discussion"]` is "Forecast &Products"; menu item label matches.
+  - Integration: Nationwide location selection routes to existing NationwideDiscussionDialog, NOT ForecastProductsDialog.
+  - Accessibility: each TextCtrl and button has an accessible label derivable from adjacent StaticText or its own `label=` string.
+
+  **Verification:**
+  - Dialog opens, reads, and navigates with a screen reader.
+  - AFD content, AFD cold-start baseline, and AFD notification behavior are unchanged (existing tests still pass).
+
+- [ ] **Unit 9: Background product fetch hooks + state extensions + alert affected-zones**
+
+  **Goal:** Pre-warm the dialog across all saved US locations and prepare the state surface for new notifications.
+
+  **Requirements:** B-R3, B-R4, B-R10 (state-shape pieces).
+
+  **Dependencies:** Unit 6 (fetch), Unit 1 (stored zones).
+
+  **Files:**
+  - Modify: `src/accessiweather/ui/main_window.py` (extend `_pre_warm_other_locations` at ~1273-1290 to also call `ForecastProductService` for each of AFD/HWO/SPS per US location with populated `cwa_office`; add product fetch + dispatch step after `_fetch_weather_data` success at ~1108-1186 for the active location)
+  - Modify: `src/accessiweather/notifications/notification_event_manager.py` (extend `NotificationState` dataclass with `last_hwo_issuance_time`, `last_hwo_text`, `last_hwo_summary_signature`, `last_sps_product_ids: set[str]`)
+  - Modify: `src/accessiweather/runtime_state.py` (add `hwo` and `sps` sub-sections to `_DEFAULT_RUNTIME_STATE` at 14-37; parallel entries in `_runtime_section_to_legacy_shape` and `_legacy_shape_to_runtime_section` at 297-340)
+  - Modify: `src/accessiweather/cache.py` (extend `WeatherAlert` serializer at 422-455 with additive `affected_zones: list[str]` field, defensive `.get()` on deserialize)
+  - Test: `tests/test_main_window_product_prewarm.py` (new)
+  - Test: `tests/test_notification_state_hwo_sps_fields.py` (new)
+  - Test: `tests/test_runtime_state_hwo_sps.py` (new)
+  - Test: `tests/test_cache_weather_alert_affected_zones.py` (new)
+
+  **Approach:**
+  - Pre-warm iterates all saved locations; for each US location with populated `cwa_office`, request AFD + HWO + SPS through `ForecastProductService`. Failures per `(product_type, location)` are swallowed and debug-logged — one failure NEVER cascades.
+  - Active-location: the existing `_fetch_weather_data` success branch triggers the same three product fetches plus the HWO / SPS notification checks (Units 10 and 11). AFD notification stays in `_check_discussion_update` unchanged.
+  - State-shape changes are additive; no `schema_version` bump; reload of a legacy runtime_state.json `.get()`s defaults for the new fields.
+  - `WeatherAlert.affected_zones` is additive — older cache entries deserialize to empty list; new writes persist the real zone list from `alert_geocode.py`.
+
+  **Patterns to follow:**
+  - `src/accessiweather/ui/main_window.py:1273-1290` iteration shape.
+  - `src/accessiweather/notifications/notification_event_manager.py:182-222` for additive `NotificationState` field pattern.
+  - `src/accessiweather/runtime_state.py:297-340` parallel-update rule for converters.
+  - `src/accessiweather/cache.py:422-455` for additive `WeatherAlert` serializer extension.
+
+  **Test scenarios:**
+  - Happy path: three saved US locations with populated `cwa_office` → pre-warm issues 9 product fetches (3 × 3 types).
+  - Happy path: one non-US location + two US → 6 product fetches total (non-US skipped).
+  - Edge case: US location with `cwa_office = None` → 0 product fetches for that location.
+  - Error path: one location's HWO fetch fails → the other two product types for that location still attempt; other locations unaffected.
+  - Happy path (state): `NotificationState` with all new fields populated round-trips through runtime_state JSON.
+  - Happy path (state): legacy runtime_state.json (no `hwo` / `sps` sections) loads with defaults; new fields null/empty.
+  - Happy path (alerts): `WeatherAlert.affected_zones` serializes and deserializes identically when populated.
+  - Happy path (alerts legacy): cache entry without `affected_zones` deserializes with `affected_zones = []`.
+  - Integration: pre-warm failure for HWO of location A does not prevent SPS fetch for location A or any fetch for location B.
+
+  **Verification:**
+  - Opening Forecast Products dialog after initial refresh cycle shows pre-populated content with no perceptible load time.
+  - Runtime state round-trips cleanly.
+  - Existing alert cache hits continue to work; new `affected_zones` populates on re-fetch.
+
+- [ ] **Unit 10: HWO update notification stream**
+
+  **Goal:** Fire a notification when a WFO's HWO content has meaningfully changed.
+
+  **Requirements:** B-R10 (HWO portion), B-R11 (HWO content).
+
+  **Dependencies:** Units 6 and 9.
+
+  **Files:**
+  - Modify: `src/accessiweather/notifications/notification_event_manager.py` (new `_check_hwo_update(location, hwo_product)` method following `_check_discussion_update` at 404-455; cold-start baseline following 427-435)
+  - Modify: `src/accessiweather/notifications/notification_event_manager.py` (add ephemeral `self._last_product_notified_at: dict[tuple[str, str], datetime]` for per-stream rate limiting)
+  - Test: `tests/test_notification_hwo_update.py` (new)
+
+  **Approach:**
+  - On each new HWO fetch per location, compare `issuance_time` and a content signature (hash of `product_text` normalized for whitespace) against stored state.
+  - First-fetch path: store silently. No notification (matches AFD pattern at 427-435).
+  - Subsequent change: fire notification — content via `summarize_discussion_change(stored_text, new_text)` if it returns a usable summary; else "Hazardous Weather Outlook updated for {cwa_office} — tap to view."
+  - Rate-limit check: compare `now - self._last_product_notified_at[("HWO", location_id)] >= timedelta(minutes=30)`; skip notification if within window, but always persist the new baseline so we don't re-trigger forever.
+  - Gated by `notify_hwo_update` setting (default ON).
+
+  **Patterns to follow:**
+  - `_check_discussion_update` at `notification_event_manager.py:404-455`.
+  - Cold-start silent-store pattern at `:427-435`.
+  - `format_accessible_message` helper for notification body formatting.
+
+  **Test scenarios:**
+  - Happy path (cold start): first HWO fetch for a location → baseline stored, `dispatch_notification` NOT called.
+  - Happy path (content change): second fetch with new `issuance_time` and changed `product_text` → notification dispatched with summarizer output if non-empty.
+  - Happy path (summarizer fallback): summarizer returns empty/short → generic "Hazardous Weather Outlook updated for {cwa_office} — tap to view." dispatched.
+  - Edge case (unchanged): second fetch with same `issuance_time` → no notification, no state update.
+  - Edge case (rate limited): change arrives within 30 min of last notification → state updates, notification suppressed.
+  - Edge case (disabled): `notify_hwo_update = False` → no dispatch regardless of change.
+  - Edge case (None): HWO fetch returned None (empty @graph) → no-op, no crash.
+  - Integration: multi-location — notifications fire independently per `(HWO, location)` rate bucket.
+
+  **Verification:**
+  - WFO issuing an HWO update triggers a desktop notification.
+  - Notification content is sensible (summarizer output or generic fallback).
+  - After a prolonged app closure, reopening produces at most one HWO notification per location within 30 min.
+
+- [ ] **Unit 11: SPS notification stream with alert dedupe**
+
+  **Goal:** Surface informational SPS (Case B) as notifications while never duplicating event-style SPS (Case A) that the alert pipeline already shows.
+
+  **Requirements:** B-R10 (SPS portion), B-R11 (SPS content).
+
+  **Dependencies:** Units 6 and 9 (needs `affected_zones` on cached alerts).
+
+  **Files:**
+  - Modify: `src/accessiweather/notifications/notification_event_manager.py` (new `_check_sps_new(location, sps_products, cached_alerts)` method)
+  - Test: `tests/test_notification_sps_dedupe.py` (new)
+
+  **Approach:**
+  - Input: list of `TextProduct` (SPS) + currently-cached `WeatherAlerts` for the location.
+  - For each SPS product not in `NotificationState.last_sps_product_ids`:
+    1. Filter cached alerts to `event == "Special Weather Statement"`.
+    2. Intersect the SPS product's zone scope (derived from `TextProduct` — typically in `wmoCollectiveId` / affected-zones metadata in the `/products/{id}` response; capture this in Unit 6's `TextProduct` dataclass) with each alert's `affected_zones`.
+    3. If any alert zones intersect → Case A; add ID to `last_sps_product_ids` silently (dedupe), no notification.
+    4. If no intersection → Case B; fire notification with `headline` (or first non-empty line of `productText` if headline null), body format `"{headline} — {cwa_office}"`, truncate at 160 chars.
+  - Rate-limit check: `("SPS", location_id)` bucket, same 30-min sliding window.
+  - Expiration: for product IDs present in `last_sps_product_ids` but not in the latest fetch, remove silently (no notification).
+  - Gated by `notify_sps_issued` setting (default ON).
+  - Fallback when zone data unavailable (shouldn't happen with Unit 9's `affected_zones` extension, but defensive): substring match on `headline` between SPS product and active alerts.
+
+  **Execution note:** Write failing tests for both Case A and Case B against the live-verified PHI fire-weather example before implementation — getting the dedupe wrong is the one user-visible regression that would undermine the feature.
+
+  **Patterns to follow:**
+  - Cold-start silent-store at `notification_event_manager.py:427-435`.
+  - `format_accessible_message` for notification body.
+
+  **Test scenarios:**
+  - Happy path (Case B): SPS product with zones `[PHZ007, PHZ008]`; no active alerts for those zones → notification dispatched with headline.
+  - Happy path (Case A): SPS product with zones `[PHZ007]`; active alert with `affected_zones=[PHZ007, PHZ008]` and `event="Special Weather Statement"` → suppressed; ID added to seen.
+  - Happy path (cold start): first fetch with three SPS → all IDs recorded; no notifications.
+  - Happy path (expiration): previously-seen SPS disappears from `@graph` → removed from `last_sps_product_ids`; no notification.
+  - Edge case (headline null): SPS headline null → body uses first non-empty line of `productText`, truncated at 160 chars with ellipsis.
+  - Edge case (rate limited): new Case B SPS within 30 min of last → state updates, notification suppressed.
+  - Edge case (disabled): `notify_sps_issued = False` → no dispatch.
+  - Edge case (fallback): `affected_zones` empty on both SPS and alert → headline substring match used.
+  - Integration: Case A + Case B in same fetch → only Case B notifies; both IDs recorded in state.
+  - Integration (realistic): replay live-verified PHI fire-weather product from 2026-04-16 — notification fires because alerts feed has no matching SSS.
+
+  **Verification:**
+  - The verified PHI fire-weather SPS scenario produces exactly one notification.
+  - Event-style SPS that are also in `/alerts/active` produce zero notifications from this stream (the alert pipeline handles them).
+  - Closing the app for 18 hours and reopening does not produce a notification storm.
+
+- [ ] **Unit 12: Settings notifications tab — new toggles + intro copy rewrite**
+
+  **Goal:** User-facing controls for the two new notification streams and honest section copy.
+
+  **Requirements:** B-R10 (settings surface).
+
+  **Dependencies:** Unit 9 (`NotificationState` shape), Units 10–11 (consumers).
+
+  **Files:**
+  - Modify: `src/accessiweather/ui/dialogs/settings_tabs/notifications.py` (~110-125; add `notify_hwo_update` and `notify_sps_issued` checkboxes as siblings to `notify_discussion_update`; rewrite section intro `wx.StaticText`)
+  - Modify: `src/accessiweather/models/config.py` (`AppSettings` — new bool fields with defaults: `notify_hwo_update=True`, `notify_sps_issued=True`; round-trip via `_as_bool` pattern)
+  - Test: `tests/test_settings_notification_toggles.py` (new)
+
+  **Approach:**
+  - New intro copy: "Updates beyond standard alerts. HWO and SPS updates are on by default since they deliver information not in the alerts feed. Others are off unless you turn them on."
+  - Checkbox labels (descriptive — screen readers read them directly):
+    - `Notify on Hazardous Weather Outlook updates`
+    - `Notify on Special Weather Statement (informational)`
+  - Wire through `save()` and `load()` at existing `~258` and `~297` lines following the `notify_discussion_update` pattern.
+
+  **Patterns to follow:**
+  - Existing `notify_discussion_update` row at `settings_tabs/notifications.py:116-125`.
+  - `AppSettings._as_bool(data.get("...", <default>), <default>)` at `models/config.py`.
+
+  **Test scenarios:**
+  - Happy path: fresh config loads with both new toggles checked (defaults ON).
+  - Happy path: saving with `notify_hwo_update=False` persists to JSON; reload round-trips.
+  - Happy path: legacy config (no new keys) loads with both defaults ON.
+  - Accessibility: both checkboxes have label strings that describe intent without relying on nearby context.
+  - Happy path (intro copy): rendered text reflects the two defaults-ON behavior (assert against exact string).
+
+  **Verification:**
+  - User can toggle each stream independently and the setting sticks.
+  - Intro copy accurately describes default behavior.
+
+## System-Wide Impact
+
+- **Interaction graph:** `/points` response now flows into `Location` persistence (save + drift) and into the alert-fetch path. Text-product fetches flow into the dialog (synchronous on open), the notification pipeline (per-stream checks), and two new settings toggles. Main-window `_on_discussion` is forked: Nationwide branch untouched, non-Nationwide routed to new `_on_forecast_products`. `wx.CallAfter` carries drift-correction persistence from refresh thread to main thread.
+- **Error propagation:** Per-product + per-location fetch failures are isolated and debug-logged — never cascade. `/points` failures at save-time or during drift are swallowed silently (location still saves or no update). LLM errors in `explain_text_product` surface into the AI result TextCtrl per the hidden-until-clicked visibility design; they do not close the dialog.
+- **State lifecycle risks:** Two runtime-state sub-sections added; both converters must be updated in parallel or `hwo` / `sps` fields silently drop on round-trip (mitigated by Unit 9 tests). `ConfigManager.save_config` has no in-process lock — drift writes are funneled via `wx.CallAfter` to avoid racing with user-initiated saves; a proper lock is deferred. Cold-start baseline for HWO and SPS uses the AFD pattern: first fetch stores silently, so long absences never burst notifications. Rate-limit buckets are sliding-window, not calendar-reset, avoiding the `docs/alert_audit_report.md` §7 pattern.
+- **API surface parity:** Six new `Location` fields, four new `NotificationState` fields, two new `runtime_state.notification_events` sub-sections, one new `WeatherAlert.affected_zones` field, two new `AppSettings` bools — all additive, all backward-compatible via defensive `.get()`. No `schema_version` bump.
+- **Integration coverage:** Unit 9 and Unit 11 both require real multi-module integration tests (pre-warm iteration + dispatch, SPS dedupe against cached alerts). Unit tests alone won't prove correctness for these. The PHI fire-weather live-verified example from 2026-04-16 is captured as a fixture for Unit 11.
+- **Unchanged invariants:** Nationwide discussion dialog, AFD notification content and cadence, AFD issuance-time tracking, AFD AI-summary behavior, `schema_version`, `get_nws_discussion`'s public signature. Alert fetching returns the same shape; only the internal resolution path changes. Discussion dialog's AI visibility design (`docs/superpowers/specs/2026-04-08`) is mirrored exactly in the new panel.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| SPS zone-intersection dedupe misclassifies a Case A as Case B (double-notification) | Unit 11 replays the live-verified PHI 2026-04-16 example as a fixture; tests assert Case A → 0 notifications, Case B → 1; fallback heuristic (headline substring match) catches obvious misses. |
+| SPS dedupe misclassifies a Case B as Case A (silent miss of novel capability) | Zone-intersection threshold is "any zone overlap" (conservative toward notification); headline fallback also favors notifying when ambiguous. |
+| `ConfigManager.save_config` race between refresh thread and user save | `wx.CallAfter` bounce to main thread for drift persistence (Unit 3). Proper `threading.Lock` deferred to separate task. |
+| Runtime state converters updated in only one direction | Unit 9 tests assert round-trip both ways; documented as "parallel update rule" in Context & Research. |
+| `_pre_warm_other_locations` becomes slow with many saved locations × three products | Per-type TTL caching (AFD 1h, HWO 2h, SPS 15min) absorbs repeat calls; failure isolation prevents cascade; realistic location counts (< 20) and cache hits keep the cost bounded. Measurable via existing log timing. |
+| HWO summarizer quality low on structured grid text | Length-heuristic fallback to generic copy in Unit 10; tune threshold during implementation against live products. |
+| `WeatherAlert.affected_zones` not populated for legacy cache entries | Additive field with `.get()` default `[]`; dedupe falls back to headline substring match when empty. |
+| wx.Notebook focus-on-tab-switch inconsistent across screen readers | `wx.CallAfter(panel.product_textctrl.SetFocus)` is the most reliable pattern in wxPython; validate manually on NVDA + JAWS before shipping. |
+| Edit Location Fit-based sizer regresses on small DPI | `SetMinSize((420, -1))` preserves baseline width; validate at 100%/125%/150% DPI. |
+| CLAUDE.md's Toga references mislead future agents | Project memory already flags this; docs cleanup is out of scope for PR 1 but a reasonable follow-up issue. |
+
+## Documentation / Operational Notes
+
+- **CHANGELOG.md** entry required (user-facing):
+  - "Forecast Products dialog: AFD, HWO, and SPS in one tabbed view per location"
+  - "New notifications: Hazardous Weather Outlook updates and informational Special Weather Statements"
+  - "Zone metadata caching: faster alerts, fewer API calls"
+- **Release note callouts:** default-ON for HWO and SPS notifications is a behavioral change from today — mention explicitly so upgraders know they can opt out.
+- **No new keys in `.env.example`.** No new dependencies.
+- **Monitoring:** pre-warm fetch timing and SPS dedupe outcomes are debug-logged; no new user-facing telemetry.
+- **Rollout:** single shipping moment. No feature flag — the change is binary per user (they open the dialog or they don't). Revert path is `git revert` of the merge.
+
+## Sources & References
+
+- **Origin — Zone Enrichment:** [docs/brainstorms/2026-04-20-zone-metadata-enrichment-requirements.md](../brainstorms/2026-04-20-zone-metadata-enrichment-requirements.md)
+- **Origin — Text Products Registry:** [docs/brainstorms/2026-04-20-nws-text-products-registry-requirements.md](../brainstorms/2026-04-20-nws-text-products-registry-requirements.md)
+- **Upstream ideation:** [docs/ideation/2026-04-20-api-endpoints-ideation.md](../ideation/2026-04-20-api-endpoints-ideation.md)
+- **Related audit (alert bug context):** [docs/alert_audit_report.md](../alert_audit_report.md) §3 and §7
+- **Related design (AI visibility):** [docs/superpowers/specs/2026-04-08-discussion-dialog-ai-visibility-design.md](../superpowers/specs/2026-04-08-discussion-dialog-ai-visibility-design.md)
+- **Related design (nationwide notebook precedent):** [docs/nationwide_discussions.md](../nationwide_discussions.md)
+- **Key source code touchpoints:**
+  - `src/accessiweather/models/weather.py:124-141`
+  - `src/accessiweather/models/config.py:700-745`
+  - `src/accessiweather/config/locations.py:59-70`
+  - `src/accessiweather/api/nws/point_location.py:86-141`
+  - `src/accessiweather/weather_client_nws.py:769-844, 873-941`
+  - `src/accessiweather/cache.py:46-165, 422-455`
+  - `src/accessiweather/notifications/notification_event_manager.py:182-222, 404-455`
+  - `src/accessiweather/runtime_state.py:14-37, 297-340`
+  - `src/accessiweather/ai_explainer.py:741, 746-941`
+  - `src/accessiweather/ui/dialogs/discussion_dialog.py`
+  - `src/accessiweather/ui/dialogs/location_dialog.py:81-125`
+  - `src/accessiweather/ui/dialogs/settings_tabs/notifications.py:110-125`
+  - `src/accessiweather/ui/main_window.py:31-40, 674-686, 1108-1290`
+  - `src/accessiweather/display/presentation/forecast.py:40-51`
+  - `tests/conftest.py:19-100` (wx stub pattern)

--- a/src/accessiweather/api/nws/point_location.py
+++ b/src/accessiweather/api/nws/point_location.py
@@ -97,6 +97,9 @@ class NwsPointLocation:
                     "fireWeatherZone": properties.get("fireWeatherZone"),
                     "timeZone": properties.get("timeZone"),
                     "radarStation": properties.get("radarStation"),
+                    "cwa": properties.get("cwa"),
+                    "forecastZone": properties.get("forecastZone"),
+                    "gridId": properties.get("gridId"),
                 }
             }
         else:
@@ -116,6 +119,9 @@ class NwsPointLocation:
                         "fire_weather_zone",
                         "time_zone",
                         "radar_station",
+                        "cwa",
+                        "forecast_zone",
+                        "grid_id",
                     ]:
                         if hasattr(properties_obj, attr):
                             properties[attr] = getattr(properties_obj, attr)
@@ -135,6 +141,10 @@ class NwsPointLocation:
                         "timeZone": properties.get("timeZone") or properties.get("time_zone"),
                         "radarStation": properties.get("radarStation")
                         or properties.get("radar_station"),
+                        "cwa": properties.get("cwa"),
+                        "forecastZone": properties.get("forecastZone")
+                        or properties.get("forecast_zone"),
+                        "gridId": properties.get("gridId") or properties.get("grid_id"),
                     }
                 }
             else:

--- a/src/accessiweather/config/locations.py
+++ b/src/accessiweather/config/locations.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from ..models import Location
 
 if TYPE_CHECKING:
+    from ..services.zone_enrichment_service import ZoneEnrichmentService
     from .config_manager import ConfigManager
 
 logger = logging.getLogger("accessiweather.config")
@@ -16,9 +17,25 @@ logger = logging.getLogger("accessiweather.config")
 class LocationOperations:
     """Encapsulate location CRUD operations for the configuration manager."""
 
-    def __init__(self, manager: ConfigManager) -> None:
-        """Keep a handle to the orchestrating configuration manager."""
+    def __init__(
+        self,
+        manager: ConfigManager,
+        *,
+        zone_enrichment_service: ZoneEnrichmentService | None = None,
+    ) -> None:
+        """
+        Keep a handle to the orchestrating configuration manager.
+
+        Args:
+            manager: The owning :class:`ConfigManager` instance.
+            zone_enrichment_service: Optional pre-built enrichment service for
+                NWS zone metadata. When ``None``, the service is lazily
+                constructed on first use of
+                :meth:`add_location_with_enrichment`.
+
+        """
         self._manager = manager
+        self._zone_enrichment_service = zone_enrichment_service
 
     @property
     def logger(self) -> logging.Logger:
@@ -55,6 +72,63 @@ class LocationOperations:
 
         self.logger.info(f"Added location: {name} ({latitude}, {longitude})")
         return self._manager.save_config()
+
+    async def add_location_with_enrichment(
+        self,
+        name: str,
+        latitude: float,
+        longitude: float,
+        country_code: str | None = None,
+        marine_mode: bool = False,
+    ) -> bool:
+        """
+        Add a new location, enriching it with NWS zone metadata first.
+
+        For US locations, this fetches ``/points`` once and populates the
+        ``timezone``, ``cwa_office``, ``forecast_zone_id``, ``county_zone_id``,
+        ``fire_zone_id``, and ``radar_station`` fields before persisting.
+
+        Non-US locations and ``/points`` failures never block the save: in
+        those cases the zone fields remain null and the location is still
+        saved.
+        """
+        config = self._manager.get_config()
+
+        for existing_location in config.locations:
+            if existing_location.name == name:
+                self.logger.warning(f"Location {name} already exists")
+                return False
+
+        new_location = Location(
+            name=name,
+            latitude=latitude,
+            longitude=longitude,
+            country_code=country_code,
+            marine_mode=marine_mode,
+        )
+
+        try:
+            service = self._get_zone_enrichment_service()
+            new_location = await service.enrich_location(new_location)
+        except Exception as exc:  # noqa: BLE001 - never block save on enrichment
+            self.logger.debug("Zone enrichment raised unexpectedly for %s: %s", name, exc)
+
+        config.locations.append(new_location)
+
+        if config.current_location is None:
+            config.current_location = new_location
+            self.logger.info(f"Set {name} as current location (first location)")
+
+        self.logger.info(f"Added location: {name} ({latitude}, {longitude})")
+        return self._manager.save_config()
+
+    def _get_zone_enrichment_service(self) -> ZoneEnrichmentService:
+        """Return the injected enrichment service, lazily constructing one."""
+        if self._zone_enrichment_service is None:
+            from ..services.zone_enrichment_service import ZoneEnrichmentService
+
+            self._zone_enrichment_service = ZoneEnrichmentService()
+        return self._zone_enrichment_service
 
     def update_location_marine_mode(self, name: str, marine_mode: bool) -> bool:
         """Update marine_mode on an existing location and persist it."""

--- a/src/accessiweather/config/locations.py
+++ b/src/accessiweather/config/locations.py
@@ -130,6 +130,54 @@ class LocationOperations:
             self._zone_enrichment_service = ZoneEnrichmentService()
         return self._zone_enrichment_service
 
+    def update_zone_metadata(self, location_name: str, fields: dict[str, str]) -> bool:
+        """
+        Apply zone-metadata updates to an existing location and persist.
+
+        Used by the refresh-time drift-correction hook in
+        :mod:`accessiweather.weather_client_nws`. Designed to be called on the
+        main thread via ``wx.CallAfter`` so it can safely invoke
+        :meth:`ConfigManager.save_config` (which currently lacks an in-process
+        lock).
+
+        Args:
+            location_name: The ``name`` of the location to update.
+            fields: Mapping of field name to new value. Only zone-metadata
+                fields should be passed — the caller (the drift diff) is
+                responsible for ensuring this.
+
+        Returns:
+            ``True`` if the location was found and updates were applied and
+            persisted. ``False`` if no location matched, or if ``fields`` is
+            empty.
+
+        """
+        if not fields:
+            return False
+
+        from dataclasses import replace
+
+        config = self._manager.get_config()
+
+        for index, location in enumerate(config.locations):
+            if location.name == location_name:
+                updated = replace(location, **fields)
+                config.locations[index] = updated
+                # Keep current_location pointer coherent if it references this
+                # same location by name.
+                current = config.current_location
+                if current is not None and current.name == location_name:
+                    config.current_location = updated
+                self.logger.info(
+                    "Updated zone metadata on %s: %s",
+                    location_name,
+                    sorted(fields.keys()),
+                )
+                return self._manager.save_config()
+
+        self.logger.debug("update_zone_metadata: location %s not found (skipped)", location_name)
+        return False
+
     def update_location_marine_mode(self, name: str, marine_mode: bool) -> bool:
         """Update marine_mode on an existing location and persist it."""
         config = self._manager.get_config()

--- a/src/accessiweather/models/config.py
+++ b/src/accessiweather/models/config.py
@@ -708,6 +708,12 @@ class AppConfig:
                     "longitude": loc.longitude,
                     **({"country_code": loc.country_code} if loc.country_code else {}),
                     **({"marine_mode": True} if loc.marine_mode else {}),
+                    **({"timezone": loc.timezone} if loc.timezone else {}),
+                    **({"forecast_zone_id": loc.forecast_zone_id} if loc.forecast_zone_id else {}),
+                    **({"cwa_office": loc.cwa_office} if loc.cwa_office else {}),
+                    **({"county_zone_id": loc.county_zone_id} if loc.county_zone_id else {}),
+                    **({"fire_zone_id": loc.fire_zone_id} if loc.fire_zone_id else {}),
+                    **({"radar_station": loc.radar_station} if loc.radar_station else {}),
                 }
                 for loc in self.locations
             ],
@@ -721,6 +727,36 @@ class AppConfig:
                     else {}
                 ),
                 **({"marine_mode": True} if self.current_location.marine_mode else {}),
+                **(
+                    {"timezone": self.current_location.timezone}
+                    if self.current_location.timezone
+                    else {}
+                ),
+                **(
+                    {"forecast_zone_id": self.current_location.forecast_zone_id}
+                    if self.current_location.forecast_zone_id
+                    else {}
+                ),
+                **(
+                    {"cwa_office": self.current_location.cwa_office}
+                    if self.current_location.cwa_office
+                    else {}
+                ),
+                **(
+                    {"county_zone_id": self.current_location.county_zone_id}
+                    if self.current_location.county_zone_id
+                    else {}
+                ),
+                **(
+                    {"fire_zone_id": self.current_location.fire_zone_id}
+                    if self.current_location.fire_zone_id
+                    else {}
+                ),
+                **(
+                    {"radar_station": self.current_location.radar_station}
+                    if self.current_location.radar_station
+                    else {}
+                ),
             }
             if self.current_location
             else None,
@@ -738,8 +774,14 @@ class AppConfig:
                     name=loc_data["name"],
                     latitude=loc_data["latitude"],
                     longitude=loc_data["longitude"],
+                    timezone=loc_data.get("timezone"),
                     country_code=loc_data.get("country_code"),
                     marine_mode=bool(loc_data.get("marine_mode", False)),
+                    forecast_zone_id=loc_data.get("forecast_zone_id"),
+                    cwa_office=loc_data.get("cwa_office"),
+                    county_zone_id=loc_data.get("county_zone_id"),
+                    fire_zone_id=loc_data.get("fire_zone_id"),
+                    radar_station=loc_data.get("radar_station"),
                 )
             )
 
@@ -750,8 +792,14 @@ class AppConfig:
                 name=loc_data["name"],
                 latitude=loc_data["latitude"],
                 longitude=loc_data["longitude"],
+                timezone=loc_data.get("timezone"),
                 country_code=loc_data.get("country_code"),
                 marine_mode=bool(loc_data.get("marine_mode", False)),
+                forecast_zone_id=loc_data.get("forecast_zone_id"),
+                cwa_office=loc_data.get("cwa_office"),
+                county_zone_id=loc_data.get("county_zone_id"),
+                fire_zone_id=loc_data.get("fire_zone_id"),
+                radar_station=loc_data.get("radar_station"),
             )
 
         return cls(

--- a/src/accessiweather/models/weather.py
+++ b/src/accessiweather/models/weather.py
@@ -131,6 +131,12 @@ class Location:
     timezone: str | None = None
     country_code: str | None = None
     marine_mode: bool = False
+    # NWS zone metadata (populated for US locations on save/refresh)
+    forecast_zone_id: str | None = None
+    cwa_office: str | None = None
+    county_zone_id: str | None = None
+    fire_zone_id: str | None = None
+    radar_station: str | None = None
 
     def __str__(self) -> str:
         return self.name

--- a/src/accessiweather/services/zone_enrichment_service.py
+++ b/src/accessiweather/services/zone_enrichment_service.py
@@ -1,0 +1,206 @@
+"""
+Zone enrichment service for NWS /points metadata.
+
+On save of a new US location, this service fetches the NWS /points endpoint
+once and maps the response onto six zone-related fields of a ``Location``
+dataclass (``timezone``, ``cwa_office``, ``forecast_zone_id``,
+``county_zone_id``, ``fire_zone_id``, ``radar_station``).
+
+Non-US locations and /points failures must never block the save: the service
+returns the original ``Location`` unchanged, and no exception propagates.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+import httpx
+
+if TYPE_CHECKING:
+    from ..models import Location
+
+logger = logging.getLogger(__name__)
+
+NWS_API_BASE = "https://api.weather.gov"
+DEFAULT_USER_AGENT = "AccessiWeather/1.0 (AccessiWeather)"
+DEFAULT_TIMEOUT = 10.0
+
+
+def _is_us_location(location: Location) -> bool:
+    """
+    Return True when the location should use NWS (US) data sources.
+
+    Mirrors the heuristic in ``display/presentation/forecast.py`` so enrichment
+    and forecast-rendering agree on what counts as a US location.
+    """
+    country_code = getattr(location, "country_code", None)
+    if country_code:
+        return country_code.upper() == "US"
+
+    lat = location.latitude
+    lon = location.longitude
+    in_continental_bounds = 24.0 <= lat <= 49.0 and -125.0 <= lon <= -66.0
+    in_alaska_bounds = 51.0 <= lat <= 71.5 and -172.0 <= lon <= -130.0
+    in_hawaii_bounds = 18.0 <= lat <= 23.0 and -161.0 <= lon <= -154.0
+    return in_continental_bounds or in_alaska_bounds or in_hawaii_bounds
+
+
+def _last_path_segment(url: str | None) -> str | None:
+    """
+    Extract the last non-empty path segment from a URL.
+
+    Example: ``"https://api.weather.gov/zones/forecast/PAZ106"`` -> ``"PAZ106"``.
+    Returns ``None`` for falsy or non-string input.
+    """
+    if not url or not isinstance(url, str):
+        return None
+    # Strip any trailing slash, then take the final segment.
+    trimmed = url.rstrip("/")
+    if not trimmed:
+        return None
+    segment = trimmed.rsplit("/", 1)[-1]
+    return segment or None
+
+
+def _extract_zone_fields(properties: dict) -> dict[str, str | None]:
+    """
+    Map a /points ``properties`` payload to Location zone field values.
+
+    Missing keys are returned as ``None`` so callers can cleanly merge the
+    result onto a Location without clobbering fields that were not present
+    in the response.
+    """
+    time_zone = properties.get("timeZone")
+    cwa = properties.get("cwa")
+    radar_station = properties.get("radarStation")
+
+    return {
+        "timezone": time_zone if isinstance(time_zone, str) and time_zone else None,
+        "cwa_office": cwa if isinstance(cwa, str) and cwa else None,
+        "forecast_zone_id": _last_path_segment(properties.get("forecastZone")),
+        "county_zone_id": _last_path_segment(properties.get("county")),
+        "fire_zone_id": _last_path_segment(properties.get("fireWeatherZone")),
+        "radar_station": (
+            radar_station if isinstance(radar_station, str) and radar_station else None
+        ),
+    }
+
+
+class ZoneEnrichmentService:
+    """
+    Fetch NWS /points zone metadata and map it onto a Location.
+
+    The service is intentionally minimal: constructor injection for the
+    async HTTP client (so tests can substitute a mock), and a single
+    ``enrich_location`` entry point that never raises.
+    """
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient | None = None,
+        *,
+        base_url: str = NWS_API_BASE,
+        user_agent: str = DEFAULT_USER_AGENT,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        """
+        Create a new enrichment service.
+
+        Args:
+            client: Optional pre-built ``httpx.AsyncClient``. When omitted,
+                each ``enrich_location`` call constructs a short-lived client.
+            base_url: NWS API base URL (overrideable for tests).
+            user_agent: User-Agent header value required by NWS.
+            timeout: Per-request timeout in seconds.
+
+        """
+        self._client = client
+        self._base_url = base_url.rstrip("/")
+        self._user_agent = user_agent
+        self._timeout = timeout
+
+    async def enrich_location(self, location: Location) -> Location:
+        """
+        Return a new ``Location`` with zone fields populated.
+
+        Returns the original ``location`` unchanged when:
+          * the location is not in the US, or
+          * the /points fetch fails for any reason (HTTP error, timeout,
+            non-200 response, malformed payload).
+
+        This method never raises.
+        """
+        if not _is_us_location(location):
+            logger.debug("Skipping zone enrichment for non-US location: %s", location.name)
+            return location
+
+        properties = await self._fetch_points_properties(location.latitude, location.longitude)
+        if properties is None:
+            # Already logged at debug inside the fetch helper.
+            return location
+
+        fields = _extract_zone_fields(properties)
+        # Only set fields that are actually present in the payload so we don't
+        # blow away any values the caller may have pre-populated.
+        updates = {key: value for key, value in fields.items() if value is not None}
+        if not updates:
+            logger.debug("No zone fields present in /points payload for %s", location.name)
+            return location
+
+        return replace(location, **updates)
+
+    async def _fetch_points_properties(self, lat: float, lon: float) -> dict | None:
+        """
+        Fetch ``/points/{lat},{lon}`` and return the ``properties`` dict.
+
+        Returns ``None`` on any failure. All errors are swallowed and logged
+        at debug level so a transient API issue never blocks a location save.
+        """
+        url = f"{self._base_url}/points/{lat},{lon}"
+        headers = {
+            "User-Agent": self._user_agent,
+            "Accept": "application/geo+json",
+        }
+
+        try:
+            if self._client is not None:
+                response = await self._client.get(url, headers=headers, timeout=self._timeout)
+            else:
+                async with httpx.AsyncClient(
+                    timeout=self._timeout, follow_redirects=True
+                ) as client:
+                    response = await client.get(url, headers=headers)
+        except httpx.HTTPError as exc:
+            logger.debug("Zone enrichment /points request failed: %s", exc)
+            return None
+        except Exception as exc:  # noqa: BLE001 - defensive: never block save
+            logger.debug("Zone enrichment /points unexpected error: %s", exc)
+            return None
+
+        if response.status_code != 200:
+            logger.debug(
+                "Zone enrichment /points returned status %s for (%s, %s)",
+                response.status_code,
+                lat,
+                lon,
+            )
+            return None
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            logger.debug("Zone enrichment /points returned invalid JSON: %s", exc)
+            return None
+
+        if not isinstance(payload, dict):
+            logger.debug("Zone enrichment /points payload not a dict: %r", type(payload))
+            return None
+
+        properties = payload.get("properties")
+        if not isinstance(properties, dict):
+            logger.debug("Zone enrichment /points payload missing 'properties' key")
+            return None
+
+        return properties

--- a/src/accessiweather/services/zone_enrichment_service.py
+++ b/src/accessiweather/services/zone_enrichment_service.py
@@ -13,6 +13,7 @@ returns the original ``Location`` unchanged, and no exception propagates.
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from dataclasses import replace
 from typing import TYPE_CHECKING
 
@@ -62,6 +63,44 @@ def _last_path_segment(url: str | None) -> str | None:
         return None
     segment = trimmed.rsplit("/", 1)[-1]
     return segment or None
+
+
+_ZONE_FIELD_NAMES: tuple[str, ...] = (
+    "timezone",
+    "cwa_office",
+    "forecast_zone_id",
+    "county_zone_id",
+    "fire_zone_id",
+    "radar_station",
+)
+
+
+def diff_zone_fields(stored: Location, fresh: Mapping[str, str | None]) -> dict[str, str]:
+    """
+    Return the subset of zone fields that should be written to ``stored``.
+
+    Rules (mirrors plan A-R4):
+      * Stored null + fresh non-null -> populate.
+      * Stored non-null + fresh non-null and differ -> overwrite.
+      * Fresh null/missing -> no update (NEVER overwrite populated with null).
+      * Equal values are omitted from the result.
+
+    Returns:
+        Dict mapping field name -> new value, containing only fields that
+        should be updated. Empty dict when no change is warranted.
+
+    """
+    changes: dict[str, str] = {}
+    for field_name in _ZONE_FIELD_NAMES:
+        fresh_value = fresh.get(field_name)
+        if fresh_value is None:
+            # Never overwrite a populated stored value with a null fresh value.
+            continue
+        stored_value = getattr(stored, field_name, None)
+        if stored_value == fresh_value:
+            continue
+        changes[field_name] = fresh_value
+    return changes
 
 
 def _extract_zone_fields(properties: dict) -> dict[str, str | None]:

--- a/src/accessiweather/ui/dialogs/location_dialog.py
+++ b/src/accessiweather/ui/dialogs/location_dialog.py
@@ -78,6 +78,30 @@ def show_edit_location_dialog(parent, app: AccessiWeatherApp, location) -> bool 
         return None
 
 
+_ZONE_NOT_RESOLVED_MSG = "Not yet resolved - will populate after next weather refresh"
+
+
+def _edit_location_is_us(location) -> bool:
+    """
+    Determine whether a location should display NWS zone information.
+
+    Uses the country_code fast path first, then falls back to coordinate bounds
+    consistent with ``accessiweather.display.presentation.forecast._is_us_location``.
+    """
+    country_code = getattr(location, "country_code", None)
+    if country_code:
+        return str(country_code).upper() == "US"
+
+    lat = getattr(location, "latitude", None)
+    lon = getattr(location, "longitude", None)
+    if lat is None or lon is None:
+        return False
+    in_continental_bounds = 24.0 <= lat <= 49.0 and -125.0 <= lon <= -66.0
+    in_alaska_bounds = 51.0 <= lat <= 71.5 and -172.0 <= lon <= -130.0
+    in_hawaii_bounds = 18.0 <= lat <= 23.0 and -161.0 <= lon <= -154.0
+    return in_continental_bounds or in_alaska_bounds or in_hawaii_bounds
+
+
 class EditLocationDialog(wx.Dialog):
     """Small dialog for editing an existing location's marine-mode flag."""
 
@@ -86,7 +110,6 @@ class EditLocationDialog(wx.Dialog):
         super().__init__(
             parent,
             title=f"Edit Location: {location.name}",
-            size=(420, 200),
             style=wx.DEFAULT_DIALOG_STYLE,
         )
         self._location = location
@@ -108,6 +131,29 @@ class EditLocationDialog(wx.Dialog):
         self.marine_checkbox.SetName("Enable Marine Mode for this location")
         sizer.Add(self.marine_checkbox, 0, wx.ALL | wx.EXPAND, 10)
 
+        # NWS Zone Information section (US locations only, snapshot at open).
+        self._zone_info_box = wx.StaticBox(panel, label="NWS Zone Information")
+        zone_sizer = wx.StaticBoxSizer(self._zone_info_box, wx.VERTICAL)
+
+        zone_parent = self._zone_info_box
+        zone_id = getattr(location, "forecast_zone_id", None)
+        office = getattr(location, "cwa_office", None)
+
+        forecast_zone_text = (
+            f"Forecast Zone: {zone_id}" if zone_id else f"Forecast Zone: {_ZONE_NOT_RESOLVED_MSG}"
+        )
+        office_text = f"NWS Office: {office}" if office else f"NWS Office: {_ZONE_NOT_RESOLVED_MSG}"
+
+        self._forecast_zone_label = wx.StaticText(zone_parent, label=forecast_zone_text)
+        self._cwa_office_label = wx.StaticText(zone_parent, label=office_text)
+        zone_sizer.Add(self._forecast_zone_label, 0, wx.ALL, 5)
+        zone_sizer.Add(self._cwa_office_label, 0, wx.ALL, 5)
+        sizer.Add(zone_sizer, 0, wx.ALL | wx.EXPAND, 10)
+
+        if not _edit_location_is_us(location):
+            # Hide the entire box for non-US locations (no "N/A" fallback).
+            self._zone_info_box.Show(False)
+
         button_sizer = wx.StdDialogButtonSizer()
         ok_button = wx.Button(panel, wx.ID_OK, "&Save")
         cancel_button = wx.Button(panel, wx.ID_CANCEL, "Cancel")
@@ -118,6 +164,10 @@ class EditLocationDialog(wx.Dialog):
 
         panel.SetSizer(sizer)
         ok_button.SetDefault()
+
+        # Fit to content, but keep a baseline minimum width.
+        self.SetMinSize(wx.Size(420, -1))
+        self.Fit()
 
     def get_marine_mode(self) -> bool:
         """Return the marine_mode value chosen in the dialog."""

--- a/src/accessiweather/weather_client_nws.py
+++ b/src/accessiweather/weather_client_nws.py
@@ -21,6 +21,10 @@ from .models import (
     WeatherAlert,
     WeatherAlerts,
 )
+from .services.zone_enrichment_service import (
+    _extract_zone_fields,
+    diff_zone_fields,
+)
 from .utils.retry_utils import (
     RETRYABLE_EXCEPTIONS,
     async_retry_with_backoff,
@@ -32,7 +36,88 @@ from .weather_client_parsers import (
     convert_wind_speed_to_mph_and_kph,
 )
 
+# wxPython is an optional runtime dep. Import lazily via a module-level handle
+# so tests (and headless CI) can patch or stub it without importing the full
+# wx package. When wx is unavailable, CallAfter becomes a best-effort direct
+# call — acceptable since the drift hook is a no-op under those conditions
+# (no sink is registered in non-GUI test contexts).
+try:
+    import wx  # type: ignore[import-untyped]
+except ImportError:  # pragma: no cover - handled at runtime
+    wx = None  # type: ignore[assignment]
+
+# Registered drift-correction sink. Wired up by app initialization to point at
+# the application's ``LocationOperations`` instance. Unit tests register their
+# own sink directly. The hook is a silent no-op until a sink is installed.
+_ZONE_DRIFT_SINK: Any = None
+
 logger = logging.getLogger(__name__)
+
+
+def set_zone_drift_sink(sink: Any) -> None:
+    """
+    Register (or clear) the object used to persist drift-corrected zone fields.
+
+    The ``sink`` must expose an ``update_zone_metadata(location_name, fields)``
+    callable — typically a :class:`accessiweather.config.locations.LocationOperations`
+    instance. Pass ``None`` to clear.
+
+    This is intentionally a module-global registration: weather-client HTTP
+    helpers are shared across the app and cannot easily thread an extra
+    dependency through every signature. Wiring is performed once during app
+    startup; tests install/clear the sink as needed.
+    """
+    global _ZONE_DRIFT_SINK
+    _ZONE_DRIFT_SINK = sink
+
+
+def _apply_zone_drift_correction(location: Location, point_data: dict[str, Any] | None) -> None:
+    """
+    Diff fresh ``/points`` properties against ``location`` and persist drift.
+
+    Called from the weather-refresh thread after each successful ``/points``
+    fetch. Never raises: a drift bug must never cascade into breaking the
+    weather refresh flow.
+
+    Persistence is funneled through ``wx.CallAfter`` so that the main thread
+    performs the actual config write — ``ConfigManager.save_config`` has no
+    in-process lock, and main-thread bounce is the smallest correct fix.
+    """
+    sink = _ZONE_DRIFT_SINK
+    if sink is None:
+        return
+    try:
+        if not isinstance(point_data, dict):
+            return
+        properties = point_data.get("properties")
+        if not isinstance(properties, dict):
+            return
+
+        fresh_fields = _extract_zone_fields(properties)
+        changes = diff_zone_fields(location, fresh_fields)
+        if not changes:
+            return
+
+        persist = getattr(sink, "update_zone_metadata", None)
+        if persist is None:
+            return
+
+        call_after = getattr(wx, "CallAfter", None) if wx is not None else None
+        if call_after is None:
+            # No wx event loop available — skip silently rather than writing
+            # from a background thread unprotected.
+            logger.debug("Zone drift: wx.CallAfter unavailable, skipping persist")
+            return
+
+        call_after(persist, location.name, changes)
+        logger.debug(
+            "Zone drift: scheduled update for %s: %s",
+            location.name,
+            sorted(changes.keys()),
+        )
+    except Exception as exc:  # noqa: BLE001 - must never break refresh
+        logger.debug("Zone drift correction raised (suppressed): %s", exc)
+
 
 MAX_STATION_OBSERVATION_ATTEMPTS = 10
 MAX_OBSERVATION_AGE = timedelta(hours=2)
@@ -338,6 +423,9 @@ async def get_nws_all_data_parallel(
         response = await _client_get(client, grid_url, headers=headers)
         response.raise_for_status()
         grid_data = response.json()
+
+        # Opportunistic zone-metadata drift correction. Never raises.
+        _apply_zone_drift_correction(location, grid_data)
 
         # Now fetch all other data in parallel, reusing grid_data
         current_task = asyncio.create_task(

--- a/src/accessiweather/weather_client_nws.py
+++ b/src/accessiweather/weather_client_nws.py
@@ -959,23 +959,35 @@ async def get_nws_alerts(
 
         # Build params based on alert_radius_type
         if alert_radius_type == "county":
-            # Get county zone from point data
-            point_url = f"{nws_base_url}/points/{location.latitude},{location.longitude}"
-            if client is not None:
-                point_response = await _client_get(client, point_url, headers=headers)
+            # Prefer the stored county_zone_id (populated by zone enrichment and
+            # kept fresh by drift correction). This skips a redundant /points
+            # round-trip on each refresh. Fall back to /points resolution when
+            # the stored field is absent.
+            if location.county_zone_id:
+                params = {"zone": location.county_zone_id, "status": "actual"}
             else:
-                async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as new_client:
-                    point_response = await new_client.get(point_url, headers=headers)
-            point_response.raise_for_status()
-            point_data = point_response.json()
+                # Get county zone from point data
+                point_url = f"{nws_base_url}/points/{location.latitude},{location.longitude}"
+                if client is not None:
+                    point_response = await _client_get(client, point_url, headers=headers)
+                else:
+                    async with httpx.AsyncClient(
+                        timeout=timeout, follow_redirects=True
+                    ) as new_client:
+                        point_response = await new_client.get(point_url, headers=headers)
+                point_response.raise_for_status()
+                point_data = point_response.json()
 
-            county_url = point_data.get("properties", {}).get("county")
-            if county_url and "/county/" in county_url:
-                zone_id = county_url.split("/county/")[1]
-                params = {"zone": zone_id, "status": "actual"}
-            else:
-                logger.warning("Could not determine county zone, falling back to point query")
-                params = {"point": f"{location.latitude},{location.longitude}", "status": "actual"}
+                county_url = point_data.get("properties", {}).get("county")
+                if county_url and "/county/" in county_url:
+                    zone_id = county_url.split("/county/")[1]
+                    params = {"zone": zone_id, "status": "actual"}
+                else:
+                    logger.warning("Could not determine county zone, falling back to point query")
+                    params = {
+                        "point": f"{location.latitude},{location.longitude}",
+                        "status": "actual",
+                    }
 
         elif alert_radius_type == "state":
             # Get state from location - need to fetch point data first
@@ -1001,32 +1013,44 @@ async def get_nws_alerts(
                 params = {"point": f"{location.latitude},{location.longitude}", "status": "actual"}
 
         elif alert_radius_type == "zone":
-            # Get zone from point data
-            point_url = f"{nws_base_url}/points/{location.latitude},{location.longitude}"
-            if client is not None:
-                point_response = await _client_get(client, point_url, headers=headers)
+            # Prefer the stored forecast_zone_id (populated by zone enrichment
+            # and kept fresh by drift correction). This skips a redundant
+            # /points round-trip on each refresh. Fall back to /points
+            # resolution when the stored field is absent.
+            if location.forecast_zone_id:
+                params = {"zone": location.forecast_zone_id, "status": "actual"}
             else:
-                async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as new_client:
-                    point_response = await new_client.get(point_url, headers=headers)
-            point_response.raise_for_status()
-            point_data = point_response.json()
+                # Get zone from point data
+                point_url = f"{nws_base_url}/points/{location.latitude},{location.longitude}"
+                if client is not None:
+                    point_response = await _client_get(client, point_url, headers=headers)
+                else:
+                    async with httpx.AsyncClient(
+                        timeout=timeout, follow_redirects=True
+                    ) as new_client:
+                        point_response = await new_client.get(point_url, headers=headers)
+                point_response.raise_for_status()
+                point_data = point_response.json()
 
-            # Try to get zone ID (prefer county, then forecast zone)
-            zone_id = None
-            county_url = point_data.get("properties", {}).get("county")
-            if county_url and "/county/" in county_url:
-                zone_id = county_url.split("/county/")[1]
-            if not zone_id:
-                forecast_zone_url = point_data.get("properties", {}).get("forecastZone")
-                if forecast_zone_url and "/forecast/" in forecast_zone_url:
-                    zone_id = forecast_zone_url.split("/forecast/")[1]
+                # Try to get zone ID (prefer county, then forecast zone)
+                zone_id = None
+                county_url = point_data.get("properties", {}).get("county")
+                if county_url and "/county/" in county_url:
+                    zone_id = county_url.split("/county/")[1]
+                if not zone_id:
+                    forecast_zone_url = point_data.get("properties", {}).get("forecastZone")
+                    if forecast_zone_url and "/forecast/" in forecast_zone_url:
+                        zone_id = forecast_zone_url.split("/forecast/")[1]
 
-            if zone_id:
-                params = {"zone": zone_id, "status": "actual"}
-            else:
-                # Fall back to point query if zone not found
-                logger.warning("Could not determine zone, falling back to point query")
-                params = {"point": f"{location.latitude},{location.longitude}", "status": "actual"}
+                if zone_id:
+                    params = {"zone": zone_id, "status": "actual"}
+                else:
+                    # Fall back to point query if zone not found
+                    logger.warning("Could not determine zone, falling back to point query")
+                    params = {
+                        "point": f"{location.latitude},{location.longitude}",
+                        "status": "actual",
+                    }
 
         else:  # "point" (default) - most precise
             params = {

--- a/tests/gui/test_location_dialog_zone_info.py
+++ b/tests/gui/test_location_dialog_zone_info.py
@@ -1,0 +1,339 @@
+"""
+Tests for the NWS Zone Information section in EditLocationDialog.
+
+Covers Unit 5 of the Forecast Products PR 1 plan (A-R8, A-R9):
+- "Forecast Zone" and "NWS Office" rows under a StaticBox
+- Hidden for non-US locations (country_code != "US")
+- "Not yet resolved" fallback for US locations with null zone fields
+- Sizing switches from fixed (420, 200) to Fit()-based with 420 min width
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Extend the wx stub with the constants/classes EditLocationDialog needs.
+# ---------------------------------------------------------------------------
+_wx = sys.modules["wx"]
+
+for _attr, _val in {
+    "DEFAULT_DIALOG_STYLE": 0,
+    "ALIGN_RIGHT": 0x0200,
+    "LEFT": 0x0010,
+    "RIGHT": 0x0020,
+    "TOP": 0x0040,
+    "BOTTOM": 0x0080,
+}.items():
+    if not hasattr(_wx, _attr):
+        setattr(_wx, _attr, _val)
+
+# StaticBox / StaticBoxSizer / StdDialogButtonSizer / Size are not in the root stub.
+for _attr in ("StaticBox", "StaticBoxSizer", "StdDialogButtonSizer", "Size"):
+    if not hasattr(_wx, _attr):
+        setattr(_wx, _attr, MagicMock(name=_attr))
+
+_USING_STUB = (
+    not hasattr(sys.modules.get("wx", None), "App") or _wx.Dialog.__name__ == "_WxStubBase"
+)
+
+# Ensure Dialog base class has the instance methods the dialog invokes on self.
+_StubBase = _wx.Dialog
+for _meth in ("SetSize", "SetMinSize", "Fit", "Show", "Hide", "Bind", "EndModal"):
+    if not hasattr(_StubBase, _meth):
+        setattr(_StubBase, _meth, lambda self, *a, **kw: None)
+
+
+from accessiweather.models import Location  # noqa: E402
+from accessiweather.ui.dialogs.location_dialog import EditLocationDialog  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+class _DialogRecorder:
+    """Captures constructor args and tracks widgets created during init."""
+
+    def __init__(self):
+        self.dialog_kwargs: dict = {}
+        self.static_boxes: list[MagicMock] = []
+        self.static_texts: list[MagicMock] = []
+        self.min_size_calls: list = []
+        self.fit_calls: int = 0
+
+
+@pytest.fixture
+def recorder():
+    """Patch wx classes to capture widgets and dialog init kwargs."""
+    rec = _DialogRecorder()
+    saved: dict = {}
+    active_patches: list = []
+
+    if not _USING_STUB:
+        # Real wx installed — patch Dialog.__init__ and instance methods.
+        for method in ("__init__", "SetSize", "Bind", "EndModal", "Show", "Hide"):
+            if method == "__init__":
+                p = patch.object(_wx.Dialog, "__init__", lambda self, *a, **kw: None)
+            else:
+                p = patch.object(_wx.Dialog, method, lambda self, *a, **kw: None)
+            active_patches.append(p)
+            p.start()
+
+    # Track Dialog __init__ kwargs via a wrapper around the base class.
+    _orig_dialog_init = _wx.Dialog.__init__
+
+    def _dialog_init(self, *a, **kw):
+        rec.dialog_kwargs = dict(kw)
+        # For tests, do NOT forward to super() (stub) to keep behaviour trivial.
+        return
+
+    saved["Dialog.__init__"] = _orig_dialog_init
+    _wx.Dialog.__init__ = _dialog_init
+
+    # Track SetMinSize and Fit on the Dialog base class
+    def _set_min_size(self, *a, **kw):
+        rec.min_size_calls.append(a[0] if a else kw)
+
+    def _fit(self, *a, **kw):
+        rec.fit_calls += 1
+
+    _StubBase.SetMinSize = _set_min_size
+    _StubBase.Fit = _fit
+
+    # Track StaticText creations — return real MagicMocks that retain the label
+    # so GetLabel() returns what was passed in.
+    def _make_static_text(*args, **kwargs):
+        st = MagicMock(name="StaticText")
+        label = kwargs.get("label", args[1] if len(args) > 1 else "")
+        st.GetLabel.return_value = label
+        st._test_label = label  # convenience for assertions
+        rec.static_texts.append(st)
+        return st
+
+    saved["StaticText"] = _wx.StaticText
+    _wx.StaticText = _make_static_text
+
+    # Track StaticBox creations — record Show() calls for visibility assertions.
+    def _make_static_box(*args, **kwargs):
+        box = MagicMock(name="StaticBox")
+        box.IsShown.return_value = True
+
+        def _box_show(visible=True):
+            box.IsShown.return_value = bool(visible)
+
+        box.Show.side_effect = _box_show
+        rec.static_boxes.append(box)
+        return box
+
+    saved["StaticBox"] = _wx.StaticBox
+    _wx.StaticBox = _make_static_box
+
+    # StaticBoxSizer is called with (box, orient) — return a MagicMock sizer.
+    saved["StaticBoxSizer"] = _wx.StaticBoxSizer
+    _wx.StaticBoxSizer = MagicMock(
+        name="StaticBoxSizer", side_effect=lambda *a, **kw: MagicMock(name="StaticBoxSizerInst")
+    )
+
+    saved["StdDialogButtonSizer"] = _wx.StdDialogButtonSizer
+    _wx.StdDialogButtonSizer = MagicMock(
+        name="StdDialogButtonSizer",
+        side_effect=lambda *a, **kw: MagicMock(name="StdDialogButtonSizerInst"),
+    )
+
+    # BoxSizer likewise — return a MagicMock so Add() is tracked.
+    saved["BoxSizer"] = _wx.BoxSizer
+    _wx.BoxSizer = MagicMock(
+        name="BoxSizer", side_effect=lambda *a, **kw: MagicMock(name="BoxSizerInst")
+    )
+
+    saved["Panel"] = _wx.Panel
+    _wx.Panel = MagicMock(name="Panel", side_effect=lambda *a, **kw: MagicMock(name="PanelInst"))
+
+    saved["Button"] = _wx.Button
+    _wx.Button = MagicMock(name="Button", side_effect=lambda *a, **kw: MagicMock(name="ButtonInst"))
+
+    saved["CheckBox"] = _wx.CheckBox
+    _wx.CheckBox = MagicMock(
+        name="CheckBox", side_effect=lambda *a, **kw: MagicMock(name="CheckBoxInst")
+    )
+
+    # Patch wx.Size with a MagicMock so ctor calls are tracked even when
+    # real wxPython is installed on the host.
+    saved["Size"] = _wx.Size
+    _wx.Size = MagicMock(name="Size", side_effect=lambda *a, **kw: (a, kw))
+
+    yield rec
+
+    # Restore
+    _wx.Dialog.__init__ = saved["Dialog.__init__"]
+    for name in (
+        "StaticText",
+        "StaticBox",
+        "StaticBoxSizer",
+        "StdDialogButtonSizer",
+        "BoxSizer",
+        "Panel",
+        "Button",
+        "CheckBox",
+        "Size",
+    ):
+        setattr(_wx, name, saved[name])
+
+    for p in active_patches:
+        p.stop()
+
+
+def _find_text_with_prefix(texts, prefix: str):
+    """Return the first StaticText mock whose label starts with prefix."""
+    for t in texts:
+        if t._test_label.startswith(prefix):
+            return t
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+class TestEditLocationDialogZoneInfo:
+    """Covers the NWS Zone Information StaticBox in EditLocationDialog."""
+
+    def test_happy_path_us_populated(self, recorder):
+        """US location with populated zone fields renders both rows."""
+        loc = Location(
+            name="Raleigh, NC",
+            latitude=35.78,
+            longitude=-78.64,
+            country_code="US",
+            forecast_zone_id="NCZ027",
+            cwa_office="RAH",
+        )
+
+        EditLocationDialog(parent=MagicMock(), location=loc)
+
+        zone_row = _find_text_with_prefix(recorder.static_texts, "Forecast Zone:")
+        office_row = _find_text_with_prefix(recorder.static_texts, "NWS Office:")
+        assert zone_row is not None
+        assert office_row is not None
+        assert zone_row._test_label == "Forecast Zone: NCZ027"
+        assert office_row._test_label == "NWS Office: RAH"
+
+        # StaticBox exists and was NOT hidden.
+        assert len(recorder.static_boxes) == 1
+        assert recorder.static_boxes[0].IsShown() is True
+
+    def test_non_us_location_hides_staticbox(self, recorder):
+        """Non-US location hides the entire NWS Zone Information StaticBox."""
+        loc = Location(
+            name="London, UK",
+            latitude=51.5074,
+            longitude=-0.1278,
+            country_code="GB",
+            forecast_zone_id=None,
+            cwa_office=None,
+        )
+
+        EditLocationDialog(parent=MagicMock(), location=loc)
+
+        assert len(recorder.static_boxes) == 1
+        box = recorder.static_boxes[0]
+        # Show(False) was called on the box.
+        box.Show.assert_called_once_with(False)
+        assert box.IsShown() is False
+
+    def test_us_both_null_shows_not_yet_resolved(self, recorder):
+        """US location with both fields null shows the 'Not yet resolved' message."""
+        loc = Location(
+            name="Phoenix, AZ",
+            latitude=33.45,
+            longitude=-112.07,
+            country_code="US",
+            forecast_zone_id=None,
+            cwa_office=None,
+        )
+
+        EditLocationDialog(parent=MagicMock(), location=loc)
+
+        zone_row = _find_text_with_prefix(recorder.static_texts, "Forecast Zone:")
+        office_row = _find_text_with_prefix(recorder.static_texts, "NWS Office:")
+        assert zone_row is not None
+        assert office_row is not None
+        assert "Not yet resolved" in zone_row._test_label
+        assert "Not yet resolved" in office_row._test_label
+
+        # StaticBox is still shown (US location).
+        assert recorder.static_boxes[0].IsShown() is True
+        recorder.static_boxes[0].Show.assert_not_called()
+
+    def test_us_partial_mixed_values(self, recorder):
+        """US location with one field populated and the other null."""
+        loc = Location(
+            name="Somewhere, US",
+            latitude=40.0,
+            longitude=-100.0,
+            country_code="US",
+            forecast_zone_id="ABZ001",
+            cwa_office=None,
+        )
+
+        EditLocationDialog(parent=MagicMock(), location=loc)
+
+        zone_row = _find_text_with_prefix(recorder.static_texts, "Forecast Zone:")
+        office_row = _find_text_with_prefix(recorder.static_texts, "NWS Office:")
+        assert zone_row is not None and office_row is not None
+        assert zone_row._test_label == "Forecast Zone: ABZ001"
+        assert "Not yet resolved" in office_row._test_label
+
+    def test_sizing_uses_fit_and_min_size(self, recorder):
+        """Dialog calls SetMinSize((420, -1)) + Fit(), not the old fixed size."""
+        loc = Location(
+            name="Raleigh, NC",
+            latitude=35.78,
+            longitude=-78.64,
+            country_code="US",
+            forecast_zone_id="NCZ027",
+            cwa_office="RAH",
+        )
+
+        EditLocationDialog(parent=MagicMock(), location=loc)
+
+        # Fit() was called at least once
+        assert recorder.fit_calls >= 1
+        # SetMinSize was called (with a wx.Size built from 420, -1).
+        assert len(recorder.min_size_calls) >= 1
+        # wx.Size was constructed with (420, -1) during dialog init.
+        size_ctor_calls = [(c.args, c.kwargs) for c in getattr(_wx.Size, "call_args_list", [])]
+        assert ((420, -1), {}) in size_ctor_calls
+
+        # And the fixed size=(420, 200) is no longer passed to Dialog.__init__.
+        assert "size" not in recorder.dialog_kwargs or recorder.dialog_kwargs.get("size") != (
+            420,
+            200,
+        )
+
+    def test_accessibility_labels_via_getlabel(self, recorder):
+        """
+        Each StaticText row's GetLabel() returns the label-prefixed string.
+
+        Screen readers announce adjacent wx.StaticText content — this is the
+        accessibility affordance, not SetName() or tooltips.
+        """
+        loc = Location(
+            name="Raleigh, NC",
+            latitude=35.78,
+            longitude=-78.64,
+            country_code="US",
+            forecast_zone_id="NCZ027",
+            cwa_office="RAH",
+        )
+
+        EditLocationDialog(parent=MagicMock(), location=loc)
+
+        zone_row = _find_text_with_prefix(recorder.static_texts, "Forecast Zone:")
+        office_row = _find_text_with_prefix(recorder.static_texts, "NWS Office:")
+
+        assert zone_row is not None and office_row is not None
+        assert zone_row.GetLabel() == "Forecast Zone: NCZ027"
+        assert office_row.GetLabel() == "NWS Office: RAH"

--- a/tests/test_models_config_location_zones.py
+++ b/tests/test_models_config_location_zones.py
@@ -1,0 +1,193 @@
+"""
+Tests for Location zone-metadata fields and their JSON round-trip.
+
+Covers Unit 1 of the Forecast Products PR 1 plan: zone fields on `Location`,
+round-trip through `AppConfig.to_dict`/`from_dict`, and the
+`_transform_point_data` passthrough of cwa/forecastZone/gridId.
+"""
+
+from __future__ import annotations
+
+from accessiweather.api.nws.point_location import NwsPointLocation
+from accessiweather.models import AppConfig, AppSettings, Location
+
+
+def _make_config_with(location: Location) -> AppConfig:
+    return AppConfig(
+        settings=AppSettings(),
+        locations=[location],
+        current_location=location,
+    )
+
+
+class TestLocationZoneFieldsRoundTrip:
+    """Round-trip scenarios for the six zone-metadata fields on Location."""
+
+    def test_all_zone_fields_populated_round_trip(self):
+        """All six zone fields round-trip identically through to_dict/from_dict."""
+        loc = Location(
+            name="Philadelphia",
+            latitude=39.9526,
+            longitude=-75.1652,
+            timezone="America/New_York",
+            country_code="US",
+            forecast_zone_id="PAZ106",
+            cwa_office="PHI",
+            county_zone_id="PAC101",
+            fire_zone_id="PAZ106",
+            radar_station="KDIX",
+        )
+
+        data = _make_config_with(loc).to_dict()
+        restored = AppConfig.from_dict(data)
+
+        assert restored.current_location is not None
+        restored_loc = restored.current_location
+        assert restored_loc.forecast_zone_id == "PAZ106"
+        assert restored_loc.cwa_office == "PHI"
+        assert restored_loc.county_zone_id == "PAC101"
+        assert restored_loc.fire_zone_id == "PAZ106"
+        assert restored_loc.radar_station == "KDIX"
+        assert restored_loc.timezone == "America/New_York"
+
+        # And the same via the locations list
+        assert len(restored.locations) == 1
+        assert restored.locations[0].cwa_office == "PHI"
+
+    def test_all_zone_fields_null_no_null_keys_emitted(self):
+        """When zone fields are None, keys must not appear in serialized JSON."""
+        loc = Location(name="Test", latitude=40.0, longitude=-74.0)
+
+        data = _make_config_with(loc).to_dict()
+
+        loc_json = data["locations"][0]
+        current_json = data["current_location"]
+
+        for zone_key in (
+            "forecast_zone_id",
+            "cwa_office",
+            "county_zone_id",
+            "fire_zone_id",
+            "radar_station",
+            "timezone",
+        ):
+            assert zone_key not in loc_json, f"{zone_key} should not be emitted when null"
+            assert zone_key not in current_json, (
+                f"{zone_key} should not be emitted when null on current_location"
+            )
+
+        # And round-trip still produces None
+        restored = AppConfig.from_dict(data)
+        assert restored.current_location is not None
+        assert restored.current_location.forecast_zone_id is None
+        assert restored.current_location.cwa_office is None
+        assert restored.current_location.county_zone_id is None
+        assert restored.current_location.fire_zone_id is None
+        assert restored.current_location.radar_station is None
+        assert restored.current_location.timezone is None
+
+    def test_legacy_json_without_zone_fields_deserializes_cleanly(self):
+        """Legacy JSON missing zone keys yields a Location with all-null zone fields."""
+        legacy_data = {
+            "settings": {},
+            "locations": [
+                {
+                    "name": "Legacy City",
+                    "latitude": 40.0,
+                    "longitude": -74.0,
+                }
+            ],
+            "current_location": {
+                "name": "Legacy City",
+                "latitude": 40.0,
+                "longitude": -74.0,
+            },
+        }
+
+        config = AppConfig.from_dict(legacy_data)
+
+        assert len(config.locations) == 1
+        legacy_loc = config.locations[0]
+        assert legacy_loc.name == "Legacy City"
+        assert legacy_loc.forecast_zone_id is None
+        assert legacy_loc.cwa_office is None
+        assert legacy_loc.county_zone_id is None
+        assert legacy_loc.fire_zone_id is None
+        assert legacy_loc.radar_station is None
+        assert legacy_loc.timezone is None
+        assert legacy_loc.country_code is None
+        assert legacy_loc.marine_mode is False
+
+        assert config.current_location is not None
+        assert config.current_location.cwa_office is None
+
+    def test_partial_population_only_cwa_office_round_trips(self):
+        """Only cwa_office populated: other zone keys must not appear in JSON."""
+        loc = Location(
+            name="Partial",
+            latitude=41.0,
+            longitude=-75.0,
+            cwa_office="PHI",
+        )
+
+        data = _make_config_with(loc).to_dict()
+        loc_json = data["locations"][0]
+
+        assert loc_json["cwa_office"] == "PHI"
+        for zone_key in (
+            "forecast_zone_id",
+            "county_zone_id",
+            "fire_zone_id",
+            "radar_station",
+            "timezone",
+        ):
+            assert zone_key not in loc_json
+
+        restored = AppConfig.from_dict(data)
+        restored_loc = restored.locations[0]
+        assert restored_loc.cwa_office == "PHI"
+        assert restored_loc.forecast_zone_id is None
+        assert restored_loc.county_zone_id is None
+        assert restored_loc.fire_zone_id is None
+        assert restored_loc.radar_station is None
+        assert restored_loc.timezone is None
+
+
+class TestTransformPointDataZonePassthrough:
+    """_transform_point_data must expose cwa, forecastZone, gridId."""
+
+    def test_transform_point_data_includes_zone_passthroughs(self):
+        """Realistic /points response: cwa, forecastZone, gridId pass through unchanged."""
+        # Minimal-but-realistic NWS /points response fixture.
+        raw_point_response = {
+            "properties": {
+                "forecast": "https://api.weather.gov/gridpoints/PHI/50,75/forecast",
+                "forecastHourly": ("https://api.weather.gov/gridpoints/PHI/50,75/forecast/hourly"),
+                "forecastGridData": "https://api.weather.gov/gridpoints/PHI/50,75",
+                "observationStations": ("https://api.weather.gov/gridpoints/PHI/50,75/stations"),
+                "county": "https://api.weather.gov/zones/county/PAC101",
+                "fireWeatherZone": "https://api.weather.gov/zones/fire/PAZ106",
+                "timeZone": "America/New_York",
+                "radarStation": "KDIX",
+                "cwa": "PHI",
+                "forecastZone": "https://api.weather.gov/zones/forecast/PAZ106",
+                "gridId": "PHI",
+            }
+        }
+
+        # _transform_point_data doesn't rely on wrapper internals.
+        transformer = NwsPointLocation(wrapper_instance=None)
+        transformed = transformer._transform_point_data(raw_point_response)
+
+        props = transformed["properties"]
+        # New passthroughs
+        assert props["cwa"] == "PHI"
+        assert props["forecastZone"] == "https://api.weather.gov/zones/forecast/PAZ106"
+        assert props["gridId"] == "PHI"
+
+        # Existing passthroughs remain intact (regression guard)
+        assert props["county"] == "https://api.weather.gov/zones/county/PAC101"
+        assert props["fireWeatherZone"] == "https://api.weather.gov/zones/fire/PAZ106"
+        assert props["timeZone"] == "America/New_York"
+        assert props["radarStation"] == "KDIX"
+        assert props["forecast"] == ("https://api.weather.gov/gridpoints/PHI/50,75/forecast")

--- a/tests/test_weather_client_nws_alerts_zone_reuse.py
+++ b/tests/test_weather_client_nws_alerts_zone_reuse.py
@@ -1,0 +1,307 @@
+"""
+Tests for zone-reuse optimization in the NWS alert-fetch path.
+
+Unit 4 of the Forecast Products PR 1 plan (A-R6): when a ``Location`` has
+a stored ``county_zone_id`` (or ``forecast_zone_id`` for the zone radius
+type), ``get_nws_alerts`` should use it directly and skip the per-refresh
+``/points`` call. When the stored field is absent, the existing ``/points``
+resolution path is used.
+
+Tests mock ``httpx`` so no network calls are made.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from accessiweather.models import Location
+from accessiweather.weather_client_nws import get_nws_alerts
+
+BASE_URL = "https://api.weather.gov"
+USER_AGENT = "Test/1.0"
+
+
+def _make_response(payload: dict, status_code: int = 200) -> MagicMock:
+    """Build a mock httpx response object."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    response.raise_for_status = MagicMock()
+    if status_code >= 400:
+        # Simulate httpx raising for error responses.
+        def _raise() -> None:
+            request = httpx.Request("GET", BASE_URL)
+            raise httpx.HTTPStatusError(
+                f"HTTP {status_code}",
+                request=request,
+                response=httpx.Response(status_code, request=request),
+            )
+
+        response.raise_for_status.side_effect = _raise
+    return response
+
+
+def _classify_call(call) -> str:
+    """Classify a mock httpx GET call as points/alerts/other."""
+    # httpx.AsyncClient.get(url, headers=..., params=...) — url is positional arg 0.
+    url = call.args[0] if call.args else call.kwargs.get("url", "")
+    if "/points/" in url:
+        return "points"
+    if "/alerts/active" in url:
+        return "alerts"
+    return "other"
+
+
+def _count_calls(mock_client: AsyncMock) -> dict[str, int]:
+    counts = {"points": 0, "alerts": 0, "other": 0}
+    for call in mock_client.get.call_args_list:
+        counts[_classify_call(call)] += 1
+    return counts
+
+
+@pytest.fixture
+def stored_location() -> Location:
+    """Return a US location with zone metadata already populated."""
+    return Location(
+        name="Stored City",
+        latitude=40.7128,
+        longitude=-74.0060,
+        county_zone_id="NYC061",
+        forecast_zone_id="NYZ072",
+    )
+
+
+@pytest.fixture
+def unstored_location() -> Location:
+    """Return a US location without zone metadata — should fall back to /points."""
+    return Location(
+        name="Unstored City",
+        latitude=40.7128,
+        longitude=-74.0060,
+    )
+
+
+@pytest.fixture
+def empty_alerts_payload() -> dict:
+    return {"features": []}
+
+
+@pytest.fixture
+def points_payload() -> dict:
+    """Minimal /points payload with county + forecastZone URLs."""
+    return {
+        "properties": {
+            "county": "https://api.weather.gov/zones/county/NYC061",
+            "forecastZone": "https://api.weather.gov/zones/forecast/NYZ072",
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_county_happy_path_uses_stored_zone(stored_location, empty_alerts_payload):
+    """County radius + stored county_zone_id → zone param used, no /points call."""
+    alerts_response = _make_response(empty_alerts_payload)
+
+    with patch("accessiweather.weather_client_nws.httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client.get.return_value = alerts_response
+
+        result = await get_nws_alerts(
+            location=stored_location,
+            nws_base_url=BASE_URL,
+            user_agent=USER_AGENT,
+            timeout=10.0,
+            alert_radius_type="county",
+        )
+
+    assert result is not None
+    counts = _count_calls(mock_client)
+    assert counts["points"] == 0, "Stored county_zone_id must skip /points"
+    assert counts["alerts"] == 1
+
+    # Inspect the alert call's params.
+    alert_call = next(c for c in mock_client.get.call_args_list if _classify_call(c) == "alerts")
+    params = alert_call.kwargs.get("params", {})
+    assert params.get("zone") == "NYC061"
+    assert params.get("status") == "actual"
+    assert "point" not in params
+
+
+@pytest.mark.asyncio
+async def test_zone_happy_path_uses_stored_forecast_zone(stored_location, empty_alerts_payload):
+    """Zone radius + stored forecast_zone_id → zone param used, no /points call."""
+    alerts_response = _make_response(empty_alerts_payload)
+
+    with patch("accessiweather.weather_client_nws.httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client.get.return_value = alerts_response
+
+        result = await get_nws_alerts(
+            location=stored_location,
+            nws_base_url=BASE_URL,
+            user_agent=USER_AGENT,
+            timeout=10.0,
+            alert_radius_type="zone",
+        )
+
+    assert result is not None
+    counts = _count_calls(mock_client)
+    assert counts["points"] == 0, "Stored forecast_zone_id must skip /points"
+    assert counts["alerts"] == 1
+
+    alert_call = next(c for c in mock_client.get.call_args_list if _classify_call(c) == "alerts")
+    params = alert_call.kwargs.get("params", {})
+    assert params.get("zone") == "NYZ072"
+    assert params.get("status") == "actual"
+
+
+@pytest.mark.asyncio
+async def test_county_fallback_when_stored_fields_absent(
+    unstored_location, empty_alerts_payload, points_payload
+):
+    """County radius + no stored zone → /points runs + alerts request works."""
+    points_response = _make_response(points_payload)
+    alerts_response = _make_response(empty_alerts_payload)
+
+    with patch("accessiweather.weather_client_nws.httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        def _dispatch(url: str, *_args: object, **_kwargs: object):  # noqa: ARG001
+            del _args, _kwargs
+            if "/points/" in url:
+                return points_response
+            return alerts_response
+
+        mock_client.get.side_effect = _dispatch
+
+        result = await get_nws_alerts(
+            location=unstored_location,
+            nws_base_url=BASE_URL,
+            user_agent=USER_AGENT,
+            timeout=10.0,
+            alert_radius_type="county",
+        )
+
+    assert result is not None
+    counts = _count_calls(mock_client)
+    assert counts["points"] == 1, "Without stored fields, /points resolution must run"
+    assert counts["alerts"] == 1
+
+    alert_call = next(c for c in mock_client.get.call_args_list if _classify_call(c) == "alerts")
+    params = alert_call.kwargs.get("params", {})
+    assert params.get("zone") == "NYC061"
+
+
+@pytest.mark.asyncio
+async def test_stored_zone_404_surfaces_as_error(stored_location):
+    """
+    Stale stored zone + NWS 404 on zone-alerts → returns safe empty alerts.
+
+    Mirrors the pre-existing behavior of get_nws_alerts: non-retryable
+    errors are swallowed and an empty WeatherAlerts is returned. The
+    important assertion is that the error surfaces normally (no silent
+    downgrade to point query) — i.e. only the zone-alert call is made,
+    and no /points call happens to "rescue" the request.
+    """
+    # 404 from NWS on the zone-alerts fetch.
+    bad_response = _make_response({}, status_code=404)
+
+    with patch("accessiweather.weather_client_nws.httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client.get.return_value = bad_response
+
+        result = await get_nws_alerts(
+            location=stored_location,
+            nws_base_url=BASE_URL,
+            user_agent=USER_AGENT,
+            timeout=10.0,
+            alert_radius_type="county",
+        )
+
+    # Pre-existing behavior: non-retryable error → empty WeatherAlerts.
+    assert result is not None
+    assert result.alerts == []
+
+    counts = _count_calls(mock_client)
+    # No silent /points downgrade — just the one failed zone-alert call.
+    assert counts["points"] == 0
+    assert counts["alerts"] == 1
+
+    alert_call = next(c for c in mock_client.get.call_args_list if _classify_call(c) == "alerts")
+    params = alert_call.kwargs.get("params", {})
+    assert params.get("zone") == "NYC061"
+
+
+@pytest.mark.asyncio
+async def test_integration_second_refresh_has_one_fewer_http_call(
+    empty_alerts_payload, points_payload
+):
+    """
+    Before-stored vs after-stored: second refresh makes exactly one fewer HTTP call.
+
+    Simulates the real-world flow: first refresh with no stored zones must
+    call /points + /alerts (2 calls). After zone enrichment populates
+    county_zone_id, the second refresh calls only /alerts (1 call).
+    """
+    first_location = Location(name="City", latitude=40.7128, longitude=-74.0060)
+    second_location = Location(
+        name="City",
+        latitude=40.7128,
+        longitude=-74.0060,
+        county_zone_id="NYC061",
+    )
+
+    # --- First refresh: no stored fields, /points + /alerts ---
+    with patch("accessiweather.weather_client_nws.httpx.AsyncClient") as mock_client_class:
+        mock_client_first = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client_first
+
+        def _first_dispatch(url: str, *_args: object, **_kwargs: object):  # noqa: ARG001
+            del _args, _kwargs
+            if "/points/" in url:
+                return _make_response(points_payload)
+            return _make_response(empty_alerts_payload)
+
+        mock_client_first.get.side_effect = _first_dispatch
+
+        await get_nws_alerts(
+            location=first_location,
+            nws_base_url=BASE_URL,
+            user_agent=USER_AGENT,
+            timeout=10.0,
+            alert_radius_type="county",
+        )
+
+    first_counts = _count_calls(mock_client_first)
+    first_total = sum(first_counts.values())
+
+    # --- Second refresh: stored county_zone_id, just /alerts ---
+    with patch("accessiweather.weather_client_nws.httpx.AsyncClient") as mock_client_class:
+        mock_client_second = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client_second
+        mock_client_second.get.return_value = _make_response(empty_alerts_payload)
+
+        await get_nws_alerts(
+            location=second_location,
+            nws_base_url=BASE_URL,
+            user_agent=USER_AGENT,
+            timeout=10.0,
+            alert_radius_type="county",
+        )
+
+    second_counts = _count_calls(mock_client_second)
+    second_total = sum(second_counts.values())
+
+    assert first_counts == {"points": 1, "alerts": 1, "other": 0}
+    assert second_counts == {"points": 0, "alerts": 1, "other": 0}
+    assert second_total == first_total - 1, (
+        f"Expected one fewer HTTP call after zone metadata is stored; "
+        f"first={first_total}, second={second_total}"
+    )

--- a/tests/test_zone_enrichment_drift.py
+++ b/tests/test_zone_enrichment_drift.py
@@ -1,0 +1,425 @@
+"""
+Tests for zone-metadata drift correction on weather refresh (Unit 3).
+
+Covers the seven scenarios enumerated in the Forecast Products PR 1 plan:
+
+1. Stored field null + fresh non-null -> diff returns that field; update persists.
+2. Stored and fresh both non-null and equal -> no update, no persist.
+3. Stored and fresh both non-null and differ -> diff returns changed field; overwrite.
+4. Stored non-null + fresh null/missing -> diff returns empty; stored value preserved.
+5. Stored all six null + fresh all six present -> all six populated in one call.
+6. /points raises -> drift skipped silently; refresh not broken; no persist.
+7. Drift write from refresh thread is bounced via wx.CallAfter to the main thread.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from accessiweather.config.config_manager import ConfigManager
+from accessiweather.config.locations import LocationOperations
+from accessiweather.models import AppConfig, AppSettings, Location
+from accessiweather.services.zone_enrichment_service import (
+    diff_zone_fields,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+FULL_FRESH_FIELDS = {
+    "timezone": "America/New_York",
+    "cwa_office": "PHI",
+    "forecast_zone_id": "PAZ106",
+    "county_zone_id": "PAC091",
+    "fire_zone_id": "PAZ106",
+    "radar_station": "KDIX",
+}
+
+FULL_POINTS_PROPERTIES = {
+    "cwa": "PHI",
+    "forecastZone": "https://api.weather.gov/zones/forecast/PAZ106",
+    "county": "https://api.weather.gov/zones/county/PAC091",
+    "fireWeatherZone": "https://api.weather.gov/zones/fire/PAZ106",
+    "radarStation": "KDIX",
+    "timeZone": "America/New_York",
+}
+
+
+class _FakeConfigManager:
+    """Minimal stand-in for ``ConfigManager`` used by LocationOperations tests."""
+
+    def __init__(self, locations: list[Location] | None = None) -> None:
+        self.save_calls = 0
+        self._config = AppConfig(
+            settings=AppSettings(),
+            locations=list(locations) if locations else [],
+            current_location=None,
+        )
+
+    def get_config(self) -> AppConfig:
+        return self._config
+
+    def save_config(self) -> bool:
+        self.save_calls += 1
+        return True
+
+    def _get_logger(self) -> logging.Logger:
+        return logging.getLogger("accessiweather.config.test")
+
+
+def _us_location(**overrides) -> Location:
+    """Build a US location with optional zone-field overrides."""
+    base = {
+        "name": "Philadelphia, PA",
+        "latitude": 39.95,
+        "longitude": -75.16,
+        "country_code": "US",
+    }
+    base.update(overrides)
+    return Location(**base)
+
+
+# ---------------------------------------------------------------------------
+# Scenarios 1-5: diff_zone_fields pure-data behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestDiffZoneFieldsPopulateNull:
+    """Scenario 1: stored null + fresh non-null -> diff returns that field."""
+
+    def test_single_null_field_populated_from_fresh(self):
+        stored = _us_location(cwa_office="PHI")  # all others null
+        fresh = {
+            "timezone": "America/New_York",
+            "cwa_office": "PHI",
+            "forecast_zone_id": None,
+            "county_zone_id": None,
+            "fire_zone_id": None,
+            "radar_station": None,
+        }
+
+        changes = diff_zone_fields(stored, fresh)
+
+        assert changes == {"timezone": "America/New_York"}
+
+
+class TestDiffZoneFieldsNoChangeWhenEqual:
+    """Scenario 2: stored and fresh both non-null and equal -> no update."""
+
+    def test_no_changes_when_all_fields_match(self):
+        stored = _us_location(**FULL_FRESH_FIELDS)
+        fresh = dict(FULL_FRESH_FIELDS)
+
+        changes = diff_zone_fields(stored, fresh)
+
+        assert changes == {}
+
+
+class TestDiffZoneFieldsOverwriteOnChange:
+    """Scenario 3: stored and fresh both non-null and differ -> diff overwrites."""
+
+    def test_single_field_overwritten_when_fresh_differs(self):
+        stored = _us_location(cwa_office="PHI", forecast_zone_id="PAZ106")
+        fresh = {
+            "timezone": None,
+            "cwa_office": "LWX",  # <-- boundary change
+            "forecast_zone_id": "PAZ106",
+            "county_zone_id": None,
+            "fire_zone_id": None,
+            "radar_station": None,
+        }
+
+        changes = diff_zone_fields(stored, fresh)
+
+        assert changes == {"cwa_office": "LWX"}
+
+
+class TestDiffZoneFieldsFreshNullPreserved:
+    """Scenario 4: stored non-null + fresh null/missing -> stored value preserved."""
+
+    def test_fresh_null_does_not_overwrite_populated_stored_value(self):
+        stored = _us_location(
+            cwa_office="PHI",
+            forecast_zone_id="PAZ106",
+            timezone="America/New_York",
+        )
+        fresh = {
+            "timezone": None,
+            "cwa_office": None,
+            "forecast_zone_id": None,
+            "county_zone_id": None,
+            "fire_zone_id": None,
+            "radar_station": None,
+        }
+
+        changes = diff_zone_fields(stored, fresh)
+
+        assert changes == {}
+
+    def test_fresh_missing_keys_do_not_overwrite_stored(self):
+        stored = _us_location(
+            cwa_office="PHI",
+            forecast_zone_id="PAZ106",
+        )
+        # fresh dict omits half the keys entirely
+        fresh = {"cwa_office": "PHI"}
+
+        changes = diff_zone_fields(stored, fresh)
+
+        assert changes == {}
+
+
+class TestDiffZoneFieldsLegacyLocationFirstRefresh:
+    """Scenario 5: stored all six null + fresh all six present -> all populated."""
+
+    def test_legacy_location_populates_all_fields_from_fresh(self):
+        stored = _us_location()  # all six zone fields null
+        fresh = dict(FULL_FRESH_FIELDS)
+
+        changes = diff_zone_fields(stored, fresh)
+
+        assert changes == FULL_FRESH_FIELDS
+        assert set(changes.keys()) == {
+            "timezone",
+            "cwa_office",
+            "forecast_zone_id",
+            "county_zone_id",
+            "fire_zone_id",
+            "radar_station",
+        }
+
+
+# ---------------------------------------------------------------------------
+# update_zone_metadata persistence
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateZoneMetadata:
+    """LocationOperations.update_zone_metadata mutates + persists via save_config."""
+
+    def test_applies_changes_and_persists(self):
+        stored = _us_location()  # all null
+        manager = _FakeConfigManager(locations=[stored])
+        ops = LocationOperations(cast(ConfigManager, manager))
+
+        ok = ops.update_zone_metadata("Philadelphia, PA", dict(FULL_FRESH_FIELDS))
+
+        assert ok is True
+        assert manager.save_calls == 1
+        updated = manager.get_config().locations[0]
+        assert updated.timezone == "America/New_York"
+        assert updated.cwa_office == "PHI"
+        assert updated.forecast_zone_id == "PAZ106"
+        assert updated.county_zone_id == "PAC091"
+        assert updated.fire_zone_id == "PAZ106"
+        assert updated.radar_station == "KDIX"
+        # Identity fields untouched
+        assert updated.name == "Philadelphia, PA"
+        assert updated.latitude == pytest.approx(39.95)
+
+    def test_updates_current_location_pointer_when_same_location(self):
+        stored = _us_location()
+        manager = _FakeConfigManager(locations=[stored])
+        manager._config.current_location = stored
+        ops = LocationOperations(cast(ConfigManager, manager))
+
+        ok = ops.update_zone_metadata("Philadelphia, PA", {"cwa_office": "PHI"})
+
+        assert ok is True
+        # current_location should reflect the new fields as well
+        current = manager.get_config().current_location
+        assert current is not None
+        assert current.cwa_office == "PHI"
+
+    def test_returns_false_when_location_not_found(self):
+        manager = _FakeConfigManager(locations=[_us_location()])
+        ops = LocationOperations(cast(ConfigManager, manager))
+
+        ok = ops.update_zone_metadata("Does Not Exist", {"cwa_office": "PHI"})
+
+        assert ok is False
+        assert manager.save_calls == 0
+
+    def test_empty_fields_dict_is_noop(self):
+        stored = _us_location(cwa_office="PHI")
+        manager = _FakeConfigManager(locations=[stored])
+        ops = LocationOperations(cast(ConfigManager, manager))
+
+        ok = ops.update_zone_metadata("Philadelphia, PA", {})
+
+        # Idempotent: nothing to persist, treat as success (no change).
+        assert ok is False
+        assert manager.save_calls == 0
+
+    def test_idempotent_when_values_unchanged(self):
+        stored = _us_location(cwa_office="PHI")
+        manager = _FakeConfigManager(locations=[stored])
+        ops = LocationOperations(cast(ConfigManager, manager))
+
+        # Re-apply the same value — cheap, should not corrupt anything.
+        ok = ops.update_zone_metadata("Philadelphia, PA", {"cwa_office": "PHI"})
+
+        # We still persist (caller already filtered via diff); either result is
+        # acceptable as long as the field ends up correct.
+        assert ok is True
+        assert manager.get_config().locations[0].cwa_office == "PHI"
+
+
+# ---------------------------------------------------------------------------
+# Drift hook wiring in weather_client_nws
+# ---------------------------------------------------------------------------
+
+
+class TestWeatherClientDriftHook:
+    """Scenario 7: drift hook runs in the refresh path and uses wx.CallAfter."""
+
+    def test_drift_hook_calls_wx_callafter_with_update_zone_metadata(self):
+        """After /points succeeds and diff produces changes, wx.CallAfter is invoked."""
+        from accessiweather import weather_client_nws
+
+        stored = _us_location()  # legacy: all zone fields null
+        manager = _FakeConfigManager(locations=[stored])
+        ops = LocationOperations(cast(ConfigManager, manager))
+
+        # Install sink pointing at our ops
+        weather_client_nws.set_zone_drift_sink(ops)
+        try:
+            with patch.object(weather_client_nws, "wx") as mock_wx:
+                weather_client_nws._apply_zone_drift_correction(
+                    stored, {"properties": FULL_POINTS_PROPERTIES}
+                )
+                mock_wx.CallAfter.assert_called_once()
+                args, _ = mock_wx.CallAfter.call_args
+                callable_arg, location_name, fields_dict = args[0], args[1], args[2]
+                # The callable should be the bound update_zone_metadata
+                assert callable_arg == ops.update_zone_metadata
+                assert location_name == "Philadelphia, PA"
+                assert fields_dict == FULL_FRESH_FIELDS
+        finally:
+            weather_client_nws.set_zone_drift_sink(None)
+
+    def test_drift_hook_noop_when_no_changes(self):
+        """Equal stored + fresh produces no wx.CallAfter invocation."""
+        from accessiweather import weather_client_nws
+
+        stored = _us_location(**FULL_FRESH_FIELDS)
+        manager = _FakeConfigManager(locations=[stored])
+        ops = LocationOperations(cast(ConfigManager, manager))
+
+        weather_client_nws.set_zone_drift_sink(ops)
+        try:
+            with patch.object(weather_client_nws, "wx") as mock_wx:
+                weather_client_nws._apply_zone_drift_correction(
+                    stored, {"properties": FULL_POINTS_PROPERTIES}
+                )
+                mock_wx.CallAfter.assert_not_called()
+        finally:
+            weather_client_nws.set_zone_drift_sink(None)
+
+    def test_drift_hook_noop_when_no_sink_installed(self):
+        """With no sink registered, the hook is a silent no-op."""
+        from accessiweather import weather_client_nws
+
+        # Ensure sink is cleared
+        weather_client_nws.set_zone_drift_sink(None)
+
+        stored = _us_location()
+        # Should not raise, even though we'd otherwise have changes to persist.
+        with patch.object(weather_client_nws, "wx") as mock_wx:
+            weather_client_nws._apply_zone_drift_correction(
+                stored, {"properties": FULL_POINTS_PROPERTIES}
+            )
+            mock_wx.CallAfter.assert_not_called()
+
+    def test_drift_exception_never_breaks_caller(self):
+        """A buggy sink must not raise out of the drift hook."""
+        from accessiweather import weather_client_nws
+
+        stored = _us_location()
+        broken_ops = MagicMock()
+        broken_ops.update_zone_metadata.side_effect = RuntimeError("boom")
+        # Make the diff path itself raise by pointing wx.CallAfter at a side-effect
+        weather_client_nws.set_zone_drift_sink(broken_ops)
+        try:
+            with patch.object(weather_client_nws, "wx") as mock_wx:
+                mock_wx.CallAfter.side_effect = RuntimeError("wx blew up")
+                # Must not raise
+                weather_client_nws._apply_zone_drift_correction(
+                    stored, {"properties": FULL_POINTS_PROPERTIES}
+                )
+        finally:
+            weather_client_nws.set_zone_drift_sink(None)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 6: /points raises -> drift skipped, no cascade
+# ---------------------------------------------------------------------------
+
+
+class TestPointsFetchErrorSkipsDrift:
+    """Scenario 6: if /points raises, drift is skipped and refresh continues."""
+
+    async def test_points_raise_does_not_persist_and_does_not_cascade(self):
+        """
+        Simulate the refresh path's /points fetch failing with an HTTP error.
+
+        The drift code path must not run (no wx.CallAfter), and the exception is
+        the caller's concern — weather_client_nws surfaces errors via its
+        existing retry/return-None mechanism. Here we just assert that our drift
+        helper is not invoked when the points properties argument is missing or
+        malformed.
+        """
+        from accessiweather import weather_client_nws
+
+        stored = _us_location()
+        manager = _FakeConfigManager(locations=[stored])
+        ops = LocationOperations(cast(ConfigManager, manager))
+
+        weather_client_nws.set_zone_drift_sink(ops)
+        try:
+            with patch.object(weather_client_nws, "wx") as mock_wx:
+                # Simulate malformed/absent properties (what we'd have if /points
+                # itself raised before producing a payload).
+                weather_client_nws._apply_zone_drift_correction(stored, None)
+                weather_client_nws._apply_zone_drift_correction(stored, {})
+                weather_client_nws._apply_zone_drift_correction(stored, {"properties": None})
+                mock_wx.CallAfter.assert_not_called()
+        finally:
+            weather_client_nws.set_zone_drift_sink(None)
+        assert manager.save_calls == 0
+
+    async def test_get_nws_all_data_parallel_raising_does_not_cascade_drift(self):
+        """Integration-lite: when the /points HTTP call raises, drift isn't attempted."""
+        from accessiweather import weather_client_nws
+
+        stored = _us_location()
+        manager = _FakeConfigManager(locations=[stored])
+        ops = LocationOperations(cast(ConfigManager, manager))
+
+        # Install sink; wire a mock http client whose .get raises on the first call
+        weather_client_nws.set_zone_drift_sink(ops)
+        try:
+            mock_client = MagicMock(spec=httpx.AsyncClient)
+            # Use a non-retryable exception so the decorator doesn't re-raise —
+            # get_nws_all_data_parallel should convert to a (None, ...) tuple.
+            mock_client.get = AsyncMock(side_effect=ValueError("bad points payload"))
+
+            with patch.object(weather_client_nws, "wx") as mock_wx:
+                result = await weather_client_nws.get_nws_all_data_parallel.__wrapped__(
+                    stored,
+                    "https://api.weather.gov",
+                    "UA",
+                    5.0,
+                    mock_client,
+                )
+                assert result == (None, None, None, None, None, None)
+                mock_wx.CallAfter.assert_not_called()
+        finally:
+            weather_client_nws.set_zone_drift_sink(None)
+        assert manager.save_calls == 0

--- a/tests/test_zone_enrichment_service.py
+++ b/tests/test_zone_enrichment_service.py
@@ -1,0 +1,452 @@
+"""
+Tests for ZoneEnrichmentService and the enriched add-location flow.
+
+Covers the six scenarios enumerated in the Forecast Products PR 1 plan:
+
+1. US happy path: /points fetched, all six fields populated.
+2. Non-US: /points never called, fields stay null.
+3. /points raises httpx.HTTPError: save still proceeds, fields null, debug log.
+4. /points returns non-200: save still proceeds, fields null.
+5. Partial payload: present fields are populated, missing stay null.
+6. No modal dialog is ever shown for a /points failure (pure service).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from accessiweather.config.config_manager import ConfigManager
+from accessiweather.config.locations import LocationOperations
+from accessiweather.models import AppConfig, AppSettings, Location
+from accessiweather.services.zone_enrichment_service import (
+    ZoneEnrichmentService,
+    _extract_zone_fields,
+    _is_us_location,
+    _last_path_segment,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+FULL_POINTS_PROPERTIES = {
+    "cwa": "PHI",
+    "forecastZone": "https://api.weather.gov/zones/forecast/PAZ106",
+    "county": "https://api.weather.gov/zones/county/PAC091",
+    "fireWeatherZone": "https://api.weather.gov/zones/fire/PAZ106",
+    "radarStation": "KDIX",
+    "timeZone": "America/New_York",
+}
+
+
+def _build_response(status_code: int, json_body: dict | None = None) -> MagicMock:
+    """Construct a mock httpx.Response-shaped object for the service."""
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.json.return_value = json_body if json_body is not None else {}
+    return response
+
+
+def _make_service_with_response(response: MagicMock) -> tuple[ZoneEnrichmentService, AsyncMock]:
+    """Build a ZoneEnrichmentService wired to a mock async client returning ``response``."""
+    mock_client = MagicMock(spec=httpx.AsyncClient)
+    mock_client.get = AsyncMock(return_value=response)
+    service = ZoneEnrichmentService(client=mock_client)
+    return service, mock_client.get
+
+
+def _make_service_with_error(error: Exception) -> tuple[ZoneEnrichmentService, AsyncMock]:
+    """Build a service where the mock client raises ``error`` on .get()."""
+    mock_client = MagicMock(spec=httpx.AsyncClient)
+    mock_client.get = AsyncMock(side_effect=error)
+    service = ZoneEnrichmentService(client=mock_client)
+    return service, mock_client.get
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the small helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestLastPathSegment:
+    """_last_path_segment extracts the final URL path component."""
+
+    def test_typical_forecast_zone_url(self):
+        assert _last_path_segment("https://api.weather.gov/zones/forecast/PAZ106") == "PAZ106"
+
+    def test_trailing_slash_stripped(self):
+        assert _last_path_segment("https://api.weather.gov/zones/county/PAC091/") == "PAC091"
+
+    def test_none_returns_none(self):
+        assert _last_path_segment(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert _last_path_segment("") is None
+
+    def test_non_string_returns_none(self):
+        assert _last_path_segment(12345) is None  # type: ignore[arg-type]
+
+
+class TestIsUsLocation:
+    """_is_us_location honours country_code then falls back to bounds."""
+
+    def test_explicit_us_country_code(self):
+        loc = Location(name="X", latitude=0.0, longitude=0.0, country_code="US")
+        assert _is_us_location(loc) is True
+
+    def test_explicit_non_us_country_code(self):
+        loc = Location(name="X", latitude=40.0, longitude=-75.0, country_code="GB")
+        assert _is_us_location(loc) is False
+
+    def test_continental_us_bounds(self):
+        loc = Location(name="Philly", latitude=39.95, longitude=-75.16)
+        assert _is_us_location(loc) is True
+
+    def test_outside_us_bounds(self):
+        loc = Location(name="London", latitude=51.5, longitude=-0.12)
+        assert _is_us_location(loc) is False
+
+
+# ---------------------------------------------------------------------------
+# ZoneEnrichmentService scenarios (plan A-R1 / A-R2 / A-R3)
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichmentHappyPath:
+    """Scenario 1: US location, working /points call populates all six fields."""
+
+    async def test_all_six_fields_populated(self):
+        service, get_mock = _make_service_with_response(
+            _build_response(200, {"properties": FULL_POINTS_PROPERTIES})
+        )
+
+        location = Location(
+            name="Philadelphia, PA",
+            latitude=39.95,
+            longitude=-75.16,
+            country_code="US",
+        )
+
+        enriched = await service.enrich_location(location)
+
+        get_mock.assert_awaited_once()
+        assert enriched.timezone == "America/New_York"
+        assert enriched.cwa_office == "PHI"
+        assert enriched.forecast_zone_id == "PAZ106"
+        assert enriched.county_zone_id == "PAC091"
+        assert enriched.fire_zone_id == "PAZ106"
+        assert enriched.radar_station == "KDIX"
+        # Original identity fields untouched
+        assert enriched.name == "Philadelphia, PA"
+        assert enriched.latitude == pytest.approx(39.95)
+        assert enriched.longitude == pytest.approx(-75.16)
+
+
+class TestEnrichmentNonUs:
+    """Scenario 2: non-US locations never trigger a /points call."""
+
+    async def test_non_us_location_skipped(self):
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_client.get = AsyncMock()
+        service = ZoneEnrichmentService(client=mock_client)
+
+        location = Location(
+            name="London, UK",
+            latitude=51.5,
+            longitude=-0.12,
+            country_code="GB",
+        )
+
+        enriched = await service.enrich_location(location)
+
+        mock_client.get.assert_not_awaited()
+        assert enriched is location  # returned unchanged
+        assert enriched.timezone is None
+        assert enriched.cwa_office is None
+        assert enriched.forecast_zone_id is None
+        assert enriched.county_zone_id is None
+        assert enriched.fire_zone_id is None
+        assert enriched.radar_station is None
+
+
+class TestEnrichmentHttpError:
+    """Scenario 3: /points raises httpx.HTTPError -> fields stay null, debug log."""
+
+    async def test_http_error_does_not_raise(self, caplog):
+        service, _ = _make_service_with_error(httpx.ConnectError("boom"))
+
+        location = Location(
+            name="US loc",
+            latitude=39.95,
+            longitude=-75.16,
+            country_code="US",
+        )
+
+        with caplog.at_level(
+            logging.DEBUG, logger="accessiweather.services.zone_enrichment_service"
+        ):
+            enriched = await service.enrich_location(location)
+
+        assert enriched.timezone is None
+        assert enriched.cwa_office is None
+        assert enriched.forecast_zone_id is None
+        assert enriched.county_zone_id is None
+        assert enriched.fire_zone_id is None
+        assert enriched.radar_station is None
+        # Debug log emitted (not higher level so user is not alarmed)
+        assert any(
+            "points request failed" in record.message.lower() or "points" in record.message.lower()
+            for record in caplog.records
+        )
+
+    async def test_timeout_is_handled(self):
+        service, _ = _make_service_with_error(httpx.ReadTimeout("slow"))
+        location = Location(name="US loc", latitude=39.95, longitude=-75.16, country_code="US")
+
+        enriched = await service.enrich_location(location)
+        assert enriched.forecast_zone_id is None
+
+
+class TestEnrichmentNon200:
+    """Scenario 4: /points returns a non-200 -> fields stay null."""
+
+    async def test_404_leaves_fields_null(self):
+        service, _ = _make_service_with_response(_build_response(404, {"error": "nope"}))
+
+        location = Location(name="US loc", latitude=39.95, longitude=-75.16, country_code="US")
+
+        enriched = await service.enrich_location(location)
+
+        assert enriched.forecast_zone_id is None
+        assert enriched.cwa_office is None
+        assert enriched.timezone is None
+
+    async def test_500_leaves_fields_null(self):
+        service, _ = _make_service_with_response(_build_response(500, {}))
+
+        location = Location(name="US loc", latitude=39.95, longitude=-75.16, country_code="US")
+
+        enriched = await service.enrich_location(location)
+        assert enriched.radar_station is None
+
+
+class TestEnrichmentPartialPayload:
+    """Scenario 5: present fields populated, absent fields stay null."""
+
+    async def test_only_cwa_and_timezone_present(self):
+        partial_properties = {
+            "cwa": "PHI",
+            "timeZone": "America/New_York",
+            # forecastZone, county, fireWeatherZone, radarStation all absent
+        }
+        service, _ = _make_service_with_response(
+            _build_response(200, {"properties": partial_properties})
+        )
+
+        location = Location(name="US loc", latitude=39.95, longitude=-75.16, country_code="US")
+
+        enriched = await service.enrich_location(location)
+
+        assert enriched.cwa_office == "PHI"
+        assert enriched.timezone == "America/New_York"
+        assert enriched.forecast_zone_id is None
+        assert enriched.county_zone_id is None
+        assert enriched.fire_zone_id is None
+        assert enriched.radar_station is None
+
+    async def test_properties_key_missing_leaves_fields_null(self):
+        # Valid 200 but no 'properties' dict at all
+        service, _ = _make_service_with_response(_build_response(200, {"foo": "bar"}))
+
+        location = Location(name="US loc", latitude=39.95, longitude=-75.16, country_code="US")
+
+        enriched = await service.enrich_location(location)
+        assert enriched.forecast_zone_id is None
+        assert enriched.cwa_office is None
+
+
+class TestExtractZoneFields:
+    """Unit test for the pure mapping helper."""
+
+    def test_full_mapping(self):
+        fields = _extract_zone_fields(FULL_POINTS_PROPERTIES)
+        assert fields == {
+            "timezone": "America/New_York",
+            "cwa_office": "PHI",
+            "forecast_zone_id": "PAZ106",
+            "county_zone_id": "PAC091",
+            "fire_zone_id": "PAZ106",
+            "radar_station": "KDIX",
+        }
+
+    def test_partial_mapping_nulls_missing(self):
+        fields = _extract_zone_fields({"cwa": "PHI"})
+        assert fields["cwa_office"] == "PHI"
+        assert fields["forecast_zone_id"] is None
+        assert fields["timezone"] is None
+
+    def test_empty_dict(self):
+        fields = _extract_zone_fields({})
+        assert all(value is None for value in fields.values())
+
+
+# ---------------------------------------------------------------------------
+# Integration with LocationOperations (save flow)
+# ---------------------------------------------------------------------------
+
+
+class _FakeConfigManager:
+    """Minimal stand-in for ``ConfigManager`` used by LocationOperations tests."""
+
+    def __init__(self) -> None:
+        self.save_calls = 0
+        self._config = AppConfig(
+            settings=AppSettings(),
+            locations=[],
+            current_location=None,
+        )
+
+    def get_config(self) -> AppConfig:
+        return self._config
+
+    def save_config(self) -> bool:
+        self.save_calls += 1
+        return True
+
+    def _get_logger(self) -> logging.Logger:
+        return logging.getLogger("accessiweather.config.test")
+
+
+class TestAddLocationWithEnrichment:
+    """LocationOperations.add_location_with_enrichment integrates the service."""
+
+    async def test_us_location_persists_enriched_fields(self):
+        mock_service = MagicMock(spec=ZoneEnrichmentService)
+
+        def _enrich(loc: Location) -> Location:
+            from dataclasses import replace
+
+            return replace(
+                loc,
+                timezone="America/New_York",
+                cwa_office="PHI",
+                forecast_zone_id="PAZ106",
+                county_zone_id="PAC091",
+                fire_zone_id="PAZ106",
+                radar_station="KDIX",
+            )
+
+        mock_service.enrich_location = AsyncMock(side_effect=_enrich)
+
+        manager = _FakeConfigManager()
+        ops = LocationOperations(cast(ConfigManager, manager), zone_enrichment_service=mock_service)
+
+        ok = await ops.add_location_with_enrichment(
+            "Philadelphia, PA",
+            39.95,
+            -75.16,
+            country_code="US",
+        )
+
+        assert ok is True
+        assert manager.save_calls == 1
+        assert len(manager.get_config().locations) == 1
+        saved = manager.get_config().locations[0]
+        assert saved.cwa_office == "PHI"
+        assert saved.forecast_zone_id == "PAZ106"
+        assert saved.county_zone_id == "PAC091"
+        assert saved.fire_zone_id == "PAZ106"
+        assert saved.radar_station == "KDIX"
+        assert saved.timezone == "America/New_York"
+        mock_service.enrich_location.assert_awaited_once()
+
+    async def test_non_us_location_still_saved_without_enrichment(self):
+        # Return original unchanged (what the real service would do for non-US)
+        mock_service = MagicMock(spec=ZoneEnrichmentService)
+        mock_service.enrich_location = AsyncMock(side_effect=lambda loc: loc)
+
+        manager = _FakeConfigManager()
+        ops = LocationOperations(cast(ConfigManager, manager), zone_enrichment_service=mock_service)
+
+        ok = await ops.add_location_with_enrichment(
+            "London, UK",
+            51.5,
+            -0.12,
+            country_code="GB",
+        )
+
+        assert ok is True
+        saved = manager.get_config().locations[0]
+        assert saved.cwa_office is None
+        assert saved.forecast_zone_id is None
+        assert saved.timezone is None
+
+    async def test_enrichment_failure_never_blocks_save(self):
+        """Scenario 6: even a catastrophic enrichment error never blocks save."""
+        mock_service = MagicMock(spec=ZoneEnrichmentService)
+        # Real service never raises, but defend against future regressions:
+        mock_service.enrich_location = AsyncMock(side_effect=RuntimeError("unexpected"))
+
+        manager = _FakeConfigManager()
+        ops = LocationOperations(cast(ConfigManager, manager), zone_enrichment_service=mock_service)
+
+        ok = await ops.add_location_with_enrichment("US loc", 39.95, -75.16, country_code="US")
+
+        assert ok is True
+        saved = manager.get_config().locations[0]
+        assert saved.cwa_office is None
+        assert saved.forecast_zone_id is None
+
+    async def test_duplicate_name_rejected_without_calling_service(self):
+        mock_service = MagicMock(spec=ZoneEnrichmentService)
+        mock_service.enrich_location = AsyncMock(side_effect=lambda loc: loc)
+
+        manager = _FakeConfigManager()
+        manager._config.locations.append(Location(name="dupe", latitude=1.0, longitude=2.0))
+        ops = LocationOperations(cast(ConfigManager, manager), zone_enrichment_service=mock_service)
+
+        ok = await ops.add_location_with_enrichment("dupe", 1.0, 2.0)
+
+        assert ok is False
+        mock_service.enrich_location.assert_not_awaited()
+        assert manager.save_calls == 0
+
+
+class TestNoModalDialog:
+    """Scenario 6: save flow never spawns a modal dialog on /points failure."""
+
+    async def test_http_error_does_not_touch_wx(self):
+        service, _ = _make_service_with_error(httpx.ConnectError("no net"))
+
+        location = Location(name="US loc", latitude=39.95, longitude=-75.16, country_code="US")
+
+        # Patch wx.MessageDialog (if importable) to fail loudly if anyone uses it.
+        patchers = []
+        if importlib.util.find_spec("wx") is not None:
+            msg_dialog_patcher = patch(
+                "wx.MessageDialog",
+                side_effect=AssertionError("wx.MessageDialog must not be invoked"),
+            )
+            message_box_patcher = patch(
+                "wx.MessageBox",
+                side_effect=AssertionError("wx.MessageBox must not be invoked"),
+            )
+            msg_dialog_patcher.start()
+            message_box_patcher.start()
+            patchers.extend([msg_dialog_patcher, message_box_patcher])
+
+        try:
+            enriched = await service.enrich_location(location)
+        finally:
+            for p in patchers:
+                p.stop()
+
+        # Service completed normally and never touched wx
+        assert enriched.forecast_zone_id is None


### PR DESCRIPTION
## What this delivers

Phase A of bundled PR 1: every saved US location now carries NWS zone metadata (`cwa_office`, `forecast_zone_id`, `county_zone_id`, `fire_zone_id`, `radar_station`, `timezone`) populated on save and drift-corrected on each weather refresh. The alert-fetch path reuses the stored zone IDs, dropping one HTTP round-trip per refresh.

This is the quiet plumbing that the Forecast Products Dialog (AFD / HWO / SPS — Phase B, a stacked PR) will consume. Zone enrichment on its own has one visible surface: the Edit Location dialog now shows forecast zone + NWS office.

## Why it's a draft

This is **Phase A of a two-phase PR 1**. Phase B (forecast products dialog, HWO + SPS notifications, settings toggles) stacks on top as a separate PR. Phase A ships clean on its own — the drift hook is a silent no-op until Phase B wires its sink, and the only user-visible change is the Edit Location section.

Marking draft so reviewers can land it behind Phase B when both are ready.

## What's in each commit

| Commit | What |
|--------|------|
| `14374cf` | Six zone fields on `Location` + JSON round-trip + point-transform fix |
| `0a1d79e` | `ZoneEnrichmentService` + `add_location_with_enrichment` async path |
| `28713ec` | Opportunistic drift correction on `/points` refresh (wx.CallAfter bounce) |
| `c7031f2` | `get_nws_alerts` prefers stored zone IDs — one fewer HTTP call/refresh |
| `fd507bc` | Edit Location dialog: "NWS Zone Information" section (forecast zone + CWA) |

Plus two docs commits carrying the ideation, brainstorms, and plan (`9fd9267`, `f5fcd5d`).

## Design decisions worth noting

- **No `schema_version` bump.** Every new field is additive with defensive `.get()` + conditional-spread serialize — matches the precedent for `country_code` and `marine_mode`.
- **Drift persistence via `wx.CallAfter`.** `ConfigManager.save_config` has no in-process lock; bouncing persistence to the main thread is the simplest correct fix for PR 1. A proper `threading.Lock` is deferred as a follow-up.
- **Never overwrite a populated stored value with null.** The diff rule is explicit about this — a missing/null fresh value is a no-op, not a wipe. Covered by a dedicated test.
- **Non-US locations stay untouched.** `/points` is never called for them; zone fields stay null; Edit Location hides the zone section entirely.
- **The generalized `_transform_point_data` change is backward-compatible.** Existing passthroughs keep working; three new keys (`cwa`, `forecastZone`, `gridId`) are now exposed where they were previously stripped.

## Known deferrals (intentional — picked up by Phase B)

- Drift hook sink registration at app startup is not wired yet. The hook is a silent no-op until then; safe to land as-is.
- The Edit Location save path still calls the sync `add_location`, not the async `add_location_with_enrichment`. Wiring needs a wx event-loop bridge; tackled in Phase B.
- `ConfigManager.save_config` thread lock — tracked as a follow-up issue.

## Testing

Each unit ships with its own test file:
- `tests/test_models_config_location_zones.py` (5 scenarios — round-trip)
- `tests/test_zone_enrichment_service.py` (25 scenarios — service + integration)
- `tests/test_zone_enrichment_drift.py` (17 scenarios — diff rule + thread-bounce)
- `tests/test_weather_client_nws_alerts_zone_reuse.py` (5 scenarios — county/zone/fallback/404/integration)
- `tests/gui/test_location_dialog_zone_info.py` (6 scenarios — US/non-US/null/partial/sizing/accessibility)

Full regression sweep passed (`tests/ -k "location or config or enrichment or nws or drift or weather_client or point"`): **710 passed**.

## Test plan

- [ ] Add a US location — zone fields populate from `/points` on save
- [ ] Add a non-US location (e.g., London, UK) — save succeeds, zone fields stay null, dialog section hidden
- [ ] Disconnect network, add a US location — save succeeds, zone fields stay null (self-heal next refresh)
- [ ] Open Edit Location for a US location that's been refreshed — "Forecast Zone" and "NWS Office" rows render
- [ ] Edit stored `cwa_office` to a wrong value in config.json, reopen app, refresh — value corrects silently on next /points response
- [ ] Verify alert fetching still surfaces active alerts for a populated location