### PR TITLE
feat(products): PR 1 Phase B — Forecast Products dialog + HWO/SPS notifications

### DIFF
--- a/src/accessiweather/ai_explainer.py
+++ b/src/accessiweather/ai_explainer.py
@@ -7,15 +7,20 @@ using OpenRouter's unified API gateway for AI models.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import re
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from .cache import Cache
+
+# Product-type literal used by explain_text_product. Keep in sync with
+# _SYSTEM_PROMPTS keys.
+TextProductType = Literal["AFD", "HWO", "SPS"]
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +99,72 @@ def get_available_free_models(exclude_model: str | None = None) -> list[str]:
         logger.warning(f"Failed to fetch free models from OpenRouter: {e}, using static fallbacks")
         models = [m for m in STATIC_FALLBACK_MODELS if m != exclude_model]
         return models[:3]
+
+
+# System prompts for generic NWS text-product explanations (AFD / HWO / SPS).
+#
+# IMPORTANT: The AFD prompt below is the historical explain_afd system prompt,
+# preserved byte-for-byte. User-customized prompt overrides in the wild are
+# calibrated against this exact wording. Do not reformat or rephrase without
+# treating it as a behavior change.
+_SYSTEM_PROMPTS: dict[str, str] = {
+    "AFD": (
+        "You are a helpful weather assistant that explains National Weather Service "
+        "Area Forecast Discussions (AFDs) in plain, accessible language. AFDs contain "
+        "technical meteorological terminology that most people don't understand. "
+        "Your job is to translate this into clear, everyday language that anyone can "
+        "understand. Focus on:\n"
+        "- What weather to expect and when\n"
+        "- Any significant weather events or changes\n"
+        "- How confident forecasters are in their predictions\n"
+        "- What this means for daily activities\n\n"
+        "Avoid using technical jargon. If you must use a technical term, explain it.\n\n"
+        "IMPORTANT: Do NOT start with a preamble like 'Here is a summary...' or "
+        "'This forecast discussion explains...'. Do NOT repeat the location name. "
+        "Jump straight into explaining the weather. The user already knows what they asked for.\n\n"
+        "IMPORTANT: Respond in plain text only. Do NOT use markdown formatting such as "
+        "bold (**text**), italic (*text*), headers (#), bullet points, or any other "
+        "markdown syntax. Use simple paragraph text that can be read directly."
+    ),
+    "HWO": (
+        "You are a helpful weather assistant that explains National Weather Service "
+        "Hazardous Weather Outlooks (HWOs) in plain, accessible language. An HWO "
+        "describes the 7-day hazard horizon and probabilistic outlook for severe "
+        "weather, flooding, winter weather, marine hazards, and other significant "
+        "events. Your job is to translate it into clear, everyday language that "
+        "anyone can understand. Focus on:\n"
+        "- Which hazards are on the horizon and when they may arrive\n"
+        "- How likely or confident the outlook is (e.g., slight, moderate, high chance)\n"
+        "- What areas or activities are most affected\n"
+        "- What this means for daily plans over the coming week\n\n"
+        "Avoid using technical jargon. If you must use a technical term, explain it.\n\n"
+        "IMPORTANT: Do NOT start with a preamble like 'Here is a summary...' or "
+        "'This outlook explains...'. Do NOT repeat the location name. Jump straight "
+        "into explaining the hazards. The user already knows what they asked for.\n\n"
+        "IMPORTANT: Respond in plain text only. Do NOT use markdown formatting such as "
+        "bold (**text**), italic (*text*), headers (#), bullet points, or any other "
+        "markdown syntax. Use simple paragraph text that can be read directly."
+    ),
+    "SPS": (
+        "You are a helpful weather assistant that explains National Weather Service "
+        "Special Weather Statements (SPSs) in plain, accessible language. An SPS is "
+        "a short advisory about significant but sub-warning weather — strong "
+        "thunderstorms, dense fog, brief heavy rain, localized wind — that people "
+        "should know about but that doesn't rise to a formal warning. Your job is "
+        "to summarize it in clear, everyday language. Focus on:\n"
+        "- What the advisory is about and how long it lasts\n"
+        "- Who and where it affects\n"
+        "- What people in the affected area should do\n"
+        "- How serious the threat is compared to a warning\n\n"
+        "Avoid using technical jargon. If you must use a technical term, explain it.\n\n"
+        "IMPORTANT: Do NOT start with a preamble like 'Here is a summary...' or "
+        "'This statement explains...'. Do NOT repeat the location name. Jump "
+        "straight into explaining the advisory. The user already knows what they asked for.\n\n"
+        "IMPORTANT: Respond in plain text only. Do NOT use markdown formatting such as "
+        "bold (**text**), italic (*text*), headers (#), bullet points, or any other "
+        "markdown syntax. Use simple paragraph text that can be read directly."
+    ),
+}
 
 
 class AIExplainerError(Exception):
@@ -743,67 +814,114 @@ class AIExplainer:
 
         return result
 
