### PR TITLE
fix(tests): stop leaking test values into developer keyring

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -432,8 +432,8 @@ def _isolate_keyring_from_real_backend():
 
     fake_store: dict[tuple[str, str], str] = {}
     fake_keyring = MagicMock()
-    fake_keyring.set_password.side_effect = (
-        lambda service, username, password: fake_store.__setitem__((service, username), password)
+    fake_keyring.set_password.side_effect = lambda service, username, password: (
+        fake_store.__setitem__((service, username), password)
     )
     fake_keyring.get_password.side_effect = lambda service, username: fake_store.get(
         (service, username)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -411,3 +411,43 @@ def _mock_keyring_available():
     ss._keyring_available = True
     yield
     ss._keyring_available = original
+
+
+# ---------------------------------------------------------------------------
+# Keyring isolation: prevent tests from ever touching the real system keyring.
+# Tests that need to assert on set/get/delete should patch `_get_keyring` or
+# `SecureStorage.*_password` explicitly — those explicit patches shadow this
+# autouse one. Without this safety net, a single missing @patch (see the
+# 2026-04-20 "secret_key" pirate_weather_api_key pollution incident) leaks
+# literal test values into the developer's system keyring across installs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_keyring_from_real_backend():
+    """Route all SecureStorage calls through an in-memory fake keyring."""
+    from unittest.mock import MagicMock
+
+    import accessiweather.config.secure_storage as ss
+
+    fake_store: dict[tuple[str, str], str] = {}
+    fake_keyring = MagicMock()
+    fake_keyring.set_password.side_effect = (
+        lambda service, username, password: fake_store.__setitem__((service, username), password)
+    )
+    fake_keyring.get_password.side_effect = lambda service, username: fake_store.get(
+        (service, username)
+    )
+    fake_keyring.delete_password.side_effect = lambda service, username: fake_store.pop(
+        (service, username), None
+    )
+
+    original_module = ss._keyring_module
+    original_checked = ss._keyring_checked
+    ss._keyring_module = fake_keyring
+    ss._keyring_checked = True
+    try:
+        yield fake_keyring
+    finally:
+        ss._keyring_module = original_module
+        ss._keyring_checked = original_checked

--- a/tests/test_settings_operations.py
+++ b/tests/test_settings_operations.py
@@ -374,8 +374,11 @@ class TestUpdateSettings:
 
         assert result is False
 
-    def test_redacted_logging(self, operations, mock_manager):
+    @patch("accessiweather.config.settings.SecureStorage.set_password")
+    def test_redacted_logging(self, mock_set_password, operations, mock_manager):
         """Test that sensitive values are redacted in logs."""
+        mock_set_password.return_value = True
+
         operations.update_settings(pirate_weather_api_key="secret_key")
 
         logger = mock_manager._get_logger.return_value


### PR DESCRIPTION
New AccessiWeather installs on a machine that had run the test suite showed `secret_key` pre-filled in the Pirate Weather provider field. The Settings dialog was fine — the developer's Windows Credential Manager actually contained the literal string `secret_key` under service `accessiweather`, username `pirate_weather_api_key`, and the production load path (`LazySecureStorage` → keyring) faithfully read it back on every new install.

The source was [tests/test_settings_operations.py](tests/test_settings_operations.py): `test_redacted_logging` called `operations.update_settings(pirate_weather_api_key="secret_key")` without patching `SecureStorage.set_password`, so every local `pytest` run committed `secret_key` to the real keyring. Its sibling `test_update_secure_setting` right above it already used `@patch("accessiweather.config.settings.SecureStorage.set_password")` — the redaction test was a copy-paste miss. Visual Crossing and OpenRouter escaped only because no equivalent unmocked test ever ran for them.

The existing autouse `_mock_keyring_available` fixture in [tests/conftest.py](tests/conftest.py) faked the availability probe but never intercepted writes, so it offered no protection.

This PR fixes both layers:

- Add the missing `@patch("accessiweather.config.settings.SecureStorage.set_password")` to `test_redacted_logging`.
- Add an autouse `_isolate_keyring_from_real_backend` fixture in `tests/conftest.py` that swaps `accessiweather.config.secure_storage._keyring_module` with an in-memory fake for every test. Explicit `@patch` of `_get_keyring` or `SecureStorage.*_password` in individual tests still wins, so `test_secure_storage.py`, `test_portable_secrets.py`, and the startup-guidance suite keep passing unchanged.

Impact is limited to developers who ran the test suite locally. CI runners use ephemeral backends and end users never run these tests, so published installers and fresh user installs were never affected. The already-polluted `pirate_weather_api_key` (and an unrelated `avwx_api_key` with a pasted \`gh pr checkout 480\` string) were cleared from the developer's keyring during investigation.

## Test plan

- \`pytest tests/test_settings_operations.py\` — 38 pass, including the newly-patched \`test_redacted_logging\`.
- \`pytest tests/test_secure_storage.py tests/test_portable_secrets.py tests/test_settings_dialog_api_key_guard.py tests/test_config_manager.py tests/test_startup_guidance_prompts.py\` — 95 pass, confirming the autouse fixture does not interfere with tests that explicitly patch \`_get_keyring\` or \`SecureStorage\`.
- After both test runs, \`keyring.get_password("accessiweather", "pirate_weather_api_key")\` still returns \`None\` — the isolation holds.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)