### PR TITLE
fix(weather): prefer provider-native time metadata

### DIFF
--- a/src/accessiweather/pirate_weather_client.py
+++ b/src/accessiweather/pirate_weather_client.py
@@ -412,8 +412,7 @@ class PirateWeatherClient:
         daily_data = data.get("daily", {}).get("data", [])
         if daily_data:
             today = daily_data[0]
-            tz_offset = data.get("offset", 0)
-            location_tz = timezone(timedelta(hours=tz_offset))
+            location_tz = _resolve_response_timezone(data)
             sr = today.get("sunriseTime")
             ss = today.get("sunsetTime")
             if sr:
@@ -555,8 +554,7 @@ class PirateWeatherClient:
     def _parse_hourly_forecast(self, data: dict) -> HourlyForecast:
         """Parse Pirate Weather ``hourly`` block into an HourlyForecast."""
         hourly_items = data.get("hourly", {}).get("data", [])
-        tz_offset = data.get("offset", 0)
-        location_tz = timezone(timedelta(hours=tz_offset))
+        location_tz = _resolve_response_timezone(data)
         using_us = self.units == "us"
 
         periods: list[HourlyForecastPeriod] = []
@@ -692,8 +690,7 @@ class PirateWeatherClient:
         raw_alerts = data.get("alerts", [])
         alerts: list[WeatherAlert] = []
 
-        tz_offset = data.get("offset", 0)
-        location_tz = timezone(timedelta(hours=tz_offset))
+        location_tz = _resolve_response_timezone(data)
 
         for _i, alert_data in enumerate(raw_alerts):
             title = alert_data.get("title") or "Weather Alert"

--- a/src/accessiweather/visual_crossing_client.py
+++ b/src/accessiweather/visual_crossing_client.py
@@ -420,8 +420,8 @@ class VisualCrossingClient:
         """Parse Visual Crossing current conditions data."""
         current = data.get("currentConditions", {})
 
-        # Get timezone offset from API response for creating timezone-aware datetimes
-        # Visual Crossing returns tzoffset as hours (e.g., -5.0 for EST)
+        # Get timezone offset from API response for creating timezone-aware datetimes.
+        # Visual Crossing returns tzoffset as hours (e.g., -5.0 for EST).
         tz_offset_hours = data.get("tzoffset", 0)
         location_tz = timezone(timedelta(hours=tz_offset_hours))
 
@@ -461,21 +461,30 @@ class VisualCrossingClient:
         days = data.get("days", [])
         if days:
             day_data = days[0]
-            # Get the date for combining with time strings
+            # Prefer provider-supplied epoch fields. They already encode the
+            # instant, avoiding local date/time reconstruction around DST.
             date_str = day_data.get("datetime", "")
+            sunrise_time = self._parse_vc_epoch(day_data.get("sunriseEpoch"), location_tz)
+            sunset_time = self._parse_vc_epoch(day_data.get("sunsetEpoch"), location_tz)
+            moonrise_time = self._parse_vc_epoch(day_data.get("moonriseEpoch"), location_tz)
+            moonset_time = self._parse_vc_epoch(day_data.get("moonsetEpoch"), location_tz)
 
-            # Parse sun/moon times from string format (already in local time)
-            # Visual Crossing returns times like "07:08:45" in the location's timezone
-            sunrise_time = self._parse_vc_time_string(
-                date_str, day_data.get("sunrise"), location_tz
-            )
-            sunset_time = self._parse_vc_time_string(date_str, day_data.get("sunset"), location_tz)
-            moonrise_time = self._parse_vc_time_string(
-                date_str, day_data.get("moonrise"), location_tz
-            )
-            moonset_time = self._parse_vc_time_string(
-                date_str, day_data.get("moonset"), location_tz
-            )
+            if sunrise_time is None:
+                sunrise_time = self._parse_vc_time_string(
+                    date_str, day_data.get("sunrise"), location_tz
+                )
+            if sunset_time is None:
+                sunset_time = self._parse_vc_time_string(
+                    date_str, day_data.get("sunset"), location_tz
+                )
+            if moonrise_time is None:
+                moonrise_time = self._parse_vc_time_string(
+                    date_str, day_data.get("moonrise"), location_tz
+                )
+            if moonset_time is None:
+                moonset_time = self._parse_vc_time_string(
+                    date_str, day_data.get("moonset"), location_tz
+                )
 
             moon_phase = describe_moon_phase(day_data.get("moonphase"))
 
@@ -869,4 +878,15 @@ class VisualCrossingClient:
             return dt.replace(tzinfo=tz)
         except (ValueError, TypeError) as e:
             logger.debug(f"Failed to parse VC time '{date_str}T{time_str}': {e}")
+            return None
+
+    def _parse_vc_epoch(self, epoch_value: object, tz: timezone) -> datetime | None:
+        """Parse a Visual Crossing epoch timestamp into the response timezone."""
+        if epoch_value is None:
+            return None
+
+        try:
+            return datetime.fromtimestamp(float(epoch_value), tz=tz)
+        except (OSError, OverflowError, TypeError, ValueError) as e:
+            logger.debug("Failed to parse VC epoch %r: %s", epoch_value, e)
             return None

--- a/tests/test_pirate_weather_client.py
+++ b/tests/test_pirate_weather_client.py
@@ -213,6 +213,26 @@ class TestParseCurrentConditions:
         assert result.sunrise_time is not None
         assert result.sunset_time is not None
 