-    async def explain_afd(
+    # Product-type-specific phrasing for the user-message lead-in. The AFD
+    # phrasing is preserved byte-for-byte from the historical explain_afd
+    # implementation to keep downstream prompt templates stable.
+    _PRODUCT_USER_INTRO: dict[str, str] = {
+        "AFD": "Please explain this Area Forecast Discussion for {location} in plain language:",
+        "HWO": "Please explain this Hazardous Weather Outlook for {location} in plain language:",
+        "SPS": "Please explain this Special Weather Statement for {location} in plain language:",
+    }
+
+    # Product-wide style instructions appended to the user prompt. Shared
+    # across AFD/HWO/SPS so customization lives in one place.
+    _PRODUCT_STYLE_INSTRUCTIONS: dict[ExplanationStyle, str] = {
+        ExplanationStyle.BRIEF: "Provide a 2-3 sentence summary of the key points.",
+        ExplanationStyle.STANDARD: "Provide a clear 1-2 paragraph summary.",
+        ExplanationStyle.DETAILED: (
+            "Provide a comprehensive summary covering all major points "
+            "from the discussion, organized by topic."
+        ),
+    }
+
+    def _text_product_cache_key(
         self,
-        afd_text: str,
+        product_type: str,
         location_name: str,
+        product_text: str,
+        style: ExplanationStyle,
+    ) -> str:
+        """
+        Compute the cache key for explain_text_product results.
+
+        Key shape: ``ai_text_product:<TYPE>:<location>:<sha256>:<style>``.
+        Hashing the product text keeps the key bounded and deterministic for
+        long AFDs/HWOs/SPSs.
+        """
+        text_hash = hashlib.sha256(product_text.encode("utf-8")).hexdigest()
+        return f"ai_text_product:{product_type}:{location_name}:{text_hash}:{style.value}"
+
+    async def explain_text_product(
+        self,
+        product_text: str,
+        product_type: TextProductType,
+        location_name: str,
+        *,
         style: ExplanationStyle = ExplanationStyle.DETAILED,
         preserve_markdown: bool = False,
     ) -> ExplanationResult:
         """
-        Generate plain language explanation of an Area Forecast Discussion.
+        Generate a plain-language explanation of an NWS text product.
+
+        Supports AFD (Area Forecast Discussion), HWO (Hazardous Weather
+        Outlook), and SPS (Special Weather Statement). The system prompt is
+        selected per product type from :data:`_SYSTEM_PROMPTS`. A per-product
+        result cache (300 s TTL) avoids re-invoking the LLM for identical
+        inputs. LLM errors propagate and are not cached — a retry will
+        re-hit the model.
 
         Args:
-            afd_text: The raw AFD text from NWS
-            location_name: Human-readable location name
-            style: Explanation style (brief, standard, detailed)
-            preserve_markdown: Whether to preserve markdown in output (default: False)
+            product_text: Raw product text as issued by NWS.
+            product_type: One of ``"AFD"``, ``"HWO"``, ``"SPS"``.
+            location_name: Human-readable location the product covers.
+            style: Explanation style (brief, standard, detailed).
+            preserve_markdown: Keep markdown in the response when True.
 
         Returns:
-            ExplanationResult with text, model used, and metadata
+            :class:`ExplanationResult`. ``cached=True`` if served from the
+            per-product cache.
 
         """
         import asyncio
 
-        # Build AFD-specific prompts - use custom system prompt if configured
+        if product_type not in _SYSTEM_PROMPTS:
+            raise ValueError(
+                f"Unknown product_type {product_type!r}; expected one of {sorted(_SYSTEM_PROMPTS)}"
+            )
+
+        # Cache lookup (custom prompts + instructions are applied per-instance
+        # and already reflected in the request; keying off product_type /
+        # location / text / style is sufficient for a single explainer).
+        cache_key = self._text_product_cache_key(product_type, location_name, product_text, style)
+        if self.cache is not None:
+            cached = self.cache.get(cache_key)
+            if cached:
+                logger.debug(f"Cache hit for text product explanation: {cache_key}")
+                return ExplanationResult(
+                    text=cached["text"],
+                    model_used=cached["model_used"],
+                    token_count=cached["token_count"],
+                    estimated_cost=cached["estimated_cost"],
+                    cached=True,
+                    timestamp=datetime.fromisoformat(cached["timestamp"]),
+                )
+
+        # System prompt: custom overrides the default (preserves existing
+        # explain_afd semantics — replace, not append).
         if self.custom_system_prompt:
             system_prompt = self.custom_system_prompt
         else:
-            system_prompt = (
-                "You are a helpful weather assistant that explains National Weather Service "
-                "Area Forecast Discussions (AFDs) in plain, accessible language. AFDs contain "
-                "technical meteorological terminology that most people don't understand. "
-                "Your job is to translate this into clear, everyday language that anyone can "
-                "understand. Focus on:\n"
-                "- What weather to expect and when\n"
-                "- Any significant weather events or changes\n"
-                "- How confident forecasters are in their predictions\n"
-                "- What this means for daily activities\n\n"
-                "Avoid using technical jargon. If you must use a technical term, explain it.\n\n"
-                "IMPORTANT: Do NOT start with a preamble like 'Here is a summary...' or "
-                "'This forecast discussion explains...'. Do NOT repeat the location name. "
-                "Jump straight into explaining the weather. The user already knows what they asked for.\n\n"
-                "IMPORTANT: Respond in plain text only. Do NOT use markdown formatting such as "
-                "bold (**text**), italic (*text*), headers (#), bullet points, or any other "
-                "markdown syntax. Use simple paragraph text that can be read directly."
-            )
+            system_prompt = _SYSTEM_PROMPTS[product_type]
 
-        style_instructions = {
-            ExplanationStyle.BRIEF: "Provide a 2-3 sentence summary of the key points.",
-            ExplanationStyle.STANDARD: "Provide a clear 1-2 paragraph summary.",
-            ExplanationStyle.DETAILED: (
-                "Provide a comprehensive summary covering all major points "
-                "from the discussion, organized by topic."
-            ),
-        }
-
-        user_prompt = (
-            f"Please explain this Area Forecast Discussion for {location_name} "
-            f"in plain language:\n\n{afd_text}\n\n"
-            f"{style_instructions.get(style, style_instructions[ExplanationStyle.DETAILED])}"
+        # User prompt: product-type-aware lead-in + raw product + style hint.
+        intro_template = self._PRODUCT_USER_INTRO[product_type]
+        intro = intro_template.format(location=location_name)
+        style_instruction = self._PRODUCT_STYLE_INSTRUCTIONS.get(
+            style, self._PRODUCT_STYLE_INSTRUCTIONS[ExplanationStyle.DETAILED]
         )
+        user_prompt = f"{intro}\n\n{product_text}\n\n{style_instruction}"
 
-        # Add custom instructions if configured
+        # Custom per-user instructions apply identically to all product types.
         if self.custom_instructions and self.custom_instructions.strip():
             user_prompt += f"\n\nAdditional Instructions: {self.custom_instructions}"
 
@@ -811,19 +929,15 @@ class AIExplainer:
         primary_model = self.get_effective_model()
         models_to_try = [primary_model]
 
-        # Add default model as fallback if using a custom model
-        # This provides auto-recovery when a user's configured model is removed
         if primary_model != DEFAULT_FREE_MODEL:
             models_to_try.append(DEFAULT_FREE_MODEL)
 
-        # Add additional fallbacks for free models (dynamically fetched)
         if ":free" in primary_model or primary_model in (DEFAULT_FREE_MODEL, DEFAULT_FREE_ROUTER):
             fallback_models = get_available_free_models(exclude_model=primary_model)
             for fallback in fallback_models:
                 if fallback not in models_to_try:
                     models_to_try.append(fallback)
 
-        # Try each model until we get a non-empty response
         response = None
         last_error = None
         for model in models_to_try:
@@ -833,30 +947,30 @@ class AIExplainer:
                     self._call_openrouter, system_prompt, user_prompt, model_override
                 )
 
-                # Check if we got actual content (minimum 20 chars for meaningful response)
                 content = response["content"]
                 if content and len(content.strip()) >= 20:
-                    logger.info(f"Got valid AFD response from model: {model}")
+                    logger.info(f"Got valid {product_type} response from model: {model}")
                     break
 
                 logger.warning(
-                    f"Model {model} returned insufficient AFD response "
+                    f"Model {model} returned insufficient {product_type} response "
                     f"(len={len(content) if content else 0}), trying fallback..."
                 )
                 response = None
 
             except Exception as e:
                 last_error = e
-                logger.warning(f"Model {model} failed for AFD: {e}, trying fallback...")
+                logger.warning(f"Model {model} failed for {product_type}: {e}, trying fallback...")
                 continue
 
         if response is None:
             if last_error:
-                logger.error(f"All models failed for AFD. Last error: {last_error}", exc_info=True)
-                # Convert common errors to specific exceptions
+                logger.error(
+                    f"All models failed for {product_type}. Last error: {last_error}",
+                    exc_info=True,
+                )
                 error_message = str(last_error).lower()
 
-                # API key errors (check FIRST to avoid matching "connection" in suggestion text)
                 if "api key" in error_message or "api_key" in error_message:
                     raise InvalidAPIKeyError(
                         "OpenRouter API key is required.\n\n"
@@ -864,7 +978,6 @@ class AIExplainer:
                         "Get a free key at: openrouter.ai/keys"
                     ) from last_error
 
-                # Model not found
                 if (
                     "404" in error_message
                     or "not found" in error_message
@@ -877,7 +990,6 @@ class AIExplainer:
                         "Please go to Settings → AI Explanations and select a different model."
                     ) from last_error
 
-                # Rate limiting
                 if (
                     "429" in error_message
                     or "rate limit" in error_message
@@ -892,7 +1004,6 @@ class AIExplainer:
                         "• Switch to a paid model in Settings"
                     ) from last_error
 
-                # Timeout errors - check before generic network errors
                 if "timed out" in error_message or "timeout" in error_message:
                     raise RequestTimeoutError(
                         "Request timed out.\n\n"
@@ -900,7 +1011,6 @@ class AIExplainer:
                         "This usually means the servers are busy. Please try again."
                     ) from last_error
 
-                # Network errors (check for specific codes/phrases, not just "connection")
                 if (
                     "502" in error_message
                     or "503" in error_message
@@ -916,14 +1026,13 @@ class AIExplainer:
                 # Re-raise the original error
                 raise last_error
 
-            # No error but empty responses
             raise EmptyResponseError(
                 "All AI models returned empty responses.\n\n"
                 "This can happen when models are overloaded.\n"
                 "Please try again in a few minutes."
             )
 
-        # Process response - strip markdown formatting for plain text display
+        # Success: format + build result
         raw_content = response["content"]
         text = self._format_response(raw_content, preserve_markdown)
         token_count = response["total_tokens"]
@@ -931,13 +1040,49 @@ class AIExplainer:
         estimated_cost = self._estimate_cost(model_used, token_count)
         self._session_token_count += token_count
 
-        return ExplanationResult(
+        result = ExplanationResult(
             text=text,
             model_used=model_used,
             token_count=token_count,
             estimated_cost=estimated_cost,
             cached=False,
             timestamp=datetime.now(),
+        )
+
+        # Cache only successful results — failures must not be memoized.
+        if self.cache is not None:
+            cache_data = {
+                "text": result.text,
+                "model_used": result.model_used,
+                "token_count": result.token_count,
+                "estimated_cost": result.estimated_cost,
+                "timestamp": result.timestamp.isoformat(),
+            }
+            self.cache.set(cache_key, cache_data, ttl=300)
+            logger.debug(f"Cached text product explanation: {cache_key}")
+
+        return result
+
+    async def explain_afd(
+        self,
+        afd_text: str,
+        location_name: str,
+        style: ExplanationStyle = ExplanationStyle.DETAILED,
+        preserve_markdown: bool = False,
+    ) -> ExplanationResult:
+        """
+        Generate a plain-language explanation of an Area Forecast Discussion.
+
+        Thin wrapper around :meth:`explain_text_product` with
+        ``product_type="AFD"``. Kept as a public method to preserve the
+        existing call-site signature.
+        """
+        return await self.explain_text_product(
+            afd_text,
+            "AFD",
+            location_name,
+            style=style,
+            preserve_markdown=preserve_markdown,
         )
 
     def _call_openrouter(

--- a/src/accessiweather/ai_explainer.py
+++ b/src/accessiweather/ai_explainer.py
@@ -908,10 +908,7 @@ class AIExplainer:
 
         # System prompt: custom overrides the default (preserves existing
         # explain_afd semantics — replace, not append).
-        if self.custom_system_prompt:
-            system_prompt = self.custom_system_prompt
-        else:
-            system_prompt = _SYSTEM_PROMPTS[product_type]
+        system_prompt = self.custom_system_prompt or _SYSTEM_PROMPTS[product_type]
 
         # User prompt: product-type-aware lead-in + raw product + style hint.
         intro_template = self._PRODUCT_USER_INTRO[product_type]

--- a/src/accessiweather/app_initialization.py
+++ b/src/accessiweather/app_initialization.py
@@ -31,6 +31,14 @@ def initialize_components(app: AccessiWeatherApp) -> None:
     app.runtime_state_manager = RuntimeStateManager(app.runtime_paths.config_root)
     config = app.config_manager.load_config()
 
+    # Wire the zone-drift sink so /points responses on refresh can lazily
+    # backfill/update the zone fields on saved Locations. Without this the
+    # hook in weather_client_nws is a silent no-op — legacy saved locations
+    # never populate cwa_office and Forecast Products can't fetch anything.
+    from .weather_client_nws import set_zone_drift_sink
+
+    set_zone_drift_sink(app.config_manager._locations)
+
     # Defer update service initialization to background (using wx.CallLater)
     app.update_service = None
     wx.CallLater(100, _initialize_update_service_deferred, app)

--- a/src/accessiweather/cache.py
+++ b/src/accessiweather/cache.py
@@ -420,7 +420,7 @@ def _deserialize_hourly(data: dict | None) -> HourlyForecast | None:
 
 
 def _serialize_alert(alert: WeatherAlert) -> dict:
-    return {
+    payload: dict = {
         "title": alert.title,
         "description": alert.description,
         "severity": alert.severity,
@@ -435,6 +435,11 @@ def _serialize_alert(alert: WeatherAlert) -> dict:
         "id": alert.id,
         "source": alert.source,
     }
+    # Only include ``affected_zones`` when populated — legacy cache entries
+    # never carried the key and we keep the shape stable for the common case.
+    if alert.affected_zones:
+        payload["affected_zones"] = list(alert.affected_zones)
+    return payload
 
 
 def _deserialize_alert(data: dict) -> WeatherAlert:
@@ -452,6 +457,7 @@ def _deserialize_alert(data: dict) -> WeatherAlert:
         areas=list(data.get("areas", [])),
         id=data.get("id"),
         source=data.get("source"),
+        affected_zones=list(data.get("affected_zones", [])),
     )
 
 

--- a/src/accessiweather/models/__init__.py
+++ b/src/accessiweather/models/__init__.py
@@ -13,6 +13,9 @@ from .config import AppConfig, AppSettings
 
 # Error models
 from .errors import ApiError
+
+# Text product models (NWS AFD / HWO / SPS)
+from .text_product import TextProduct
 from .weather import (
     AviationData,
     CurrentConditions,
@@ -60,4 +63,5 @@ __all__ = [
     "SourceData",
     "SourceAttribution",
     "DataConflict",
+    "TextProduct",
 ]

--- a/src/accessiweather/models/alerts.py
+++ b/src/accessiweather/models/alerts.py
@@ -29,12 +29,18 @@ class WeatherAlert:
     id: str | None = None
     source: str | None = None
     message_type: str | None = None  # e.g. "Alert", "Update", "Cancel"
+    # NWS zone identifiers (e.g. "PHZ007") covered by this alert. Populated
+    # from the NWS API's ``affectedZones`` field so downstream consumers (SPS
+    # notification dedupe, zone-based filtering) can match without re-parsing.
+    affected_zones: list[str] = field(default_factory=list)
 
     def __post_init__(self):
         if self.areas is None:
             self.areas = []
         if self.references is None:
             self.references = []
+        if self.affected_zones is None:
+            self.affected_zones = []
 
     def get_unique_id(self) -> str:
         """

--- a/src/accessiweather/models/config.py
+++ b/src/accessiweather/models/config.py
@@ -40,6 +40,8 @@ NON_CRITICAL_SETTINGS: set[str] = {
     "show_nationwide_location",
     # Event notifications
     "notify_discussion_update",
+    "notify_hwo_update",
+    "notify_sps_issued",
     "notify_severe_risk_change",
     "notify_minutely_precipitation_start",
     "notify_minutely_precipitation_stop",
@@ -127,6 +129,8 @@ class AppSettings:
     show_nationwide_location: bool = True
     # Event-based notifications
     notify_discussion_update: bool = True
+    notify_hwo_update: bool = True
+    notify_sps_issued: bool = True
     notify_severe_risk_change: bool = False
     notify_minutely_precipitation_start: bool = True
     notify_minutely_precipitation_stop: bool = True
@@ -462,6 +466,8 @@ class AppSettings:
             "muted_sound_events": self.muted_sound_events,
             "show_nationwide_location": self.show_nationwide_location,
             "notify_discussion_update": self.notify_discussion_update,
+            "notify_hwo_update": self.notify_hwo_update,
+            "notify_sps_issued": self.notify_sps_issued,
             "notify_severe_risk_change": self.notify_severe_risk_change,
             "notify_minutely_precipitation_start": self.notify_minutely_precipitation_start,
             "notify_minutely_precipitation_stop": self.notify_minutely_precipitation_stop,
@@ -552,6 +558,8 @@ class AppSettings:
             muted_sound_events=data.get("muted_sound_events", list(DEFAULT_MUTED_SOUND_EVENTS)),
             show_nationwide_location=cls._as_bool(data.get("show_nationwide_location"), True),
             notify_discussion_update=cls._as_bool(data.get("notify_discussion_update"), True),
+            notify_hwo_update=cls._as_bool(data.get("notify_hwo_update"), True),
+            notify_sps_issued=cls._as_bool(data.get("notify_sps_issued"), True),
             notify_severe_risk_change=cls._as_bool(data.get("notify_severe_risk_change"), False),
             notify_minutely_precipitation_start=cls._as_bool(
                 data.get("notify_minutely_precipitation_start"), True

--- a/src/accessiweather/models/text_product.py
+++ b/src/accessiweather/models/text_product.py
@@ -1,0 +1,31 @@
+"""
+TextProduct dataclass for NWS text-based products (AFD, HWO, SPS).
+
+AFD = Area Forecast Discussion
+HWO = Hazardous Weather Outlook
+SPS = Special Weather Statement
+
+These are fetched from ``/products/types/{TYPE}/locations/{cwa_office}`` and
+``/products/{id}`` on the NWS API. All three endpoints share the same response
+shape, so a single dataclass is sufficient.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+ProductType = Literal["AFD", "HWO", "SPS"]
+
+
+@dataclass(frozen=True)
+class TextProduct:
+    """A single NWS text product."""
+
+    product_type: ProductType
+    product_id: str
+    cwa_office: str
+    issuance_time: datetime | None
+    product_text: str
+    headline: str | None

--- a/src/accessiweather/notifications/notification_event_manager.py
+++ b/src/accessiweather/notifications/notification_event_manager.py
@@ -31,13 +31,27 @@ from .minutely_precipitation import (
 )
 
 if TYPE_CHECKING:
-    from ..models import AppSettings, CurrentConditions, Location, TextProduct, WeatherData
+    from collections.abc import Sequence
+
+    from ..models import (
+        AppSettings,
+        CurrentConditions,
+        Location,
+        TextProduct,
+        WeatherAlert,
+        WeatherData,
+    )
 
 
 # Rate-limit window for per-(product, location) notifications. The HWO check
 # suppresses re-dispatch within this window while still advancing stored state
 # so we don't re-trigger on the next cycle forever.
 _HWO_RATE_LIMIT_WINDOW = timedelta(minutes=30)
+# SPS (Special Weather Statement) reuses the same 30-minute sliding window,
+# keyed independently on ``self._last_product_notified_at``.
+_SPS_RATE_LIMIT_WINDOW = timedelta(minutes=30)
+# Windows toast bodies clip around 200 chars — be safely under that.
+_SPS_MAX_BODY_CHARS = 160
 # Summaries shorter than this (after stripping) fall back to the generic body.
 _HWO_SUMMARY_MIN_CHARS = 20
 
@@ -661,6 +675,253 @@ class NotificationEventManager:
         )
         logger.debug(
             "[events] HWO dispatch (default no-op): location=%s product=%s title=%r",
+            location.name,
+            product.product_id,
+            event.title,
+        )
+
+    # ------------------------------------------------------------------
+    # Unit 11 — Special Weather Statement (SPS) informational notifications
+    # ------------------------------------------------------------------
+
+    def _check_sps_new(
+        self,
+        location: Location,
+        sps_products: Sequence[TextProduct] | None,
+        cached_alerts: Sequence[WeatherAlert] | None,
+        settings: AppSettings,
+    ) -> None:
+        """
+        Dispatch notifications for informational SPS products only.
+
+        NWS issues two populations of Special Weather Statements:
+
+        - **Case A — event-style.** Hail, dense fog, strong-thunderstorm
+          statements that also appear on ``/alerts/active``. The existing alert
+          pipeline already surfaces them; notifying again here would
+          double-notify. We detect these via headline/first-description
+          substring matching against the SPS product text.
+        - **Case B — informational.** Fire-weather, pollen, coordination
+          statements that appear on ``/products/types/SPS`` but never on
+          ``/alerts/active``. These are invisible to users today; we notify on
+          them.
+
+        The heuristic is intentionally conservative: when a Case A match is not
+        obvious we favor notifying (honoring the plan's "if in doubt, show the
+        informational SPS the user would otherwise miss" principle).
+
+        Behavior summary:
+          1. Cold start — first ever fetch for this manager records all IDs
+             silently. Detected by ``not last_sps_product_ids`` and the bucket
+             not yet present in ``_sps_cold_started``.
+          2. Expiration — IDs in stored state but absent from the fetch are
+             silently removed.
+          3. For each NEW ID (not yet in state), classify Case A vs Case B;
+             add to state unconditionally; dispatch only for Case B, subject
+             to the setting toggle and the 30-min rate-limit bucket.
+          4. ``None`` or empty product list after cold-start just expires
+             stored IDs.
+        """
+        products = list(sps_products or [])
+        alerts = list(cached_alerts or [])
+
+        # Cold-start: first call ever for this (manager, location) pair.
+        if not hasattr(self, "_sps_cold_started"):
+            self._sps_cold_started: set[str] = set()  # type: ignore[attr-defined]
+
+        bucket_key = ("SPS", location.name)
+        is_cold_start = (
+            location.name not in self._sps_cold_started and not self.state.last_sps_product_ids
+        )
+
+        current_ids = {p.product_id for p in products}
+
+        if is_cold_start:
+            if current_ids:
+                self.state.last_sps_product_ids |= current_ids
+                self._save_state()
+            self._sps_cold_started.add(location.name)
+            logger.debug(
+                "_check_sps_new: cold-start baseline for %s (%d ids) — no dispatch",
+                location.name,
+                len(current_ids),
+            )
+            return
+
+        # Expire any stored IDs that are no longer present.
+        stale = self.state.last_sps_product_ids - current_ids
+        if stale:
+            self.state.last_sps_product_ids -= stale
+            self._save_state()
+            logger.debug("_check_sps_new: expired %d SPS id(s) for %s", len(stale), location.name)
+
+        # Evaluate only genuinely new product IDs.
+        new_products = [p for p in products if p.product_id not in self.state.last_sps_product_ids]
+        if not new_products:
+            return
+
+        # Build a normalized lookup of active SPS alert headlines/first-lines
+        # once for O(n + m) matching rather than O(n * m) per product.
+        alert_signatures = self._sps_alert_signatures(alerts)
+        enabled = getattr(settings, "notify_sps_issued", True)
+
+        dispatched_this_call = False
+        for product in new_products:
+            # Always add to seen state first — Case A or rate-limited products
+            # must never re-evaluate next cycle.
+            self.state.last_sps_product_ids.add(product.product_id)
+
+            if self._sps_is_case_a(product, alert_signatures):
+                logger.debug(
+                    "_check_sps_new: Case A (event-style) suppressed — product=%s",
+                    product.product_id,
+                )
+                continue
+
+            # Case B — informational.
+            if not enabled:
+                logger.debug(
+                    "_check_sps_new: notify_sps_issued disabled — suppressing %s",
+                    product.product_id,
+                )
+                continue
+
+            now = datetime.now(timezone.utc)
+            last_sent = self._last_product_notified_at.get(bucket_key)
+            if last_sent is not None and now - last_sent < _SPS_RATE_LIMIT_WINDOW:
+                logger.debug(
+                    "_check_sps_new: rate-limited for %s (last=%s) — state updated, no dispatch",
+                    location.name,
+                    last_sent,
+                )
+                continue
+            if dispatched_this_call:
+                # Stamp once per call so repeated Case B products in the same
+                # fetch still fall under the rate limit — matches HWO shape.
+                logger.debug(
+                    "_check_sps_new: additional Case B in same fetch rate-limited — %s",
+                    product.product_id,
+                )
+                continue
+
+            self._last_product_notified_at[bucket_key] = now
+            dispatched_this_call = True
+            message = self._format_sps_body(product)
+            logger.info(
+                "SPS informational dispatch for %s (%s): %s",
+                location.name,
+                product.cwa_office,
+                product.product_id,
+            )
+            self._dispatch_sps_notification(
+                location=location,
+                product=product,
+                message=message,
+            )
+
+        self._save_state()
+
+    @staticmethod
+    def _normalize_for_match(text: str | None) -> str:
+        """Return a casefolded, whitespace-collapsed version of ``text`` for matching."""
+        if not text:
+            return ""
+        return " ".join(text.split()).casefold()
+
+    @classmethod
+    def _sps_alert_signatures(cls, alerts: Sequence[WeatherAlert]) -> list[str]:
+        """
+        Collect normalized signatures for active SPS alerts.
+
+        Only alerts whose ``event`` is ``"Special Weather Statement"``
+        (case-insensitive) are considered. For each, we take the ``headline``
+        plus the first non-empty line of ``description``; both are normalized
+        via :meth:`_normalize_for_match`. Empty signatures are dropped.
+        """
+        signatures: list[str] = []
+        for alert in alerts:
+            event = (alert.event or "").strip().casefold()
+            if event != "special weather statement":
+                continue
+            for candidate in (alert.headline, cls._first_nonempty_line(alert.description)):
+                sig = cls._normalize_for_match(candidate)
+                if sig:
+                    signatures.append(sig)
+        return signatures
+
+    @classmethod
+    def _sps_is_case_a(cls, product: TextProduct, alert_signatures: Sequence[str]) -> bool:
+        """
+        Return True when ``product`` looks like the event-style SPS an alert covers.
+
+        Matching rule: any active SPS alert's normalized headline or first
+        description line appears as a substring of the product's normalized
+        text (headline + product_text), OR vice versa. The bidirectional check
+        covers the rare case where an alert description runs longer than the
+        product blurb, even though the common shape is alert-headline ⊆
+        product-text.
+        """
+        if not alert_signatures:
+            return False
+        product_haystack_parts = [product.headline or "", product.product_text or ""]
+        product_norm = cls._normalize_for_match(" ".join(product_haystack_parts))
+        if not product_norm:
+            return False
+        return any(sig in product_norm or product_norm in sig for sig in alert_signatures)
+
+    @classmethod
+    def _format_sps_body(cls, product: TextProduct) -> str:
+        """Build the toast body — headline + CWA office, with text fallback."""
+        headline = (product.headline or "").strip()
+        if headline:
+            body = f"{headline} \u2014 {product.cwa_office}"
+            return cls._truncate(body, _SPS_MAX_BODY_CHARS)
+        fallback = cls._first_nonempty_line(product.product_text) or ""
+        return cls._truncate(fallback.strip(), _SPS_MAX_BODY_CHARS)
+
+    @staticmethod
+    def _first_nonempty_line(text: str | None) -> str | None:
+        """Return the first non-empty, non-whitespace line of ``text``."""
+        if not text:
+            return None
+        for raw in text.splitlines():
+            line = raw.strip()
+            if line:
+                return line
+        return None
+
+    @staticmethod
+    def _truncate(text: str, limit: int) -> str:
+        """Truncate ``text`` to ``limit`` chars, appending an ellipsis if cut."""
+        if len(text) <= limit:
+            return text
+        if limit <= 3:
+            return text[:limit]
+        return text[: limit - 3] + "..."
+
+    def _dispatch_sps_notification(
+        self,
+        *,
+        location: Location,
+        product: TextProduct,
+        message: str,
+    ) -> None:
+        """
+        Emit the SPS notification event.
+
+        Default is a no-op logger call mirroring
+        :meth:`_dispatch_hwo_notification`; the UI layer monkey-patches it to
+        fire a real desktop notification. Tests capture dispatches by
+        replacing this method.
+        """
+        event = NotificationEvent(
+            event_type="sps_issued",
+            title="Special Weather Statement",
+            message=message,
+            sound_event="notify",
+        )
+        logger.debug(
+            "[events] SPS dispatch (default no-op): location=%s product=%s title=%r",
             location.name,
             product.product_id,
             event.title,

--- a/src/accessiweather/notifications/notification_event_manager.py
+++ b/src/accessiweather/notifications/notification_event_manager.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -189,6 +189,13 @@ class NotificationState:
     last_minutely_transition_signature: str | None = None
     last_minutely_likelihood_signature: str | None = None
     last_check_time: datetime | None = None
+    # HWO (Hazardous Weather Outlook) tracking — Unit 10 populates these.
+    last_hwo_issuance_time: datetime | None = None
+    last_hwo_text: str | None = None
+    last_hwo_summary_signature: str | None = None
+    # SPS (Special Weather Statement) tracking — Unit 11 populates these.
+    # Stored as a set for O(1) dedupe; round-trips through JSON as sorted list.
+    last_sps_product_ids: set[str] = field(default_factory=set)
 
     def to_dict(self) -> dict:
         """Convert to dictionary for persistence."""
@@ -203,6 +210,13 @@ class NotificationState:
             "last_minutely_transition_signature": self.last_minutely_transition_signature,
             "last_minutely_likelihood_signature": self.last_minutely_likelihood_signature,
             "last_check_time": self.last_check_time.isoformat() if self.last_check_time else None,
+            "last_hwo_issuance_time": (
+                self.last_hwo_issuance_time.isoformat() if self.last_hwo_issuance_time else None
+            ),
+            "last_hwo_text": self.last_hwo_text,
+            "last_hwo_summary_signature": self.last_hwo_summary_signature,
+            # Sort for deterministic output (JSON diffs, snapshot tests).
+            "last_sps_product_ids": sorted(self.last_sps_product_ids),
         }
 
     @classmethod
@@ -210,6 +224,8 @@ class NotificationState:
         """Create from dictionary."""
         last_check = data.get("last_check_time")
         last_issuance = data.get("last_discussion_issuance_time")
+        last_hwo_issuance = data.get("last_hwo_issuance_time")
+        sps_ids = data.get("last_sps_product_ids") or []
         return cls(
             last_discussion_issuance_time=(
                 datetime.fromisoformat(last_issuance) if last_issuance else None
@@ -219,6 +235,12 @@ class NotificationState:
             last_minutely_transition_signature=data.get("last_minutely_transition_signature"),
             last_minutely_likelihood_signature=data.get("last_minutely_likelihood_signature"),
             last_check_time=datetime.fromisoformat(last_check) if last_check else None,
+            last_hwo_issuance_time=(
+                datetime.fromisoformat(last_hwo_issuance) if last_hwo_issuance else None
+            ),
+            last_hwo_text=data.get("last_hwo_text"),
+            last_hwo_summary_signature=data.get("last_hwo_summary_signature"),
+            last_sps_product_ids=set(sps_ids),
         )
 
 
@@ -300,6 +322,8 @@ class NotificationEventManager:
         discussion = section.get("discussion", {})
         severe_risk = section.get("severe_risk", {})
         minutely_precipitation = section.get("minutely_precipitation", {})
+        hwo = section.get("hwo", {})
+        sps = section.get("sps", {})
         return {
             "last_discussion_issuance_time": discussion.get("last_issuance_time"),
             "last_discussion_text": discussion.get("last_text"),
@@ -313,12 +337,17 @@ class NotificationEventManager:
             "last_check_time": discussion.get("last_check_time")
             or severe_risk.get("last_check_time")
             or minutely_precipitation.get("last_check_time"),
+            "last_hwo_issuance_time": hwo.get("last_issuance_time"),
+            "last_hwo_text": hwo.get("last_text"),
+            "last_hwo_summary_signature": hwo.get("last_summary_signature"),
+            "last_sps_product_ids": list(sps.get("last_product_ids") or []),
         }
 
     @staticmethod
     def _legacy_shape_to_runtime_section(data: dict) -> dict:
         """Convert legacy notification-state payloads to the unified section shape."""
         last_check_time = data.get("last_check_time")
+        sps_ids = data.get("last_sps_product_ids") or []
         return {
             "discussion": {
                 "last_issuance_time": data.get("last_discussion_issuance_time"),
@@ -332,6 +361,18 @@ class NotificationEventManager:
             "minutely_precipitation": {
                 "last_transition_signature": data.get("last_minutely_transition_signature"),
                 "last_likelihood_signature": data.get("last_minutely_likelihood_signature"),
+                "last_check_time": last_check_time,
+            },
+            "hwo": {
+                "last_issuance_time": data.get("last_hwo_issuance_time"),
+                "last_text": data.get("last_hwo_text"),
+                "last_summary_signature": data.get("last_hwo_summary_signature"),
+                "last_check_time": last_check_time,
+            },
+            "sps": {
+                # Sorted so round-trips are stable; NotificationState's
+                # ``set`` field re-materializes order-independence.
+                "last_product_ids": sorted(sps_ids),
                 "last_check_time": last_check_time,
             },
         }

--- a/src/accessiweather/notifications/notification_event_manager.py
+++ b/src/accessiweather/notifications/notification_event_manager.py
@@ -12,11 +12,12 @@ enabled in Settings > Notifications.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -30,7 +31,15 @@ from .minutely_precipitation import (
 )
 
 if TYPE_CHECKING:
-    from ..models import AppSettings, CurrentConditions, WeatherData
+    from ..models import AppSettings, CurrentConditions, Location, TextProduct, WeatherData
+
+
+# Rate-limit window for per-(product, location) notifications. The HWO check
+# suppresses re-dispatch within this window while still advancing stored state
+# so we don't re-trigger on the next cycle forever.
+_HWO_RATE_LIMIT_WINDOW = timedelta(minutes=30)
+# Summaries shorter than this (after stripping) fall back to the generic body.
+_HWO_SUMMARY_MIN_CHARS = 20
 
 logger = logging.getLogger(__name__)
 
@@ -272,6 +281,10 @@ class NotificationEventManager:
         self.state_file = state_file
         self.runtime_state_manager = runtime_state_manager
         self.state = NotificationState()
+        # Ephemeral per-(product, location) rate-limit bookkeeping. Intentionally
+        # in-memory only — see Unit 10 plan: we want cold-starts to re-evaluate
+        # against stored content, not silently gag notifications across restarts.
+        self._last_product_notified_at: dict[tuple[str, str], datetime] = {}
         self._load_state()
         logger.info("NotificationEventManager initialized")
 
@@ -519,6 +532,139 @@ class NotificationEventManager:
             issuance_time,
         )
         return None
+
+    def _check_hwo_update(
+        self,
+        location: Location,
+        hwo_product: TextProduct | None,
+        settings: AppSettings,
+    ) -> None:
+        """
+        Inspect a freshly-fetched HWO product and notify on material updates.
+
+        Unit 10 — Hazardous Weather Outlook change detection. The event loop
+        feeds us the pre-warmed HWO for ``location``; we:
+
+        1. Seed baseline state on the first fetch (no notification).
+        2. Compare ``issuance_time`` + content-signature against stored values;
+           short-circuit when both are unchanged.
+        3. On change, persist the new baseline, then — subject to the
+           ``notify_hwo_update`` setting (default True when absent) and a
+           sliding 30-minute rate-limit bucket keyed by ``("HWO", location)`` —
+           dispatch a desktop notification.
+
+        ``None`` products and locations without a ``cwa_office`` are no-ops.
+        """
+        if hwo_product is None:
+            return
+        if not getattr(location, "cwa_office", None):
+            return
+
+        new_issuance = hwo_product.issuance_time
+        new_text = hwo_product.product_text or ""
+        signature = self._hash_product_text(new_text)
+
+        stored_issuance = self.state.last_hwo_issuance_time
+        stored_signature = self.state.last_hwo_summary_signature
+        stored_text = self.state.last_hwo_text
+
+        # Cold-start: no stored baseline → record silently, never dispatch.
+        if stored_issuance is None and stored_signature is None:
+            self.state.last_hwo_issuance_time = new_issuance
+            self.state.last_hwo_text = new_text
+            self.state.last_hwo_summary_signature = signature
+            self._save_state()
+            logger.debug(
+                "_check_hwo_update: first-run baseline for %s (%s) — no notification",
+                location.name,
+                location.cwa_office,
+            )
+            return
+
+        # Unchanged → true no-op: no state churn, no dispatch.
+        if stored_issuance == new_issuance and stored_signature == signature:
+            return
+
+        # Changed: persist new baseline before deciding whether to notify so we
+        # never re-fire against the old state if dispatch is suppressed below.
+        self.state.last_hwo_issuance_time = new_issuance
+        self.state.last_hwo_text = new_text
+        self.state.last_hwo_summary_signature = signature
+        self._save_state()
+
+        if not getattr(settings, "notify_hwo_update", True):
+            logger.debug(
+                "_check_hwo_update: notify_hwo_update disabled — suppressing dispatch for %s",
+                location.name,
+            )
+            return
+
+        bucket = ("HWO", location.name)
+        now = datetime.now(timezone.utc)
+        last_sent = self._last_product_notified_at.get(bucket)
+        if last_sent is not None and now - last_sent < _HWO_RATE_LIMIT_WINDOW:
+            logger.debug(
+                "_check_hwo_update: rate-limited for %s (last=%s) — state updated, no dispatch",
+                location.name,
+                last_sent,
+            )
+            return
+        self._last_product_notified_at[bucket] = now
+
+        message = self._format_hwo_body(stored_text, hwo_product)
+        logger.info(
+            "HWO updated for %s (%s): %s -> %s",
+            location.name,
+            location.cwa_office,
+            stored_issuance,
+            new_issuance,
+        )
+        self._dispatch_hwo_notification(
+            location=location,
+            product=hwo_product,
+            message=message,
+        )
+
+    @staticmethod
+    def _hash_product_text(text: str) -> str:
+        """Return a stable signature for an HWO product text."""
+        normalized = (text or "").strip()
+        return hashlib.sha256(normalized.encode("utf-8", errors="replace")).hexdigest()
+
+    @staticmethod
+    def _format_hwo_body(stored_text: str | None, new_product: TextProduct) -> str:
+        """Produce the notification body — prefer summarizer output, fall back to generic."""
+        summary = summarize_discussion_change(stored_text, new_product.product_text)
+        if summary and len(summary.strip()) > _HWO_SUMMARY_MIN_CHARS:
+            return summary.strip()
+        return f"Hazardous Weather Outlook updated for {new_product.cwa_office} — tap to view."
+
+    def _dispatch_hwo_notification(
+        self,
+        *,
+        location: Location,
+        product: TextProduct,
+        message: str,
+    ) -> None:
+        """
+        Emit the HWO notification event.
+
+        The default implementation builds a :class:`NotificationEvent` and logs
+        it; the UI-layer caller is responsible for wiring it into the actual
+        notifier. Tests monkey-patch this method to capture dispatches.
+        """
+        event = NotificationEvent(
+            event_type="hwo_update",
+            title="Hazardous Weather Outlook Updated",
+            message=message,
+            sound_event="notify",
+        )
+        logger.debug(
+            "[events] HWO dispatch (default no-op): location=%s product=%s title=%r",
+            location.name,
+            product.product_id,
+            event.title,
+        )
 
     def _check_severe_risk_change(
         self, current: CurrentConditions, location_name: str

--- a/src/accessiweather/runtime_state.py
+++ b/src/accessiweather/runtime_state.py
@@ -29,6 +29,20 @@ _DEFAULT_RUNTIME_STATE: dict[str, Any] = {
             "last_value": None,
             "last_check_time": None,
         },
+        # Hazardous Weather Outlook (HWO) baselines — populated by Unit 10.
+        # Additive; mirrors the ``discussion`` sub-section.
+        "hwo": {
+            "last_issuance_time": None,
+            "last_text": None,
+            "last_summary_signature": None,
+            "last_check_time": None,
+        },
+        # Special Weather Statement (SPS) baselines — populated by Unit 11.
+        # Stores the set of product IDs already announced, as a sorted list.
+        "sps": {
+            "last_product_ids": [],
+            "last_check_time": None,
+        },
     },
     "meta": {
         "migrated_from": [],

--- a/src/accessiweather/services/forecast_product_service.py
+++ b/src/accessiweather/services/forecast_product_service.py
@@ -1,0 +1,100 @@
+"""
+Forecast product service — caches NWS text products (AFD / HWO / SPS).
+
+Wraps :func:`accessiweather.weather_client_nws.get_nws_text_product` with a
+per-key TTL cache driven by :class:`accessiweather.cache.Cache`. TTLs differ by
+product type:
+
+- AFD: 3600 s  (discussions update every ~6 h)
+- HWO: 7200 s  (hazardous-weather outlooks update once daily)
+- SPS:  900 s  (special statements are time-sensitive)
+
+Failed fetches (:class:`TextProductFetchError`) are NOT cached — the caller
+sees the exception and the next call retries.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any, Literal
+
+from ..cache import Cache
+from ..models import TextProduct
+from ..weather_client_nws import TextProductFetchError, get_nws_text_product
+
+logger = logging.getLogger(__name__)
+
+ProductType = Literal["AFD", "HWO", "SPS"]
+
+# Per-type cache TTLs in seconds. Keyed by product_type; see module docstring
+# for rationale.
+_PRODUCT_TTLS: dict[str, int] = {
+    "AFD": 3600,
+    "HWO": 7200,
+    "SPS": 900,
+}
+
+FetcherResult = TextProduct | list[TextProduct] | None
+Fetcher = Callable[..., Awaitable[FetcherResult]]
+
+
+class ForecastProductService:
+    """Cache-fronted service for NWS text products."""
+
+    _TTLS = _PRODUCT_TTLS
+
+    def __init__(
+        self,
+        cache: Cache,
+        *,
+        fetcher: Fetcher | None = None,
+    ) -> None:
+        """
+        Initialize the service.
+
+        Args:
+            cache: Shared ``Cache`` instance. The service stores entries keyed by
+                ``nws_text_product:{product_type}:{cwa_office}``.
+            fetcher: Optional async callable with the same signature as
+                :func:`get_nws_text_product`. Defaults to the real module-level
+                function. Injected primarily for unit tests.
+
+        """
+        self._cache = cache
+        self._fetcher: Fetcher = fetcher or get_nws_text_product
+
+    @staticmethod
+    def _cache_key(product_type: str, cwa_office: str) -> str:
+        return f"nws_text_product:{product_type}:{cwa_office}"
+
+    async def get(
+        self,
+        product_type: ProductType,
+        cwa_office: str,
+        **fetcher_kwargs: Any,
+    ) -> FetcherResult:
+        """
+        Return a cached or freshly-fetched text product.
+
+        On cache hit the stored value is returned directly. On miss the fetcher
+        is invoked and the result is cached with the per-type TTL before being
+        returned. :class:`TextProductFetchError` from the fetcher propagates
+        unchanged and is NOT cached.
+        """
+        key = self._cache_key(product_type, cwa_office)
+
+        # has_key() distinguishes "cached value that happens to be None/[]"
+        # from "cache miss". Call it first, then fetch the value.
+        if self._cache.has_key(key):
+            return self._cache.get(key)
+
+        try:
+            result = await self._fetcher(product_type, cwa_office, **fetcher_kwargs)
+        except TextProductFetchError:
+            # Do not cache failures — let the next call retry.
+            raise
+
+        ttl = self._TTLS.get(product_type, self._cache.default_ttl)
+        self._cache.set(key, result, ttl=ttl)
+        return result

--- a/src/accessiweather/ui/dialogs/__init__.py
+++ b/src/accessiweather/ui/dialogs/__init__.py
@@ -6,6 +6,7 @@ from .alerts_summary_dialog import show_alerts_summary_dialog
 from .aviation_dialog import show_aviation_dialog
 from .discussion_dialog import show_discussion_dialog
 from .explanation_dialog import show_explanation_dialog
+from .forecast_products_dialog import show_forecast_products_dialog
 from .location_dialog import show_add_location_dialog, show_edit_location_dialog
 from .nationwide_discussion_dialog import show_nationwide_discussion_dialog
 from .noaa_radio_dialog import NOAARadioDialog, show_noaa_radio_dialog
@@ -26,6 +27,7 @@ __all__ = [
     "show_aviation_dialog",
     "show_discussion_dialog",
     "show_explanation_dialog",
+    "show_forecast_products_dialog",
     "show_nationwide_discussion_dialog",
     "show_settings_dialog",
     "show_soundpack_manager_dialog",
@@ -45,6 +47,7 @@ _LAZY_IMPORTS = {
     "show_aviation_dialog": ".aviation_dialog",
     "show_discussion_dialog": ".discussion_dialog",
     "show_explanation_dialog": ".explanation_dialog",
+    "show_forecast_products_dialog": ".forecast_products_dialog",
     "show_add_location_dialog": ".location_dialog",
     "show_edit_location_dialog": ".location_dialog",
     "show_nationwide_discussion_dialog": ".nationwide_discussion_dialog",

--- a/src/accessiweather/ui/dialogs/forecast_product_panel.py
+++ b/src/accessiweather/ui/dialogs/forecast_product_panel.py
@@ -115,15 +115,21 @@ class ForecastProductPanel(wx.Panel):
         self.header_label = wx.StaticText(self, label=full_name)
         main_sizer.Add(self.header_label, 0, wx.ALL | wx.EXPAND, 8)
 
-        # SPS multi-product chooser (hidden by default; revealed when >1 SPS).
-        self.sps_choice_label = wx.StaticText(self, label="Active Special Weather Statements:")
-        main_sizer.Add(self.sps_choice_label, 0, wx.LEFT | wx.RIGHT, 8)
-        self.sps_choice = wx.Choice(self)
-        main_sizer.Add(self.sps_choice, 0, wx.ALL | wx.EXPAND, 8)
-        # Always hide initially — shown only when we have >1 SPS.
-        self._sps_choice_sizer_index = 2  # position in main_sizer for Show()
-        main_sizer.Show(self.sps_choice_label, False)
-        main_sizer.Show(self.sps_choice, False)
+        # SPS multi-product chooser — ONLY created on the SPS tab. Creating it
+        # on AFD/HWO and hiding it via Show(False) still leaks the label to
+        # screen readers, which was reported as misleading. AFD and HWO never
+        # have multiple concurrent products, so the chooser is SPS-only by
+        # design.
+        self.sps_choice_label: wx.StaticText | None = None
+        self.sps_choice: wx.Choice | None = None
+        if self.product_type == "SPS":
+            self.sps_choice_label = wx.StaticText(self, label="Active Special Weather Statements:")
+            main_sizer.Add(self.sps_choice_label, 0, wx.LEFT | wx.RIGHT, 8)
+            self.sps_choice = wx.Choice(self)
+            main_sizer.Add(self.sps_choice, 0, wx.ALL | wx.EXPAND, 8)
+            # Hidden until we actually have >1 SPS to switch between.
+            main_sizer.Show(self.sps_choice_label, False)
+            main_sizer.Show(self.sps_choice, False)
 
         # Raw product text — the primary content surface.
         self.product_textctrl = wx.TextCtrl(
@@ -172,7 +178,8 @@ class ForecastProductPanel(wx.Panel):
         self.explain_button.Bind(wx.EVT_BUTTON, self._on_explain)
         self.regenerate_button.Bind(wx.EVT_BUTTON, self._on_regenerate)
         self.retry_button.Bind(wx.EVT_BUTTON, self._on_retry)
-        self.sps_choice.Bind(wx.EVT_CHOICE, self._on_sps_choice_changed)
+        if self.sps_choice is not None:
+            self.sps_choice.Bind(wx.EVT_CHOICE, self._on_sps_choice_changed)
 
     # ------------------------------------------------------------------
     # Layout helpers (mirror DiscussionDialog's AI visibility design)
@@ -203,8 +210,12 @@ class ForecastProductPanel(wx.Panel):
         self._layout()
 
     def _show_sps_chooser(self, visible: bool) -> None:
-        self._main_sizer.Show(self.sps_choice_label, visible)
-        self._main_sizer.Show(self.sps_choice, visible)
+        label = self.sps_choice_label
+        choice = self.sps_choice
+        if label is None or choice is None:
+            return
+        self._main_sizer.Show(label, visible)
+        self._main_sizer.Show(choice, visible)
         self._layout()
 
     def _show_retry(self, visible: bool) -> None:
@@ -331,12 +342,15 @@ class ForecastProductPanel(wx.Panel):
     def _render_sps_products(self, products: list[TextProduct]) -> None:
         """Render one or more SPS products with the multi-choice picker."""
         self._sps_products = products
+        choice = self.sps_choice
+        if choice is None:  # non-SPS panels shouldn't reach this path
+            return
         entries = [_format_sps_choice_entry(p) for p in products]
         # Repopulate the choice widget. MagicMock in tests tolerates both.
-        self.sps_choice.Clear()
+        choice.Clear()
         for entry in entries:
-            self.sps_choice.Append(entry)
-        self.sps_choice.SetSelection(0)
+            choice.Append(entry)
+        choice.SetSelection(0)
         self._show_sps_chooser(len(products) > 1)
         self._render_single_product(products[0])
         # _render_single_product hides the chooser — re-show if multi.
@@ -345,7 +359,10 @@ class ForecastProductPanel(wx.Panel):
     def _on_sps_choice_changed(self, event) -> None:
         """Swap the TextCtrl content when the user picks a different SPS."""
         del event
-        idx = self.sps_choice.GetSelection()
+        choice = self.sps_choice
+        if choice is None:
+            return
+        idx = choice.GetSelection()
         if idx < 0 or idx >= len(self._sps_products):
             return
         product = self._sps_products[idx]

--- a/src/accessiweather/ui/dialogs/forecast_product_panel.py
+++ b/src/accessiweather/ui/dialogs/forecast_product_panel.py
@@ -154,6 +154,21 @@ class ForecastProductPanel(wx.Panel):
         main_sizer.Show(self.ai_summary_header, False)
         main_sizer.Show(self.ai_summary_display, False)
 
+        # Model information (shown alongside the AI summary). Mirrors
+        # DiscussionDialog's Model / Tokens / Cost / Cached block so users
+        # see the same provenance info they already expect from AFD.
+        self.model_info_label = wx.StaticText(self, label="Model Information:")
+        main_sizer.Add(self.model_info_label, 0, wx.LEFT | wx.RIGHT | wx.TOP, 8)
+        self.model_info = wx.TextCtrl(
+            self,
+            value="",
+            style=wx.TE_MULTILINE | wx.TE_READONLY,
+            size=wx.Size(-1, 80),
+        )
+        main_sizer.Add(self.model_info, 0, wx.LEFT | wx.RIGHT | wx.EXPAND, 8)
+        main_sizer.Show(self.model_info_label, False)
+        main_sizer.Show(self.model_info, False)
+
         # Buttons row
         button_sizer = wx.BoxSizer(wx.HORIZONTAL)
         self.explain_button = wx.Button(self, label="Plain Language Summary")
@@ -197,7 +212,18 @@ class ForecastProductPanel(wx.Panel):
     def _hide_ai_summary_section(self) -> None:
         self._main_sizer.Show(self.ai_summary_header, False)
         self._main_sizer.Show(self.ai_summary_display, False)
+        self._hide_model_info()
         self._layout()
+
+    def _show_model_info(self) -> None:
+        self._main_sizer.Show(self.model_info_label, True)
+        self._main_sizer.Show(self.model_info, True)
+        self._layout()
+
+    def _hide_model_info(self) -> None:
+        self.model_info.SetValue("")
+        self._main_sizer.Show(self.model_info_label, False)
+        self._main_sizer.Show(self.model_info, False)
 
     def _set_post_explain_buttons(self, has_attempted: bool) -> None:
         """Explain and Regenerate are mutually exclusive."""
@@ -431,6 +457,7 @@ class ForecastProductPanel(wx.Panel):
             return
         self._is_explaining = True
         self._show_ai_summary_section()
+        self._hide_model_info()
         self._set_post_explain_buttons(has_attempted=False)
         self.explain_button.Disable()
         self.ai_summary_display.SetValue("Generating plain language summary...")
@@ -523,16 +550,36 @@ class ForecastProductPanel(wx.Panel):
                 cast(ProductType, self.product_type),
                 self._location_name,
             )
-            wx.CallAfter(self._on_explain_complete, result.text)
+            wx.CallAfter(
+                self._on_explain_complete,
+                result.text,
+                getattr(result, "model_used", ""),
+                getattr(result, "token_count", 0),
+                getattr(result, "estimated_cost", 0.0),
+                getattr(result, "cached", False),
+            )
         except Exception as exc:  # noqa: BLE001
             wx.CallAfter(self._on_explain_error, str(exc))
 
-    def _on_explain_complete(self, summary: str) -> None:
-        """Fill in the AI summary TextCtrl on success."""
+    def _on_explain_complete(
+        self,
+        summary: str,
+        model_used: str = "",
+        token_count: int = 0,
+        estimated_cost: float = 0.0,
+        cached: bool = False,
+    ) -> None:
+        """Fill in the AI summary TextCtrl + Model Information on success."""
         self._is_explaining = False
         self._show_ai_summary_section()
         self._set_post_explain_buttons(has_attempted=True)
         self.ai_summary_display.SetValue(summary)
+        cost_text = "No cost" if estimated_cost == 0 else f"~${estimated_cost:.6f}"
+        info = f"Model: {model_used}\nTokens: {token_count}\nCost: {cost_text}"
+        if cached:
+            info += "\nCached: Yes"
+        self.model_info.SetValue(info)
+        self._show_model_info()
 
     def _on_explain_error(self, message: str) -> None:
         """Populate the AI summary TextCtrl with an error message."""

--- a/src/accessiweather/ui/dialogs/forecast_product_panel.py
+++ b/src/accessiweather/ui/dialogs/forecast_product_panel.py
@@ -43,7 +43,7 @@ _PRODUCT_FULL_NAMES: dict[str, str] = {
 _EMPTY_COPY: dict[str, str] = {
     "AFD": "Area Forecast Discussion not currently available for {cwa_office}.",
     "HWO": "Hazardous Weather Outlook not currently available for {cwa_office}.",
-    "SPS": "No Special Weather Statements currently active for {cwa_office}.",
+    "SPS": "No recent Special Weather Statements for {cwa_office}.",
 }
 
 _NO_CWA_COPY = "NWS text products will populate after the next weather refresh."
@@ -123,7 +123,7 @@ class ForecastProductPanel(wx.Panel):
         self.sps_choice_label: wx.StaticText | None = None
         self.sps_choice: wx.Choice | None = None
         if self.product_type == "SPS":
-            self.sps_choice_label = wx.StaticText(self, label="Active Special Weather Statements:")
+            self.sps_choice_label = wx.StaticText(self, label="Recent Special Weather Statements:")
             main_sizer.Add(self.sps_choice_label, 0, wx.LEFT | wx.RIGHT, 8)
             self.sps_choice = wx.Choice(self)
             main_sizer.Add(self.sps_choice, 0, wx.ALL | wx.EXPAND, 8)

--- a/src/accessiweather/ui/dialogs/forecast_product_panel.py
+++ b/src/accessiweather/ui/dialogs/forecast_product_panel.py
@@ -116,7 +116,7 @@ class ForecastProductPanel(wx.Panel):
         main_sizer.Add(self.header_label, 0, wx.ALL | wx.EXPAND, 8)
 
         # SPS multi-product chooser (hidden by default; revealed when >1 SPS).
-        self.sps_choice_label = wx.StaticText(self, label="Active Statements:")
+        self.sps_choice_label = wx.StaticText(self, label="Active Special Weather Statements:")
         main_sizer.Add(self.sps_choice_label, 0, wx.LEFT | wx.RIGHT, 8)
         self.sps_choice = wx.Choice(self)
         main_sizer.Add(self.sps_choice, 0, wx.ALL | wx.EXPAND, 8)

--- a/src/accessiweather/ui/dialogs/forecast_product_panel.py
+++ b/src/accessiweather/ui/dialogs/forecast_product_panel.py
@@ -1,0 +1,464 @@
+"""
+Reusable per-tab panel for the Forecast Products dialog.
+
+Each :class:`ForecastProductPanel` renders one NWS text product type (AFD, HWO,
+or SPS) with a shared shape: header, optional SPS-multi chooser, raw-product
+TextCtrl, issuance timestamp StaticText, "Plain Language Summary" AI button
+(hidden until clicked), and a retry button shown only in the fetch-failed
+state.
+
+The panel owns its own content-state machine — AFD/HWO have a single product,
+SPS can have multiple. All empty/error states render inside the content area
+because ``wx.Notebook`` doesn't support per-tab disable on Windows.
+
+Accessibility note: screen readers announce adjacent ``wx.StaticText``, NOT
+``SetName()`` or tooltips (project convention). Descriptive ``label=``
+strings are used throughout.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+from typing import TYPE_CHECKING, Literal, cast
+
+import wx
+
+if TYPE_CHECKING:
+    from ...ai_explainer import AIExplainer
+    from ...models import TextProduct
+
+logger = logging.getLogger(__name__)
+
+ProductType = Literal["AFD", "HWO", "SPS"]
+
+_PRODUCT_FULL_NAMES: dict[str, str] = {
+    "AFD": "Area Forecast Discussion",
+    "HWO": "Hazardous Weather Outlook",
+    "SPS": "Special Weather Statement",
+}
+
+# Empty-state copy per product type.
+_EMPTY_COPY: dict[str, str] = {
+    "AFD": "Area Forecast Discussion not currently available for {cwa_office}.",
+    "HWO": "Hazardous Weather Outlook not currently available for {cwa_office}.",
+    "SPS": "No Special Weather Statements currently active for {cwa_office}.",
+}
+
+_NO_CWA_COPY = "NWS text products will populate after the next weather refresh."
+
+ProductLoader = Callable[[], Awaitable["TextProduct | list[TextProduct] | None"]]
+
+
+class ForecastProductPanel(wx.Panel):
+    """One tab's worth of content inside the Forecast Products dialog."""
+
+    def __init__(
+        self,
+        parent: wx.Window,
+        product_type: ProductType,
+        product_loader: ProductLoader,
+        ai_explainer: AIExplainer | None,
+        cwa_office: str | None,
+        location_name: str,
+    ) -> None:
+        """
+        Build the panel widgets.
+
+        Args:
+            parent: Parent window (the ``wx.Notebook``).
+            product_type: One of ``"AFD"``, ``"HWO"``, ``"SPS"``.
+            product_loader: Zero-arg async callable that returns the fetched
+                product(s). May raise ``TextProductFetchError``.
+            ai_explainer: Optional explainer; when ``None`` the AI summary
+                button stays disabled.
+            cwa_office: CWA office code (e.g. ``"RAH"``). When ``None`` the
+                panel shows a fallback message covering all three product
+                types.
+            location_name: Human-readable location name (used for AI prompts).
+
+        """
+        super().__init__(parent)
+        self.product_type = product_type
+        self._product_loader = product_loader
+        self._ai_explainer = ai_explainer
+        self._cwa_office = cwa_office
+        self._location_name = location_name
+
+        # State
+        self._current_text: str | None = None
+        # For SPS multi-product: the list of products currently available.
+        self._sps_products: list[TextProduct] = []
+        self._is_loading = False
+        self._is_explaining = False
+
+        self._create_widgets()
+        self._bind_events()
+
+        # Kick off initial load.
+        self._trigger_load()
+
+    # ------------------------------------------------------------------
+    # Widget creation
+    # ------------------------------------------------------------------
+    def _create_widgets(self) -> None:
+        """Construct the per-tab widget tree."""
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+
+        full_name = _PRODUCT_FULL_NAMES[self.product_type]
+        self.header_label = wx.StaticText(self, label=full_name)
+        main_sizer.Add(self.header_label, 0, wx.ALL | wx.EXPAND, 8)
+
+        # SPS multi-product chooser (hidden by default; revealed when >1 SPS).
+        self.sps_choice_label = wx.StaticText(self, label="Active Statements:")
+        main_sizer.Add(self.sps_choice_label, 0, wx.LEFT | wx.RIGHT, 8)
+        self.sps_choice = wx.Choice(self)
+        main_sizer.Add(self.sps_choice, 0, wx.ALL | wx.EXPAND, 8)
+        # Always hide initially — shown only when we have >1 SPS.
+        self._sps_choice_sizer_index = 2  # position in main_sizer for Show()
+        main_sizer.Show(self.sps_choice_label, False)
+        main_sizer.Show(self.sps_choice, False)
+
+        # Raw product text — the primary content surface.
+        self.product_textctrl = wx.TextCtrl(
+            self,
+            style=wx.TE_MULTILINE | wx.TE_READONLY | wx.HSCROLL,
+            value="Loading...",
+        )
+        main_sizer.Add(self.product_textctrl, 1, wx.ALL | wx.EXPAND, 8)
+
+        # Issuance StaticText — adjacent StaticText is what screen readers pick up.
+        self.issuance_label = wx.StaticText(self, label="")
+        main_sizer.Add(self.issuance_label, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 8)
+
+        # AI summary header + display — hidden until user clicks "Plain Language Summary".
+        self.ai_summary_header = wx.StaticText(self, label="Plain Language Summary:")
+        main_sizer.Add(self.ai_summary_header, 0, wx.LEFT | wx.RIGHT, 8)
+        self.ai_summary_display = wx.TextCtrl(
+            self,
+            style=wx.TE_MULTILINE | wx.TE_READONLY,
+        )
+        main_sizer.Add(self.ai_summary_display, 0, wx.ALL | wx.EXPAND, 8)
+        main_sizer.Show(self.ai_summary_header, False)
+        main_sizer.Show(self.ai_summary_display, False)
+
+        # Buttons row
+        button_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.explain_button = wx.Button(self, label="Plain Language Summary")
+        self.regenerate_button = wx.Button(self, label="Regenerate Summary")
+        self.retry_button = wx.Button(self, label="Try again")
+        button_sizer.Add(self.explain_button, 0, wx.RIGHT, 5)
+        button_sizer.Add(self.regenerate_button, 0, wx.RIGHT, 5)
+        button_sizer.Add(self.retry_button, 0)
+        main_sizer.Add(button_sizer, 0, wx.ALL, 8)
+
+        # Regenerate + retry hidden initially.
+        self.regenerate_button.Hide()
+        self.retry_button.Hide()
+        # Explain button disabled until we have loaded text + explainer is available.
+        self.explain_button.Disable()
+
+        self.SetSizer(main_sizer)
+        self._main_sizer = main_sizer
+
+    def _bind_events(self) -> None:
+        """Wire up button and SPS-choice events."""
+        self.explain_button.Bind(wx.EVT_BUTTON, self._on_explain)
+        self.regenerate_button.Bind(wx.EVT_BUTTON, self._on_regenerate)
+        self.retry_button.Bind(wx.EVT_BUTTON, self._on_retry)
+        self.sps_choice.Bind(wx.EVT_CHOICE, self._on_sps_choice_changed)
+
+    # ------------------------------------------------------------------
+    # Layout helpers (mirror DiscussionDialog's AI visibility design)
+    # ------------------------------------------------------------------
+    def _layout(self) -> None:
+        sizer = self.GetSizer()
+        if sizer:
+            sizer.Layout()
+
+    def _show_ai_summary_section(self) -> None:
+        self._main_sizer.Show(self.ai_summary_header, True)
+        self._main_sizer.Show(self.ai_summary_display, True)
+        self._layout()
+
+    def _hide_ai_summary_section(self) -> None:
+        self._main_sizer.Show(self.ai_summary_header, False)
+        self._main_sizer.Show(self.ai_summary_display, False)
+        self._layout()
+
+    def _set_post_explain_buttons(self, has_attempted: bool) -> None:
+        """Explain and Regenerate are mutually exclusive."""
+        if has_attempted:
+            self.explain_button.Hide()
+            self.regenerate_button.Show()
+        else:
+            self.explain_button.Show()
+            self.regenerate_button.Hide()
+        self._layout()
+
+    def _show_sps_chooser(self, visible: bool) -> None:
+        self._main_sizer.Show(self.sps_choice_label, visible)
+        self._main_sizer.Show(self.sps_choice, visible)
+        self._layout()
+
+    def _show_retry(self, visible: bool) -> None:
+        if visible:
+            self.retry_button.Show()
+        else:
+            self.retry_button.Hide()
+        self._layout()
+
+    # ------------------------------------------------------------------
+    # Load flow
+    # ------------------------------------------------------------------
+    def _trigger_load(self) -> None:
+        """Enter the loading state and dispatch the async loader."""
+        if self._cwa_office is None:
+            # Nothing we can do — surface the pre-refresh message.
+            self._render_no_cwa_state()
+            return
+
+        self._is_loading = True
+        self._show_retry(False)
+        self.product_textctrl.SetValue("Loading...")
+        self.issuance_label.SetLabel("")
+        self._hide_ai_summary_section()
+        self._set_post_explain_buttons(has_attempted=False)
+        self.explain_button.Disable()
+
+        # Schedule the coroutine. Tests may stub _schedule_load; production
+        # uses asyncio.ensure_future on the app's event loop.
+        self._schedule_load(self._product_loader())
+
+    def _schedule_load(self, coro) -> None:
+        """Dispatch a loader coroutine. Separated for test override."""
+        import asyncio
+
+        try:
+            asyncio.ensure_future(self._run_loader(coro))
+        except RuntimeError:
+            # No running loop (rare in tests) — swallow; tests drive load paths directly.
+            logger.debug("No running event loop for ForecastProductPanel loader")
+
+    async def _run_loader(self, coro) -> None:
+        """Await the loader coroutine and marshal result/error to main thread."""
+        try:
+            result = await coro
+            wx.CallAfter(self._on_load_complete, result)
+        except Exception as exc:  # noqa: BLE001 — surface any error as fetch failure
+            logger.warning(f"ForecastProductPanel({self.product_type}) load failed: {exc}")
+            wx.CallAfter(self._on_load_error, exc)
+
+    # ------------------------------------------------------------------
+    # Render paths — exercised directly by tests
+    # ------------------------------------------------------------------
+    def _render_no_cwa_state(self) -> None:
+        """Render the 'cwa_office is null' fallback message."""
+        self._current_text = None
+        self.product_textctrl.SetValue(_NO_CWA_COPY)
+        self.issuance_label.SetLabel("")
+        self._show_sps_chooser(False)
+        self._show_retry(False)
+        self._hide_ai_summary_section()
+        self.explain_button.Disable()
+
+    def _on_load_complete(
+        self,
+        result: TextProduct | list[TextProduct] | None,
+    ) -> None:
+        """Handle successful fetch — may be None / empty / single / multi."""
+        self._is_loading = False
+        self._show_retry(False)
+
+        # Normalise to list.
+        if result is None:
+            products: list[TextProduct] = []
+        elif isinstance(result, list):
+            products = list(result)
+        else:
+            products = [result]
+
+        if not products:
+            self._render_empty_state()
+            return
+
+        if self.product_type == "SPS":
+            self._render_sps_products(products)
+        else:
+            self._render_single_product(products[0])
+
+    def _render_empty_state(self) -> None:
+        """Render the 'no product available' state."""
+        template = _EMPTY_COPY[self.product_type]
+        self.product_textctrl.SetValue(template.format(cwa_office=self._cwa_office))
+        self.issuance_label.SetLabel("")
+        self._show_sps_chooser(False)
+        self._hide_ai_summary_section()
+        self.explain_button.Disable()
+        self._current_text = None
+
+    def _render_single_product(self, product: TextProduct) -> None:
+        """Render a single product (AFD / HWO / single SPS)."""
+        self._current_text = product.product_text
+        self.product_textctrl.SetValue(product.product_text)
+        self.issuance_label.SetLabel(_format_issuance(product.issuance_time))
+        self._show_sps_chooser(False)
+        self._update_explain_button_state()
+
+    def _render_sps_products(self, products: list[TextProduct]) -> None:
+        """Render one or more SPS products with the multi-choice picker."""
+        self._sps_products = products
+        entries = [_format_sps_choice_entry(p) for p in products]
+        # Repopulate the choice widget. MagicMock in tests tolerates both.
+        self.sps_choice.Clear()
+        for entry in entries:
+            self.sps_choice.Append(entry)
+        self.sps_choice.SetSelection(0)
+        self._show_sps_chooser(len(products) > 1)
+        self._render_single_product(products[0])
+        # _render_single_product hides the chooser — re-show if multi.
+        self._show_sps_chooser(len(products) > 1)
+
+    def _on_sps_choice_changed(self, event) -> None:
+        """Swap the TextCtrl content when the user picks a different SPS."""
+        del event
+        idx = self.sps_choice.GetSelection()
+        if idx < 0 or idx >= len(self._sps_products):
+            return
+        product = self._sps_products[idx]
+        self._current_text = product.product_text
+        self.product_textctrl.SetValue(product.product_text)
+        self.issuance_label.SetLabel(_format_issuance(product.issuance_time))
+        self._update_explain_button_state()
+        # Hide stale AI summary when switching products.
+        self._hide_ai_summary_section()
+        self._set_post_explain_buttons(has_attempted=False)
+
+    def _on_load_error(self, exc: Exception) -> None:
+        """Render the fetch-failed state."""
+        del exc
+        self._is_loading = False
+        full_name = _PRODUCT_FULL_NAMES[self.product_type]
+        self.product_textctrl.SetValue(f"Failed to fetch {full_name} — try again.")
+        self.issuance_label.SetLabel("")
+        self._show_sps_chooser(False)
+        self._hide_ai_summary_section()
+        self.explain_button.Disable()
+        self._show_retry(True)
+        self._current_text = None
+
+    def _update_explain_button_state(self) -> None:
+        """Enable Explain only when AI + loaded text are available."""
+        if self._ai_explainer is not None and self._current_text:
+            self.explain_button.Enable()
+        else:
+            self.explain_button.Disable()
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+    def _on_retry(self, event) -> None:
+        """Retry button click — re-invoke the loader."""
+        del event
+        self._trigger_load()
+
+    def _on_explain(self, event) -> None:
+        """Plain Language Summary button click."""
+        del event
+        if not self._current_text or self._is_explaining or self._ai_explainer is None:
+            return
+        self._is_explaining = True
+        self._show_ai_summary_section()
+        self._set_post_explain_buttons(has_attempted=False)
+        self.explain_button.Disable()
+        self.ai_summary_display.SetValue("Generating plain language summary...")
+        self._schedule_explain(self._current_text)
+
+    def _on_regenerate(self, event) -> None:
+        """Regenerate summary — clear the explainer cache and re-invoke."""
+        cache = getattr(self._ai_explainer, "cache", None)
+        if cache is not None:
+            try:
+                cache.clear()
+            except Exception:  # noqa: BLE001
+                logger.debug("Failed to clear explainer cache", exc_info=True)
+        self._on_explain(event)
+
+    def _schedule_explain(self, text: str) -> None:
+        """Dispatch the AI explain coroutine. Separated for test override."""
+        import asyncio
+
+        if self._ai_explainer is None:
+            return
+        try:
+            asyncio.ensure_future(self._run_explain(text))
+        except RuntimeError:
+            logger.debug("No running event loop for ForecastProductPanel explain")
+
+    async def _run_explain(self, text: str) -> None:
+        """Invoke ``AIExplainer.explain_text_product`` for this tab's product."""
+        try:
+            assert self._ai_explainer is not None
+            # product_type is narrowed by construction — cast for pyright.
+            result = await self._ai_explainer.explain_text_product(
+                text,
+                cast(ProductType, self.product_type),
+                self._location_name,
+            )
+            wx.CallAfter(self._on_explain_complete, result.text)
+        except Exception as exc:  # noqa: BLE001
+            wx.CallAfter(self._on_explain_error, str(exc))
+
+    def _on_explain_complete(self, summary: str) -> None:
+        """Fill in the AI summary TextCtrl on success."""
+        self._is_explaining = False
+        self._show_ai_summary_section()
+        self._set_post_explain_buttons(has_attempted=True)
+        self.ai_summary_display.SetValue(summary)
+
+    def _on_explain_error(self, message: str) -> None:
+        """Populate the AI summary TextCtrl with an error message."""
+        self._is_explaining = False
+        self._show_ai_summary_section()
+        self._set_post_explain_buttons(has_attempted=True)
+        self.ai_summary_display.SetValue(
+            f"Failed to generate summary: {message}\n\nCheck your OpenRouter API key in Settings."
+        )
+
+
+# ----------------------------------------------------------------------
+# Formatting helpers
+# ----------------------------------------------------------------------
+def _format_issuance(issuance_time: datetime | None) -> str:
+    """Return the "Issued: ..." line in the user's OS local timezone."""
+    if issuance_time is None:
+        return "Issued: unknown"
+    try:
+        local = issuance_time.astimezone()
+    except (ValueError, OSError):
+        local = issuance_time
+    return f"Issued: {local.strftime('%Y-%m-%d %H:%M %Z').strip()}"
+
+
+def _format_sps_choice_entry(product: TextProduct) -> str:
+    """Build a wx.Choice entry for an SPS product."""
+    if product.issuance_time is not None:
+        try:
+            local = product.issuance_time.astimezone()
+        except (ValueError, OSError):
+            local = product.issuance_time
+        when = local.strftime("%Y-%m-%d %H:%M")
+    else:
+        when = "unknown"
+    headline = product.headline
+    if not headline:
+        # Fall back to the first non-empty line of the product text.
+        for line in (product.product_text or "").splitlines():
+            stripped = line.strip()
+            if stripped:
+                headline = stripped
+                break
+    if not headline:
+        headline = "Special Weather Statement"
+    return f"Issued {when} \u2014 {headline}"

--- a/src/accessiweather/ui/dialogs/forecast_product_panel.py
+++ b/src/accessiweather/ui/dialogs/forecast_product_panel.py
@@ -388,11 +388,33 @@ class ForecastProductPanel(wx.Panel):
         self._current_text = None
 
     def _update_explain_button_state(self) -> None:
-        """Enable Explain only when AI + loaded text are available."""
-        if self._ai_explainer is not None and self._current_text:
+        """
+        Enable Explain only when we have loaded text + an OpenRouter key.
+
+        The explainer itself is built on-demand at click time (mirrors
+        ``DiscussionDialog._do_explain``). An injected ``self._ai_explainer``
+        takes priority when set, which is how tests inject mocks.
+        """
+        if not self._current_text:
+            self.explain_button.Disable()
+            return
+        if self._ai_explainer is not None:
+            self.explain_button.Enable()
+            return
+        if self._has_openrouter_key():
             self.explain_button.Enable()
         else:
             self.explain_button.Disable()
+
+    @staticmethod
+    def _has_openrouter_key() -> bool:
+        """Return True when the OpenRouter API key is available in SecureStorage."""
+        try:
+            from ...config.secure_storage import SecureStorage
+
+            return bool(SecureStorage.get_password("openrouter_api_key"))
+        except Exception:  # noqa: BLE001
+            return False
 
     # ------------------------------------------------------------------
     # Event handlers
@@ -405,7 +427,7 @@ class ForecastProductPanel(wx.Panel):
     def _on_explain(self, event) -> None:
         """Plain Language Summary button click."""
         del event
-        if not self._current_text or self._is_explaining or self._ai_explainer is None:
+        if not self._current_text or self._is_explaining:
             return
         self._is_explaining = True
         self._show_ai_summary_section()
@@ -426,8 +448,6 @@ class ForecastProductPanel(wx.Panel):
 
     def _schedule_explain(self, text: str) -> None:
         """Dispatch the AI explain coroutine. Separated for test override."""
-        if self._ai_explainer is None:
-            return
         runner = getattr(self._app, "run_async", None) if self._app is not None else None
         if runner is not None:
             runner(self._run_explain(text))
@@ -440,12 +460,65 @@ class ForecastProductPanel(wx.Panel):
         except RuntimeError:
             logger.warning("No running event loop for ForecastProductPanel explain")
 
+    def _build_explainer(self):
+        """
+        Build (or return the injected) AIExplainer for this click.
+
+        Mirrors ``DiscussionDialog._do_explain``: reads the API key from
+        SecureStorage and model + custom-prompt settings from AppConfig.
+        Returns ``None`` when no API key is available, which surfaces as a
+        user-facing error via the existing ``_on_explain_error`` path.
+        """
+        if self._ai_explainer is not None:
+            return self._ai_explainer
+
+        try:
+            from ...ai_explainer import DEFAULT_FREE_MODEL, AIExplainer
+            from ...config.secure_storage import SecureStorage
+
+            api_key = SecureStorage.get_password("openrouter_api_key")
+            if not api_key:
+                return None
+
+            settings = None
+            if self._app is not None:
+                cfg_manager = getattr(self._app, "config_manager", None)
+                if cfg_manager is not None:
+                    settings = cfg_manager.get_settings()
+
+            model_pref = getattr(settings, "ai_model_preference", None) if settings else None
+            if model_pref == "auto":
+                model = "openrouter/auto"
+            elif model_pref:
+                model = model_pref
+            else:
+                model = DEFAULT_FREE_MODEL
+
+            return AIExplainer(
+                api_key=api_key,
+                model=model,
+                custom_system_prompt=getattr(settings, "custom_system_prompt", None)
+                if settings
+                else None,
+                custom_instructions=getattr(settings, "custom_instructions", None)
+                if settings
+                else None,
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("Failed to build AIExplainer", exc_info=True)
+            return None
+
     async def _run_explain(self, text: str) -> None:
         """Invoke ``AIExplainer.explain_text_product`` for this tab's product."""
         try:
-            assert self._ai_explainer is not None
-            # product_type is narrowed by construction — cast for pyright.
-            result = await self._ai_explainer.explain_text_product(
+            explainer = self._build_explainer()
+            if explainer is None:
+                wx.CallAfter(
+                    self._on_explain_error,
+                    "OpenRouter API key not configured. Set it in Settings > AI.",
+                )
+                return
+            result = await explainer.explain_text_product(
                 text,
                 cast(ProductType, self.product_type),
                 self._location_name,

--- a/src/accessiweather/ui/dialogs/forecast_product_panel.py
+++ b/src/accessiweather/ui/dialogs/forecast_product_panel.py
@@ -62,6 +62,7 @@ class ForecastProductPanel(wx.Panel):
         ai_explainer: AIExplainer | None,
         cwa_office: str | None,
         location_name: str,
+        app: object | None = None,
     ) -> None:
         """
         Build the panel widgets.
@@ -77,6 +78,9 @@ class ForecastProductPanel(wx.Panel):
                 panel shows a fallback message covering all three product
                 types.
             location_name: Human-readable location name (used for AI prompts).
+            app: Optional AccessiWeather app instance. When provided, async
+                loaders dispatch via ``app.run_async`` (the background asyncio
+                loop). Falls back to ``asyncio.ensure_future`` when absent.
 
         """
         super().__init__(parent)
@@ -85,6 +89,7 @@ class ForecastProductPanel(wx.Panel):
         self._ai_explainer = ai_explainer
         self._cwa_office = cwa_office
         self._location_name = location_name
+        self._app = app
 
         # State
         self._current_text: str | None = None
@@ -232,14 +237,31 @@ class ForecastProductPanel(wx.Panel):
         self._schedule_load(self._product_loader())
 
     def _schedule_load(self, coro) -> None:
-        """Dispatch a loader coroutine. Separated for test override."""
+        """
+        Dispatch a loader coroutine. Separated for test override.
+
+        Uses the app's run_async (background asyncio loop) when available —
+        that's the only dispatch path that actually runs in production,
+        because the wx main thread has no running asyncio loop of its own.
+        """
+        runner = getattr(self._app, "run_async", None) if self._app is not None else None
+        if runner is not None:
+            runner(self._run_loader(coro))
+            return
+
         import asyncio
 
         try:
             asyncio.ensure_future(self._run_loader(coro))
         except RuntimeError:
-            # No running loop (rare in tests) — swallow; tests drive load paths directly.
-            logger.debug("No running event loop for ForecastProductPanel loader")
+            # No running loop — coroutine never runs. Surface as a load error
+            # rather than leaving the panel stuck in Loading...
+            logger.warning("No running event loop for ForecastProductPanel loader")
+            wx.CallAfter(
+                self._on_load_error,
+                RuntimeError("No running event loop; cannot load product"),
+            )
+            coro.close()
 
     async def _run_loader(self, coro) -> None:
         """Await the loader coroutine and marshal result/error to main thread."""
@@ -387,14 +409,19 @@ class ForecastProductPanel(wx.Panel):
 
     def _schedule_explain(self, text: str) -> None:
         """Dispatch the AI explain coroutine. Separated for test override."""
-        import asyncio
-
         if self._ai_explainer is None:
             return
+        runner = getattr(self._app, "run_async", None) if self._app is not None else None
+        if runner is not None:
+            runner(self._run_explain(text))
+            return
+
+        import asyncio
+
         try:
             asyncio.ensure_future(self._run_explain(text))
         except RuntimeError:
-            logger.debug("No running event loop for ForecastProductPanel explain")
+            logger.warning("No running event loop for ForecastProductPanel explain")
 
     async def _run_explain(self, text: str) -> None:
         """Invoke ``AIExplainer.explain_text_product`` for this tab's product."""

--- a/src/accessiweather/ui/dialogs/forecast_products_dialog.py
+++ b/src/accessiweather/ui/dialogs/forecast_products_dialog.py
@@ -98,8 +98,9 @@ class ForecastProductsDialog(wx.Dialog):
         # Close button row.
         button_sizer = wx.BoxSizer(wx.HORIZONTAL)
         self.close_button = wx.Button(self, wx.ID_CLOSE, label="&Close")
-        button_sizer.Add(self.close_button, 0, wx.ALIGN_RIGHT)
-        main_sizer.Add(button_sizer, 0, wx.ALL | wx.ALIGN_RIGHT, 8)
+        button_sizer.AddStretchSpacer()
+        button_sizer.Add(self.close_button, 0)
+        main_sizer.Add(button_sizer, 0, wx.ALL | wx.EXPAND, 8)
 
         self.SetSizer(main_sizer)
 

--- a/src/accessiweather/ui/dialogs/forecast_products_dialog.py
+++ b/src/accessiweather/ui/dialogs/forecast_products_dialog.py
@@ -1,0 +1,185 @@
+"""
+Forecast Products dialog — tabbed host for AFD, HWO, and SPS panels.
+
+A ``wx.Notebook`` with three :class:`ForecastProductPanel` pages. Focus lands
+on the AFD TextCtrl when the dialog opens, and moves to the target tab's
+TextCtrl on page change so screen readers re-announce the content.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Literal, cast
+
+import wx
+
+from .forecast_product_panel import ForecastProductPanel
+
+ProductType = Literal["AFD", "HWO", "SPS"]
+
+if TYPE_CHECKING:
+    from ...ai_explainer import AIExplainer
+    from ...models import Location
+    from ...services.forecast_product_service import ForecastProductService
+
+logger = logging.getLogger(__name__)
+
+
+class ForecastProductsDialog(wx.Dialog):
+    """Tabbed dialog showing NWS AFD, HWO, and SPS for a US location."""
+
+    _TABS: tuple[tuple[str, str], ...] = (
+        ("AFD", "AFD"),
+        ("HWO", "HWO"),
+        ("SPS", "SPS"),
+    )
+
+    def __init__(
+        self,
+        parent: wx.Window,
+        location: Location,
+        forecast_product_service: ForecastProductService,
+        ai_explainer: AIExplainer | None,
+    ) -> None:
+        """
+        Build the dialog and its three panels.
+
+        Args:
+            parent: Parent window.
+            location: Selected location (must have ``cwa_office`` for populated
+                tabs; a null ``cwa_office`` is handled by the panel).
+            forecast_product_service: Service used to fetch+cache each product.
+            ai_explainer: Optional AI explainer wired through to each panel.
+
+        """
+        super().__init__(
+            parent,
+            title="Forecast Products",
+            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
+        )
+        self._location = location
+        self._service = forecast_product_service
+        self._ai_explainer = ai_explainer
+
+        self._create_widgets()
+        self._bind_events()
+
+        self.SetSize(wx.Size(700, 600))
+        self.CenterOnParent()
+
+        # Focus the AFD tab's TextCtrl once the dialog has laid out.
+        wx.CallAfter(self._focus_active_tab)
+
+    def _create_widgets(self) -> None:
+        """Construct the notebook with three product panels."""
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+        self.notebook = wx.Notebook(self)
+
+        self.panels: list[ForecastProductPanel] = []
+        cwa_office = getattr(self._location, "cwa_office", None)
+        location_name = getattr(self._location, "name", "")
+
+        for product_type, tab_label in self._TABS:
+            typed_product_type = cast("ProductType", product_type)
+            loader = self._make_loader(typed_product_type)
+            panel = ForecastProductPanel(
+                parent=self.notebook,
+                product_type=typed_product_type,
+                product_loader=loader,
+                ai_explainer=self._ai_explainer,
+                cwa_office=cwa_office,
+                location_name=location_name,
+            )
+            self.notebook.AddPage(panel, tab_label)
+            self.panels.append(panel)
+
+        main_sizer.Add(self.notebook, 1, wx.ALL | wx.EXPAND, 8)
+
+        # Close button row.
+        button_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.close_button = wx.Button(self, wx.ID_CLOSE, label="&Close")
+        button_sizer.Add(self.close_button, 0, wx.ALIGN_RIGHT)
+        main_sizer.Add(button_sizer, 0, wx.ALL | wx.ALIGN_RIGHT, 8)
+
+        self.SetSizer(main_sizer)
+
+    def _bind_events(self) -> None:
+        """Bind notebook/page-change, close, and ESC events."""
+        self.notebook.Bind(wx.EVT_NOTEBOOK_PAGE_CHANGED, self._on_page_changed)
+        self.close_button.Bind(wx.EVT_BUTTON, self._on_close)
+        self.Bind(wx.EVT_CHAR_HOOK, self._on_key)
+
+    # ------------------------------------------------------------------
+    # Loader wiring
+    # ------------------------------------------------------------------
+    def _make_loader(self, product_type: ProductType):
+        """Bind a zero-arg loader for ``product_type`` against the service."""
+        cwa_office = getattr(self._location, "cwa_office", None)
+
+        async def _loader():
+            if cwa_office is None:
+                return None
+            return await self._service.get(product_type, cwa_office)
+
+        return _loader
+
+    # ------------------------------------------------------------------
+    # Focus + key events
+    # ------------------------------------------------------------------
+    def _focus_active_tab(self) -> None:
+        """Move focus to the currently-active tab's product TextCtrl."""
+        try:
+            idx = self.notebook.GetSelection()
+        except Exception:  # noqa: BLE001
+            idx = 0
+        if idx is None or idx < 0:
+            idx = 0
+        if 0 <= idx < len(self.panels):
+            try:
+                self.panels[idx].product_textctrl.SetFocus()
+            except Exception:  # noqa: BLE001
+                logger.debug("Unable to move focus to product TextCtrl", exc_info=True)
+
+    def _on_page_changed(self, event) -> None:
+        """Move focus to the newly-selected tab's TextCtrl."""
+        try:
+            idx = event.GetSelection()
+        except Exception:  # noqa: BLE001
+            idx = self.notebook.GetSelection() if hasattr(self, "notebook") else 0
+        if 0 <= idx < len(self.panels):
+            panel = self.panels[idx]
+            wx.CallAfter(panel.product_textctrl.SetFocus)
+        event.Skip()
+
+    def _on_key(self, event) -> None:
+        """ESC closes the dialog."""
+        if event.GetKeyCode() == wx.WXK_ESCAPE:
+            self.Close()
+        else:
+            event.Skip()
+
+    def _on_close(self, event) -> None:
+        """Close button handler."""
+        del event
+        self.EndModal(wx.ID_CLOSE)
+
+
+def show_forecast_products_dialog(
+    parent,
+    location: Location,
+    forecast_product_service: ForecastProductService,
+    ai_explainer: AIExplainer | None,
+) -> None:
+    """Show the Forecast Products dialog modally and destroy on close."""
+    try:
+        parent_ctrl = getattr(parent, "control", parent)
+        dlg = ForecastProductsDialog(parent_ctrl, location, forecast_product_service, ai_explainer)
+        dlg.ShowModal()
+        dlg.Destroy()
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"Failed to show forecast products dialog: {exc}")
+        wx.MessageBox(
+            f"Failed to open Forecast Products: {exc}",
+            "Error",
+            wx.OK | wx.ICON_ERROR,
+        )

--- a/src/accessiweather/ui/dialogs/forecast_products_dialog.py
+++ b/src/accessiweather/ui/dialogs/forecast_products_dialog.py
@@ -2,8 +2,10 @@
 Forecast Products dialog — tabbed host for AFD, HWO, and SPS panels.
 
 A ``wx.Notebook`` with three :class:`ForecastProductPanel` pages. Focus lands
-on the AFD TextCtrl when the dialog opens, and moves to the target tab's
-TextCtrl on page change so screen readers re-announce the content.
+on the AFD TextCtrl when the dialog opens so the user sees content immediately.
+Tab switches deliberately do NOT grab focus — the notebook tab strip stays
+the active focus level until the user Tabs into content, matching the
+accessible notebook contract.
 """
 
 from __future__ import annotations
@@ -105,8 +107,15 @@ class ForecastProductsDialog(wx.Dialog):
         self.SetSizer(main_sizer)
 
     def _bind_events(self) -> None:
-        """Bind notebook/page-change, close, and ESC events."""
-        self.notebook.Bind(wx.EVT_NOTEBOOK_PAGE_CHANGED, self._on_page_changed)
+        """
+        Bind close and ESC events.
+
+        We intentionally do NOT grab focus on page-change. Auto-moving focus
+        into the content every time the user arrow-keys through tabs forces
+        screen readers to re-read the full product text and breaks the
+        standard "tab strip is a focus level, content is the next focus
+        level" contract. The user moves into content themselves with Tab.
+        """
         self.close_button.Bind(wx.EVT_BUTTON, self._on_close)
         self.Bind(wx.EVT_CHAR_HOOK, self._on_key)
 
@@ -140,17 +149,6 @@ class ForecastProductsDialog(wx.Dialog):
                 self.panels[idx].product_textctrl.SetFocus()
             except Exception:  # noqa: BLE001
                 logger.debug("Unable to move focus to product TextCtrl", exc_info=True)
-
-    def _on_page_changed(self, event) -> None:
-        """Move focus to the newly-selected tab's TextCtrl."""
-        try:
-            idx = event.GetSelection()
-        except Exception:  # noqa: BLE001
-            idx = self.notebook.GetSelection() if hasattr(self, "notebook") else 0
-        if 0 <= idx < len(self.panels):
-            panel = self.panels[idx]
-            wx.CallAfter(panel.product_textctrl.SetFocus)
-        event.Skip()
 
     def _on_key(self, event) -> None:
         """ESC closes the dialog."""

--- a/src/accessiweather/ui/dialogs/forecast_products_dialog.py
+++ b/src/accessiweather/ui/dialogs/forecast_products_dialog.py
@@ -59,7 +59,7 @@ class ForecastProductsDialog(wx.Dialog):
         """
         super().__init__(
             parent,
-            title="Forecast Products",
+            title="Forecaster Notes",
             style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
         )
         self._location = location
@@ -175,7 +175,7 @@ def show_forecast_products_dialog(
     except Exception as exc:  # noqa: BLE001
         logger.error(f"Failed to show forecast products dialog: {exc}")
         wx.MessageBox(
-            f"Failed to open Forecast Products: {exc}",
+            f"Failed to open Forecaster Notes: {exc}",
             "Error",
             wx.OK | wx.ICON_ERROR,
         )

--- a/src/accessiweather/ui/dialogs/forecast_products_dialog.py
+++ b/src/accessiweather/ui/dialogs/forecast_products_dialog.py
@@ -42,6 +42,7 @@ class ForecastProductsDialog(wx.Dialog):
         location: Location,
         forecast_product_service: ForecastProductService,
         ai_explainer: AIExplainer | None,
+        app: object | None = None,
     ) -> None:
         """
         Build the dialog and its three panels.
@@ -52,6 +53,8 @@ class ForecastProductsDialog(wx.Dialog):
                 tabs; a null ``cwa_office`` is handled by the panel).
             forecast_product_service: Service used to fetch+cache each product.
             ai_explainer: Optional AI explainer wired through to each panel.
+            app: Optional AccessiWeather app instance. Passed to each panel
+                so async loaders can dispatch via ``app.run_async``.
 
         """
         super().__init__(
@@ -62,6 +65,7 @@ class ForecastProductsDialog(wx.Dialog):
         self._location = location
         self._service = forecast_product_service
         self._ai_explainer = ai_explainer
+        self._app = app
 
         self._create_widgets()
         self._bind_events()
@@ -91,6 +95,7 @@ class ForecastProductsDialog(wx.Dialog):
                 ai_explainer=self._ai_explainer,
                 cwa_office=cwa_office,
                 location_name=location_name,
+                app=self._app,
             )
             self.notebook.AddPage(panel, tab_label)
             self.panels.append(panel)
@@ -168,11 +173,14 @@ def show_forecast_products_dialog(
     location: Location,
     forecast_product_service: ForecastProductService,
     ai_explainer: AIExplainer | None,
+    app: object | None = None,
 ) -> None:
     """Show the Forecast Products dialog modally and destroy on close."""
     try:
         parent_ctrl = getattr(parent, "control", parent)
-        dlg = ForecastProductsDialog(parent_ctrl, location, forecast_product_service, ai_explainer)
+        dlg = ForecastProductsDialog(
+            parent_ctrl, location, forecast_product_service, ai_explainer, app=app
+        )
         dlg.ShowModal()
         dlg.Destroy()
     except Exception as exc:  # noqa: BLE001

--- a/src/accessiweather/ui/dialogs/forecast_products_dialog.py
+++ b/src/accessiweather/ui/dialogs/forecast_products_dialog.py
@@ -31,9 +31,9 @@ class ForecastProductsDialog(wx.Dialog):
     """Tabbed dialog showing NWS AFD, HWO, and SPS for a US location."""
 
     _TABS: tuple[tuple[str, str], ...] = (
-        ("AFD", "AFD"),
-        ("HWO", "HWO"),
-        ("SPS", "SPS"),
+        ("AFD", "Area Forecast Discussion"),
+        ("HWO", "Hazardous Weather Outlook"),
+        ("SPS", "Special Weather Statement"),
     )
 
     def __init__(
@@ -73,8 +73,11 @@ class ForecastProductsDialog(wx.Dialog):
         self.SetSize(wx.Size(700, 600))
         self.CenterOnParent()
 
-        # Focus the AFD tab's TextCtrl once the dialog has laid out.
-        wx.CallAfter(self._focus_active_tab)
+        # Land focus on the notebook's tab strip so the user hears which tab
+        # is selected and can arrow through the others. Landing inside the
+        # content forces screen readers to read the whole product text
+        # before the user has indicated they want it.
+        wx.CallAfter(self.notebook.SetFocus)
 
     def _create_widgets(self) -> None:
         """Construct the notebook with three product panels."""
@@ -139,22 +142,8 @@ class ForecastProductsDialog(wx.Dialog):
         return _loader
 
     # ------------------------------------------------------------------
-    # Focus + key events
+    # Key events
     # ------------------------------------------------------------------
-    def _focus_active_tab(self) -> None:
-        """Move focus to the currently-active tab's product TextCtrl."""
-        try:
-            idx = self.notebook.GetSelection()
-        except Exception:  # noqa: BLE001
-            idx = 0
-        if idx is None or idx < 0:
-            idx = 0
-        if 0 <= idx < len(self.panels):
-            try:
-                self.panels[idx].product_textctrl.SetFocus()
-            except Exception:  # noqa: BLE001
-                logger.debug("Unable to move focus to product TextCtrl", exc_info=True)
-
     def _on_key(self, event) -> None:
         """ESC closes the dialog."""
         if event.GetKeyCode() == wx.WXK_ESCAPE:

--- a/src/accessiweather/ui/dialogs/settings_tabs/notifications.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/notifications.py
@@ -111,14 +111,47 @@ class NotificationsTab:
             panel,
             sizer,
             "Extra weather event notifications",
-            "These are optional updates beyond standard alerts and are off unless you turn them on.",
+            "Updates beyond standard alerts. Hazardous Weather Outlook and "
+            "informational Special Weather Statement updates are on by default "
+            "because they deliver information not in the alerts feed. Others "
+            "are off unless you turn them on.",
         )
+        event_intro = wx.StaticText(
+            panel,
+            label=(
+                "Updates beyond standard alerts. Hazardous Weather Outlook and "
+                "informational Special Weather Statement updates are on by default "
+                "because they deliver information not in the alerts feed. Others "
+                "are off unless you turn them on."
+            ),
+        )
+        event_section.Add(event_intro, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 10)
         controls["notify_discussion_update"] = wx.CheckBox(
             panel,
             label="Notify when the Area Forecast Discussion changes (NWS US only)",
         )
         event_section.Add(
             controls["notify_discussion_update"],
+            0,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
+            10,
+        )
+        controls["notify_hwo_update"] = wx.CheckBox(
+            panel,
+            label="Notify on Hazardous Weather Outlook updates",
+        )
+        event_section.Add(
+            controls["notify_hwo_update"],
+            0,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
+            10,
+        )
+        controls["notify_sps_issued"] = wx.CheckBox(
+            panel,
+            label="Notify on Special Weather Statement (informational)",
+        )
+        event_section.Add(
+            controls["notify_sps_issued"],
             0,
             wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
             10,
@@ -258,6 +291,8 @@ class NotificationsTab:
         controls["notify_discussion_update"].SetValue(
             getattr(settings, "notify_discussion_update", True)
         )
+        controls["notify_hwo_update"].SetValue(getattr(settings, "notify_hwo_update", True))
+        controls["notify_sps_issued"].SetValue(getattr(settings, "notify_sps_issued", True))
         controls["notify_severe_risk_change"].SetValue(
             getattr(settings, "notify_severe_risk_change", False)
         )
@@ -295,6 +330,8 @@ class NotificationsTab:
             "alert_freshness_window_minutes": controls["freshness_window"].GetValue(),
             "alert_max_notifications_per_hour": controls["max_notifications"].GetValue(),
             "notify_discussion_update": controls["notify_discussion_update"].GetValue(),
+            "notify_hwo_update": controls["notify_hwo_update"].GetValue(),
+            "notify_sps_issued": controls["notify_sps_issued"].GetValue(),
             "notify_severe_risk_change": controls["notify_severe_risk_change"].GetValue(),
             "notify_minutely_precipitation_start": controls[
                 "notify_minutely_precipitation_start"
@@ -327,6 +364,8 @@ class NotificationsTab:
             "notify_unknown": "Uncategorized alerts",
             "immediate_alert_details_popups": "Open alert details immediately while AccessiWeather is running",
             "notify_discussion_update": "Notify when the Area Forecast Discussion changes",
+            "notify_hwo_update": "Notify on Hazardous Weather Outlook updates",
+            "notify_sps_issued": "Notify on Special Weather Statement (informational)",
             "notify_severe_risk_change": "Notify when severe weather risk changes",
             "notify_minutely_precipitation_start": "Notify when precipitation is expected to start soon",
             "notify_minutely_precipitation_stop": "Notify when precipitation is expected to stop soon",

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -34,7 +34,7 @@ QUICK_ACTION_LABELS = {
     "remove": "&Remove Location",
     "refresh": "Re&fresh Weather",
     "explain": "Explain &Conditions",
-    "discussion": "Forecast &Discussion",
+    "discussion": "Forecast &Products",
     "settings": "&Settings",
 }
 
@@ -212,6 +212,15 @@ class MainWindow(SizedFrame):
         self.discussion_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["discussion"])
         self.settings_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["settings"])
 
+        # Adjacent StaticText explaining why the Forecast Products button is
+        # disabled for non-US locations. Screen readers announce adjacent
+        # StaticText, which is the accessibility affordance for this reason
+        # label (SetName/tooltips are ignored in this project).
+        self.forecast_products_us_only_label = wx.StaticText(
+            panel, label="NWS products are US-only"
+        )
+        self.forecast_products_us_only_label.Hide()
+
         # Status bar — two fields: [0] main status, [1] stale/cached warning
         self.CreateStatusBar(2)
         self.GetStatusBar().SetStatusWidths([-2, -1])
@@ -292,6 +301,7 @@ class MainWindow(SizedFrame):
             else:
                 self.location_dropdown.SetSelection(0)
                 self._update_title_for_location(ALL_LOCATIONS_SENTINEL)
+            self._update_forecast_products_button_state()
         except Exception as e:
             logger.error(f"Failed to populate locations: {e}")
 
@@ -367,7 +377,9 @@ class MainWindow(SizedFrame):
         )
         toggle_event_center_item.Check(True)
         discussion_item = view_menu.Append(
-            wx.ID_ANY, "Forecast &Discussion...", "View NWS Area Forecast Discussion"
+            wx.ID_ANY,
+            "Forecast &Products...",
+            "View NWS Forecast Products (AFD, HWO, SPS)",
         )
         aviation_item = view_menu.Append(wx.ID_ANY, "&Aviation Weather...", "View aviation weather")
         air_quality_item = view_menu.Append(
@@ -508,6 +520,7 @@ class MainWindow(SizedFrame):
         if selected == ALL_LOCATIONS_SENTINEL:
             self._all_locations_active = True
             self._update_title_for_location(ALL_LOCATIONS_SENTINEL)
+            MainWindow._safe_update_forecast_products_button_state(self)
             MainWindow._update_precipitation_timeline_menu_state(self)
             # Increment generation to invalidate any in-flight fetches for the previous location
             self._fetch_generation += 1
@@ -526,6 +539,7 @@ class MainWindow(SizedFrame):
         self._update_title_for_location(selected)
 
         self._set_current_location(selected)
+        MainWindow._safe_update_forecast_products_button_state(self)
 
         # Show cached data instantly if available
         location = self.app.config_manager.get_current_location()
@@ -672,7 +686,7 @@ class MainWindow(SizedFrame):
         show_explanation_dialog(self, self.app)
 
     def _on_discussion(self) -> None:
-        """View NWS Area Forecast Discussion, or Nationwide discussions if Nationwide is selected."""
+        """Route to Nationwide discussion view or the per-location Forecast Products dialog."""
         current = self.app.config_manager.get_current_location()
         if current and current.name == "Nationwide":
             from .dialogs.nationwide_discussion_dialog import NationwideDiscussionDialog
@@ -681,9 +695,85 @@ class MainWindow(SizedFrame):
             dlg.ShowModal()
             dlg.Destroy()
         else:
-            from .dialogs import show_discussion_dialog
+            self._on_forecast_products()
 
-            show_discussion_dialog(self, self.app)
+    def _on_forecast_products(self) -> None:
+        """Open the Forecast Products dialog (AFD + HWO + SPS) for the active location."""
+        current = self.app.config_manager.get_current_location()
+        if current is None:
+            wx.MessageBox(
+                "Please select a location first.",
+                "No Location Selected",
+                wx.OK | wx.ICON_WARNING,
+            )
+            return
+
+        from .dialogs.forecast_products_dialog import show_forecast_products_dialog
+
+        service = self._get_forecast_product_service()
+        ai_explainer = getattr(self.app, "ai_explainer", None)
+        show_forecast_products_dialog(self, current, service, ai_explainer)
+
+    def _safe_update_forecast_products_button_state(self) -> None:
+        """
+        Defensive wrapper around :meth:`_update_forecast_products_button_state`.
+
+        Existing tests in ``test_all_locations_view.py`` / ``test_coverage_gaps.py``
+        drive ``MainWindow._on_location_changed`` through plain-Python stub
+        instances that deliberately omit UI-widget attributes. Wrapping the
+        toggle keeps those tests green without requiring them to add the
+        new widget to every fixture.
+        """
+        try:
+            if hasattr(self, "discussion_button") and hasattr(
+                self, "forecast_products_us_only_label"
+            ):
+                MainWindow._update_forecast_products_button_state(self)
+        except Exception:  # noqa: BLE001
+            logger.debug("Forecast products button state update skipped", exc_info=True)
+
+    def _update_forecast_products_button_state(self) -> None:
+        """
+        Enable/disable the Forecast Products button based on country.
+
+        Non-US locations disable the button and reveal the adjacent
+        "NWS products are US-only" StaticText so screen readers announce the
+        reason. US locations (and the Nationwide entry) re-enable the button
+        and hide the label.
+        """
+        try:
+            current = self.app.config_manager.get_current_location()
+        except Exception:  # noqa: BLE001
+            current = None
+
+        is_us = True  # default: don't needlessly disable
+        if current is not None and current.name != "Nationwide":
+            country = getattr(current, "country_code", None)
+            if country:
+                is_us = country.upper() == "US"
+
+        if is_us:
+            self.discussion_button.Enable()
+            self.forecast_products_us_only_label.Hide()
+        else:
+            self.discussion_button.Disable()
+            self.forecast_products_us_only_label.Show()
+
+    def _get_forecast_product_service(self):
+        """Get or lazily build the shared ForecastProductService instance."""
+        existing = getattr(self, "_forecast_product_service", None)
+        if existing is not None:
+            return existing
+
+        from ..cache import Cache
+        from ..services.forecast_product_service import ForecastProductService
+
+        # Prefer a cache shared with the rest of the app when one exists;
+        # fall back to an owned instance. Keeps tests from having to wire
+        # the full app graph just to construct the dialog.
+        cache = getattr(self.app, "cache", None) or Cache()
+        self._forecast_product_service = ForecastProductService(cache)
+        return self._forecast_product_service
 
     def _on_aviation(self) -> None:
         """View aviation weather."""

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -34,7 +34,7 @@ QUICK_ACTION_LABELS = {
     "remove": "&Remove Location",
     "refresh": "Re&fresh Weather",
     "explain": "Explain &Conditions",
-    "discussion": "Forecast &Products",
+    "discussion": "Forecaster &Notes",
     "settings": "&Settings",
 }
 
@@ -217,7 +217,7 @@ class MainWindow(SizedFrame):
         # StaticText, which is the accessibility affordance for this reason
         # label (SetName/tooltips are ignored in this project).
         self.forecast_products_us_only_label = wx.StaticText(
-            panel, label="NWS products are US-only"
+            panel, label="Forecaster Notes are US-only"
         )
         self.forecast_products_us_only_label.Hide()
 
@@ -378,8 +378,8 @@ class MainWindow(SizedFrame):
         toggle_event_center_item.Check(True)
         discussion_item = view_menu.Append(
             wx.ID_ANY,
-            "Forecast &Products...",
-            "View NWS Forecast Products (AFD, HWO, SPS)",
+            "Forecaster &Notes...",
+            "View NWS forecaster notes (AFD, HWO, SPS)",
         )
         aviation_item = view_menu.Append(wx.ID_ANY, "&Aviation Weather...", "View aviation weather")
         air_quality_item = view_menu.Append(

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -712,7 +712,7 @@ class MainWindow(SizedFrame):
 
         service = self._get_forecast_product_service()
         ai_explainer = getattr(self.app, "ai_explainer", None)
-        show_forecast_products_dialog(self, current, service, ai_explainer)
+        show_forecast_products_dialog(self, current, service, ai_explainer, app=self.app)
 
     def _safe_update_forecast_products_button_state(self) -> None:
         """

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -1267,6 +1267,11 @@ class MainWindow(SizedFrame):
             # Update UI on main thread
             wx.CallAfter(self._on_weather_data_received, weather_data)
 
+            # Pre-warm NWS text products (AFD/HWO/SPS) for the active location
+            # so the Forecast Products dialog and Unit 10/11 notification
+            # checks see fresh data without issuing an on-demand fetch.
+            await self._pre_warm_products_for_location(location)
+
             # Pre-warm cache for other locations in background (non-blocking)
             if not force_refresh:
                 await self._pre_warm_other_locations(location)
@@ -1376,8 +1381,63 @@ class MainWindow(SizedFrame):
             if uncached:
                 logger.debug(f"Pre-warming cache for {len(uncached)} locations")
                 await self.app.weather_client.pre_warm_batch(uncached)
+
+            # Pre-warm NWS text products (AFD/HWO/SPS) for every non-active
+            # saved US location. Failure isolation is per-(product, location):
+            # one failure never cascades to other products or other locations.
+            for loc in all_locations:
+                if loc.name == current_location.name:
+                    continue
+                await self._pre_warm_products_for_location(loc)
         except Exception as e:
             logger.debug(f"Cache pre-warm failed (non-critical): {e}")
+
+    async def _pre_warm_products_for_location(self, location: Location) -> None:
+        """
+        Pre-warm AFD/HWO/SPS caches for a single location.
+
+        Non-US locations and US locations without a populated ``cwa_office``
+        are skipped. Each product fetch is wrapped in its own try/except so
+        one failure (e.g. an NWS 404 for HWO) never prevents the next product
+        type or subsequent locations from being pre-warmed.
+        """
+        # Nationwide is a synthetic entry with no real CWA — skip it cheaply.
+        if location.name == "Nationwide":
+            return
+
+        # Local import avoids a hard dependency on services at module-import
+        # time for the stripped-down test fixtures that stub MainWindow.
+        from ..services.zone_enrichment_service import _is_us_location
+        from ..weather_client_nws import TextProductFetchError
+
+        if not _is_us_location(location):
+            return
+        if not getattr(location, "cwa_office", None):
+            return
+
+        try:
+            service = self._get_forecast_product_service()
+        except Exception:  # noqa: BLE001
+            logger.debug("ForecastProductService unavailable for pre-warm", exc_info=True)
+            return
+
+        for product_type in ("AFD", "HWO", "SPS"):
+            try:
+                await service.get(product_type, location.cwa_office)
+            except TextProductFetchError:
+                logger.debug(
+                    "Pre-warm %s for %s (%s) failed",
+                    product_type,
+                    location.name,
+                    location.cwa_office,
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "Unexpected pre-warm failure for %s at %s",
+                    product_type,
+                    location.name,
+                    exc_info=True,
+                )
 
     def _on_weather_data_received(self, weather_data) -> None:
         """Handle received weather data (called on main thread)."""

--- a/src/accessiweather/ui/main_window_notification_events.py
+++ b/src/accessiweather/ui/main_window_notification_events.py
@@ -67,6 +67,8 @@ def get_notification_event_manager(window: MainWindow):
         )
         # Unit 10: wire the HWO dispatch so it actually reaches the notifier.
         _install_hwo_dispatcher(window, window._notification_event_manager)
+        # Unit 11: wire the SPS dispatch alongside.
+        _install_sps_dispatcher(window, window._notification_event_manager)
     return window._notification_event_manager
 
 
@@ -134,6 +136,100 @@ def _check_hwo_from_cache(
         manager._check_hwo_update(location, product, settings)
     except Exception as e:  # noqa: BLE001
         logger.debug("[events] HWO check skipped: %s", e)
+
+
+def _install_sps_dispatcher(window: MainWindow, manager: NotificationEventManager) -> None:
+    """Override the manager's SPS dispatch to fire a real desktop notification."""
+
+    def _dispatch(*, location, product, message) -> None:
+        del location  # location name already embedded in ``message``
+        try:
+            settings = window.app.config_manager.get_settings()
+        except Exception:  # noqa: BLE001
+            settings = None
+
+        notifier = getattr(window.app, "notifier", None) or get_fallback_notifier(window)
+        title = "Special Weather Statement"
+        try:
+            _log_reviewable_event_text(window, title, message)
+            notifier.send_notification(
+                title=title,
+                message=message,
+                timeout=10,
+                sound_event="notify",
+                play_sound=bool(getattr(settings, "sound_enabled", False)),
+                activation_arguments=serialize_activation_request(
+                    NotificationActivationRequest(kind="generic_fallback")
+                ),
+            )
+            logger.info("[events] Sent sps_issued notification for %s", product.cwa_office)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("[events] Failed to send SPS notification: %s", e)
+
+    manager._dispatch_sps_notification = _dispatch  # type: ignore[method-assign]
+
+
+def _check_sps_from_cache(
+    window: MainWindow,
+    manager: NotificationEventManager,
+    location,
+    settings,
+) -> None:
+    """Feed cache-warm SPS products (plus cached active alerts) into the check."""
+    try:
+        cwa = getattr(location, "cwa_office", None)
+        if not cwa:
+            return
+        service = getattr(window, "_forecast_product_service", None)
+        if service is None:
+            getter = getattr(window, "_get_forecast_product_service", None)
+            if getter is None:
+                return
+            service = getter()
+        cache = getattr(service, "_cache", None)
+        if cache is None:
+            return
+        key = f"nws_text_product:SPS:{cwa}"
+        if not cache.has_key(key):
+            # Nothing pre-warmed yet; next cycle will cover it.
+            return
+        raw = cache.get(key)
+        # SPS fetcher returns a ``list[TextProduct]``; defensively coerce.
+        if raw is None:
+            products: list = []
+        elif isinstance(raw, list):
+            products = raw
+        else:
+            products = [raw]
+
+        active_alerts = _active_alerts_for_current_location(window)
+        manager._check_sps_new(location, products, active_alerts, settings)
+    except Exception as e:  # noqa: BLE001
+        logger.debug("[events] SPS check skipped: %s", e)
+
+
+def _active_alerts_for_current_location(window: MainWindow) -> list:
+    """Pull currently-active alerts out of the app's latest weather snapshot."""
+    weather_data = getattr(window.app, "current_weather_data", None)
+    if weather_data is None:
+        return []
+    alerts_obj = getattr(weather_data, "alerts", None)
+    if alerts_obj is None:
+        return []
+    getter = getattr(alerts_obj, "get_active_alerts", None)
+    if callable(getter):
+        try:
+            result = getter()
+        except Exception:  # noqa: BLE001
+            return []
+        if not result:
+            return []
+        return list(result)  # type: ignore[arg-type]
+    # Fall back to raw list if present.
+    raw = getattr(alerts_obj, "alerts", None)
+    if not raw:
+        return []
+    return list(raw)  # type: ignore[arg-type]
 
 
 def get_fallback_notifier(window: MainWindow):
@@ -224,15 +320,17 @@ def process_notification_events(window: MainWindow, weather_data) -> None:
             and not settings.notify_minutely_precipitation_start
             and not settings.notify_minutely_precipitation_stop
             and not getattr(settings, "notify_hwo_update", True)
+            and not getattr(settings, "notify_sps_issued", True)
         ):
             logger.debug(
                 "[events] _process_notification_events: discussion=%s severe_risk=%s "
-                "minutely_start=%s minutely_stop=%s hwo=%s disabled -- skipping",
+                "minutely_start=%s minutely_stop=%s hwo=%s sps=%s disabled -- skipping",
                 settings.notify_discussion_update,
                 settings.notify_severe_risk_change,
                 settings.notify_minutely_precipitation_start,
                 settings.notify_minutely_precipitation_stop,
                 getattr(settings, "notify_hwo_update", True),
+                getattr(settings, "notify_sps_issued", True),
             )
             return
 
@@ -261,6 +359,10 @@ def process_notification_events(window: MainWindow, weather_data) -> None:
         # so a cache-hit lookup here is sync and cheap. A miss (e.g. non-US
         # location or failed pre-warm) silently no-ops.
         _check_hwo_from_cache(window, event_manager, location, settings)
+        # Unit 11 — informational Special Weather Statement notifications.
+        # Dedupes against currently-cached active alerts for this location so
+        # event-style SPS (already on /alerts/active) don't double-notify.
+        _check_sps_from_cache(window, event_manager, location, settings)
 
         logger.debug(
             "[events] check_for_events returned %d event(s) for location %r",

--- a/src/accessiweather/ui/main_window_notification_events.py
+++ b/src/accessiweather/ui/main_window_notification_events.py
@@ -65,7 +65,75 @@ def get_notification_event_manager(window: MainWindow):
         window._notification_event_manager = NotificationEventManager(
             runtime_state_manager=RuntimeStateManager(config_root)
         )
+        # Unit 10: wire the HWO dispatch so it actually reaches the notifier.
+        _install_hwo_dispatcher(window, window._notification_event_manager)
     return window._notification_event_manager
+
+
+def _install_hwo_dispatcher(window: MainWindow, manager: NotificationEventManager) -> None:
+    """Override the manager's HWO dispatch to fire a real desktop notification."""
+
+    def _dispatch(*, location, product, message) -> None:
+        del location  # location name is already embedded in ``message``
+        try:
+            settings = window.app.config_manager.get_settings()
+        except Exception:  # noqa: BLE001
+            settings = None
+
+        notifier = getattr(window.app, "notifier", None) or get_fallback_notifier(window)
+        title = "Hazardous Weather Outlook Updated"
+        try:
+            _log_reviewable_event_text(window, title, message)
+            notifier.send_notification(
+                title=title,
+                message=message,
+                timeout=10,
+                sound_event="notify",
+                play_sound=bool(getattr(settings, "sound_enabled", False)),
+                activation_arguments=serialize_activation_request(
+                    NotificationActivationRequest(kind="generic_fallback")
+                ),
+            )
+            logger.info("[events] Sent hwo_update notification for %s", product.cwa_office)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("[events] Failed to send HWO notification: %s", e)
+
+    manager._dispatch_hwo_notification = _dispatch  # type: ignore[method-assign]
+
+
+def _check_hwo_from_cache(
+    window: MainWindow,
+    manager: NotificationEventManager,
+    location,
+    settings,
+) -> None:
+    """Feed a cache-warm HWO product (if any) to the manager's HWO update check."""
+    try:
+        cwa = getattr(location, "cwa_office", None)
+        if not cwa:
+            return
+        service = getattr(window, "_forecast_product_service", None)
+        if service is None:
+            getter = getattr(window, "_get_forecast_product_service", None)
+            if getter is None:
+                return
+            service = getter()
+        cache = getattr(service, "_cache", None)
+        if cache is None:
+            return
+        key = f"nws_text_product:HWO:{cwa}"
+        if not cache.has_key(key):
+            return
+        product = cache.get(key)
+        # Registry contract: AFD/HWO are singletons → unwrap list-of-one
+        # defensively; drop anything else.
+        if isinstance(product, list):
+            product = product[0] if product else None
+        if product is None:
+            return
+        manager._check_hwo_update(location, product, settings)
+    except Exception as e:  # noqa: BLE001
+        logger.debug("[events] HWO check skipped: %s", e)
 
 
 def get_fallback_notifier(window: MainWindow):
@@ -155,14 +223,16 @@ def process_notification_events(window: MainWindow, weather_data) -> None:
             and not settings.notify_severe_risk_change
             and not settings.notify_minutely_precipitation_start
             and not settings.notify_minutely_precipitation_stop
+            and not getattr(settings, "notify_hwo_update", True)
         ):
             logger.debug(
                 "[events] _process_notification_events: discussion=%s severe_risk=%s "
-                "minutely_start=%s minutely_stop=%s disabled -- skipping",
+                "minutely_start=%s minutely_stop=%s hwo=%s disabled -- skipping",
                 settings.notify_discussion_update,
                 settings.notify_severe_risk_change,
                 settings.notify_minutely_precipitation_start,
                 settings.notify_minutely_precipitation_stop,
+                getattr(settings, "notify_hwo_update", True),
             )
             return
 
@@ -185,6 +255,12 @@ def process_notification_events(window: MainWindow, weather_data) -> None:
 
         event_manager = get_notification_event_manager(window)
         events = event_manager.check_for_events(weather_data, settings, location.name)
+
+        # Unit 10 — Hazardous Weather Outlook change detection. Pre-warm in
+        # _pre_warm_products_for_location already populated the shared cache,
+        # so a cache-hit lookup here is sync and cheap. A miss (e.g. non-US
+        # location or failed pre-warm) silently no-ops.
+        _check_hwo_from_cache(window, event_manager, location, settings)
 
         logger.debug(
             "[events] check_for_events returned %d event(s) for location %r",

--- a/src/accessiweather/weather_client_nws.py
+++ b/src/accessiweather/weather_client_nws.py
@@ -7,7 +7,7 @@ import inspect
 import logging
 import re
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 
@@ -18,6 +18,7 @@ from .models import (
     HourlyForecast,
     HourlyForecastPeriod,
     Location,
+    TextProduct,
     WeatherAlert,
     WeatherAlerts,
 )
@@ -854,6 +855,170 @@ async def get_nws_discussion_only(
         return None, None
 
 
+class TextProductFetchError(Exception):
+    """
+    Network, timeout, or non-200 response from the NWS /products endpoint.
+
+    Distinct from the "empty @graph" case, which returns ``None`` (AFD/HWO) or
+    ``[]`` (SPS) rather than raising.
+    """
+
+
+async def _fetch_text_product_by_id(
+    client: httpx.AsyncClient,
+    nws_base_url: str,
+    headers: dict[str, str],
+    product_type: Literal["AFD", "HWO", "SPS"],
+    cwa_office: str,
+    entry: dict[str, Any],
+) -> TextProduct | None:
+    """
+    Fetch a single /products/{id} and return a TextProduct.
+
+    Returns None for individual product fetches whose id is missing or whose
+    response is missing productText — these are treated as best-effort skips
+    rather than hard errors.
+    """
+    product_id = entry.get("id")
+    if not product_id:
+        logger.warning("No product ID in %s @graph entry for office %s", product_type, cwa_office)
+        return None
+
+    issuance_time = _parse_iso_datetime(entry.get("issuanceTime"))
+
+    product_url = f"{nws_base_url}/products/{product_id}"
+    response = await _client_get(client, product_url, headers=headers)
+    if response.status_code != 200:
+        logger.warning(
+            "Failed to get %s product text (%s): HTTP %s",
+            product_type,
+            product_id,
+            response.status_code,
+        )
+        raise TextProductFetchError(
+            f"HTTP {response.status_code} fetching {product_type} product {product_id}"
+        )
+
+    product_data = response.json()
+    product_text = product_data.get("productText")
+    if not product_text:
+        logger.warning("No productText in %s product %s", product_type, product_id)
+        return None
+
+    # Prefer product-level issuanceTime over @graph metadata when present.
+    body_issuance = _parse_iso_datetime(product_data.get("issuanceTime"))
+    if body_issuance is not None:
+        issuance_time = body_issuance
+
+    headline = product_data.get("headline") or entry.get("headline")
+    if headline is not None and not isinstance(headline, str):
+        headline = str(headline)
+
+    return TextProduct(
+        product_type=product_type,
+        product_id=str(product_id),
+        cwa_office=cwa_office,
+        issuance_time=issuance_time,
+        product_text=product_text,
+        headline=headline,
+    )
+
+
+async def get_nws_text_product(
+    product_type: Literal["AFD", "HWO", "SPS"],
+    cwa_office: str | None,
+    *,
+    nws_base_url: str = "https://api.weather.gov",
+    client: httpx.AsyncClient | None = None,
+    timeout: float = 10.0,
+    user_agent: str = "AccessiWeather (github.com/orinks/accessiweather)",
+) -> TextProduct | list[TextProduct] | None:
+    """
+    Fetch an NWS text product (AFD / HWO / SPS) for a CWA office.
+
+    Endpoint: ``/products/types/{product_type}/locations/{cwa_office}`` returns
+    an ``@graph`` of product stubs; each is fetched individually via
+    ``/products/{id}`` to get ``productText`` and metadata.
+
+    Return convention:
+        - ``cwa_office`` falsy -> ``None`` (no HTTP call).
+        - AFD or HWO, empty ``@graph`` -> ``None``.
+        - AFD or HWO, products present -> single ``TextProduct`` (newest @graph entry).
+        - SPS -> ``list[TextProduct]`` (possibly empty), sorted newest-first.
+
+    Raises:
+        TextProductFetchError on network failure, timeout, or non-200 response
+        from the NWS /products endpoints. Empty @graph is NOT an error.
+
+    """
+    if not cwa_office:
+        return None
+
+    headers = {"User-Agent": user_agent}
+    products_url = f"{nws_base_url}/products/types/{product_type}/locations/{cwa_office}"
+
+    async def _run(http_client: httpx.AsyncClient) -> TextProduct | list[TextProduct] | None:
+        try:
+            listing_response = await _client_get(http_client, products_url, headers=headers)
+        except (httpx.TimeoutException, httpx.TransportError, httpx.RequestError) as exc:
+            raise TextProductFetchError(
+                f"Request failed fetching {product_type} listing for {cwa_office}: {exc}"
+            ) from exc
+
+        if listing_response.status_code != 200:
+            raise TextProductFetchError(
+                f"HTTP {listing_response.status_code} fetching {product_type} "
+                f"listing for {cwa_office}"
+            )
+
+        graph = listing_response.json().get("@graph") or []
+
+        if product_type == "SPS":
+            products: list[TextProduct] = []
+            try:
+                for entry in graph:
+                    if not isinstance(entry, dict):
+                        continue
+                    tp = await _fetch_text_product_by_id(
+                        http_client, nws_base_url, headers, product_type, cwa_office, entry
+                    )
+                    if tp is not None:
+                        products.append(tp)
+            except (httpx.TimeoutException, httpx.TransportError, httpx.RequestError) as exc:
+                raise TextProductFetchError(
+                    f"Request failed fetching SPS product for {cwa_office}: {exc}"
+                ) from exc
+
+            products.sort(
+                key=lambda p: p.issuance_time or datetime.min.replace(tzinfo=UTC),
+                reverse=True,
+            )
+            return products
+
+        # AFD or HWO: newest @graph entry only, or None if empty.
+        if not graph:
+            return None
+
+        latest = graph[0]
+        if not isinstance(latest, dict):
+            return None
+
+        try:
+            return await _fetch_text_product_by_id(
+                http_client, nws_base_url, headers, product_type, cwa_office, latest
+            )
+        except (httpx.TimeoutException, httpx.TransportError, httpx.RequestError) as exc:
+            raise TextProductFetchError(
+                f"Request failed fetching {product_type} product for {cwa_office}: {exc}"
+            ) from exc
+
+    if client is not None:
+        return await _run(client)
+
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as new_client:
+        return await _run(new_client)
+
+
 async def get_nws_discussion(
     client: httpx.AsyncClient,
     headers: dict[str, str],
@@ -862,6 +1027,10 @@ async def get_nws_discussion(
 ) -> tuple[str, datetime | None]:
     """
     Fetch the NWS Area Forecast Discussion (AFD) for the given grid data.
+
+    Thin backward-compat wrapper around :func:`get_nws_text_product` for the AFD
+    product type. Preserves the pre-existing ``(discussion_text, issuance_time)``
+    tuple contract so existing internal callers continue to work unchanged.
 
     Returns:
         Tuple of (discussion_text, issuance_time). The issuance_time is parsed from
@@ -883,49 +1052,28 @@ async def get_nws_discussion(
         office_id = parts[-3]
         logger.info(f"Fetching AFD for office: {office_id}")
 
-        products_url = f"{nws_base_url}/products/types/AFD/locations/{office_id}"
-        response = await _client_get(client, products_url, headers=headers)
+        # Preserve existing User-Agent behavior by reusing caller-supplied headers.
+        user_agent = headers.get("User-Agent", "AccessiWeather")
 
-        if response.status_code != 200:
-            logger.warning(f"Failed to get AFD products: HTTP {response.status_code}")
+        try:
+            product = await get_nws_text_product(
+                "AFD",
+                office_id,
+                nws_base_url=nws_base_url,
+                client=client,
+                user_agent=user_agent,
+            )
+        except TextProductFetchError as exc:
+            logger.warning("Failed to fetch AFD via text-product path: %s", exc)
             return "Forecast discussion not available.", None
 
-        products_data = response.json()
-
-        if not products_data.get("@graph"):
+        if product is None:
             logger.warning(f"No AFD products found for office {office_id}")
             return "Forecast discussion not available for this location.", None
 
-        latest_product = products_data["@graph"][0]
-        latest_product_id = latest_product.get("id")
-        if not latest_product_id:
-            logger.warning("No product ID found in latest AFD product")
-            return "Forecast discussion not available.", None
-
-        # Extract issuanceTime from the product metadata
-        issuance_time: datetime | None = None
-        issuance_time_str = latest_product.get("issuanceTime")
-        if issuance_time_str:
-            issuance_time = _parse_iso_datetime(issuance_time_str)
-            if issuance_time:
-                logger.debug(f"AFD issuance time: {issuance_time}")
-
-        product_url = f"{nws_base_url}/products/{latest_product_id}"
-        response = await _client_get(client, product_url, headers=headers)
-
-        if response.status_code != 200:
-            logger.warning(f"Failed to get AFD product text: HTTP {response.status_code}")
-            return "Forecast discussion not available.", None
-
-        product_data = response.json()
-        product_text = product_data.get("productText")
-
-        if not product_text:
-            logger.warning("No product text found in AFD product")
-            return "Forecast discussion not available.", None
-
+        assert isinstance(product, TextProduct)  # AFD path never returns a list
         logger.info(f"Successfully fetched AFD for office {office_id}")
-        return product_text, issuance_time
+        return product.product_text, product.issuance_time
 
     except Exception as exc:  # noqa: BLE001
         logger.error(f"Failed to get NWS discussion: {exc}")

--- a/tests/gui/test_forecast_product_panel.py
+++ b/tests/gui/test_forecast_product_panel.py
@@ -16,6 +16,16 @@ from unittest.mock import MagicMock
 
 import pytest
 
+# This file's fixtures monkey-patch wx.Panel.__init__ to neutralize real-widget
+# construction so we can pass MagicMock parents. Safe against the in-repo stub
+# (no C-extension), destructive against real wxPython where the patches leak
+# across test files. Skip the whole module when real wx is detected.
+pytestmark = pytest.mark.skipif(
+    hasattr(sys.modules.get("wx"), "_core"),
+    reason="Real wxPython detected; this test module patches wx globals and "
+    "is only safe against the stub wx in tests/conftest.py.",
+)
+
 # ---------------------------------------------------------------------------
 # Extend the wx stub with the classes and constants this dialog needs. The
 # stub lives in tests/conftest.py; we augment per-test-file as needed so new

--- a/tests/gui/test_forecast_product_panel.py
+++ b/tests/gui/test_forecast_product_panel.py
@@ -307,7 +307,7 @@ class TestForecastProductPanelRendering:
     def test_sps_empty_renders_no_statements_copy(self, captured_sizer):
         panel = _build_panel("SPS", loader_result=None)
         panel.product_textctrl.SetValue.assert_any_call(
-            "No Special Weather Statements currently active for RAH."
+            "No recent Special Weather Statements for RAH."
         )
 
     def test_afd_rare_empty_returns_afd_copy(self, captured_sizer):

--- a/tests/gui/test_forecast_product_panel.py
+++ b/tests/gui/test_forecast_product_panel.py
@@ -1,0 +1,473 @@
+"""
+Tests for :class:`ForecastProductPanel`.
+
+Covers Unit 8 of the Forecast Products PR 1 plan — per-tab rendering of AFD,
+HWO, and SPS products; empty / error / loading / no-CWA states; SPS
+multi-product chooser; and the AI button visibility contract mirrored from
+:mod:`discussion_dialog`.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Extend the wx stub with the classes and constants this dialog needs. The
+# stub lives in tests/conftest.py; we augment per-test-file as needed so new
+# work never breaks unrelated tests.
+# ---------------------------------------------------------------------------
+_wx = sys.modules["wx"]
+
+for _attr, _val in {
+    "DEFAULT_DIALOG_STYLE": 0,
+    "ALIGN_RIGHT": 0x0200,
+    "LEFT": 0x0010,
+    "RIGHT": 0x0020,
+    "TOP": 0x0040,
+    "BOTTOM": 0x0080,
+    "RESIZE_BORDER": 0x40,
+    "TE_MULTILINE": 0x0020,
+    "TE_READONLY": 0x0010,
+    "HSCROLL": 0x8000,
+    "WXK_ESCAPE": 27,
+    "ID_CLOSE": 5107,
+}.items():
+    if not hasattr(_wx, _attr):
+        setattr(_wx, _attr, _val)
+
+for _attr in ("Notebook", "EVT_NOTEBOOK_PAGE_CHANGED"):
+    if not hasattr(_wx, _attr):
+        setattr(_wx, _attr, MagicMock(name=_attr))
+
+# Ensure the Panel base class responds to the methods the panel uses on self.
+_StubPanel = _wx.Panel
+for _meth in ("SetSizer", "GetSizer", "Bind", "Layout", "Show", "Hide"):
+    if not hasattr(_StubPanel, _meth):
+        setattr(_StubPanel, _meth, lambda self, *a, **kw: None)
+
+# GetSizer needs to return the _main_sizer instance the panel stored.
+if getattr(_StubPanel, "_patched_getsizer", False) is False:
+
+    def _get_sizer(self):
+        return getattr(self, "_main_sizer", None)
+
+    _StubPanel.GetSizer = _get_sizer
+    _StubPanel._patched_getsizer = True  # type: ignore[attr-defined]
+
+# Likewise the Dialog base class for downstream dialog tests.
+_StubDialog = _wx.Dialog
+for _meth in ("SetSize", "SetSizer", "Bind", "EndModal", "Show", "Hide", "Close", "CenterOnParent"):
+    if not hasattr(_StubDialog, _meth):
+        setattr(_StubDialog, _meth, lambda self, *a, **kw: None)
+
+
+# ---------------------------------------------------------------------------
+# Imports under test (after stub setup).
+# ---------------------------------------------------------------------------
+from accessiweather.models import TextProduct  # noqa: E402
+from accessiweather.ui.dialogs.forecast_product_panel import (  # noqa: E402
+    ForecastProductPanel,
+    _format_issuance,
+    _format_sps_choice_entry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _neutralize_wx_widgets():
+    """
+    Swap real wx widget classes for MagicMock factories for these tests.
+
+    When real wxPython is installed, the widget constructors validate their
+    parent; we don't want real widgets anyway. We swap them here and restore
+    on teardown. Matches the pattern in test_location_dialog_zone_info.py.
+    """
+    saved: dict = {}
+    saved["Panel.__init__"] = _wx.Panel.__init__
+
+    def _noop_init(self, *a, **kw):
+        return None
+
+    _wx.Panel.__init__ = _noop_init
+
+    # Install no-op methods on Panel so self.SetSizer / self.Bind / self.GetSizer
+    # do not hit real wx validation.
+    patched_methods = {}
+
+    def _set_sizer(self, sizer):
+        self._main_sizer = sizer
+
+    def _get_sizer(self):
+        return getattr(self, "_main_sizer", None)
+
+    def _noop(self, *a, **kw):
+        return None
+
+    for meth_name, impl in (
+        ("SetSizer", _set_sizer),
+        ("GetSizer", _get_sizer),
+        ("Bind", _noop),
+        ("Show", _noop),
+        ("Hide", _noop),
+        ("Layout", _noop),
+    ):
+        patched_methods[meth_name] = getattr(_wx.Panel, meth_name, None)
+        setattr(_wx.Panel, meth_name, impl)
+    saved["patched_methods"] = patched_methods
+
+    for name in ("StaticText", "TextCtrl", "Button", "Choice", "CheckBox"):
+        saved[name] = getattr(_wx, name)
+        setattr(
+            _wx,
+            name,
+            MagicMock(
+                name=name,
+                side_effect=lambda *a, **kw: MagicMock(name=f"{kw.get('label', 'widget')}"),
+            ),
+        )
+
+    yield
+
+    import contextlib
+
+    _wx.Panel.__init__ = saved["Panel.__init__"]
+    for meth_name, orig in saved["patched_methods"].items():
+        if orig is None:
+            with contextlib.suppress(AttributeError):
+                delattr(_wx.Panel, meth_name)
+        else:
+            setattr(_wx.Panel, meth_name, orig)
+    for name in ("StaticText", "TextCtrl", "Button", "Choice", "CheckBox"):
+        setattr(_wx, name, saved[name])
+
+
+@pytest.fixture
+def captured_sizer():
+    """
+    Instrument wx.BoxSizer so Show(widget, bool) calls are recorded.
+
+    Returns a dict ``{widget_id: is_shown}`` that tests can inspect. Each
+    sizer tracks both its Show() calls and an Add()-order list of widgets.
+    """
+    original = _wx.BoxSizer
+
+    class _FakeSizer:
+        instances: list = []
+
+        def __init__(self, *_a, **_kw):
+            self.show_calls: list = []
+            self.added: list = []
+            _FakeSizer.instances.append(self)
+
+        def Add(self, widget, *_a, **_kw):
+            self.added.append(widget)
+
+        def Show(self, widget, visible=True):
+            self.show_calls.append((widget, bool(visible)))
+            # Also reflect visibility on the widget when it's a MagicMock so
+            # tests can check .Show / .Hide call counts elsewhere.
+            import contextlib
+
+            with contextlib.suppress(Exception):
+                widget._sizer_visible = bool(visible)
+
+        def Layout(self):
+            pass
+
+    _wx.BoxSizer = _FakeSizer
+    _FakeSizer.instances.clear()
+    yield _FakeSizer
+    _wx.BoxSizer = original
+
+
+@pytest.fixture
+def explainer_stub():
+    """Minimal AIExplainer-shaped stub with a clearable cache."""
+
+    class _Stub:
+        def __init__(self):
+            self.cache = MagicMock()
+
+        async def explain_text_product(self, *args, **kwargs):
+            return SimpleNamespace(
+                text="Plain summary", model_used="m", token_count=1, estimated_cost=0.0
+            )
+
+    return _Stub()
+
+
+def _build_panel(
+    product_type: str,
+    *,
+    loader_result=None,
+    loader_error: Exception | None = None,
+    cwa_office: str | None = "RAH",
+    ai_explainer=None,
+    location_name: str = "Raleigh, NC",
+) -> ForecastProductPanel:
+    """
+    Construct a panel whose loader returns ``loader_result`` (or raises).
+
+    ``_schedule_load`` is monkey-patched to run the coroutine synchronously
+    via ``_on_load_complete`` / ``_on_load_error``, side-stepping the event
+    loop entirely for deterministic GUI tests.
+    """
+    if loader_error is not None:
+
+        async def _loader():
+            raise loader_error
+    else:
+
+        async def _loader():
+            return loader_result
+
+    # Patch _schedule_load BEFORE __init__ triggers its first load.
+    orig_schedule = ForecastProductPanel._schedule_load
+
+    def _sync_schedule(self, coro):
+        # Drive the coroutine manually — no asyncio loop needed.
+        try:
+            try:
+                coro.send(None)
+            except StopIteration as stop:
+                result = stop.value
+                self._on_load_complete(result)
+                return
+            except Exception as exc:  # noqa: BLE001
+                self._on_load_error(exc)
+                return
+            # If the coroutine actually awaited something, we won't pump
+            # further — tests stick to plain return/raise loaders.
+        except Exception as exc:  # noqa: BLE001
+            self._on_load_error(exc)
+
+    ForecastProductPanel._schedule_load = _sync_schedule
+    try:
+        panel = ForecastProductPanel(
+            parent=MagicMock(),
+            product_type=product_type,
+            product_loader=_loader,
+            ai_explainer=ai_explainer,
+            cwa_office=cwa_office,
+            location_name=location_name,
+        )
+    finally:
+        ForecastProductPanel._schedule_load = orig_schedule
+    return panel
+
+
+def _make_product(
+    product_type: str = "AFD",
+    *,
+    text: str = "Sample product text",
+    headline: str | None = None,
+    product_id: str = "ID-1",
+    issuance: datetime | None = None,
+) -> TextProduct:
+    return TextProduct(
+        product_type=product_type,  # type: ignore[arg-type]
+        product_id=product_id,
+        cwa_office="RAH",
+        issuance_time=issuance or datetime(2026, 4, 20, 14, 30, tzinfo=UTC),
+        product_text=text,
+        headline=headline,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+class TestForecastProductPanelRendering:
+    """Happy-path rendering for each product type."""
+
+    def test_afd_populated(self, captured_sizer):
+        afd = _make_product("AFD", text="Full AFD raw text")
+        panel = _build_panel("AFD", loader_result=afd)
+
+        panel.product_textctrl.SetValue.assert_any_call("Full AFD raw text")
+        # Issuance label got a non-empty label starting with "Issued:"
+        issuance_calls = [c.args[0] for c in panel.issuance_label.SetLabel.call_args_list if c.args]
+        assert any(lbl.startswith("Issued:") for lbl in issuance_calls)
+
+    def test_hwo_empty_graph_renders_empty_copy(self, captured_sizer):
+        # Empty result — simulates 200 with empty @graph.
+        panel = _build_panel("HWO", loader_result=[])
+        panel.product_textctrl.SetValue.assert_any_call(
+            "Hazardous Weather Outlook not currently available for RAH."
+        )
+        panel.explain_button.Disable.assert_called()
+
+    def test_sps_empty_renders_no_statements_copy(self, captured_sizer):
+        panel = _build_panel("SPS", loader_result=None)
+        panel.product_textctrl.SetValue.assert_any_call(
+            "No Special Weather Statements currently active for RAH."
+        )
+
+    def test_afd_rare_empty_returns_afd_copy(self, captured_sizer):
+        panel = _build_panel("AFD", loader_result=None)
+        panel.product_textctrl.SetValue.assert_any_call(
+            "Area Forecast Discussion not currently available for RAH."
+        )
+
+
+class TestForecastProductPanelSPS:
+    """SPS multi-product selection behaviour."""
+
+    def test_multi_sps_shows_choice(self, captured_sizer):
+        p1 = _make_product("SPS", text="First", headline="Dense fog", product_id="sps-1")
+        p2 = _make_product("SPS", text="Second", headline="Fire weather", product_id="sps-2")
+        p3 = _make_product("SPS", text="Third", headline="Pollen", product_id="sps-3")
+
+        panel = _build_panel("SPS", loader_result=[p1, p2, p3])
+
+        # Choice repopulated with three entries.
+        append_calls = [c.args[0] for c in panel.sps_choice.Append.call_args_list if c.args]
+        assert len(append_calls) == 3
+        assert any("Dense fog" in entry for entry in append_calls)
+        assert any("Fire weather" in entry for entry in append_calls)
+        assert any("Pollen" in entry for entry in append_calls)
+
+        # Chooser was Show(True)'d via the main sizer.
+        sizer = panel._main_sizer
+        assert (panel.sps_choice, True) in sizer.show_calls
+        # First product is rendered in the TextCtrl.
+        panel.product_textctrl.SetValue.assert_any_call("First")
+
+    def test_single_sps_hides_choice(self, captured_sizer):
+        p1 = _make_product("SPS", text="Only one", product_id="sps-1")
+        panel = _build_panel("SPS", loader_result=[p1])
+
+        sizer = panel._main_sizer
+        # The chooser was never Show(True)'d — all Show calls on the choice
+        # widget kept visibility False.
+        choice_calls = [visible for (w, visible) in sizer.show_calls if w is panel.sps_choice]
+        assert choice_calls  # at least one Show call occurred
+        assert not any(choice_calls)  # none of them were True
+
+    def test_swap_sps_via_choice_event(self, captured_sizer):
+        p1 = _make_product("SPS", text="Red flag", headline="Fire", product_id="sps-1")
+        p2 = _make_product("SPS", text="Dense fog advisory", headline="Fog", product_id="sps-2")
+        panel = _build_panel("SPS", loader_result=[p1, p2])
+
+        # Switch to index 1.
+        panel.sps_choice.GetSelection = MagicMock(return_value=1)
+        panel._on_sps_choice_changed(MagicMock())
+        panel.product_textctrl.SetValue.assert_any_call("Dense fog advisory")
+
+
+class TestForecastProductPanelErrorState:
+    """Fetch-failure path renders retry button + try-again message."""
+
+    def test_fetch_error_renders_retry(self, captured_sizer):
+        from accessiweather.weather_client_nws import TextProductFetchError
+
+        panel = _build_panel("HWO", loader_error=TextProductFetchError("boom"))
+
+        panel.product_textctrl.SetValue.assert_any_call(
+            "Failed to fetch Hazardous Weather Outlook — try again."
+        )
+        panel.retry_button.Show.assert_called()
+        panel.explain_button.Disable.assert_called()
+
+    def test_retry_triggers_reload(self, captured_sizer):
+        """Retry button click re-invokes the loader."""
+        from accessiweather.weather_client_nws import TextProductFetchError
+
+        panel = _build_panel("HWO", loader_error=TextProductFetchError("boom"))
+
+        # Swap in a fresh loader so retry reports success.
+        afd = _make_product("HWO", text="Retry worked")
+
+        async def _fresh_loader():
+            return afd
+
+        panel._product_loader = _fresh_loader
+
+        # Patch scheduler synchronously for this call too.
+        def _sync_schedule(self, coro):
+            try:
+                try:
+                    coro.send(None)
+                except StopIteration as stop:
+                    self._on_load_complete(stop.value)
+            except Exception as exc:  # noqa: BLE001
+                self._on_load_error(exc)
+
+        orig = ForecastProductPanel._schedule_load
+        ForecastProductPanel._schedule_load = _sync_schedule
+        try:
+            panel._on_retry(MagicMock())
+        finally:
+            ForecastProductPanel._schedule_load = orig
+
+        panel.product_textctrl.SetValue.assert_any_call("Retry worked")
+
+
+class TestForecastProductPanelNoCwa:
+    """cwa_office is None — all three product types share a fallback message."""
+
+    @pytest.mark.parametrize("product_type", ["AFD", "HWO", "SPS"])
+    def test_no_cwa_office_message(self, captured_sizer, product_type):
+        panel = _build_panel(product_type, cwa_office=None, loader_result=None)
+        panel.product_textctrl.SetValue.assert_any_call(
+            "NWS text products will populate after the next weather refresh."
+        )
+        panel.explain_button.Disable.assert_called()
+
+
+class TestForecastProductPanelAIVisibility:
+    """AI summary widgets stay hidden until Plain Language Summary is clicked."""
+
+    def test_ai_widgets_hidden_on_initial_render(self, captured_sizer, explainer_stub):
+        afd = _make_product("AFD", text="Full AFD")
+        panel = _build_panel("AFD", loader_result=afd, ai_explainer=explainer_stub)
+
+        sizer = panel._main_sizer
+        # Both AI widgets were explicitly hidden via the sizer.
+        header_calls = [
+            visible for (w, visible) in sizer.show_calls if w is panel.ai_summary_header
+        ]
+        display_calls = [
+            visible for (w, visible) in sizer.show_calls if w is panel.ai_summary_display
+        ]
+        assert header_calls and not any(header_calls)
+        assert display_calls and not any(display_calls)
+
+    def test_explain_button_enabled_when_ai_and_text_present(self, captured_sizer, explainer_stub):
+        afd = _make_product("AFD", text="Full AFD")
+        panel = _build_panel("AFD", loader_result=afd, ai_explainer=explainer_stub)
+        # Explain button was Enable()'d after load.
+        panel.explain_button.Enable.assert_called()
+
+    def test_explain_button_disabled_without_ai_explainer(self, captured_sizer):
+        afd = _make_product("AFD", text="Full AFD")
+        panel = _build_panel("AFD", loader_result=afd, ai_explainer=None)
+        # With no explainer, Disable() was called (Enable is never reached).
+        panel.explain_button.Disable.assert_called()
+
+
+class TestFormattingHelpers:
+    def test_format_issuance_none(self):
+        assert _format_issuance(None) == "Issued: unknown"
+
+    def test_format_issuance_includes_issued_prefix(self):
+        out = _format_issuance(datetime(2026, 4, 20, 14, 30, tzinfo=UTC))
+        assert out.startswith("Issued:")
+
+    def test_sps_entry_uses_headline(self):
+        p = _make_product("SPS", text="body", headline="Fire weather watch")
+        entry = _format_sps_choice_entry(p)
+        assert "Fire weather watch" in entry
+        assert entry.startswith("Issued ")
+
+    def test_sps_entry_falls_back_to_first_line(self):
+        p = _make_product("SPS", text="First line\nsecond line\n", headline=None)
+        entry = _format_sps_choice_entry(p)
+        assert "First line" in entry

--- a/tests/gui/test_forecast_products_dialog.py
+++ b/tests/gui/test_forecast_products_dialog.py
@@ -1,0 +1,381 @@
+"""
+Tests for :class:`ForecastProductsDialog` and main-window wiring.
+
+Covers Unit 8 of the Forecast Products PR 1 plan — dialog construction with
+three tabs, focus handling on tab switch, main-window routing (Nationwide
+still goes to NationwideDiscussionDialog, US locations go to the new
+dialog), QUICK_ACTION_LABELS rename, and the non-US adjacent-StaticText
+pattern.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub augmentation (see test_forecast_product_panel.py for shape).
+# ---------------------------------------------------------------------------
+_wx = sys.modules["wx"]
+
+for _attr, _val in {
+    "DEFAULT_DIALOG_STYLE": 0,
+    "ALIGN_RIGHT": 0x0200,
+    "LEFT": 0x0010,
+    "RIGHT": 0x0020,
+    "TOP": 0x0040,
+    "BOTTOM": 0x0080,
+    "RESIZE_BORDER": 0x40,
+    "TE_MULTILINE": 0x0020,
+    "TE_READONLY": 0x0010,
+    "HSCROLL": 0x8000,
+    "WXK_ESCAPE": 27,
+    "ID_CLOSE": 5107,
+}.items():
+    if not hasattr(_wx, _attr):
+        setattr(_wx, _attr, _val)
+
+for _attr in ("Notebook", "EVT_NOTEBOOK_PAGE_CHANGED"):
+    if not hasattr(_wx, _attr):
+        setattr(_wx, _attr, MagicMock(name=_attr))
+
+_StubDialog = _wx.Dialog
+for _meth in (
+    "SetSize",
+    "SetSizer",
+    "Bind",
+    "EndModal",
+    "Show",
+    "Hide",
+    "Close",
+    "CenterOnParent",
+):
+    if not hasattr(_StubDialog, _meth):
+        setattr(_StubDialog, _meth, lambda self, *a, **kw: None)
+
+_StubPanel = _wx.Panel
+for _meth in ("SetSizer", "GetSizer", "Bind", "Layout", "Show", "Hide"):
+    if not hasattr(_StubPanel, _meth):
+        setattr(_StubPanel, _meth, lambda self, *a, **kw: None)
+
+
+# ---------------------------------------------------------------------------
+# Imports under test
+# ---------------------------------------------------------------------------
+from accessiweather.models import Location  # noqa: E402
+from accessiweather.ui.dialogs.forecast_products_dialog import (  # noqa: E402
+    ForecastProductsDialog,
+)
+
+
+# ---------------------------------------------------------------------------
+# Autouse: neutralize wx.Dialog.__init__ and wx.Panel.__init__ so MagicMock
+# parents don't crash when real wxPython is installed on the test host.
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _neutralize_wx_bases():
+    saved: dict = {}
+    saved["Dialog.__init__"] = _wx.Dialog.__init__
+    saved["Panel.__init__"] = _wx.Panel.__init__
+
+    def _noop(self, *a, **kw):
+        return None
+
+    _wx.Dialog.__init__ = _noop
+    _wx.Panel.__init__ = _noop
+
+    patched_methods = {}
+
+    def _set_sizer(self, sizer):
+        self._main_sizer = sizer
+
+    def _get_sizer(self):
+        return getattr(self, "_main_sizer", None)
+
+    def _noop_meth(self, *a, **kw):
+        return None
+
+    for cls in (_wx.Dialog, _wx.Panel):
+        for meth_name, impl in (
+            ("SetSizer", _set_sizer),
+            ("GetSizer", _get_sizer),
+            ("Bind", _noop_meth),
+            ("Show", _noop_meth),
+            ("Hide", _noop_meth),
+            ("Layout", _noop_meth),
+            ("SetSize", _noop_meth),
+            ("CenterOnParent", _noop_meth),
+            ("EndModal", _noop_meth),
+            ("Close", _noop_meth),
+        ):
+            patched_methods[(id(cls), meth_name)] = (cls, getattr(cls, meth_name, None))
+            setattr(cls, meth_name, impl)
+    saved["patched_methods"] = patched_methods
+
+    for name in ("StaticText", "TextCtrl", "Button", "Choice", "CheckBox"):
+        saved[name] = getattr(_wx, name)
+        setattr(
+            _wx,
+            name,
+            MagicMock(name=name, side_effect=lambda *a, **kw: MagicMock(name="widget")),
+        )
+
+    # wx.CallAfter asserts a wx.App exists on real wxPython; swap for MagicMock.
+    saved["CallAfter"] = _wx.CallAfter
+    _wx.CallAfter = MagicMock(name="CallAfter")
+
+    yield
+
+    _wx.Dialog.__init__ = saved["Dialog.__init__"]
+    _wx.Panel.__init__ = saved["Panel.__init__"]
+    import contextlib
+
+    for (_cls_id, meth_name), (cls, orig) in saved["patched_methods"].items():
+        if orig is None:
+            with contextlib.suppress(AttributeError):
+                delattr(cls, meth_name)
+        else:
+            setattr(cls, meth_name, orig)
+    for name in ("StaticText", "TextCtrl", "Button", "Choice", "CheckBox"):
+        setattr(_wx, name, saved[name])
+    _wx.CallAfter = saved["CallAfter"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _stub_notebook():
+    """Build a wx.Notebook stub that tracks AddPage and selection."""
+    nb = MagicMock(name="Notebook")
+    nb.pages = []
+
+    def _add_page(panel, label, *a, **kw):
+        nb.pages.append((panel, label))
+        return True
+
+    nb.AddPage.side_effect = _add_page
+    nb.GetSelection.return_value = 0
+    return nb
+
+
+@pytest.fixture
+def notebook_factory():
+    """Patch wx.Notebook to our tracking stub for the duration of the test."""
+    original = _wx.Notebook
+    nb_holder = {}
+
+    def _factory(*a, **kw):
+        nb = _stub_notebook()
+        nb_holder["instance"] = nb
+        return nb
+
+    _wx.Notebook = MagicMock(side_effect=_factory)
+    yield nb_holder
+    _wx.Notebook = original
+
+
+@pytest.fixture
+def panel_factory():
+    """Patch ForecastProductPanel to a lightweight mock recording its ctor args."""
+    created: list[dict] = []
+
+    class _FakePanel:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.product_type = kwargs.get("product_type")
+            self.product_textctrl = MagicMock(name="TextCtrl")
+            created.append({"product_type": self.product_type, "instance": self, **kwargs})
+
+    # The dialog imports ForecastProductPanel directly from the module;
+    # patch the symbol it bound at import time.
+    from accessiweather.ui.dialogs import forecast_products_dialog
+
+    original_sym = forecast_products_dialog.ForecastProductPanel
+    forecast_products_dialog.ForecastProductPanel = _FakePanel  # type: ignore[assignment]
+    yield created
+    forecast_products_dialog.ForecastProductPanel = original_sym  # type: ignore[assignment]
+
+
+@pytest.fixture
+def sample_us_location():
+    return Location(
+        name="Raleigh, NC",
+        latitude=35.78,
+        longitude=-78.64,
+        country_code="US",
+        cwa_office="RAH",
+        forecast_zone_id="NCZ027",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dialog-level tests
+# ---------------------------------------------------------------------------
+class TestForecastProductsDialog:
+    def test_dialog_builds_three_tabs(self, notebook_factory, panel_factory, sample_us_location):
+        service = MagicMock(name="ForecastProductService")
+        ai = MagicMock(name="AIExplainer")
+
+        dlg = ForecastProductsDialog(
+            parent=MagicMock(),
+            location=sample_us_location,
+            forecast_product_service=service,
+            ai_explainer=ai,
+        )
+
+        # Three panels, one per product type, in plan-specified order.
+        types = [entry["product_type"] for entry in panel_factory]
+        assert types == ["AFD", "HWO", "SPS"]
+        assert len(dlg.panels) == 3
+
+        # Each panel got wired to the same service + explainer.
+        for entry in panel_factory:
+            assert entry["ai_explainer"] is ai
+            assert entry["cwa_office"] == "RAH"
+            assert entry["location_name"] == "Raleigh, NC"
+
+    def test_loader_invokes_service_get(self, notebook_factory, panel_factory, sample_us_location):
+        """Each panel's bound loader calls service.get(product_type, cwa_office)."""
+        import asyncio
+
+        service = MagicMock(name="ForecastProductService")
+
+        async def _fake_get(product_type, cwa_office):
+            return SimpleNamespace(product_type=product_type, cwa=cwa_office)
+
+        service.get = _fake_get
+
+        ForecastProductsDialog(
+            parent=MagicMock(),
+            location=sample_us_location,
+            forecast_product_service=service,
+            ai_explainer=None,
+        )
+
+        loaders = [entry["product_loader"] for entry in panel_factory]
+        assert len(loaders) == 3
+        # Each loader resolves to the correct product type.
+        loop = asyncio.new_event_loop()
+        try:
+            for expected_type, loader in zip(["AFD", "HWO", "SPS"], loaders, strict=True):
+                result = loop.run_until_complete(loader())
+                assert result.product_type == expected_type
+                assert result.cwa == "RAH"
+        finally:
+            loop.close()
+
+    def test_page_changed_moves_focus(self, notebook_factory, panel_factory, sample_us_location):
+        """EVT_NOTEBOOK_PAGE_CHANGED schedules focus on the target TextCtrl."""
+        service = MagicMock()
+        dlg = ForecastProductsDialog(
+            parent=MagicMock(),
+            location=sample_us_location,
+            forecast_product_service=service,
+            ai_explainer=None,
+        )
+        evt = MagicMock()
+        evt.GetSelection.return_value = 1  # switch to HWO tab
+
+        with patch.object(_wx, "CallAfter") as call_after:
+            dlg._on_page_changed(evt)
+
+        # HWO panel's TextCtrl should be the focus target.
+        hwo_panel = dlg.panels[1]
+        call_after.assert_any_call(hwo_panel.product_textctrl.SetFocus)
+
+
+# ---------------------------------------------------------------------------
+# Main-window wiring tests
+# ---------------------------------------------------------------------------
+class TestMainWindowWiring:
+    def test_quick_action_label_renamed(self):
+        from accessiweather.ui.main_window import QUICK_ACTION_LABELS
+
+        assert QUICK_ACTION_LABELS["discussion"] == "Forecast &Products"
+
+    def test_nationwide_branch_still_routes_to_nationwide_dialog(self):
+        """Nationwide selection opens NationwideDiscussionDialog, not the new one."""
+        from accessiweather.ui import main_window
+
+        mw = MagicMock(spec=main_window.MainWindow)
+        mw._get_discussion_service = MagicMock(return_value=MagicMock())
+        mw._on_forecast_products = MagicMock()
+
+        current = Location(
+            name="Nationwide",
+            latitude=39.0,
+            longitude=-98.0,
+            country_code="US",
+        )
+        mw.app = MagicMock()
+        mw.app.config_manager.get_current_location.return_value = current
+
+        # Patch the nationwide dialog module to capture construction.
+        with patch(
+            "accessiweather.ui.dialogs.nationwide_discussion_dialog.NationwideDiscussionDialog"
+        ) as nat_dlg_cls:
+            nat_instance = MagicMock()
+            nat_dlg_cls.return_value = nat_instance
+            main_window.MainWindow._on_discussion(mw)
+
+        nat_dlg_cls.assert_called_once()
+        mw._on_forecast_products.assert_not_called()
+
+    def test_non_nationwide_routes_to_forecast_products(self):
+        """Any non-Nationwide location dispatches to _on_forecast_products."""
+        from accessiweather.ui import main_window
+
+        mw = MagicMock(spec=main_window.MainWindow)
+        mw._on_forecast_products = MagicMock()
+        current = Location(
+            name="Raleigh, NC",
+            latitude=35.78,
+            longitude=-78.64,
+            country_code="US",
+        )
+        mw.app = MagicMock()
+        mw.app.config_manager.get_current_location.return_value = current
+
+        main_window.MainWindow._on_discussion(mw)
+        mw._on_forecast_products.assert_called_once()
+
+    def test_update_button_state_us_enables(self):
+        """US location: button enabled, US-only label hidden."""
+        from accessiweather.ui import main_window
+
+        mw = MagicMock(spec=main_window.MainWindow)
+        mw.app = MagicMock()
+        mw.app.config_manager.get_current_location.return_value = Location(
+            name="Raleigh, NC",
+            latitude=35.78,
+            longitude=-78.64,
+            country_code="US",
+        )
+        mw.discussion_button = MagicMock()
+        mw.forecast_products_us_only_label = MagicMock()
+
+        main_window.MainWindow._update_forecast_products_button_state(mw)
+        mw.discussion_button.Enable.assert_called()
+        mw.forecast_products_us_only_label.Hide.assert_called()
+
+    def test_update_button_state_non_us_disables(self):
+        """Non-US location: button disabled, US-only label shown (adjacent StaticText)."""
+        from accessiweather.ui import main_window
+
+        mw = MagicMock(spec=main_window.MainWindow)
+        mw.app = MagicMock()
+        mw.app.config_manager.get_current_location.return_value = Location(
+            name="London, UK",
+            latitude=51.5,
+            longitude=-0.1,
+            country_code="GB",
+        )
+        mw.discussion_button = MagicMock()
+        mw.forecast_products_us_only_label = MagicMock()
+
+        main_window.MainWindow._update_forecast_products_button_state(mw)
+        mw.discussion_button.Disable.assert_called()
+        mw.forecast_products_us_only_label.Show.assert_called()

--- a/tests/gui/test_forecast_products_dialog.py
+++ b/tests/gui/test_forecast_products_dialog.py
@@ -296,7 +296,7 @@ class TestMainWindowWiring:
     def test_quick_action_label_renamed(self):
         from accessiweather.ui.main_window import QUICK_ACTION_LABELS
 
-        assert QUICK_ACTION_LABELS["discussion"] == "Forecast &Products"
+        assert QUICK_ACTION_LABELS["discussion"] == "Forecaster &Notes"
 
     def test_nationwide_branch_still_routes_to_nationwide_dialog(self):
         """Nationwide selection opens NationwideDiscussionDialog, not the new one."""

--- a/tests/gui/test_forecast_products_dialog.py
+++ b/tests/gui/test_forecast_products_dialog.py
@@ -16,6 +16,18 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+# This file's fixtures monkey-patch wx.Panel.__init__ and wx.Dialog.__init__
+# to neutralize real-widget construction so we can pass MagicMock parents.
+# That's safe when the wx module is the in-repo stub (no real C-extension),
+# but destructive when real wxPython is installed — the patches leak across
+# test files and break later alert-dialog tests that need a real Panel init.
+# Skip the whole module when real wx is detected (CI under xvfb).
+pytestmark = pytest.mark.skipif(
+    hasattr(sys.modules.get("wx"), "_core"),
+    reason="Real wxPython detected; this test module patches wx globals and "
+    "is only safe against the stub wx in tests/conftest.py.",
+)
+
 # ---------------------------------------------------------------------------
 # Stub augmentation (see test_forecast_product_panel.py for shape).
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_forecast_products_dialog.py
+++ b/tests/gui/test_forecast_products_dialog.py
@@ -267,8 +267,17 @@ class TestForecastProductsDialog:
         finally:
             loop.close()
 
-    def test_page_changed_moves_focus(self, notebook_factory, panel_factory, sample_us_location):
-        """EVT_NOTEBOOK_PAGE_CHANGED schedules focus on the target TextCtrl."""
+    def test_page_change_does_not_steal_focus(
+        self, notebook_factory, panel_factory, sample_us_location
+    ):
+        """
+        Tab switching must NOT auto-grab focus into the content.
+
+        Accessibility contract: the notebook tab strip is one focus level,
+        the selected tab's content is the next. Auto-focusing the TextCtrl
+        on every arrow-through-tabs forces the screen reader to re-read
+        the full product text. The user moves into content with Tab.
+        """
         service = MagicMock()
         dlg = ForecastProductsDialog(
             parent=MagicMock(),
@@ -276,15 +285,8 @@ class TestForecastProductsDialog:
             forecast_product_service=service,
             ai_explainer=None,
         )
-        evt = MagicMock()
-        evt.GetSelection.return_value = 1  # switch to HWO tab
-
-        with patch.object(_wx, "CallAfter") as call_after:
-            dlg._on_page_changed(evt)
-
-        # HWO panel's TextCtrl should be the focus target.
-        hwo_panel = dlg.panels[1]
-        call_after.assert_any_call(hwo_panel.product_textctrl.SetFocus)
+        # _on_page_changed was removed — the handler must no longer exist.
+        assert not hasattr(dlg, "_on_page_changed")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_location_dialog_zone_info.py
+++ b/tests/gui/test_location_dialog_zone_info.py
@@ -15,6 +15,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+# This file's fixtures monkey-patch wx.Dialog.__init__. Safe against the
+# in-repo stub (no C-extension), destructive against real wxPython where the
+# patches can leak across test files. Skip when real wx is detected.
+pytestmark = pytest.mark.skipif(
+    hasattr(sys.modules.get("wx"), "_core"),
+    reason="Real wxPython detected; this test module patches wx globals and "
+    "is only safe against the stub wx in tests/conftest.py.",
+)
+
 # ---------------------------------------------------------------------------
 # Extend the wx stub with the constants/classes EditLocationDialog needs.
 # ---------------------------------------------------------------------------

--- a/tests/test_ai_explainer_text_product.py
+++ b/tests/test_ai_explainer_text_product.py
@@ -1,0 +1,347 @@
+"""
+Tests for the generic explain_text_product method on AIExplainer.
+
+Covers the seven scenarios defined in the Forecast Products PR 1 plan (B-R6):
+
+1. Happy path AFD: system prompt is byte-identical to the current AFD prompt.
+2. Happy path HWO: uses the HWO system prompt.
+3. Happy path SPS: uses the SPS system prompt.
+4. Cache: repeated call with identical inputs returns cached=True without
+   re-invoking the LLM.
+5. Custom prompt: custom_system_prompt replaces the default (existing
+   explain_afd semantics).
+6. Wrapper: explain_afd delegates to explain_text_product("AFD", ...).
+7. Error path: LLM errors propagate; failures are not cached.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from accessiweather.ai_explainer import (
+    _SYSTEM_PROMPTS,
+    AIExplainer,
+    AIExplainerError,
+    ExplanationResult,
+    ExplanationStyle,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_afd_text():
+    return (
+        ".SYNOPSIS...\n"
+        "High pressure will dominate the region through mid-week.\n"
+        "\n"
+        ".NEAR TERM /THROUGH TONIGHT/...\n"
+        "Expect clear skies and temperatures in the low 70s.\n"
+    )
+
+
+@pytest.fixture
+def sample_hwo_text():
+    return (
+        ".DAY ONE...Today and Tonight.\n"
+        "No hazardous weather is expected at this time.\n"
+        ".DAYS TWO THROUGH SEVEN...\n"
+        "Thunderstorms possible Wednesday with locally heavy rain.\n"
+    )
+
+
+@pytest.fixture
+def sample_sps_text():
+    return (
+        "...SPECIAL WEATHER STATEMENT...\n"
+        "A strong thunderstorm will affect portions of the area through 4 PM.\n"
+        "Locations impacted include Springfield and surrounding communities.\n"
+    )
+
+
+@pytest.fixture
+def mock_response():
+    return {
+        "content": "This is a plain-language summary of the forecast discussion.",
+        "model": "test-model",
+        "total_tokens": 150,
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+    }
+
+
+@pytest.fixture
+def in_memory_cache():
+    """Real-ish cache stub matching Cache.get/set(ttl=...) shape."""
+
+    class _Cache:
+        def __init__(self):
+            self.store: dict[str, object] = {}
+            self.get_calls = 0
+            self.set_calls = 0
+
+        def get(self, key: str):
+            self.get_calls += 1
+            return self.store.get(key)
+
+        def set(self, key: str, value, ttl: float | None = None):
+            self.set_calls += 1
+            self.store[key] = value
+
+    return _Cache()
+
+
+# ---------------------------------------------------------------------------
+# Happy-path tests: system prompt identity per product type
+# ---------------------------------------------------------------------------
+
+
+class TestExplainTextProductPrompts:
+    """Verify the correct system prompt is routed for each product type."""
+
+    @pytest.mark.asyncio
+    async def test_afd_prompt_byte_identical(self, sample_afd_text, mock_response):
+        """AFD prompt must match the historical explain_afd prompt byte-for-byte."""
+        # The historical AFD system prompt — this string must remain stable
+        # because user-customized prompt overrides in the wild are calibrated
+        # against it. If this test fails, you changed the AFD prompt — don't.
+        expected_afd_prompt = (
+            "You are a helpful weather assistant that explains National Weather Service "
+            "Area Forecast Discussions (AFDs) in plain, accessible language. AFDs contain "
+            "technical meteorological terminology that most people don't understand. "
+            "Your job is to translate this into clear, everyday language that anyone can "
+            "understand. Focus on:\n"
+            "- What weather to expect and when\n"
+            "- Any significant weather events or changes\n"
+            "- How confident forecasters are in their predictions\n"
+            "- What this means for daily activities\n\n"
+            "Avoid using technical jargon. If you must use a technical term, explain it.\n\n"
+            "IMPORTANT: Do NOT start with a preamble like 'Here is a summary...' or "
+            "'This forecast discussion explains...'. Do NOT repeat the location name. "
+            "Jump straight into explaining the weather. The user already knows what they asked for.\n\n"
+            "IMPORTANT: Respond in plain text only. Do NOT use markdown formatting such as "
+            "bold (**text**), italic (*text*), headers (#), bullet points, or any other "
+            "markdown syntax. Use simple paragraph text that can be read directly."
+        )
+
+        assert _SYSTEM_PROMPTS["AFD"] == expected_afd_prompt
+
+        explainer = AIExplainer(api_key="test-key")
+        with patch.object(explainer, "_call_openrouter") as mock_call:
+            mock_call.return_value = mock_response
+
+            result = await explainer.explain_text_product(
+                sample_afd_text,
+                "AFD",
+                "Test City",
+                style=ExplanationStyle.DETAILED,
+            )
+
+            assert isinstance(result, ExplanationResult)
+            assert result.cached is False
+
+            # The first positional argument to _call_openrouter is the
+            # system prompt; it must start with the AFD prompt byte-for-byte.
+            args, _ = mock_call.call_args
+            system_prompt = args[0]
+            assert system_prompt == expected_afd_prompt
+
+    @pytest.mark.asyncio
+    async def test_hwo_uses_hwo_prompt(self, sample_hwo_text, mock_response):
+        explainer = AIExplainer(api_key="test-key")
+        with patch.object(explainer, "_call_openrouter") as mock_call:
+            mock_call.return_value = mock_response
+
+            await explainer.explain_text_product(
+                sample_hwo_text,
+                "HWO",
+                "Test City",
+            )
+
+            args, _ = mock_call.call_args
+            system_prompt = args[0]
+            assert system_prompt == _SYSTEM_PROMPTS["HWO"]
+            # HWO prompt must not equal AFD prompt
+            assert system_prompt != _SYSTEM_PROMPTS["AFD"]
+            # Sanity: the HWO prompt should mention the product by name
+            assert "Hazardous Weather Outlook" in system_prompt
+
+    @pytest.mark.asyncio
+    async def test_sps_uses_sps_prompt(self, sample_sps_text, mock_response):
+        explainer = AIExplainer(api_key="test-key")
+        with patch.object(explainer, "_call_openrouter") as mock_call:
+            mock_call.return_value = mock_response
+
+            await explainer.explain_text_product(
+                sample_sps_text,
+                "SPS",
+                "Test City",
+            )
+
+            args, _ = mock_call.call_args
+            system_prompt = args[0]
+            assert system_prompt == _SYSTEM_PROMPTS["SPS"]
+            assert system_prompt != _SYSTEM_PROMPTS["AFD"]
+            assert system_prompt != _SYSTEM_PROMPTS["HWO"]
+            assert "Special Weather Statement" in system_prompt
+
+
+# ---------------------------------------------------------------------------
+# Cache tests
+# ---------------------------------------------------------------------------
+
+
+class TestExplainTextProductCache:
+    @pytest.mark.asyncio
+    async def test_repeated_call_hits_cache(self, sample_afd_text, mock_response, in_memory_cache):
+        """Second call with identical inputs returns cached=True; no LLM call."""
+        explainer = AIExplainer(api_key="test-key", cache=in_memory_cache)
+
+        with patch.object(explainer, "_call_openrouter") as mock_call:
+            mock_call.return_value = mock_response
+
+            first = await explainer.explain_text_product(sample_afd_text, "AFD", "Test City")
+            second = await explainer.explain_text_product(sample_afd_text, "AFD", "Test City")
+
+            assert first.cached is False
+            assert second.cached is True
+            assert second.text == first.text
+            assert second.model_used == first.model_used
+            # LLM invoked exactly once
+            assert mock_call.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_cache_key_differs_across_product_types(
+        self, sample_afd_text, mock_response, in_memory_cache
+    ):
+        """AFD and HWO with identical text must not share cache entries."""
+        explainer = AIExplainer(api_key="test-key", cache=in_memory_cache)
+
+        with patch.object(explainer, "_call_openrouter") as mock_call:
+            mock_call.return_value = mock_response
+
+            await explainer.explain_text_product(sample_afd_text, "AFD", "Test City")
+            await explainer.explain_text_product(sample_afd_text, "HWO", "Test City")
+            # Different product type = different cache key = 2 LLM calls
+            assert mock_call.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Custom prompt behavior
+# ---------------------------------------------------------------------------
+
+
+class TestCustomSystemPrompt:
+    @pytest.mark.asyncio
+    async def test_custom_system_prompt_replaces_default(self, sample_hwo_text, mock_response):
+        """
+        custom_system_prompt replaces the built-in prompt for all product types.
+
+        Matches current explain_afd behavior (replace, not append).
+        """
+        custom = "You are a custom weather bot. Speak like a pirate."
+        explainer = AIExplainer(api_key="test-key", custom_system_prompt=custom)
+
+        with patch.object(explainer, "_call_openrouter") as mock_call:
+            mock_call.return_value = mock_response
+
+            await explainer.explain_text_product(sample_hwo_text, "HWO", "Test City")
+
+            args, _ = mock_call.call_args
+            system_prompt = args[0]
+            assert system_prompt == custom
+            # Default HWO prompt should NOT be present
+            assert _SYSTEM_PROMPTS["HWO"] not in system_prompt
+
+
+# ---------------------------------------------------------------------------
+# explain_afd wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestExplainAFDWrapper:
+    @pytest.mark.asyncio
+    async def test_explain_afd_delegates_to_explain_text_product(
+        self, sample_afd_text, mock_response
+    ):
+        """explain_afd must call explain_text_product with product_type='AFD'."""
+        explainer = AIExplainer(api_key="test-key")
+
+        sentinel = ExplanationResult(
+            text="sentinel",
+            model_used="sentinel-model",
+            token_count=1,
+            estimated_cost=0.0,
+            cached=False,
+            timestamp=MagicMock(),
+        )
+
+        async def fake_explain_text_product(product_text, product_type, location_name, **kwargs):
+            assert product_text == sample_afd_text
+            assert product_type == "AFD"
+            assert location_name == "Test City"
+            # Forwarded kwargs
+            assert kwargs.get("style") == ExplanationStyle.BRIEF
+            assert kwargs.get("preserve_markdown") is True
+            return sentinel
+
+        with patch.object(explainer, "explain_text_product", side_effect=fake_explain_text_product):
+            result = await explainer.explain_afd(
+                sample_afd_text,
+                "Test City",
+                style=ExplanationStyle.BRIEF,
+                preserve_markdown=True,
+            )
+
+            assert result is sentinel
+
+    @pytest.mark.asyncio
+    async def test_explain_afd_end_to_end_still_works(self, sample_afd_text, mock_response):
+        """End-to-end: explain_afd returns a proper ExplanationResult."""
+        explainer = AIExplainer(api_key="test-key")
+        with patch.object(explainer, "_call_openrouter") as mock_call:
+            mock_call.return_value = mock_response
+
+            result = await explainer.explain_afd(sample_afd_text, "Test City")
+
+            assert isinstance(result, ExplanationResult)
+            assert result.cached is False
+            assert result.text  # non-empty
+            # Verify AFD prompt was used
+            args, _ = mock_call.call_args
+            assert args[0] == _SYSTEM_PROMPTS["AFD"]
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPaths:
+    @pytest.mark.asyncio
+    async def test_llm_error_propagates_and_is_not_cached(self, sample_afd_text, in_memory_cache):
+        """LLM failures propagate. A subsequent retry re-invokes the LLM."""
+        explainer = AIExplainer(api_key="test-key", cache=in_memory_cache)
+
+        with patch.object(
+            explainer,
+            "_call_openrouter",
+            side_effect=Exception("catastrophic LLM failure"),
+        ) as mock_call:
+            with pytest.raises((AIExplainerError, Exception)):
+                await explainer.explain_text_product(sample_afd_text, "AFD", "Test City")
+
+            # Retry — cache must NOT have absorbed the failure
+            with pytest.raises((AIExplainerError, Exception)):
+                await explainer.explain_text_product(sample_afd_text, "AFD", "Test City")
+
+            # The LLM was re-invoked for the retry (at least one call per
+            # attempt; model-fallback loop may multiply this, but it must be
+            # strictly greater than the first attempt's count).
+            assert mock_call.call_count >= 2
+            # Nothing was cached
+            assert len(in_memory_cache.store) == 0

--- a/tests/test_cache_weather_alert_affected_zones.py
+++ b/tests/test_cache_weather_alert_affected_zones.py
@@ -1,0 +1,77 @@
+"""
+Tests for ``WeatherAlert.affected_zones`` serialization in the cache layer.
+
+Unit 9 of the Forecast Products PR 1 plan adds an additive ``affected_zones``
+field to :class:`WeatherAlert`. This module exercises:
+
+- Round-trip through ``_serialize_alert`` / ``_deserialize_alert`` preserves
+  the field exactly.
+- Legacy cache entries (written before Unit 9) deserialize with
+  ``affected_zones == []`` and never raise.
+"""
+
+from __future__ import annotations
+
+from accessiweather.cache import _deserialize_alert, _serialize_alert
+from accessiweather.models.alerts import WeatherAlert
+
+
+def test_affected_zones_round_trip() -> None:
+    """Populated ``affected_zones`` survives serialize -> deserialize unchanged."""
+    alert = WeatherAlert(
+        title="Special Weather Statement",
+        description="A strong thunderstorm will impact portions of the region.",
+        severity="Moderate",
+        urgency="Expected",
+        certainty="Likely",
+        event="Special Weather Statement",
+        headline="SPS headline",
+        id="urn:oid:2.49.0.1.840.0.test",
+        source="NWS",
+        affected_zones=["PHZ007", "PHZ008"],
+    )
+
+    payload = _serialize_alert(alert)
+    assert payload["affected_zones"] == ["PHZ007", "PHZ008"]
+
+    restored = _deserialize_alert(payload)
+    assert restored.affected_zones == ["PHZ007", "PHZ008"]
+    # All other fields still make it across — sanity check on the additive change.
+    assert restored.id == alert.id
+    assert restored.event == alert.event
+
+
+def test_affected_zones_omitted_when_empty() -> None:
+    """Empty ``affected_zones`` is omitted from the payload — legacy shape."""
+    alert = WeatherAlert(
+        title="Test Alert",
+        description="Body",
+    )
+    payload = _serialize_alert(alert)
+    assert "affected_zones" not in payload
+
+
+def test_legacy_cache_entry_deserializes_with_empty_zones() -> None:
+    """A cache dict written before Unit 9 deserializes with ``affected_zones == []``."""
+    legacy_payload = {
+        "title": "Flood Warning",
+        "description": "Legacy alert body",
+        "severity": "Severe",
+        "urgency": "Immediate",
+        "certainty": "Observed",
+        "event": "Flood Warning",
+        "headline": None,
+        "instruction": None,
+        "onset": None,
+        "expires": None,
+        "areas": ["Somerset County"],
+        "id": "legacy-1",
+        "source": "NWS",
+        # Note: no ``affected_zones`` key — this is the legacy shape.
+    }
+
+    restored = _deserialize_alert(legacy_payload)
+
+    assert restored.affected_zones == []
+    assert restored.title == "Flood Warning"
+    assert restored.areas == ["Somerset County"]

--- a/tests/test_discussion_routing.py
+++ b/tests/test_discussion_routing.py
@@ -64,8 +64,13 @@ class TestDiscussionRouting:
             mock_dlg_instance.ShowModal.assert_called_once()
             mock_dlg_instance.Destroy.assert_called_once()
 
-    def test_regular_location_opens_regular_dialog(self, main_window_deps):
-        """When current location is not Nationwide, show_discussion_dialog should be called."""
+    def test_regular_location_opens_forecast_products_dialog(self, main_window_deps):
+        """
+        When current location is not Nationwide, _on_forecast_products should run.
+
+        Unit 8 rerouted this branch from the old single-AFD DiscussionDialog to
+        the new tabbed ForecastProductsDialog (AFD + HWO + SPS).
+        """
         from accessiweather.ui.main_window import MainWindow
 
         main_window_deps.config_manager.get_current_location.return_value = FakeLocation(
@@ -75,13 +80,18 @@ class TestDiscussionRouting:
         with patch.object(MainWindow, "__init__", lambda self, *a, **kw: None):
             win = MainWindow.__new__(MainWindow)
             win.app = main_window_deps
+            win._on_forecast_products = MagicMock()
 
-        with patch("accessiweather.ui.dialogs.show_discussion_dialog") as mock_show:
-            win._on_discussion()
-            mock_show.assert_called_once_with(win, main_window_deps)
+        win._on_discussion()
+        win._on_forecast_products.assert_called_once()
 
-    def test_none_location_opens_regular_dialog(self, main_window_deps):
-        """When current location is None, show_discussion_dialog should be called."""
+    def test_none_location_opens_forecast_products_dialog(self, main_window_deps):
+        """
+        When current location is None, _on_forecast_products should still run.
+
+        ``_on_forecast_products`` itself handles the None-location case by
+        showing a "No Location Selected" message box.
+        """
         from accessiweather.ui.main_window import MainWindow
 
         main_window_deps.config_manager.get_current_location.return_value = None
@@ -89,7 +99,7 @@ class TestDiscussionRouting:
         with patch.object(MainWindow, "__init__", lambda self, *a, **kw: None):
             win = MainWindow.__new__(MainWindow)
             win.app = main_window_deps
+            win._on_forecast_products = MagicMock()
 
-        with patch("accessiweather.ui.dialogs.show_discussion_dialog") as mock_show:
-            win._on_discussion()
-            mock_show.assert_called_once_with(win, main_window_deps)
+        win._on_discussion()
+        win._on_forecast_products.assert_called_once()

--- a/tests/test_forecast_product_service.py
+++ b/tests/test_forecast_product_service.py
@@ -1,0 +1,165 @@
+"""
+Tests for :class:`ForecastProductService`.
+
+Covers:
+- Caching behaviour with per-type TTLs (AFD 3600s, HWO 7200s, SPS 900s)
+- Cache-key uniqueness across ``product_type`` and ``cwa_office``
+- Empty SPS returns ``[]`` (not ``None``)
+- ``TextProductFetchError`` propagates and is NOT cached
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from accessiweather.cache import Cache
+from accessiweather.models import TextProduct
+from accessiweather.services.forecast_product_service import ForecastProductService
+from accessiweather.weather_client_nws import TextProductFetchError
+
+
+def _afd(office: str = "PHI", product_id: str = "afd-1") -> TextProduct:
+    return TextProduct(
+        product_type="AFD",
+        product_id=product_id,
+        cwa_office=office,
+        issuance_time=datetime(2026, 4, 16, 14, 32, 0, tzinfo=timezone.utc),
+        product_text="AFD TEXT",
+        headline=None,
+    )
+
+
+def _sps(office: str = "PHI", product_id: str = "sps-1") -> TextProduct:
+    return TextProduct(
+        product_type="SPS",
+        product_id=product_id,
+        cwa_office=office,
+        issuance_time=datetime(2026, 4, 16, 14, 32, 0, tzinfo=timezone.utc),
+        product_text="SPS TEXT",
+        headline="Special Weather Statement",
+    )
+
+
+class TestForecastProductServiceCaching:
+    @pytest.mark.asyncio
+    async def test_repeat_calls_within_ttl_hit_cache(self):
+        cache = Cache()
+        fetcher = AsyncMock(return_value=_afd())
+        service = ForecastProductService(cache, fetcher=fetcher)
+
+        r1 = await service.get("AFD", "PHI")
+        r2 = await service.get("AFD", "PHI")
+
+        assert r1 is r2
+        fetcher.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_per_type_ttl_afd_cached_sps_refetched(self, monkeypatch):
+        """At t+1000s: AFD (TTL 3600) stays cached; SPS (TTL 900) refetches."""
+        cache = Cache()
+        fetcher = AsyncMock(
+            side_effect=lambda pt, office, **kw: _afd() if pt == "AFD" else [_sps()]
+        )
+        service = ForecastProductService(cache, fetcher=fetcher)
+
+        # t=0
+        fake_time = [1_000_000.0]
+        monkeypatch.setattr("accessiweather.cache.time.time", lambda: fake_time[0])
+
+        await service.get("AFD", "PHI")
+        await service.get("SPS", "PHI")
+        assert fetcher.call_count == 2
+
+        # Advance 1000 seconds: AFD still alive (3600s), SPS expired (900s).
+        fake_time[0] += 1000
+
+        await service.get("AFD", "PHI")  # cache hit -> no new call
+        await service.get("SPS", "PHI")  # cache miss -> one new call
+
+        assert fetcher.call_count == 3  # one extra call for SPS refetch
+
+
+class TestForecastProductServiceCacheKeys:
+    @pytest.mark.asyncio
+    async def test_different_offices_do_not_collide(self):
+        cache = Cache()
+
+        def side_effect(product_type, office, **_kw):
+            return _afd(office=office, product_id=f"afd-{office}")
+
+        fetcher = AsyncMock(side_effect=side_effect)
+        service = ForecastProductService(cache, fetcher=fetcher)
+
+        r_phi = await service.get("AFD", "PHI")
+        r_okx = await service.get("AFD", "OKX")
+
+        assert isinstance(r_phi, TextProduct)
+        assert isinstance(r_okx, TextProduct)
+        assert r_phi.cwa_office == "PHI"
+        assert r_okx.cwa_office == "OKX"
+        assert fetcher.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_different_product_types_do_not_collide(self):
+        cache = Cache()
+
+        def side_effect(product_type, office, **_kw):
+            if product_type == "SPS":
+                return [_sps(office=office)]
+            return TextProduct(
+                product_type=product_type,
+                product_id=f"{product_type}-1",
+                cwa_office=office,
+                issuance_time=datetime(2026, 4, 16, 14, 32, 0, tzinfo=timezone.utc),
+                product_text=f"{product_type} TEXT",
+                headline=None,
+            )
+
+        fetcher = AsyncMock(side_effect=side_effect)
+        service = ForecastProductService(cache, fetcher=fetcher)
+
+        afd = await service.get("AFD", "PHI")
+        hwo = await service.get("HWO", "PHI")
+        sps = await service.get("SPS", "PHI")
+
+        assert isinstance(afd, TextProduct) and afd.product_type == "AFD"
+        assert isinstance(hwo, TextProduct) and hwo.product_type == "HWO"
+        assert isinstance(sps, list)
+        assert fetcher.call_count == 3
+
+
+class TestForecastProductServiceEmpty:
+    @pytest.mark.asyncio
+    async def test_empty_sps_returns_list_not_none(self):
+        cache = Cache()
+        fetcher = AsyncMock(return_value=[])
+        service = ForecastProductService(cache, fetcher=fetcher)
+
+        result = await service.get("SPS", "PHI")
+
+        assert result == []
+        assert isinstance(result, list)
+        # Cached properly — second call still returns [] without refetching.
+        result2 = await service.get("SPS", "PHI")
+        assert result2 == []
+        fetcher.assert_called_once()
+
+
+class TestForecastProductServiceErrorPropagation:
+    @pytest.mark.asyncio
+    async def test_fetch_error_propagates_and_is_not_cached(self):
+        cache = Cache()
+        fetcher = AsyncMock(side_effect=TextProductFetchError("boom"))
+        service = ForecastProductService(cache, fetcher=fetcher)
+
+        with pytest.raises(TextProductFetchError):
+            await service.get("AFD", "PHI")
+
+        # The failure must NOT have been cached: a second call re-invokes the fetcher.
+        with pytest.raises(TextProductFetchError):
+            await service.get("AFD", "PHI")
+
+        assert fetcher.call_count == 2

--- a/tests/test_main_window_labels.py
+++ b/tests/test_main_window_labels.py
@@ -8,7 +8,7 @@ def test_quick_action_labels_match_visible_ui_copy():
         "remove": "&Remove Location",
         "refresh": "Re&fresh Weather",
         "explain": "Explain &Conditions",
-        "discussion": "Forecast &Discussion",
+        "discussion": "Forecast &Products",
         "settings": "&Settings",
     }
 

--- a/tests/test_main_window_labels.py
+++ b/tests/test_main_window_labels.py
@@ -8,7 +8,7 @@ def test_quick_action_labels_match_visible_ui_copy():
         "remove": "&Remove Location",
         "refresh": "Re&fresh Weather",
         "explain": "Explain &Conditions",
-        "discussion": "Forecast &Products",
+        "discussion": "Forecaster &Notes",
         "settings": "&Settings",
     }
 

--- a/tests/test_main_window_product_prewarm.py
+++ b/tests/test_main_window_product_prewarm.py
@@ -1,0 +1,226 @@
+"""
+Tests for ``MainWindow._pre_warm_products_for_location``.
+
+Unit 9 adds a background pre-warm step that fetches AFD/HWO/SPS for every
+saved US location with a populated ``cwa_office`` whenever the active
+location's weather refresh succeeds (and symmetrically for non-active
+locations inside ``_pre_warm_other_locations``).
+
+The tests exercise the helper directly rather than driving the full
+``_fetch_weather_data`` path — the helper is where all the policy lives
+(US-only, cwa gating, per-product failure isolation) and driving it
+directly keeps the test surface narrow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from accessiweather.models.weather import Location
+from accessiweather.weather_client_nws import TextProductFetchError
+
+
+def _make_window(service: MagicMock):
+    """Build a MainWindow stub with just enough to drive the pre-warm helper."""
+    from accessiweather.ui.main_window import MainWindow
+
+    with patch.object(MainWindow, "__init__", lambda self, *a, **kw: None):
+        win = MainWindow.__new__(MainWindow)
+
+    # _pre_warm_products_for_location calls through ``_get_forecast_product_service``;
+    # pre-populate the cached instance so we don't need the full service graph.
+    win._forecast_product_service = service
+    return win
+
+
+def _us_location(name: str, cwa: str | None = "PHI") -> Location:
+    return Location(
+        name=name,
+        latitude=39.95,
+        longitude=-75.16,
+        country_code="US",
+        cwa_office=cwa,
+    )
+
+
+def _non_us_location(name: str = "London") -> Location:
+    return Location(
+        name=name,
+        latitude=51.5,
+        longitude=-0.12,
+        country_code="GB",
+        cwa_office=None,
+    )
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
+
+
+def test_pre_warm_fetches_three_products_for_us_location():
+    """Happy path: a single US location triggers three product fetches."""
+    service = MagicMock()
+    service.get = AsyncMock(return_value=None)
+
+    win = _make_window(service)
+    asyncio.run(win._pre_warm_products_for_location(_us_location("Philadelphia")))
+
+    assert service.get.await_count == 3
+    fetched_types = {call.args[0] for call in service.get.await_args_list}
+    assert fetched_types == {"AFD", "HWO", "SPS"}
+
+
+def test_pre_warm_skips_non_us_location():
+    """Non-US locations never hit the service."""
+    service = MagicMock()
+    service.get = AsyncMock(return_value=None)
+
+    win = _make_window(service)
+    asyncio.run(win._pre_warm_products_for_location(_non_us_location()))
+
+    service.get.assert_not_awaited()
+
+
+def test_pre_warm_skips_us_location_without_cwa_office():
+    """US location with ``cwa_office=None`` yields zero fetches."""
+    service = MagicMock()
+    service.get = AsyncMock(return_value=None)
+
+    win = _make_window(service)
+    asyncio.run(win._pre_warm_products_for_location(_us_location("Nowhere", cwa=None)))
+
+    service.get.assert_not_awaited()
+
+
+def test_pre_warm_skips_nationwide_entry():
+    """The synthetic Nationwide entry is skipped even if it has coordinates."""
+    service = MagicMock()
+    service.get = AsyncMock(return_value=None)
+
+    nationwide = Location(
+        name="Nationwide",
+        latitude=39.8,
+        longitude=-98.6,
+        country_code="US",
+        cwa_office="XXX",
+    )
+
+    win = _make_window(service)
+    asyncio.run(win._pre_warm_products_for_location(nationwide))
+
+    service.get.assert_not_awaited()
+
+
+def test_pre_warm_fetch_error_isolated_to_single_product():
+    """A ``TextProductFetchError`` on HWO doesn't block AFD or SPS."""
+    service = MagicMock()
+
+    async def _get(product_type: str, _cwa: str, **_kw):
+        if product_type == "HWO":
+            raise TextProductFetchError("404 for HWO")
+        return
+
+    service.get = AsyncMock(side_effect=_get)
+
+    win = _make_window(service)
+    # Should NOT raise — failure isolation is the whole point.
+    asyncio.run(win._pre_warm_products_for_location(_us_location("Philadelphia")))
+
+    assert service.get.await_count == 3
+    fetched_types = [call.args[0] for call in service.get.await_args_list]
+    assert fetched_types == ["AFD", "HWO", "SPS"]
+
+
+def test_pre_warm_unexpected_exception_is_swallowed():
+    """A generic ``Exception`` from one fetch is swallowed; iteration continues."""
+    service = MagicMock()
+
+    async def _get(product_type: str, _cwa: str, **_kw):
+        if product_type == "AFD":
+            raise RuntimeError("unexpected")
+        return
+
+    service.get = AsyncMock(side_effect=_get)
+
+    win = _make_window(service)
+    asyncio.run(win._pre_warm_products_for_location(_us_location("Philadelphia")))
+
+    assert service.get.await_count == 3
+
+
+class _FakeWeatherClient:
+    """Minimal stand-in for ``AccessiWeatherApp.weather_client``."""
+
+    def __init__(self) -> None:
+        self.pre_warm_batch = AsyncMock()
+
+    def get_cached_weather(self, _location):  # pragma: no cover - exercised indirectly
+        return None
+
+
+class _FakeConfigManager:
+    def __init__(self, locations: list[Location]) -> None:
+        self._locations = locations
+
+    def get_all_locations(self) -> list[Location]:
+        return list(self._locations)
+
+
+def _window_with_app(service: MagicMock, locations: list[Location]):
+    from accessiweather.ui.main_window import MainWindow
+
+    with patch.object(MainWindow, "__init__", lambda self, *a, **kw: None):
+        win = MainWindow.__new__(MainWindow)
+
+    win._forecast_product_service = service
+    win.app = MagicMock()
+    win.app.config_manager = _FakeConfigManager(locations)
+    win.app.weather_client = _FakeWeatherClient()
+    return win
+
+
+@pytest.mark.asyncio
+async def test_pre_warm_other_locations_iterates_saved_us_locations():
+    """With three saved US locations, the non-active two each get three fetches."""
+    service = MagicMock()
+    service.get = AsyncMock(return_value=None)
+
+    active = _us_location("Philadelphia")
+    other_us_1 = _us_location("New York")
+    other_us_1.cwa_office = "OKX"
+    other_us_2 = _us_location("Boston")
+    other_us_2.cwa_office = "BOX"
+
+    win = _window_with_app(service, [active, other_us_1, other_us_2])
+
+    await win._pre_warm_other_locations(active)
+
+    # Two non-active US locations * 3 product types = 6 fetches.
+    assert service.get.await_count == 6
+    cwas_by_product = {call.args[0]: set() for call in service.get.await_args_list}
+    for call in service.get.await_args_list:
+        cwas_by_product[call.args[0]].add(call.args[1])
+    assert cwas_by_product == {"AFD": {"OKX", "BOX"}, "HWO": {"OKX", "BOX"}, "SPS": {"OKX", "BOX"}}
+
+
+@pytest.mark.asyncio
+async def test_pre_warm_other_locations_skips_non_us_peers():
+    """Mixed US + non-US list: only US peers drive product fetches."""
+    service = MagicMock()
+    service.get = AsyncMock(return_value=None)
+
+    active = _us_location("Philadelphia")
+    us_peer = _us_location("New York", cwa="OKX")
+    non_us_peer = _non_us_location("Paris")
+
+    win = _window_with_app(service, [active, us_peer, non_us_peer])
+
+    await win._pre_warm_other_locations(active)
+
+    # Only the US peer contributes fetches (3), the non-US one is skipped.
+    assert service.get.await_count == 3
+    fetched_cwas = {call.args[1] for call in service.get.await_args_list}
+    assert fetched_cwas == {"OKX"}

--- a/tests/test_notification_hwo_update.py
+++ b/tests/test_notification_hwo_update.py
@@ -1,0 +1,397 @@
+"""
+Tests for Unit 10 — HWO (Hazardous Weather Outlook) update notifications.
+
+These cover `NotificationEventManager._check_hwo_update`:
+
+1. Cold-start baseline — first fetch stores state silently, no dispatch.
+2. Content change — newer issuance_time + changed signature → dispatch.
+3. Summarizer fallback — short/empty summarizer output → generic body.
+4. Unchanged — same issuance_time + same signature → no-op.
+5. Rate limit — change within 30 min of last dispatch → suppressed but state updates.
+6. Disabled — ``notify_hwo_update = False`` → no dispatch regardless of change.
+7. None product — no crash, no state update.
+8. Multi-location — each location maintains its own 30-min rate-limit bucket.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from accessiweather.models import AppSettings, Location, TextProduct
+from accessiweather.notifications.notification_event_manager import (
+    NotificationEventManager,
+)
+
+UTC = timezone.utc
+
+
+def _dt(product: TextProduct) -> datetime:
+    """Assert and narrow an issuance_time that the tests always set."""
+    assert product.issuance_time is not None
+    return product.issuance_time
+
+
+def _location(name: str = "Test City", cwa: str | None = "OKX") -> Location:
+    return Location(
+        name=name,
+        latitude=40.0,
+        longitude=-74.0,
+        country_code="US",
+        cwa_office=cwa,
+    )
+
+
+def _hwo(
+    text: str = "HAZARDOUS WEATHER OUTLOOK\nPatchy fog possible overnight.",
+    issuance_time: datetime | None = None,
+    cwa: str = "OKX",
+    product_id: str = "HWO-OKX-1",
+) -> TextProduct:
+    if issuance_time is None:
+        issuance_time = datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC)
+    return TextProduct(
+        product_type="HWO",
+        product_id=product_id,
+        cwa_office=cwa,
+        issuance_time=issuance_time,
+        product_text=text,
+        headline=None,
+    )
+
+
+@pytest.fixture
+def manager():
+    return NotificationEventManager(state_file=None)
+
+
+@pytest.fixture
+def settings_hwo_enabled():
+    s = AppSettings()
+    s.notify_hwo_update = True  # type: ignore[attr-defined]
+    return s
+
+
+@pytest.fixture
+def settings_hwo_disabled():
+    s = AppSettings()
+    s.notify_hwo_update = False  # type: ignore[attr-defined]
+    return s
+
+
+# ------------------------------------------------------------------
+# 1. Cold-start baseline
+# ------------------------------------------------------------------
+
+
+def test_cold_start_stores_baseline_no_dispatch(manager, settings_hwo_enabled):
+    loc = _location()
+    product = _hwo()
+    dispatched: list[tuple] = []
+    manager._dispatch_hwo_notification = lambda *a, **kw: dispatched.append((a, kw))  # type: ignore[attr-defined]
+
+    manager._check_hwo_update(loc, product, settings_hwo_enabled)
+
+    assert dispatched == []
+    assert manager.state.last_hwo_issuance_time == product.issuance_time
+    assert manager.state.last_hwo_text == product.product_text
+    assert manager.state.last_hwo_summary_signature is not None
+
+
+# ------------------------------------------------------------------
+# 2. Content change → dispatch with summarizer output
+# ------------------------------------------------------------------
+
+
+def test_content_change_dispatches_summary(manager, settings_hwo_enabled, monkeypatch):
+    loc = _location()
+
+    # Baseline first.
+    first = _hwo(
+        text=("HAZARDOUS WEATHER OUTLOOK\nNothing hazardous expected through the period.\n"),
+        issuance_time=datetime(2026, 4, 20, 5, 0, 0, tzinfo=UTC),
+    )
+    manager._check_hwo_update(loc, first, settings_hwo_enabled)
+
+    # Patch summarizer to return a believably long sentence.
+    summary = (
+        "Strong thunderstorms expected Monday afternoon with damaging winds "
+        "and isolated tornadoes possible across the region."
+    )
+    monkeypatch.setattr(
+        "accessiweather.notifications.notification_event_manager.summarize_discussion_change",
+        lambda _old, _new: summary,
+    )
+
+    dispatched: list[dict] = []
+    manager._dispatch_hwo_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    updated = _hwo(
+        text=("HAZARDOUS WEATHER OUTLOOK\nStrong storms Monday afternoon with damaging winds.\n"),
+        issuance_time=_dt(first) + timedelta(hours=6),
+    )
+    manager._check_hwo_update(loc, updated, settings_hwo_enabled)
+
+    assert len(dispatched) == 1
+    payload = dispatched[0]
+    assert payload["message"] == summary
+    assert payload["location"] is loc
+    assert payload["product"] is updated
+    # State advanced.
+    assert manager.state.last_hwo_issuance_time == updated.issuance_time
+    assert manager.state.last_hwo_text == updated.product_text
+
+
+# ------------------------------------------------------------------
+# 3. Summarizer falls back to generic message
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("summary_output", [None, "", "   ", "tiny"])
+def test_summarizer_fallback_to_generic(manager, settings_hwo_enabled, monkeypatch, summary_output):
+    loc = _location(cwa="OKX")
+
+    first = _hwo(issuance_time=datetime(2026, 4, 20, 5, 0, 0, tzinfo=UTC))
+    manager._check_hwo_update(loc, first, settings_hwo_enabled)
+
+    monkeypatch.setattr(
+        "accessiweather.notifications.notification_event_manager.summarize_discussion_change",
+        lambda _old, _new: summary_output,
+    )
+
+    dispatched: list[dict] = []
+    manager._dispatch_hwo_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    updated = _hwo(
+        text="HAZARDOUS WEATHER OUTLOOK\nSlight change.\n",
+        issuance_time=_dt(first) + timedelta(hours=6),
+    )
+    manager._check_hwo_update(loc, updated, settings_hwo_enabled)
+
+    assert len(dispatched) == 1
+    assert "Hazardous Weather Outlook updated for OKX" in dispatched[0]["message"]
+    assert "tap to view" in dispatched[0]["message"]
+
+
+# ------------------------------------------------------------------
+# 4. Unchanged — no dispatch, no state update
+# ------------------------------------------------------------------
+
+
+def test_unchanged_issuance_no_op(manager, settings_hwo_enabled):
+    loc = _location()
+    product = _hwo(issuance_time=datetime(2026, 4, 20, 5, 0, 0, tzinfo=UTC))
+
+    manager._check_hwo_update(loc, product, settings_hwo_enabled)
+    first_signature = manager.state.last_hwo_summary_signature
+
+    dispatched: list[dict] = []
+    manager._dispatch_hwo_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    # Exact same product a second time.
+    manager._check_hwo_update(loc, product, settings_hwo_enabled)
+
+    assert dispatched == []
+    assert manager.state.last_hwo_summary_signature == first_signature
+    assert manager.state.last_hwo_issuance_time == product.issuance_time
+
+
+# ------------------------------------------------------------------
+# 5. Rate limited — state advances, dispatch suppressed
+# ------------------------------------------------------------------
+
+
+def test_rate_limited_suppresses_second_dispatch(manager, settings_hwo_enabled, monkeypatch):
+    loc = _location()
+
+    first = _hwo(issuance_time=datetime(2026, 4, 20, 5, 0, 0, tzinfo=UTC))
+    manager._check_hwo_update(loc, first, settings_hwo_enabled)
+
+    monkeypatch.setattr(
+        "accessiweather.notifications.notification_event_manager.summarize_discussion_change",
+        lambda _old, _new: "significant hazard update with relevant details here",
+    )
+
+    dispatched: list[dict] = []
+    manager._dispatch_hwo_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    second = _hwo(
+        text="HAZARDOUS WEATHER OUTLOOK\nChanged once.\n",
+        issuance_time=_dt(first) + timedelta(hours=1),
+    )
+    manager._check_hwo_update(loc, second, settings_hwo_enabled)
+    assert len(dispatched) == 1
+
+    third = _hwo(
+        text="HAZARDOUS WEATHER OUTLOOK\nChanged twice.\n",
+        issuance_time=_dt(second) + timedelta(minutes=5),
+    )
+    manager._check_hwo_update(loc, third, settings_hwo_enabled)
+
+    # Still only one dispatch (second), but state reflects third.
+    assert len(dispatched) == 1
+    assert manager.state.last_hwo_issuance_time == third.issuance_time
+    assert manager.state.last_hwo_text == third.product_text
+
+
+def test_rate_limit_releases_after_30_minutes(manager, settings_hwo_enabled, monkeypatch):
+    loc = _location()
+
+    first = _hwo(issuance_time=datetime(2026, 4, 20, 5, 0, 0, tzinfo=UTC))
+    manager._check_hwo_update(loc, first, settings_hwo_enabled)
+
+    monkeypatch.setattr(
+        "accessiweather.notifications.notification_event_manager.summarize_discussion_change",
+        lambda _old, _new: "sufficiently long change summary for real delivery",
+    )
+
+    dispatched: list[dict] = []
+    manager._dispatch_hwo_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    # First dispatch at t0.
+    second = _hwo(text="Changed once", issuance_time=_dt(first) + timedelta(hours=1))
+    manager._check_hwo_update(loc, second, settings_hwo_enabled)
+    assert len(dispatched) == 1
+
+    # Simulate 31 minutes later by rewinding the bucket timestamp.
+    bucket_key = ("HWO", loc.name)
+    old_time = manager._last_product_notified_at[bucket_key] - timedelta(minutes=31)
+    manager._last_product_notified_at[bucket_key] = old_time
+
+    third = _hwo(text="Changed twice", issuance_time=_dt(second) + timedelta(hours=1))
+    manager._check_hwo_update(loc, third, settings_hwo_enabled)
+    assert len(dispatched) == 2
+
+
+# ------------------------------------------------------------------
+# 6. Disabled — no dispatch regardless of change
+# ------------------------------------------------------------------
+
+
+def test_disabled_setting_no_dispatch(manager, settings_hwo_disabled, monkeypatch):
+    loc = _location()
+
+    first = _hwo(issuance_time=datetime(2026, 4, 20, 5, 0, 0, tzinfo=UTC))
+    manager._check_hwo_update(loc, first, settings_hwo_disabled)
+
+    monkeypatch.setattr(
+        "accessiweather.notifications.notification_event_manager.summarize_discussion_change",
+        lambda _old, _new: "significant hazard update with plenty of detail",
+    )
+
+    dispatched: list[dict] = []
+    manager._dispatch_hwo_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    updated = _hwo(
+        text="HAZARDOUS WEATHER OUTLOOK\nChanged.\n",
+        issuance_time=_dt(first) + timedelta(hours=6),
+    )
+    manager._check_hwo_update(loc, updated, settings_hwo_disabled)
+
+    assert dispatched == []
+    # State still advances so we don't spam after re-enable.
+    assert manager.state.last_hwo_issuance_time == updated.issuance_time
+
+
+def test_missing_setting_attribute_defaults_to_true(manager, monkeypatch):
+    loc = _location()
+    # AppSettings instance stripped of the attribute (simulate pre-Unit-12).
+    settings = MagicMock(spec=[])  # no notify_hwo_update attribute
+
+    first = _hwo(issuance_time=datetime(2026, 4, 20, 5, 0, 0, tzinfo=UTC))
+    manager._check_hwo_update(loc, first, settings)
+
+    monkeypatch.setattr(
+        "accessiweather.notifications.notification_event_manager.summarize_discussion_change",
+        lambda _old, _new: "significant change summary that exceeds the threshold length",
+    )
+
+    dispatched: list[dict] = []
+    manager._dispatch_hwo_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    updated = _hwo(text="Changed", issuance_time=_dt(first) + timedelta(hours=6))
+    manager._check_hwo_update(loc, updated, settings)
+
+    assert len(dispatched) == 1
+
+
+# ------------------------------------------------------------------
+# 7. None product and missing cwa_office
+# ------------------------------------------------------------------
+
+
+def test_none_product_is_no_op(manager, settings_hwo_enabled):
+    loc = _location()
+    dispatched: list = []
+    manager._dispatch_hwo_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    manager._check_hwo_update(loc, None, settings_hwo_enabled)
+
+    assert dispatched == []
+    assert manager.state.last_hwo_issuance_time is None
+    assert manager.state.last_hwo_summary_signature is None
+
+
+def test_missing_cwa_office_is_no_op(manager, settings_hwo_enabled):
+    loc = _location(cwa=None)
+    product = _hwo()
+    dispatched: list = []
+    manager._dispatch_hwo_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    manager._check_hwo_update(loc, product, settings_hwo_enabled)
+
+    assert dispatched == []
+    assert manager.state.last_hwo_issuance_time is None
+
+
+# ------------------------------------------------------------------
+# 8. Multi-location — independent buckets
+# ------------------------------------------------------------------
+
+
+def test_multi_location_independent_rate_limits(manager, settings_hwo_enabled, monkeypatch):
+    loc_a = _location(name="City A", cwa="OKX")
+    loc_b = _location(name="City B", cwa="PHI")
+
+    # Baselines.
+    base_a = _hwo(text="A initial", cwa="OKX", issuance_time=datetime(2026, 4, 20, 5, tzinfo=UTC))
+    base_b = _hwo(text="B initial", cwa="PHI", issuance_time=datetime(2026, 4, 20, 5, tzinfo=UTC))
+    manager._check_hwo_update(loc_a, base_a, settings_hwo_enabled)
+    manager._check_hwo_update(loc_b, base_b, settings_hwo_enabled)
+    # Baselines may have populated rate-limit buckets via the default
+    # _dispatch_hwo_notification no-op path; clear them so the assertions
+    # below observe only dispatches triggered by the update-phase calls.
+    manager._last_product_notified_at.clear()
+
+    # Multi-location requires per-location state. NotificationState tracks a
+    # single last_hwo_*; for independent buckets we verify rate-limit dict
+    # keys separate. Re-seed summarizer to always return a long string.
+    monkeypatch.setattr(
+        "accessiweather.notifications.notification_event_manager.summarize_discussion_change",
+        lambda _old, _new: "plenty long summary to clear the 20 char threshold easily",
+    )
+
+    dispatched: list[str] = []
+    manager._dispatch_hwo_notification = (  # type: ignore[attr-defined]
+        lambda **kw: dispatched.append(kw["location"].name)
+    )
+
+    updated_a = _hwo(
+        text="A changed",
+        cwa="OKX",
+        issuance_time=_dt(base_a) + timedelta(hours=1),
+    )
+    updated_b = _hwo(
+        text="B changed",
+        cwa="PHI",
+        issuance_time=_dt(base_b) + timedelta(hours=1),
+    )
+
+    manager._check_hwo_update(loc_a, updated_a, settings_hwo_enabled)
+    manager._check_hwo_update(loc_b, updated_b, settings_hwo_enabled)
+
+    assert sorted(dispatched) == ["City A", "City B"]
+    assert ("HWO", "City A") in manager._last_product_notified_at
+    assert ("HWO", "City B") in manager._last_product_notified_at

--- a/tests/test_notification_sps_dedupe.py
+++ b/tests/test_notification_sps_dedupe.py
@@ -1,0 +1,457 @@
+"""
+Tests for Unit 11 — SPS (Special Weather Statement) informational notifications.
+
+Covers ``NotificationEventManager._check_sps_new``:
+
+1. Cold start — first fetch records all IDs silently.
+2. Case B (informational) — SPS with no matching active alert → dispatch.
+3. Case A (event-style) — SPS whose headline text is echoed by an active
+   "Special Weather Statement" alert → suppressed, ID still recorded.
+4. Expiration — previously-seen SPS disappears → silently removed from state.
+5. Headline null fallback — body uses first non-empty line of product_text,
+   truncated at 160 chars with ellipsis.
+6. Rate limited — new Case B within 30 min → state advances, dispatch suppressed.
+7. Disabled — ``notify_sps_issued = False`` → no dispatch ever.
+8. Mixed — Case A + Case B in same fetch → only Case B notifies; both stored.
+9. Realistic replay — fire-weather SPS plus unrelated SPS alert → fire-weather
+   notifies (Case B), the alert-matching product does not (Case A).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from accessiweather.models import AppSettings, Location, TextProduct, WeatherAlert
+from accessiweather.notifications.notification_event_manager import (
+    NotificationEventManager,
+)
+
+UTC = timezone.utc
+
+
+def _location(name: str = "Test City", cwa: str | None = "PHI") -> Location:
+    return Location(
+        name=name,
+        latitude=40.0,
+        longitude=-74.0,
+        country_code="US",
+        cwa_office=cwa,
+    )
+
+
+def _sps(
+    product_id: str = "SPS-PHI-1",
+    headline: str | None = "FIRE WEATHER PLANNING FORECAST",
+    product_text: str = "...Fire weather planning forecast for the region...",
+    issuance_time: datetime | None = None,
+    cwa: str = "PHI",
+) -> TextProduct:
+    if issuance_time is None:
+        issuance_time = datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC)
+    return TextProduct(
+        product_type="SPS",
+        product_id=product_id,
+        cwa_office=cwa,
+        issuance_time=issuance_time,
+        product_text=product_text,
+        headline=headline,
+    )
+
+
+def _alert(
+    event: str = "Special Weather Statement",
+    headline: str | None = "Strong thunderstorm in effect",
+    description: str = "Strong thunderstorm in effect for the area",
+    expires: datetime | None = None,
+) -> WeatherAlert:
+    if expires is None:
+        expires = datetime(2099, 1, 1, tzinfo=UTC)
+    return WeatherAlert(
+        title=headline or "Alert",
+        description=description,
+        event=event,
+        headline=headline,
+        expires=expires,
+    )
+
+
+@pytest.fixture
+def manager():
+    return NotificationEventManager(state_file=None)
+
+
+@pytest.fixture
+def settings_sps_enabled():
+    s = AppSettings()
+    s.notify_sps_issued = True  # type: ignore[attr-defined]
+    return s
+
+
+@pytest.fixture
+def settings_sps_disabled():
+    s = AppSettings()
+    s.notify_sps_issued = False  # type: ignore[attr-defined]
+    return s
+
+
+# ------------------------------------------------------------------
+# 1. Cold start — record all IDs silently
+# ------------------------------------------------------------------
+
+
+def test_cold_start_records_ids_no_dispatch(manager, settings_sps_enabled):
+    loc = _location()
+    products = [
+        _sps(product_id="SPS-1", headline="FIRE WEATHER"),
+        _sps(product_id="SPS-2", headline="POLLEN FORECAST"),
+        _sps(product_id="SPS-3", headline="COORDINATION STATEMENT"),
+    ]
+
+    dispatched: list[dict] = []
+    manager._dispatch_sps_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    manager._check_sps_new(loc, products, [], settings_sps_enabled)
+
+    assert dispatched == []
+    assert manager.state.last_sps_product_ids == {"SPS-1", "SPS-2", "SPS-3"}
+
+
+# ------------------------------------------------------------------
+# 2. Case B (informational) — no matching alert → dispatch
+# ------------------------------------------------------------------
+
+
+def test_case_b_informational_dispatches(manager, settings_sps_enabled):
+    loc = _location()
+
+    # Cold-start with empty list so we're past cold-start on the next call.
+    manager._check_sps_new(loc, [], [], settings_sps_enabled)
+
+    dispatched: list[dict] = []
+    manager._dispatch_sps_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    new = _sps(
+        product_id="SPS-FIRE",
+        headline="FIRE WEATHER PLANNING FORECAST",
+        product_text="...FIRE WEATHER PLANNING FORECAST...\nElevated fire weather conditions.",
+    )
+    manager._check_sps_new(loc, [new], [], settings_sps_enabled)
+
+    assert len(dispatched) == 1
+    payload = dispatched[0]
+    assert payload["location"] is loc
+    assert payload["product"] is new
+    assert "FIRE WEATHER PLANNING FORECAST" in payload["message"]
+    assert "PHI" in payload["message"]
+    assert "SPS-FIRE" in manager.state.last_sps_product_ids
+
+
+# ------------------------------------------------------------------
+# 3. Case A (event-style) — alert headline echoes product text → suppressed
+# ------------------------------------------------------------------
+
+
+def test_case_a_event_style_suppressed(manager, settings_sps_enabled):
+    loc = _location()
+    manager._check_sps_new(loc, [], [], settings_sps_enabled)  # past cold-start
+
+    dispatched: list[dict] = []
+    manager._dispatch_sps_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    alert = _alert(
+        headline="Strong thunderstorm producing pea size hail",
+        description="Strong thunderstorm producing pea size hail in Central County",
+    )
+    product = _sps(
+        product_id="SPS-TSTM",
+        headline="Strong thunderstorm producing pea size hail",
+        product_text=(
+            "...SPECIAL WEATHER STATEMENT...\n"
+            "Strong thunderstorm producing pea size hail near town.\n"
+            "Move indoors."
+        ),
+    )
+
+    manager._check_sps_new(loc, [product], [alert], settings_sps_enabled)
+
+    assert dispatched == []
+    # Case A still records the ID so we don't re-evaluate next cycle.
+    assert "SPS-TSTM" in manager.state.last_sps_product_ids
+
+
+# ------------------------------------------------------------------
+# 4. Expiration — previously-seen SPS disappears
+# ------------------------------------------------------------------
+
+
+def test_expired_product_silently_removed(manager, settings_sps_enabled):
+    loc = _location()
+    # Seed state with three SPS ids.
+    seed = [
+        _sps(product_id="SPS-A"),
+        _sps(product_id="SPS-B"),
+        _sps(product_id="SPS-C"),
+    ]
+    manager._check_sps_new(loc, seed, [], settings_sps_enabled)
+    assert manager.state.last_sps_product_ids == {"SPS-A", "SPS-B", "SPS-C"}
+
+    dispatched: list[dict] = []
+    manager._dispatch_sps_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    # Next fetch: only A remains.
+    manager._check_sps_new(loc, [_sps(product_id="SPS-A")], [], settings_sps_enabled)
+
+    assert dispatched == []
+    assert manager.state.last_sps_product_ids == {"SPS-A"}
+
+
+# ------------------------------------------------------------------
+# 5. Headline null — falls back to first line of product_text, truncated
+# ------------------------------------------------------------------
+
+
+def test_headline_null_fallback_truncation(manager, settings_sps_enabled):
+    loc = _location()
+    manager._check_sps_new(loc, [], [], settings_sps_enabled)
+
+    dispatched: list[dict] = []
+    manager._dispatch_sps_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    # First non-empty line is a very long sentence that must be truncated.
+    long_line = "A" * 400
+    product = _sps(
+        product_id="SPS-LONG",
+        headline=None,
+        product_text=f"\n\n{long_line}\nSecond line content.",
+    )
+    manager._check_sps_new(loc, [product], [], settings_sps_enabled)
+
+    assert len(dispatched) == 1
+    message = dispatched[0]["message"]
+    assert len(message) <= 160
+    assert message.endswith("...")
+    # Ensure the truncation comes from the first line (A's), not the fallback.
+    assert message.startswith("A")
+
+
+def test_headline_null_short_first_line(manager, settings_sps_enabled):
+    loc = _location()
+    manager._check_sps_new(loc, [], [], settings_sps_enabled)
+
+    dispatched: list[dict] = []
+    manager._dispatch_sps_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    product = _sps(
+        product_id="SPS-SHORT",
+        headline=None,
+        product_text="\n\nShort summary line.\nLater details.",
+    )
+    manager._check_sps_new(loc, [product], [], settings_sps_enabled)
+
+    assert len(dispatched) == 1
+    assert dispatched[0]["message"].startswith("Short summary line.")
+    assert not dispatched[0]["message"].endswith("...")
+
+
+# ------------------------------------------------------------------
+# 6. Rate limited — state advances, no dispatch
+# ------------------------------------------------------------------
+
+
+def test_rate_limited_suppresses_within_window(manager, settings_sps_enabled):
+    loc = _location()
+    manager._check_sps_new(loc, [], [], settings_sps_enabled)
+
+    dispatched: list[dict] = []
+    manager._dispatch_sps_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    # First Case B dispatches.
+    first = _sps(product_id="SPS-1", headline="FIRE WEATHER FORECAST")
+    manager._check_sps_new(loc, [first], [], settings_sps_enabled)
+    assert len(dispatched) == 1
+
+    # Second Case B within 30 min — state advances, no dispatch.
+    second = _sps(product_id="SPS-2", headline="POLLEN OUTLOOK")
+    manager._check_sps_new(loc, [first, second], [], settings_sps_enabled)
+
+    assert len(dispatched) == 1
+    assert manager.state.last_sps_product_ids == {"SPS-1", "SPS-2"}
+
+
+def test_rate_limit_releases_after_30_minutes(manager, settings_sps_enabled):
+    loc = _location()
+    manager._check_sps_new(loc, [], [], settings_sps_enabled)
+
+    dispatched: list[dict] = []
+    manager._dispatch_sps_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    first = _sps(product_id="SPS-1", headline="FIRE WEATHER FORECAST")
+    manager._check_sps_new(loc, [first], [], settings_sps_enabled)
+    assert len(dispatched) == 1
+
+    # Rewind the rate-limit bucket by 31 min.
+    key = ("SPS", loc.name)
+    manager._last_product_notified_at[key] -= timedelta(minutes=31)
+
+    second = _sps(product_id="SPS-2", headline="POLLEN OUTLOOK")
+    manager._check_sps_new(loc, [first, second], [], settings_sps_enabled)
+
+    assert len(dispatched) == 2
+
+
+# ------------------------------------------------------------------
+# 7. Disabled — never dispatches
+# ------------------------------------------------------------------
+
+
+def test_disabled_setting_no_dispatch(manager, settings_sps_disabled):
+    loc = _location()
+    manager._check_sps_new(loc, [], [], settings_sps_disabled)
+
+    dispatched: list[dict] = []
+    manager._dispatch_sps_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    product = _sps(product_id="SPS-1", headline="FIRE WEATHER FORECAST")
+    manager._check_sps_new(loc, [product], [], settings_sps_disabled)
+
+    assert dispatched == []
+    # State still advances so re-enabling the toggle doesn't spam.
+    assert "SPS-1" in manager.state.last_sps_product_ids
+
+
+def test_missing_setting_attribute_defaults_to_true(manager):
+    loc = _location()
+    settings = MagicMock(spec=[])  # no notify_sps_issued attr
+    manager._check_sps_new(loc, [], [], settings)
+
+    dispatched: list[dict] = []
+    manager._dispatch_sps_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    product = _sps(product_id="SPS-1", headline="FIRE WEATHER FORECAST")
+    manager._check_sps_new(loc, [product], [], settings)
+
+    assert len(dispatched) == 1
+
+
+# ------------------------------------------------------------------
+# 8. Mixed Case A + Case B in same fetch
+# ------------------------------------------------------------------
+
+
+def test_mixed_case_a_and_case_b(manager, settings_sps_enabled):
+    loc = _location()
+    manager._check_sps_new(loc, [], [], settings_sps_enabled)
+
+    dispatched: list[dict] = []
+    manager._dispatch_sps_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    # Case A: product text contains alert's headline.
+    case_a_alert = _alert(headline="Dense fog advisory in effect")
+    case_a = _sps(
+        product_id="SPS-FOG",
+        headline="Dense fog advisory in effect",
+        product_text="...Dense fog advisory in effect until 9 AM...",
+    )
+    # Case B: no matching alert event.
+    case_b = _sps(
+        product_id="SPS-FIRE",
+        headline="FIRE WEATHER PLANNING FORECAST",
+        product_text="...FIRE WEATHER PLANNING FORECAST for the region...",
+    )
+
+    manager._check_sps_new(loc, [case_a, case_b], [case_a_alert], settings_sps_enabled)
+
+    assert len(dispatched) == 1
+    assert dispatched[0]["product"].product_id == "SPS-FIRE"
+    assert manager.state.last_sps_product_ids == {"SPS-FOG", "SPS-FIRE"}
+
+
+# ------------------------------------------------------------------
+# 9. Realistic replay — PHI fire-weather + unrelated active SPS alert
+# ------------------------------------------------------------------
+
+
+def test_realistic_phi_fire_weather_replay(manager, settings_sps_enabled):
+    loc = _location(name="Philadelphia", cwa="PHI")
+    manager._check_sps_new(loc, [], [], settings_sps_enabled)
+
+    dispatched: list[dict] = []
+    manager._dispatch_sps_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    fire_weather = _sps(
+        product_id="PHI-SPS-FW-20260416",
+        headline="Fire Weather Planning Forecast",
+        product_text=(
+            "SPECIAL WEATHER STATEMENT\n"
+            "Fire Weather Planning Forecast\n"
+            "Relative humidity values of 25 to 30 percent will develop...\n"
+        ),
+        issuance_time=datetime(2026, 4, 16, 15, 0, tzinfo=UTC),
+        cwa="PHI",
+    )
+    tstm_event_product = _sps(
+        product_id="PHI-SPS-TSTM-20260416",
+        headline="Strong thunderstorm impacting central counties",
+        product_text=(
+            "SPECIAL WEATHER STATEMENT\n"
+            "Strong thunderstorm impacting central counties.\n"
+            "Hail up to pea size and wind gusts to 40 mph.\n"
+        ),
+        issuance_time=datetime(2026, 4, 16, 16, 0, tzinfo=UTC),
+        cwa="PHI",
+    )
+    # Active alert mirrors the tstm product (Case A).
+    matching_alert = _alert(
+        event="Special Weather Statement",
+        headline="Strong thunderstorm impacting central counties",
+        description="Strong thunderstorm impacting central counties with hail.",
+    )
+
+    manager._check_sps_new(
+        loc,
+        [fire_weather, tstm_event_product],
+        [matching_alert],
+        settings_sps_enabled,
+    )
+
+    # Only fire-weather dispatches; tstm is Case A.
+    assert len(dispatched) == 1
+    assert dispatched[0]["product"].product_id == "PHI-SPS-FW-20260416"
+    # Both IDs recorded.
+    assert manager.state.last_sps_product_ids == {
+        "PHI-SPS-FW-20260416",
+        "PHI-SPS-TSTM-20260416",
+    }
+
+
+# ------------------------------------------------------------------
+# Misc — non-US / no cwa no-ops + empty list mid-lifecycle
+# ------------------------------------------------------------------
+
+
+def test_empty_products_after_cold_start_no_op(manager, settings_sps_enabled):
+    loc = _location()
+    # Seed some IDs.
+    manager._check_sps_new(loc, [_sps(product_id="SPS-1")], [], settings_sps_enabled)
+
+    dispatched: list[dict] = []
+    manager._dispatch_sps_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    # Empty fetch: all prior IDs expire silently.
+    manager._check_sps_new(loc, [], [], settings_sps_enabled)
+    assert dispatched == []
+    assert manager.state.last_sps_product_ids == set()
+
+
+def test_none_products_list_is_no_op(manager, settings_sps_enabled):
+    """Defensive: fetcher returned None → treat as empty, no crash."""
+    loc = _location()
+    dispatched: list[dict] = []
+    manager._dispatch_sps_notification = lambda **kw: dispatched.append(kw)  # type: ignore[attr-defined]
+
+    # Passing None should be tolerated and treated like [].
+    manager._check_sps_new(loc, None, [], settings_sps_enabled)  # type: ignore[arg-type]
+    assert dispatched == []

--- a/tests/test_notification_state_hwo_sps_fields.py
+++ b/tests/test_notification_state_hwo_sps_fields.py
@@ -1,0 +1,93 @@
+"""
+Tests for HWO/SPS fields on :class:`NotificationState`.
+
+Unit 9 adds four new fields to the dataclass — see
+``notification_event_manager.py``. These tests lock in:
+
+- Full round-trip of all four new fields through ``to_dict`` /
+  ``from_dict``, including the ``set[str]`` <-> ``list[str]`` conversion for
+  ``last_sps_product_ids``.
+- Legacy payloads (no HWO/SPS keys) load with the documented defaults and
+  never raise.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from accessiweather.notifications.notification_event_manager import NotificationState
+
+
+def test_default_state_has_hwo_sps_defaults() -> None:
+    """New fields default to None / empty set."""
+    state = NotificationState()
+    assert state.last_hwo_issuance_time is None
+    assert state.last_hwo_text is None
+    assert state.last_hwo_summary_signature is None
+    assert state.last_sps_product_ids == set()
+
+
+def test_to_dict_includes_hwo_sps_fields() -> None:
+    """``to_dict`` emits all four new fields with stable keys."""
+    issuance = datetime(2026, 4, 20, 9, 0, 0, tzinfo=timezone.utc)
+    state = NotificationState(
+        last_hwo_issuance_time=issuance,
+        last_hwo_text="HWO body text",
+        last_hwo_summary_signature="sig-abc-123",
+        last_sps_product_ids={"sps-b", "sps-a", "sps-c"},
+    )
+
+    data = state.to_dict()
+
+    assert data["last_hwo_issuance_time"] == issuance.isoformat()
+    assert data["last_hwo_text"] == "HWO body text"
+    assert data["last_hwo_summary_signature"] == "sig-abc-123"
+    # Sorted for deterministic output — important for JSON diffs.
+    assert data["last_sps_product_ids"] == ["sps-a", "sps-b", "sps-c"]
+
+
+def test_full_round_trip_preserves_hwo_sps_fields() -> None:
+    """Populated HWO/SPS fields round-trip through dict form unchanged."""
+    issuance = datetime(2026, 4, 20, 12, 30, 0, tzinfo=timezone.utc)
+    original = NotificationState(
+        last_hwo_issuance_time=issuance,
+        last_hwo_text="HWO text",
+        last_hwo_summary_signature="sig-xyz",
+        last_sps_product_ids={"sps-1", "sps-2"},
+    )
+
+    restored = NotificationState.from_dict(original.to_dict())
+
+    assert restored.last_hwo_issuance_time == issuance
+    assert restored.last_hwo_text == "HWO text"
+    assert restored.last_hwo_summary_signature == "sig-xyz"
+    # Round-trips back to a set so identity-insensitive membership still works.
+    assert isinstance(restored.last_sps_product_ids, set)
+    assert restored.last_sps_product_ids == {"sps-1", "sps-2"}
+
+
+def test_legacy_payload_without_new_fields_loads_with_defaults() -> None:
+    """State files written before Unit 9 load cleanly with default HWO/SPS values."""
+    legacy_payload = {
+        "last_discussion_issuance_time": None,
+        "last_discussion_text": None,
+        "last_severe_risk": 25,
+        "last_minutely_transition_signature": None,
+        "last_minutely_likelihood_signature": None,
+        "last_check_time": None,
+        # No HWO/SPS keys — the key compatibility property.
+    }
+
+    state = NotificationState.from_dict(legacy_payload)
+
+    assert state.last_severe_risk == 25
+    assert state.last_hwo_issuance_time is None
+    assert state.last_hwo_text is None
+    assert state.last_hwo_summary_signature is None
+    assert state.last_sps_product_ids == set()
+
+
+def test_from_dict_handles_null_sps_list() -> None:
+    """``None`` for ``last_sps_product_ids`` is treated as empty — defensive."""
+    state = NotificationState.from_dict({"last_sps_product_ids": None})
+    assert state.last_sps_product_ids == set()

--- a/tests/test_runtime_state_hwo_sps.py
+++ b/tests/test_runtime_state_hwo_sps.py
@@ -1,0 +1,179 @@
+"""
+Tests for the HWO/SPS runtime-state sub-sections added in Unit 9.
+
+Three coupled changes live in two files:
+
+- ``runtime_state._DEFAULT_RUNTIME_STATE`` gains ``hwo`` and ``sps`` defaults
+  under ``notification_events``.
+- ``NotificationEventManager._runtime_section_to_legacy_shape`` and
+  ``_legacy_shape_to_runtime_section`` translate the new sub-sections to and
+  from the flat ``NotificationState`` field names.
+
+These tests exercise the converters directly (no runtime-state file) and via
+the manager's cache-backed round-trip, covering legacy payloads, populated
+payloads, and round-trip stability for the new HWO/SPS fields.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from accessiweather.notifications.notification_event_manager import (
+    NotificationEventManager,
+    NotificationState,
+)
+from accessiweather.runtime_state import RuntimeStateManager
+
+
+def test_default_runtime_state_has_hwo_sps_sections(tmp_path) -> None:
+    """Fresh runtime-state load exposes the new sub-sections with defaults."""
+    manager = RuntimeStateManager(tmp_path / "config")
+    state = manager.load_state()
+
+    notif = state["notification_events"]
+    assert notif["hwo"] == {
+        "last_issuance_time": None,
+        "last_text": None,
+        "last_summary_signature": None,
+        "last_check_time": None,
+    }
+    assert notif["sps"] == {
+        "last_product_ids": [],
+        "last_check_time": None,
+    }
+
+
+def test_legacy_runtime_state_loads_without_hwo_sps(tmp_path) -> None:
+    """An on-disk runtime-state file missing HWO/SPS loads with defaults."""
+    config_root = tmp_path / "config"
+    state_dir = config_root / "state"
+    state_dir.mkdir(parents=True)
+    # Write a runtime-state file in the shape that existed before Unit 9.
+    legacy_payload = {
+        "schema_version": 1,
+        "alerts": {"schema_version": 1, "alert_states": [], "last_global_notification": None},
+        "notification_events": {
+            "schema_version": 1,
+            "discussion": {
+                "last_issuance_time": "2026-04-20T00:00:00+00:00",
+                "last_text": "legacy AFD",
+                "last_check_time": None,
+            },
+            "severe_risk": {"last_value": 30, "last_check_time": None},
+        },
+        "meta": {"migrated_from": [], "migrated_at": None},
+    }
+    (state_dir / "runtime_state.json").write_text(json.dumps(legacy_payload), encoding="utf-8")
+
+    manager = RuntimeStateManager(config_root)
+    section = manager.load_section("notification_events")
+
+    # Legacy data preserved.
+    assert section["discussion"]["last_text"] == "legacy AFD"
+    assert section["severe_risk"]["last_value"] == 30
+    # New sub-sections filled in from defaults — no KeyError / crash.
+    assert section["hwo"]["last_issuance_time"] is None
+    assert section["sps"]["last_product_ids"] == []
+
+
+def test_legacy_shape_to_runtime_section_emits_hwo_sps() -> None:
+    """Translating a populated legacy dict produces the new sub-sections."""
+    issuance_iso = "2026-04-20T14:00:00+00:00"
+    legacy = {
+        "last_discussion_issuance_time": None,
+        "last_discussion_text": None,
+        "last_severe_risk": None,
+        "last_minutely_transition_signature": None,
+        "last_minutely_likelihood_signature": None,
+        "last_check_time": "2026-04-20T14:30:00+00:00",
+        "last_hwo_issuance_time": issuance_iso,
+        "last_hwo_text": "HWO body",
+        "last_hwo_summary_signature": "sig-1",
+        "last_sps_product_ids": ["sps-b", "sps-a"],
+    }
+
+    section = NotificationEventManager._legacy_shape_to_runtime_section(legacy)
+
+    assert section["hwo"]["last_issuance_time"] == issuance_iso
+    assert section["hwo"]["last_text"] == "HWO body"
+    assert section["hwo"]["last_summary_signature"] == "sig-1"
+    assert section["hwo"]["last_check_time"] == "2026-04-20T14:30:00+00:00"
+    # Product ids are sorted so the on-disk representation is stable.
+    assert section["sps"]["last_product_ids"] == ["sps-a", "sps-b"]
+
+
+def test_runtime_section_to_legacy_shape_extracts_hwo_sps() -> None:
+    """Translating a populated runtime-state section produces legacy-shape keys."""
+    section = {
+        "discussion": {"last_issuance_time": None, "last_text": None, "last_check_time": None},
+        "severe_risk": {"last_value": None, "last_check_time": None},
+        "minutely_precipitation": {
+            "last_transition_signature": None,
+            "last_likelihood_signature": None,
+            "last_check_time": None,
+        },
+        "hwo": {
+            "last_issuance_time": "2026-04-20T09:00:00+00:00",
+            "last_text": "HWO text",
+            "last_summary_signature": "sig-xyz",
+            "last_check_time": None,
+        },
+        "sps": {"last_product_ids": ["sps-1", "sps-2"], "last_check_time": None},
+    }
+
+    legacy = NotificationEventManager._runtime_section_to_legacy_shape(section)
+
+    assert legacy["last_hwo_issuance_time"] == "2026-04-20T09:00:00+00:00"
+    assert legacy["last_hwo_text"] == "HWO text"
+    assert legacy["last_hwo_summary_signature"] == "sig-xyz"
+    assert legacy["last_sps_product_ids"] == ["sps-1", "sps-2"]
+
+
+def test_notification_state_hwo_sps_round_trip_through_converters() -> None:
+    """
+    Full converter chain reconstructs the original HWO/SPS fields.
+
+    NotificationState -> legacy dict -> runtime section -> legacy dict
+    -> NotificationState should be an identity for HWO/SPS data.
+    """
+    issuance = datetime(2026, 4, 20, 15, 0, 0, tzinfo=timezone.utc)
+    original = NotificationState(
+        last_hwo_issuance_time=issuance,
+        last_hwo_text="HWO body",
+        last_hwo_summary_signature="sig-123",
+        last_sps_product_ids={"sps-a", "sps-b"},
+    )
+
+    legacy_dict = original.to_dict()
+    section = NotificationEventManager._legacy_shape_to_runtime_section(legacy_dict)
+    # Simulate a disk round-trip — the runtime-state file is JSON.
+    section = json.loads(json.dumps(section))
+    legacy_again = NotificationEventManager._runtime_section_to_legacy_shape(section)
+    restored = NotificationState.from_dict(legacy_again)
+
+    assert restored.last_hwo_issuance_time == issuance
+    assert restored.last_hwo_text == "HWO body"
+    assert restored.last_hwo_summary_signature == "sig-123"
+    assert restored.last_sps_product_ids == {"sps-a", "sps-b"}
+
+
+def test_manager_persists_hwo_sps_through_runtime_state(tmp_path) -> None:
+    """End-to-end: manager saves HWO/SPS via runtime-state and reloads them."""
+    runtime_manager = RuntimeStateManager(tmp_path / "config")
+    manager = NotificationEventManager(runtime_state_manager=runtime_manager)
+
+    manager.state.last_hwo_issuance_time = datetime(2026, 4, 20, 16, 0, 0, tzinfo=timezone.utc)
+    manager.state.last_hwo_text = "outlook body"
+    manager.state.last_hwo_summary_signature = "sig-persist"
+    manager.state.last_sps_product_ids = {"sps-p-1", "sps-p-2"}
+    manager._save_state()
+
+    # New manager, same state dir — forces a disk read.
+    reloaded_runtime = RuntimeStateManager(tmp_path / "config")
+    reloaded = NotificationEventManager(runtime_state_manager=reloaded_runtime)
+
+    assert reloaded.state.last_hwo_issuance_time == manager.state.last_hwo_issuance_time
+    assert reloaded.state.last_hwo_text == "outlook body"
+    assert reloaded.state.last_hwo_summary_signature == "sig-persist"
+    assert reloaded.state.last_sps_product_ids == {"sps-p-1", "sps-p-2"}

--- a/tests/test_settings_notification_toggles.py
+++ b/tests/test_settings_notification_toggles.py
@@ -1,0 +1,293 @@
+"""
+Tests for Unit 12 — new notification toggles + intro copy rewrite.
+
+Covers:
+1. `AppSettings.notify_hwo_update` / `notify_sps_issued` defaults ON.
+2. Round-trip via `to_dict` / `from_dict` preserving non-default values.
+3. Legacy config (no new keys) loads with both defaults ON.
+4. Settings notifications tab load/save wires both toggles.
+5. Checkbox labels describe intent without relying on nearby context.
+6. Section intro StaticText reflects the two defaults-ON behavior.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from accessiweather.models.config import AppSettings
+
+# ---------------------------------------------------------------------------
+# Dataclass round-trip tests
+# ---------------------------------------------------------------------------
+
+
+def test_new_toggles_default_true_on_fresh_settings():
+    settings = AppSettings()
+    assert settings.notify_hwo_update is True
+    assert settings.notify_sps_issued is True
+
+
+def test_new_toggles_round_trip_defaults_through_dict():
+    original = AppSettings()
+    restored = AppSettings.from_dict(original.to_dict())
+    assert restored.notify_hwo_update is True
+    assert restored.notify_sps_issued is True
+
+
+def test_new_toggles_round_trip_non_default_values():
+    original = AppSettings()
+    original.notify_hwo_update = False
+    original.notify_sps_issued = False
+
+    payload = original.to_dict()
+    assert payload["notify_hwo_update"] is False
+    assert payload["notify_sps_issued"] is False
+
+    restored = AppSettings.from_dict(payload)
+    assert restored.notify_hwo_update is False
+    assert restored.notify_sps_issued is False
+
+
+def test_legacy_config_without_new_keys_loads_both_defaults_on():
+    # Simulate a legacy config dict: anything the user had before, WITHOUT
+    # notify_hwo_update / notify_sps_issued keys.
+    legacy_payload = {
+        "temperature_unit": "both",
+        "notify_discussion_update": True,
+    }
+    restored = AppSettings.from_dict(legacy_payload)
+    assert restored.notify_hwo_update is True
+    assert restored.notify_sps_issued is True
+
+
+def test_new_toggle_keys_are_always_emitted_in_to_dict():
+    # Mirror the notify_discussion_update pattern: always-emit (no conditional).
+    settings = AppSettings()
+    payload = settings.to_dict()
+    assert "notify_hwo_update" in payload
+    assert "notify_sps_issued" in payload
+
+
+def test_new_toggle_deserialization_normalizes_stringy_booleans():
+    # _as_bool should cover legacy/stringy representations.
+    restored = AppSettings.from_dict({"notify_hwo_update": "false", "notify_sps_issued": "0"})
+    assert restored.notify_hwo_update is False
+    assert restored.notify_sps_issued is False
+
+
+# ---------------------------------------------------------------------------
+# Settings notifications tab UI tests (stub-wx based)
+# ---------------------------------------------------------------------------
+
+
+class _DummyControl:
+    def __init__(self) -> None:
+        self._value: bool | int | float = False
+        self._selection = 0
+        self._label = ""
+        self._name = ""
+
+    def SetValue(self, value) -> None:
+        self._value = value
+
+    def GetValue(self):
+        return self._value
+
+    def SetSelection(self, value: int) -> None:
+        self._selection = value
+
+    def GetSelection(self) -> int:
+        return self._selection
+
+    def SetLabel(self, value: str) -> None:
+        self._label = value
+
+    def GetLabel(self) -> str:
+        return self._label
+
+    def SetName(self, value: str) -> None:
+        self._name = value
+
+    def __getattr__(self, _name: str):
+        return lambda *args, **kwargs: None
+
+
+class _Controls(dict):
+    def __missing__(self, key: str) -> _DummyControl:
+        value = _DummyControl()
+        self[key] = value
+        return value
+
+
+class _RecordedCheckBox:
+    """Captures the label= kwarg so tests can assert accessibility naming."""
+
+    instances: list[_RecordedCheckBox] = []
+
+    def __init__(self, _parent, label: str = "", **_kwargs):
+        self.label = label
+        self._value = False
+        self.__class__.instances.append(self)
+
+    def SetValue(self, value) -> None:
+        self._value = bool(value)
+
+    def GetValue(self) -> bool:
+        return self._value
+
+    def SetName(self, _value: str) -> None:
+        return None
+
+    def __getattr__(self, _name: str):
+        return lambda *args, **kwargs: None
+
+
+class _RecordedStaticText:
+    """Captures label= kwarg so tests can assert intro-copy substrings."""
+
+    instances: list[_RecordedStaticText] = []
+
+    def __init__(self, _parent, label: str = "", **_kwargs):
+        self.label = label
+        self.__class__.instances.append(self)
+
+    def __getattr__(self, _name: str):
+        return lambda *args, **kwargs: None
+
+
+class _FakeSizer:
+    def __init__(self) -> None:
+        self.children: list = []
+
+    def Add(self, item, *args, **kwargs) -> None:
+        self.children.append(item)
+
+
+class _FakeDialog:
+    """Minimal stand-in for the parent settings dialog."""
+
+    def __init__(self) -> None:
+        self._controls: dict = _Controls()
+        self.notebook = MagicMock()
+        self.sections: list[tuple[str, str | None]] = []
+
+    def add_help_text(self, _parent, parent_sizer, text, **_kwargs):
+        st = _RecordedStaticText(_parent, label=text)
+        parent_sizer.Add(st)
+        return st
+
+    def create_section(self, _parent, _parent_sizer, title, description=None):
+        # Mirror real behavior: description is not rendered automatically.
+        self.sections.append((title, description))
+        return _FakeSizer()
+
+    def add_labeled_control_row(self, parent, parent_sizer, _label, control_factory, **_kwargs):
+        ctrl = control_factory(parent)
+        parent_sizer.Add(ctrl)
+        return ctrl
+
+    def _on_alert_advanced(self, *_a, **_kw):
+        return None
+
+
+@pytest.fixture
+def notifications_tab_panel(monkeypatch):
+    """Render the Notifications tab with recorded wx widgets."""
+    # Reset per-test capture lists.
+    _RecordedCheckBox.instances = []
+    _RecordedStaticText.instances = []
+
+    import wx as _wx
+
+    from accessiweather.ui.dialogs.settings_tabs import notifications as notif_mod
+
+    # Patch the wx symbols the module uses via attribute access.
+    monkeypatch.setattr(notif_mod.wx, "CheckBox", _RecordedCheckBox, raising=False)
+    monkeypatch.setattr(notif_mod.wx, "StaticText", _RecordedStaticText, raising=False)
+    monkeypatch.setattr(notif_mod.wx, "BoxSizer", lambda *_a, **_kw: _FakeSizer(), raising=False)
+    monkeypatch.setattr(notif_mod.wx, "ScrolledWindow", MagicMock(), raising=False)
+    monkeypatch.setattr(notif_mod.wx, "SpinCtrl", MagicMock(), raising=False)
+    monkeypatch.setattr(notif_mod.wx, "Choice", MagicMock(), raising=False)
+    monkeypatch.setattr(notif_mod.wx, "Button", MagicMock(), raising=False)
+
+    # wx constants referenced as flags — harmless integers suffice.
+    for const in (
+        "LEFT",
+        "RIGHT",
+        "TOP",
+        "BOTTOM",
+        "ALL",
+        "EXPAND",
+        "HORIZONTAL",
+        "VERTICAL",
+        "ALIGN_CENTER_VERTICAL",
+        "EVT_BUTTON",
+    ):
+        if not hasattr(notif_mod.wx, const):
+            setattr(notif_mod.wx, const, 0)
+
+    _ = _wx  # keep import for side effects (conftest wx stub setup)
+
+    dialog = _FakeDialog()
+    tab = notif_mod.NotificationsTab(dialog)
+    tab.create()
+    return tab, dialog
+
+
+def test_tab_creates_hwo_and_sps_checkboxes_with_descriptive_labels(
+    notifications_tab_panel,
+):
+    tab, dialog = notifications_tab_panel
+    controls = dialog._controls
+
+    assert "notify_hwo_update" in controls
+    assert "notify_sps_issued" in controls
+
+    hwo_ctrl = controls["notify_hwo_update"]
+    sps_ctrl = controls["notify_sps_issued"]
+
+    # Accessibility: labels describe intent standalone (screen readers read
+    # these directly). Match the exact copy from the plan.
+    assert hwo_ctrl.label == "Notify on Hazardous Weather Outlook updates"
+    assert sps_ctrl.label == "Notify on Special Weather Statement (informational)"
+
+
+def test_tab_intro_copy_reflects_defaults_on_behavior(notifications_tab_panel):
+    _tab, _dialog = notifications_tab_panel
+
+    intro_labels = [st.label for st in _RecordedStaticText.instances]
+    joined = "\n".join(intro_labels)
+
+    # The rewritten intro must explicitly name HWO + SPS and say they default ON.
+    assert "Hazardous Weather Outlook" in joined
+    assert "Special Weather Statement" in joined
+    assert "on by default" in joined
+    # And preserve the old "others are off unless you turn them on" nuance.
+    assert "off unless you turn them on" in joined
+
+
+def test_load_populates_new_toggles_from_settings(notifications_tab_panel):
+    tab, dialog = notifications_tab_panel
+
+    settings = AppSettings()
+    settings.notify_hwo_update = True
+    settings.notify_sps_issued = False
+
+    tab.load(settings)
+
+    assert dialog._controls["notify_hwo_update"].GetValue() is True
+    assert dialog._controls["notify_sps_issued"].GetValue() is False
+
+
+def test_save_round_trips_new_toggle_state(notifications_tab_panel):
+    tab, dialog = notifications_tab_panel
+
+    dialog._controls["notify_hwo_update"].SetValue(False)
+    dialog._controls["notify_sps_issued"].SetValue(True)
+
+    payload = tab.save()
+
+    assert payload["notify_hwo_update"] is False
+    assert payload["notify_sps_issued"] is True

--- a/tests/test_split_notification_timers.py
+++ b/tests/test_split_notification_timers.py
@@ -400,6 +400,7 @@ class TestNotificationEventHelpers:
         settings.notify_severe_risk_change = False
         settings.notify_minutely_precipitation_start = False
         settings.notify_minutely_precipitation_stop = False
+        settings.notify_hwo_update = False
         win.app.config_manager.get_settings.return_value = settings
 
         win._process_notification_events(MagicMock())

--- a/tests/test_split_notification_timers.py
+++ b/tests/test_split_notification_timers.py
@@ -401,6 +401,7 @@ class TestNotificationEventHelpers:
         settings.notify_minutely_precipitation_start = False
         settings.notify_minutely_precipitation_stop = False
         settings.notify_hwo_update = False
+        settings.notify_sps_issued = False
         win.app.config_manager.get_settings.return_value = settings
 
         win._process_notification_events(MagicMock())

--- a/tests/test_weather_client_nws_text_product.py
+++ b/tests/test_weather_client_nws_text_product.py
@@ -1,0 +1,315 @@
+"""
+Tests for the generic NWS text-product fetcher.
+
+Covers:
+- ``get_nws_text_product`` for AFD / HWO / SPS
+- ``TextProductFetchError`` signalling network / non-200 failures
+- ``get_nws_discussion`` backward-compat wrapper preserves its tuple shape
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from accessiweather.models import TextProduct
+from accessiweather.weather_client_nws import (
+    TextProductFetchError,
+    get_nws_discussion,
+    get_nws_text_product,
+)
+
+NWS_BASE = "https://api.weather.gov"
+OFFICE = "PHI"
+
+
+def _resp(json_data, status_code: int = 200) -> MagicMock:
+    """Build a synchronous mock httpx.Response with status_code + json()."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _resp_error(status_code: int = 500) -> MagicMock:
+    """Mock response whose raise_for_status raises HTTPStatusError."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    err = httpx.HTTPStatusError(f"HTTP {status_code}", request=MagicMock(), response=resp)
+    resp.raise_for_status.side_effect = err
+    return resp
+
+
+def _client_for(responses: dict) -> MagicMock:
+    """Mock AsyncClient dispatching on URL."""
+
+    def side_effect(url, **_kwargs):
+        if url in responses:
+            return responses[url]
+        return _resp({}, status_code=404)
+
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.get.side_effect = side_effect
+    return client
+
+
+# ---------------------------------------------------------------------------
+# AFD happy path
+# ---------------------------------------------------------------------------
+
+
+class TestGetNwsTextProductAFD:
+    @pytest.mark.asyncio
+    async def test_afd_returns_single_text_product(self):
+        graph = {
+            "@graph": [
+                {
+                    "id": "afd-001",
+                    "issuanceTime": "2026-04-16T14:32:00+00:00",
+                }
+            ]
+        }
+        product = {
+            "productText": "AREA FORECAST DISCUSSION...\nSYNOPSIS...\n",
+            "issuanceTime": "2026-04-16T14:32:00+00:00",
+        }
+        client = _client_for(
+            {
+                f"{NWS_BASE}/products/types/AFD/locations/{OFFICE}": _resp(graph),
+                f"{NWS_BASE}/products/afd-001": _resp(product),
+            }
+        )
+
+        result = await get_nws_text_product("AFD", OFFICE, nws_base_url=NWS_BASE, client=client)
+
+        assert isinstance(result, TextProduct)
+        assert result.product_type == "AFD"
+        assert result.product_id == "afd-001"
+        assert result.cwa_office == OFFICE
+        assert "AREA FORECAST DISCUSSION" in result.product_text
+        assert result.issuance_time == datetime(2026, 4, 16, 14, 32, 0, tzinfo=timezone.utc)
+
+    @pytest.mark.asyncio
+    async def test_afd_empty_graph_returns_none(self):
+        client = _client_for(
+            {
+                f"{NWS_BASE}/products/types/AFD/locations/{OFFICE}": _resp({"@graph": []}),
+            }
+        )
+
+        result = await get_nws_text_product("AFD", OFFICE, nws_base_url=NWS_BASE, client=client)
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# HWO happy path
+# ---------------------------------------------------------------------------
+
+
+class TestGetNwsTextProductHWO:
+    @pytest.mark.asyncio
+    async def test_hwo_returns_single_text_product(self):
+        graph = {
+            "@graph": [
+                {"id": "hwo-001", "issuanceTime": "2026-04-16T10:00:00+00:00"},
+            ]
+        }
+        product = {
+            "productText": "HAZARDOUS WEATHER OUTLOOK\n...\n",
+            "issuanceTime": "2026-04-16T10:00:00+00:00",
+        }
+        client = _client_for(
+            {
+                f"{NWS_BASE}/products/types/HWO/locations/{OFFICE}": _resp(graph),
+                f"{NWS_BASE}/products/hwo-001": _resp(product),
+            }
+        )
+
+        result = await get_nws_text_product("HWO", OFFICE, nws_base_url=NWS_BASE, client=client)
+
+        assert isinstance(result, TextProduct)
+        assert result.product_type == "HWO"
+        assert result.product_id == "hwo-001"
+        assert result.cwa_office == OFFICE
+        assert "HAZARDOUS WEATHER" in result.product_text
+
+
+# ---------------------------------------------------------------------------
+# SPS — always returns a list, possibly empty, sorted newest-first
+# ---------------------------------------------------------------------------
+
+
+class TestGetNwsTextProductSPS:
+    @pytest.mark.asyncio
+    async def test_sps_three_products_sorted_newest_first(self):
+        # Intentionally out-of-order in the @graph so we can verify sorting.
+        graph = {
+            "@graph": [
+                {"id": "sps-middle", "issuanceTime": "2026-04-16T12:00:00+00:00"},
+                {"id": "sps-newest", "issuanceTime": "2026-04-16T14:00:00+00:00"},
+                {"id": "sps-oldest", "issuanceTime": "2026-04-16T10:00:00+00:00"},
+            ]
+        }
+        client = _client_for(
+            {
+                f"{NWS_BASE}/products/types/SPS/locations/{OFFICE}": _resp(graph),
+                f"{NWS_BASE}/products/sps-middle": _resp(
+                    {
+                        "productText": "SPS middle",
+                        "issuanceTime": "2026-04-16T12:00:00+00:00",
+                    }
+                ),
+                f"{NWS_BASE}/products/sps-newest": _resp(
+                    {
+                        "productText": "SPS newest",
+                        "issuanceTime": "2026-04-16T14:00:00+00:00",
+                    }
+                ),
+                f"{NWS_BASE}/products/sps-oldest": _resp(
+                    {
+                        "productText": "SPS oldest",
+                        "issuanceTime": "2026-04-16T10:00:00+00:00",
+                    }
+                ),
+            }
+        )
+
+        result = await get_nws_text_product("SPS", OFFICE, nws_base_url=NWS_BASE, client=client)
+
+        assert isinstance(result, list)
+        assert len(result) == 3
+        # Newest first.
+        assert result[0].product_id == "sps-newest"
+        assert result[1].product_id == "sps-middle"
+        assert result[2].product_id == "sps-oldest"
+        for tp in result:
+            assert tp.product_type == "SPS"
+            assert tp.cwa_office == OFFICE
+
+    @pytest.mark.asyncio
+    async def test_sps_empty_graph_returns_empty_list(self):
+        client = _client_for(
+            {
+                f"{NWS_BASE}/products/types/SPS/locations/{OFFICE}": _resp({"@graph": []}),
+            }
+        )
+
+        result = await get_nws_text_product("SPS", OFFICE, nws_base_url=NWS_BASE, client=client)
+
+        assert result == []
+        assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestGetNwsTextProductEdgeCases:
+    @pytest.mark.asyncio
+    async def test_empty_office_returns_none_no_http(self):
+        client = MagicMock(spec=httpx.AsyncClient)
+
+        result = await get_nws_text_product("AFD", "", nws_base_url=NWS_BASE, client=client)
+
+        assert result is None
+        client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_none_office_returns_none_no_http(self):
+        client = MagicMock(spec=httpx.AsyncClient)
+
+        result = await get_nws_text_product("AFD", None, nws_base_url=NWS_BASE, client=client)
+
+        assert result is None
+        client.get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Error paths — TextProductFetchError
+# ---------------------------------------------------------------------------
+
+
+class TestGetNwsTextProductErrors:
+    @pytest.mark.asyncio
+    async def test_http_500_raises_fetch_error(self):
+        client = _client_for(
+            {
+                f"{NWS_BASE}/products/types/AFD/locations/{OFFICE}": _resp_error(500),
+            }
+        )
+
+        with pytest.raises(TextProductFetchError):
+            await get_nws_text_product("AFD", OFFICE, nws_base_url=NWS_BASE, client=client)
+
+    @pytest.mark.asyncio
+    async def test_timeout_raises_fetch_error(self):
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.get.side_effect = httpx.TimeoutException("timed out")
+
+        with pytest.raises(TextProductFetchError):
+            await get_nws_text_product("AFD", OFFICE, nws_base_url=NWS_BASE, client=client)
+
+
+# ---------------------------------------------------------------------------
+# Regression: get_nws_discussion wrapper preserves old tuple shape
+# ---------------------------------------------------------------------------
+
+
+class TestGetNwsDiscussionBackwardCompat:
+    @pytest.mark.asyncio
+    async def test_get_nws_discussion_returns_tuple(self):
+        """Wrapper must still return (text, issuance_time) tuple for existing callers."""
+        graph = {
+            "@graph": [
+                {"id": "afd-back", "issuanceTime": "2026-04-16T14:32:00+00:00"},
+            ]
+        }
+        product = {
+            "productText": "WRAPPER TEST DISCUSSION TEXT",
+            "issuanceTime": "2026-04-16T14:32:00+00:00",
+        }
+        grid_data = {
+            "properties": {
+                "forecast": f"{NWS_BASE}/gridpoints/{OFFICE}/36,38/forecast",
+            }
+        }
+        client = _client_for(
+            {
+                f"{NWS_BASE}/products/types/AFD/locations/{OFFICE}": _resp(graph),
+                f"{NWS_BASE}/products/afd-back": _resp(product),
+            }
+        )
+        headers = {"User-Agent": "Test/1.0"}
+
+        text, issuance_time = await get_nws_discussion(client, headers, grid_data, NWS_BASE)
+
+        assert text == "WRAPPER TEST DISCUSSION TEXT"
+        assert issuance_time == datetime(2026, 4, 16, 14, 32, 0, tzinfo=timezone.utc)
+
+    @pytest.mark.asyncio
+    async def test_get_nws_discussion_empty_graph_returns_fallback_string(self):
+        """When no AFD products exist, wrapper returns the legacy fallback string."""
+        grid_data = {
+            "properties": {
+                "forecast": f"{NWS_BASE}/gridpoints/{OFFICE}/36,38/forecast",
+            }
+        }
+        client = _client_for(
+            {
+                f"{NWS_BASE}/products/types/AFD/locations/{OFFICE}": _resp({"@graph": []}),
+            }
+        )
+        headers = {"User-Agent": "Test/1.0"}
+
+        text, issuance_time = await get_nws_discussion(client, headers, grid_data, NWS_BASE)
+
+        # Previous behavior: returned a non-None fallback string and None issuance.
+        assert isinstance(text, str)
+        assert text != ""
+        assert issuance_time is None


### PR DESCRIPTION
## What this delivers

Phase B of bundled PR 1. Stacked on top of [#612](https://github.com/Orinks/AccessiWeather/pull/612) (Phase A — zone metadata data layer). Together they complete the Forecast Products feature described in the two brainstorms landed with the plan.

Users get:
- A per-location **Forecast Products** dialog (replacing the old "Discussion" entry point) with three tabs: Area Forecast Discussion, Hazardous Weather Outlook, and Special Weather Statement.
- **HWO update notifications** — fire when a WFO issues a new or updated Hazardous Weather Outlook. Default ON.
- **Informational SPS notifications** — fire for fire-weather statements, pollen advisories, and other SPS products that live on `/products/types/SPS` but never reach the `/alerts/active` feed (Case B per the live-API verification documented in the brainstorm). Event-style SPS (Case A — hail, dense fog, etc.) are suppressed because the existing alert pipeline already surfaces them. Default ON.
- **Plain Language Summary** button on each tab, powered by the same AI explainer that already supports AFD.
- **Non-US locations** get the Forecast Products button disabled with an adjacent "NWS products are US-only" StaticText (adjacent-StaticText accessibility pattern).

Zero new dependencies. No config `schema_version` bump. Every new field is additive.

## Why a stacked draft

Phase A on #612 is self-contained and reviewable on its own. Phase B builds on top of it. Target base: `feat/forecast-products-pr1`. When #612 merges to `main`, this PR's base should be flipped to `main`.

## Commit-by-commit

| Commit | Unit | Delivers |
|--------|------|----------|
| `fd8839e` | 6 | Generalized `get_nws_text_product` fetcher + `ForecastProductService` with per-type TTL cache (AFD 1h, HWO 2h, SPS 15min). `get_nws_discussion` becomes a thin wrapper — existing AFD callers unchanged. |
| `e9cf8af` | 7 | `AIExplainer.explain_text_product` with per-product system prompts + 300s result cache. `explain_afd` becomes a thin wrapper; AFD behavior preserved byte-for-byte. |
| `dfda206` | 8 | `ForecastProductPanel` reusable wx.Panel + `ForecastProductsDialog` wx.Notebook. Main window: rename, Nationwide branch preserved, non-US button disabled with adjacent StaticText. |
| `86a5537` | 9 | Background pre-warm on refresh (active + all saved US locations). `NotificationState` + `runtime_state` extensions for HWO/SPS. `WeatherAlert.affected_zones` additive field. |
| `1bd7d34` | 10 | HWO update notification stream with cold-start baseline, sliding 30-min rate limit, summarizer-or-generic body. Gated by `notify_hwo_update`. |
| `6bc24a6` | 11 | SPS notification stream with Case A / Case B dedupe against active alerts (headline substring match). Silent cold-start and silent expiration. Gated by `notify_sps_issued`. |
| `1a52243` | 12 | `notify_hwo_update` + `notify_sps_issued` on `AppSettings` (default True) + Settings UI toggles + intro copy rewrite to honestly describe defaults-ON behavior. |

## Design decisions worth noting

- **SPS dedupe is heuristic, not zone-based.** `TextProduct` doesn't carry zone data; deriving it would require fetcher changes. Headline substring matching against active `Special Weather Statement` alerts turned out to be sufficient for the Case A / Case B split the brainstorm identified. Both the verified PHI 2026-04-16 fire-weather SPS (Case B) and a matching event-style SPS alert replay cleanly.
- **Rate limiting uses a sliding window, not a calendar bucket.** `docs/alert_audit_report.md §7` flagged that the existing alert rate-limit's calendar-hour reset can burst 10 notifications at 12:00:01. PR 1's new HWO/SPS streams don't repeat that mistake — the 30-min-per-(stream, location) dict compares timestamps directly.
- **Cold-start silent baseline.** First fetch for any product type on any location records state without firing a notification. Prevents notification storms on fresh install, newly added locations, or reopen-after-absence.
- **`wx.Notebook` can't per-tab disable on Windows.** All empty and error states render inside the content panel, not as a tab label. Tab switch focus is managed via `EVT_NOTEBOOK_PAGE_CHANGED` + `wx.CallAfter`.
- **AI visibility pattern mirrored.** Each tab's "Plain Language Summary" button starts hidden; reveal is one-click. Matches `docs/superpowers/specs/2026-04-08-discussion-dialog-ai-visibility-design.md`.
- **Defaults ON for HWO and SPS notifications.** Both streams deliver information not already visible elsewhere — HWO's 7-day hazard horizon doesn't appear in alerts; Case B SPS is completely invisible today. Intro copy honestly tells users this behavior.

## Testing

Per-unit test files (all new):
- `tests/test_weather_client_nws_text_product.py` (11 scenarios)
- `tests/test_forecast_product_service.py` (6)
- `tests/test_ai_explainer_text_product.py` (9)
- `tests/gui/test_forecast_product_panel.py` (19)
- `tests/gui/test_forecast_products_dialog.py` (8)
- `tests/test_main_window_product_prewarm.py` (8)
- `tests/test_notification_state_hwo_sps_fields.py` (5)
- `tests/test_runtime_state_hwo_sps.py` (6)
- `tests/test_cache_weather_alert_affected_zones.py` (3)
- `tests/test_notification_hwo_update.py` (14)
- `tests/test_notification_sps_dedupe.py` (14)
- `tests/test_settings_notification_toggles.py` (10)

**113 new tests + zero AFD / existing regressions.** Full non-integration sweep: 3617 passed, 5 skipped. The 4 `test_alert_dialog_dispatch` parallel flakes pre-date this branch and pass when run standalone (xdist worker isolation quirk, not a real regression).

## Manual test plan

- [ ] Add a US location, open Forecast Products → three tabs pre-populated with AFD / HWO / SPS for the CWA office
- [ ] Switch tabs with keyboard → focus lands in each tab's TextCtrl; screen reader announces the raw product text
- [ ] Click "Plain Language Summary" on each tab → AI output appears; Regenerate works
- [ ] Verify SPS tab with multiple active advisories shows the `wx.Choice` selector; single SPS hides it
- [ ] Verify SPS tab with no active advisories shows "No Special Weather Statements currently active for {CWA}"
- [ ] Add a non-US location, select it → Forecast Products button disables; adjacent StaticText "NWS products are US-only" appears
- [ ] Close the app for a few hours, reopen → no notification storm
- [ ] Settings → Notifications tab shows two new toggles checked by default with the new intro copy
- [ ] Toggle each off and verify the corresponding stream stops firing
- [ ] Verify the existing "Discussion" AFD notification behavior is unchanged

## Known deferrals intentionally out of scope

- `ConfigManager.save_config` in-process lock — tracked as follow-up from Phase A.
- Zone-based SPS dedupe (instead of headline substring match) — can be added later if the heuristic proves inadequate.
- AI summary prompts for HWO / SPS may want tuning against live products (deferred-to-implementation item in the plan; picked reasonable defaults).