+    def test_current_sunrise_uses_response_timezone_name(self, client, sample_forecast_payload):
+        """IANA timezone from PW should override the fixed offset fallback."""
+        payload = dict(sample_forecast_payload)
+        payload["timezone"] = "Europe/London"
+        payload["offset"] = 0
+        payload["daily"] = {
+            "data": [
+                {
+                    **sample_forecast_payload["daily"]["data"][0],
+                    "sunriseTime": int(datetime(2025, 7, 1, 4, 0, tzinfo=UTC).timestamp()),
+                }
+            ]
+        }
+
+        result = client._parse_current_conditions(payload)
+
+        assert result.sunrise_time is not None
+        assert getattr(result.sunrise_time.tzinfo, "key", None) == "Europe/London"
+        assert result.sunrise_time.utcoffset() == timedelta(hours=1)
+
     def test_missing_currently_block(self, client):
         data = {"offset": 0, "daily": {"data": []}}
         result = client._parse_current_conditions(data)
@@ -448,6 +468,21 @@ class TestParseHourlyForecast:
         result = client._parse_hourly_forecast(sample_forecast_payload)
         assert result.periods[0].start_time.tzinfo is not None
 
+    def test_hourly_start_time_uses_response_timezone_name(self, client, sample_forecast_payload):
+        """Hourly epoch timestamps should be localized with PW's timezone name."""
+        payload = dict(sample_forecast_payload)
+        payload["timezone"] = "Europe/London"
+        payload["offset"] = 0
+        hour = dict(sample_forecast_payload["hourly"]["data"][0])
+        hour["time"] = int(datetime(2025, 7, 1, 12, 0, tzinfo=UTC).timestamp())
+        payload["hourly"] = {"data": [hour]}
+
+        result = client._parse_hourly_forecast(payload)
+
+        start_time = result.periods[0].start_time
+        assert getattr(start_time.tzinfo, "key", None) == "Europe/London"
+        assert start_time.utcoffset() == timedelta(hours=1)
+
     def test_pressure_conversion(self, client, sample_forecast_payload):
         result = client._parse_hourly_forecast(sample_forecast_payload)
         period = result.periods[0]
@@ -549,6 +584,22 @@ class TestParseAlerts:
         assert alert.onset is not None
         assert alert.expires is not None
         assert alert.expires > alert.onset
+
+    def test_alert_times_use_response_timezone_name(self, client, sample_payload_with_alerts):
+        """Alert epoch timestamps should use PW's IANA timezone when present."""
+        payload = dict(sample_payload_with_alerts)
+        payload["timezone"] = "Europe/London"
+        payload["offset"] = 0
+        alert = dict(sample_payload_with_alerts["alerts"][0])
+        alert["time"] = int(datetime(2025, 7, 1, 12, 0, tzinfo=UTC).timestamp())
+        alert["expires"] = int(datetime(2025, 7, 1, 13, 0, tzinfo=UTC).timestamp())
+        payload["alerts"] = [alert]
+
+        result = client._parse_alerts(payload)
+
+        assert result.alerts[0].onset is not None
+        assert getattr(result.alerts[0].onset.tzinfo, "key", None) == "Europe/London"
+        assert result.alerts[0].onset.utcoffset() == timedelta(hours=1)
 
     def test_lower_severity_regional_alerts_are_suppressed(
         self, client, sample_payload_with_alerts

--- a/tests/test_visual_crossing_client.py
+++ b/tests/test_visual_crossing_client.py
@@ -118,6 +118,41 @@ class TestVisualCrossingParsers:
         assert current.wind_gust_mph == 22.0
         assert current.precipitation_in == 0.1
 
+    def test_parse_current_conditions_prefers_epoch_sun_moon_times(self, client):
+        """Sun/moon fields should use VC epoch values when available."""
+        data = {
+            "tzoffset": -5,
+            "currentConditions": {"temp": 72.0, "conditions": "Clear"},
+            "days": [
+                {
+                    "datetime": "2024-01-01",
+                    "sunrise": "07:00:00",
+                    "sunset": "17:30:00",
+                    "moonrise": "21:00:00",
+                    "moonset": "09:00:00",
+                    "sunriseEpoch": 1704111000,
+                    "sunsetEpoch": 1704148200,
+                    "moonriseEpoch": 1704160800,
+                    "moonsetEpoch": 1704117600,
+                }
+            ],
+        }
+
+        current = client._parse_current_conditions(data)
+
+        assert current.sunrise_time == datetime.fromtimestamp(
+            1704111000, tz=timezone(timedelta(hours=-5))
+        )
+        assert current.sunset_time == datetime.fromtimestamp(
+            1704148200, tz=timezone(timedelta(hours=-5))
+        )
+        assert current.moonrise_time == datetime.fromtimestamp(
+            1704160800, tz=timezone(timedelta(hours=-5))
+        )
+        assert current.moonset_time == datetime.fromtimestamp(
+            1704117600, tz=timezone(timedelta(hours=-5))
+        )
+
     def test_parse_forecast(self, client):
         """Test parsing forecast."""
         data = {


### PR DESCRIPTION
## Summary
- prefer Visual Crossing epoch fields for sun and moon times before reconstructing local datetimes
- use Pirate Weather response timezone names consistently for current, hourly, and alert epoch timestamps
- add regression coverage for provider-native timestamp behavior

## Tests
- uv run pytest -q -n 0 --tb=short tests/test_visual_crossing_client.py tests/test_pirate_weather_client.py
- uv run ruff check src tests
- uv run pyright

## Notes
- Not tested against live provider APIs.