### PR TITLE
fix(weather): tighten Pirate Weather minutely precipitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,15 @@ All notable changes to this project will be documented in this file.
 - **Edit Location** — a new "Edit Location" button and menu item in the Location menu let you toggle Marine Mode on existing locations without having to remove and re-add them
 - **NOAA radio station count chooser** — the NOAA Weather Radio dialog now lets you pick how many nearby stations to load (10, 25, 50, 100, or All) without digging through the main Settings window
 - **Precipitation timeline dialog** — View > Precipitation Timeline now opens a dedicated Pirate Weather minutely precipitation timeline with a quick summary and minute-by-minute plain-text breakdown
+- **Faster Pirate Weather rain checks are opt-in** — a new notification setting lets you check minutely precipitation more often when rain is likely, while the default cadence stays closer to Pirate Weather's recommended update window
 - **Single combined alert view** — pick "Single combined view" in Settings > Display > Alert display to read the whole alert (headline, description, instruction, Issued, and Expires) in one scrollable edit box with a Close button. The original separate-fields layout is still the default
 - **Configurable date format** — choose how dates are shown: ISO (2026-04-18), US short (04/18/2026), US long (April 18, 2026), or EU (18/04/2026). Applies to timestamps in the new combined alert view for now
 
 ### Fixed
+- **Pirate Weather minutely precipitation units** — rain-start notifications now evaluate Pirate Weather minutely intensity in consistent mm/hr units, and the timeline shows the unit plus uncertainty when Pirate Weather provides it
 - **NOAA radio station count now sticks** — your nearby-station limit is saved with NOAA radio preferences and reused the next time you open the dialog, while preferred stream choices keep working as before
 - **Automatic update checks now fire on long-running sessions** — the 24-hour update check used a single long wxTimer that could silently skip its tick after the computer slept or hibernated, so users who left the app open had to check manually. The scheduler now polls every 15 minutes and uses wall-clock elapsed time, so checks run on schedule even across sleep/wake cycles
-- **Adaptive Pirate Weather minutely polling** — minutely precipitation checks now stay on your normal refresh cadence when the next few hours look dry, then speed up automatically when the hourly forecast suggests rain is likely soon (#565)
+- **Adaptive Pirate Weather minutely polling** — minutely precipitation checks now stay near Pirate Weather's recommended cadence by default, with an opt-in faster check cadence when the hourly forecast suggests rain is likely soon (#565)
 
 ## [0.4.5] - 2026-03-26
 

--- a/src/accessiweather/models/config.py
+++ b/src/accessiweather/models/config.py
@@ -45,6 +45,7 @@ NON_CRITICAL_SETTINGS: set[str] = {
     "notify_severe_risk_change",
     "notify_minutely_precipitation_start",
     "notify_minutely_precipitation_stop",
+    "minutely_precipitation_fast_polling",
     "precipitation_sensitivity",
     "notify_precipitation_likelihood",
     "precipitation_likelihood_threshold",
@@ -134,6 +135,7 @@ class AppSettings:
     notify_severe_risk_change: bool = False
     notify_minutely_precipitation_start: bool = True
     notify_minutely_precipitation_stop: bool = True
+    minutely_precipitation_fast_polling: bool = False
     # Minimum intensity level required to count as precipitation ("light", "moderate", "heavy")
     precipitation_sensitivity: str = "light"
     notify_precipitation_likelihood: bool = False
@@ -471,6 +473,7 @@ class AppSettings:
             "notify_severe_risk_change": self.notify_severe_risk_change,
             "notify_minutely_precipitation_start": self.notify_minutely_precipitation_start,
             "notify_minutely_precipitation_stop": self.notify_minutely_precipitation_stop,
+            "minutely_precipitation_fast_polling": self.minutely_precipitation_fast_polling,
             "precipitation_sensitivity": self.precipitation_sensitivity,
             "notify_precipitation_likelihood": self.notify_precipitation_likelihood,
             "precipitation_likelihood_threshold": self.precipitation_likelihood_threshold,
@@ -566,6 +569,9 @@ class AppSettings:
             ),
             notify_minutely_precipitation_stop=cls._as_bool(
                 data.get("notify_minutely_precipitation_stop"), True
+            ),
+            minutely_precipitation_fast_polling=cls._as_bool(
+                data.get("minutely_precipitation_fast_polling"), False
             ),
             precipitation_sensitivity=data.get("precipitation_sensitivity", "light"),
             notify_precipitation_likelihood=cls._as_bool(

--- a/src/accessiweather/models/weather.py
+++ b/src/accessiweather/models/weather.py
@@ -432,6 +432,9 @@ class MinutelyPrecipitationPoint:
     precipitation_intensity: float | None = None
     precipitation_probability: float | None = None
     precipitation_type: str | None = None
+    precipitation_intensity_unit: str = "mm/hr"
+    precipitation_intensity_error: float | None = None
+    precipitation_intensity_error_unit: str = "mm/hr"
 
 
 @dataclass

--- a/src/accessiweather/notifications/minutely_precipitation.py
+++ b/src/accessiweather/notifications/minutely_precipitation.py
@@ -29,8 +29,10 @@ def _probability_band(prob: float) -> str:
     return "50-70%"
 
 
-# Intensity thresholds (mm/h) for wet detection.
-# Pirate Weather light rain is typically 0.01–0.1 mm/h; moderate 0.1–1.0 mm/h.
+# Intensity thresholds (mm/hr) for wet detection.  Pirate Weather can return
+# minutely precipitation intensity as in/hr for ``units=us``; the parser
+# normalizes all minutely intensities to mm/hr before these thresholds are used.
+# Pirate Weather light rain is typically 0.01-0.1 mm/hr; moderate 0.1-1.0 mm/hr.
 INTENSITY_THRESHOLD_LIGHT = 0.01
 INTENSITY_THRESHOLD_MODERATE = 0.1
 INTENSITY_THRESHOLD_HEAVY = 1.0
@@ -88,12 +90,16 @@ class MinutelyPrecipitationLikelihood:
 
 def parse_pirate_weather_minutely_block(
     payload: Mapping[str, Any] | None,
+    *,
+    units: str = "si",
 ) -> MinutelyPrecipitationForecast | None:
     """
     Parse a Pirate Weather minutely block or full response.
 
     Accepts either the full API response containing a ``minutely`` object or the
-    ``minutely`` object itself.
+    ``minutely`` object itself.  Pirate Weather returns ``precipIntensity`` in
+    in/hr for ``units=us`` and mm/hr for other unit groups, so values are stored
+    in the model as canonical mm/hr.
     """
     if not payload:
         return None
@@ -113,12 +119,19 @@ def parse_pirate_weather_minutely_block(
         raw_time = raw_point.get("time")
         if not isinstance(raw_time, int | float):
             continue
+        intensity = _coerce_float(raw_point.get("precipIntensity"))
+        intensity_error = _coerce_float(raw_point.get("precipIntensityError"))
         points.append(
             MinutelyPrecipitationPoint(
                 time=datetime.fromtimestamp(raw_time, tz=UTC),
-                precipitation_intensity=_coerce_float(raw_point.get("precipIntensity")),
+                precipitation_intensity=_normalize_intensity_to_mm_per_hour(intensity, units),
                 precipitation_probability=_coerce_float(raw_point.get("precipProbability")),
                 precipitation_type=_normalize_precipitation_type(raw_point.get("precipType")),
+                precipitation_intensity_unit="mm/hr",
+                precipitation_intensity_error=_normalize_intensity_to_mm_per_hour(
+                    intensity_error, units
+                ),
+                precipitation_intensity_error_unit="mm/hr",
             )
         )
 
@@ -275,7 +288,11 @@ def is_wet(point: MinutelyPrecipitationPoint, threshold: float = 0.0) -> bool:
 
     """
     if point.precipitation_intensity is not None:
-        return point.precipitation_intensity > threshold
+        intensity = point.precipitation_intensity
+        error = getattr(point, "precipitation_intensity_error", None)
+        if error is not None and error > 0:
+            return (intensity - error) > threshold
+        return intensity > threshold
     if point.precipitation_probability is not None:
         return point.precipitation_probability > 0
     return False
@@ -302,6 +319,12 @@ def _coerce_float(value: Any) -> float | None:
     if isinstance(value, int | float):
         return float(value)
     return None
+
+
+def _normalize_intensity_to_mm_per_hour(value: float | None, units: str) -> float | None:
+    if value is None:
+        return None
+    return value * 25.4 if units == "us" else value
 
 
 def _normalize_precipitation_type(value: Any) -> str | None:

--- a/src/accessiweather/ui/dialogs/precipitation_timeline_dialog.py
+++ b/src/accessiweather/ui/dialogs/precipitation_timeline_dialog.py
@@ -131,8 +131,8 @@ class PrecipitationTimelineDialog(wx.Dialog):
         description = wx.StaticText(
             panel,
             label=(
-                "Pirate Weather minutely guidance for the next hour. "
-                "Summary first, followed by a plain-text timeline."
+                "Pirate Weather short-range precipitation guidance for the next hour. "
+                "Minute rows are model-interpolated guidance."
             ),
         )
         description.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
@@ -210,7 +210,13 @@ def _format_point_conditions(point: MinutelyPrecipitationPoint) -> str:
 
     intensity = getattr(point, "precipitation_intensity", None)
     if intensity is not None and intensity > 0:
-        details.append(f"{intensity:.3f} in/hr")
+        unit = getattr(point, "precipitation_intensity_unit", "mm/hr")
+        intensity_text = f"{intensity:.3f} {unit}"
+        intensity_error = getattr(point, "precipitation_intensity_error", None)
+        if intensity_error is not None and intensity_error > 0:
+            error_unit = getattr(point, "precipitation_intensity_error_unit", unit)
+            intensity_text = f"{intensity_text} (+/- {intensity_error:.3f} {error_unit})"
+        details.append(intensity_text)
 
     return " | ".join(details)
 

--- a/src/accessiweather/ui/dialogs/settings_tabs/notifications.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/notifications.py
@@ -187,6 +187,17 @@ class NotificationsTab:
             10,
         )
 
+        controls["minutely_precipitation_fast_polling"] = wx.CheckBox(
+            panel,
+            label="Check Pirate Weather precipitation more often when rain is likely",
+        )
+        event_section.Add(
+            controls["minutely_precipitation_fast_polling"],
+            0,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
+            10,
+        )
+
         row_sensitivity = wx.BoxSizer(wx.HORIZONTAL)
         row_sensitivity.Add(
             wx.StaticText(panel, label="Notify for:"),
@@ -197,9 +208,9 @@ class NotificationsTab:
         controls["precipitation_sensitivity"] = wx.Choice(
             panel,
             choices=[
-                "Light rain and above (default, \u22650.01\u00a0mm/h)",
-                "Moderate rain and above (\u22650.1\u00a0mm/h)",
-                "Heavy rain only (\u22651.0\u00a0mm/h)",
+                "Light rain and above (default, \u22650.01\u00a0mm/hr)",
+                "Moderate rain and above (\u22650.1\u00a0mm/hr)",
+                "Heavy rain only (\u22651.0\u00a0mm/hr)",
             ],
         )
         row_sensitivity.Add(controls["precipitation_sensitivity"], 0)
@@ -302,6 +313,9 @@ class NotificationsTab:
         controls["notify_minutely_precipitation_stop"].SetValue(
             getattr(settings, "notify_minutely_precipitation_stop", False)
         )
+        controls["minutely_precipitation_fast_polling"].SetValue(
+            getattr(settings, "minutely_precipitation_fast_polling", False)
+        )
         sensitivity = getattr(settings, "precipitation_sensitivity", "light")
         controls["precipitation_sensitivity"].SetSelection(_SENSITIVITY_MAP.get(sensitivity, 0))
         controls["notify_precipitation_likelihood"].SetValue(
@@ -339,6 +353,9 @@ class NotificationsTab:
             "notify_minutely_precipitation_stop": controls[
                 "notify_minutely_precipitation_stop"
             ].GetValue(),
+            "minutely_precipitation_fast_polling": controls[
+                "minutely_precipitation_fast_polling"
+            ].GetValue(),
             "precipitation_sensitivity": _SENSITIVITY_VALUES[
                 controls["precipitation_sensitivity"].GetSelection()
             ],
@@ -369,6 +386,7 @@ class NotificationsTab:
             "notify_severe_risk_change": "Notify when severe weather risk changes",
             "notify_minutely_precipitation_start": "Notify when precipitation is expected to start soon",
             "notify_minutely_precipitation_stop": "Notify when precipitation is expected to stop soon",
+            "minutely_precipitation_fast_polling": "Check Pirate Weather precipitation more often when rain is likely",
             "precipitation_sensitivity": "Notify for: precipitation sensitivity level",
             "notify_precipitation_likelihood": "Notify when precipitation is likely (probability-based)",
             "precipitation_likelihood_threshold": "Precipitation likelihood threshold",

--- a/src/accessiweather/ui/main_window_notification_events.py
+++ b/src/accessiweather/ui/main_window_notification_events.py
@@ -319,16 +319,18 @@ def process_notification_events(window: MainWindow, weather_data) -> None:
             and not settings.notify_severe_risk_change
             and not settings.notify_minutely_precipitation_start
             and not settings.notify_minutely_precipitation_stop
+            and not getattr(settings, "notify_precipitation_likelihood", False)
             and not getattr(settings, "notify_hwo_update", True)
             and not getattr(settings, "notify_sps_issued", True)
         ):
             logger.debug(
                 "[events] _process_notification_events: discussion=%s severe_risk=%s "
-                "minutely_start=%s minutely_stop=%s hwo=%s sps=%s disabled -- skipping",
+                "minutely_start=%s minutely_stop=%s likelihood=%s hwo=%s sps=%s disabled -- skipping",
                 settings.notify_discussion_update,
                 settings.notify_severe_risk_change,
                 settings.notify_minutely_precipitation_start,
                 settings.notify_minutely_precipitation_stop,
+                getattr(settings, "notify_precipitation_likelihood", False),
                 getattr(settings, "notify_hwo_update", True),
                 getattr(settings, "notify_sps_issued", True),
             )

--- a/src/accessiweather/weather_client_base.py
+++ b/src/accessiweather/weather_client_base.py
@@ -54,6 +54,7 @@ from .weather_client_parallel import ParallelFetchCoordinator
 logger = logging.getLogger(__name__)
 
 MINUTELY_FAST_POLL_INTERVAL = timedelta(minutes=5)
+MINUTELY_RECOMMENDED_MIN_POLL_INTERVAL = timedelta(minutes=15)
 MINUTELY_ADAPTIVE_PRECIP_PROBABILITY_THRESHOLD = 30
 MINUTELY_ADAPTIVE_LOOKAHEAD_HOURS = 6
 
@@ -241,8 +242,9 @@ class WeatherClient:
         normal_interval = timedelta(
             minutes=max(1, int(getattr(self.settings, "update_interval_minutes", 10)))
         )
-        target_interval = normal_interval
-        if self._should_use_fast_minutely_poll(location):
+        fast_polling = bool(getattr(self.settings, "minutely_precipitation_fast_polling", False))
+        target_interval = max(normal_interval, MINUTELY_RECOMMENDED_MIN_POLL_INTERVAL)
+        if fast_polling and self._should_use_fast_minutely_poll(location):
             target_interval = min(normal_interval, MINUTELY_FAST_POLL_INTERVAL)
 
         last_poll = self._last_minutely_poll_by_location.get(self._location_key(location))
@@ -612,8 +614,9 @@ class WeatherClient:
             ):
                 _want_start = getattr(self.settings, "notify_minutely_precipitation_start", False)
                 _want_stop = getattr(self.settings, "notify_minutely_precipitation_stop", False)
-                if (_want_start or _want_stop) and self._should_fetch_minutely_precipitation(
-                    location
+                _want_likelihood = getattr(self.settings, "notify_precipitation_likelihood", False)
+                if (_want_start or _want_stop or _want_likelihood) and (
+                    self._should_fetch_minutely_precipitation(location)
                 ):
                     weather_data.minutely_precipitation = await self._get_pirate_weather_minutely(
                         location
@@ -663,7 +666,10 @@ class WeatherClient:
                 if inspect.isawaitable(result):
                     result = await result
                 if isinstance(result, dict):
-                    return parse_pirate_weather_minutely_block(result)
+                    units = getattr(client, "units", "si")
+                    if not isinstance(units, str):
+                        units = "si"
+                    return parse_pirate_weather_minutely_block(result, units=units)
             except TypeError:
                 logger.debug(
                     "Pirate Weather client method %s has an unsupported signature", method_name
@@ -1145,9 +1151,12 @@ class WeatherClient:
 
         _want_start = getattr(self.settings, "notify_minutely_precipitation_start", False)
         _want_stop = getattr(self.settings, "notify_minutely_precipitation_stop", False)
+        _want_likelihood = getattr(self.settings, "notify_precipitation_likelihood", False)
         _pw_fetched = any(source.source == "pirateweather" for source in source_results)
         merged_minutely = None
-        if self.pirate_weather_api_key and (_pw_fetched or _want_start or _want_stop):
+        if self.pirate_weather_api_key and (
+            _pw_fetched or _want_start or _want_stop or _want_likelihood
+        ):
             merged_minutely = await self._get_pirate_weather_minutely(location)
 
         has_any_data = (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -409,12 +409,14 @@ class TestAppSettings:
         settings = AppSettings(
             notify_minutely_precipitation_start=True,
             notify_minutely_precipitation_stop=False,
+            minutely_precipitation_fast_polling=True,
         )
 
         restored = AppSettings.from_dict(settings.to_dict())
 
         assert restored.notify_minutely_precipitation_start is True
         assert restored.notify_minutely_precipitation_stop is False
+        assert restored.minutely_precipitation_fast_polling is True
 
     def test_immediate_alert_popup_setting_round_trip(self):
         """Immediate alert popup opt-in should serialize and load cleanly."""

--- a/tests/test_notification_event_manager.py
+++ b/tests/test_notification_event_manager.py
@@ -479,6 +479,29 @@ class TestNotificationEventManager:
         assert len(forecast.points) == 2
         assert forecast.points[1].precipitation_type == "rain"
 
+    def test_parse_pirate_weather_minutely_block_normalizes_us_intensity(self):
+        """US Pirate Weather minutely intensity should be converted from in/hr to mm/hr."""
+        forecast = parse_pirate_weather_minutely_block(
+            {
+                "data": [
+                    {
+                        "time": 1768917600,
+                        "precipIntensity": 0.1,
+                        "precipIntensityError": 0.01,
+                        "precipType": "rain",
+                    }
+                ]
+            },
+            units="us",
+        )
+
+        assert forecast is not None
+        point = forecast.points[0]
+        assert point.precipitation_intensity == pytest.approx(2.54)
+        assert point.precipitation_intensity_unit == "mm/hr"
+        assert point.precipitation_intensity_error == pytest.approx(0.254)
+        assert point.precipitation_intensity_error_unit == "mm/hr"
+
     def test_detect_minutely_precipitation_start_transition(self):
         """Dry-to-wet transitions should use the first wet minute and precip type."""
         forecast = parse_pirate_weather_minutely_block(
@@ -648,6 +671,26 @@ class TestNotificationEventManager:
         heavy = MinutelyPrecipitationPoint(time=datetime.now(UTC), precipitation_intensity=1.5)
         assert not is_wet(moderate, threshold=INTENSITY_THRESHOLD_HEAVY)
         assert is_wet(heavy, threshold=INTENSITY_THRESHOLD_HEAVY)
+
+    def test_is_wet_uses_precipitation_intensity_error_as_lower_bound(self):
+        """Uncertain marginal precipitation should not trip wet detection."""
+        from datetime import UTC, datetime
+
+        from accessiweather.models import MinutelyPrecipitationPoint
+
+        marginal = MinutelyPrecipitationPoint(
+            time=datetime.now(UTC),
+            precipitation_intensity=0.03,
+            precipitation_intensity_error=0.025,
+        )
+        confident = MinutelyPrecipitationPoint(
+            time=datetime.now(UTC),
+            precipitation_intensity=0.08,
+            precipitation_intensity_error=0.02,
+        )
+
+        assert not is_wet(marginal, threshold=INTENSITY_THRESHOLD_LIGHT)
+        assert is_wet(confident, threshold=INTENSITY_THRESHOLD_LIGHT)
 
     def test_detect_transition_with_moderate_threshold_ignores_light_rain(self):
         """With moderate threshold, light rain should not trigger a wet transition."""

--- a/tests/test_precipitation_timeline_dialog.py
+++ b/tests/test_precipitation_timeline_dialog.py
@@ -50,7 +50,25 @@ def test_build_precipitation_timeline_text_returns_plain_text_timeline():
     assert "Now" in text
     assert "+01m" in text
     assert "3:04 PM" in text
-    assert "Rain | 60% chance | 0.120 in/hr" in text
+    assert "Rain | 60% chance | 0.120 mm/hr" in text
+
+
+def test_build_precipitation_timeline_text_includes_intensity_error():
+    start = datetime(2026, 1, 1, 15, 4, tzinfo=UTC)
+    forecast = MinutelyPrecipitationForecast(
+        points=[
+            MinutelyPrecipitationPoint(
+                time=start,
+                precipitation_intensity=0.12,
+                precipitation_intensity_error=0.03,
+                precipitation_type="rain",
+            )
+        ]
+    )
+
+    text = build_precipitation_timeline_text(forecast)
+
+    assert "0.120 mm/hr (+/- 0.030 mm/hr)" in text
 
 
 def test_show_precipitation_timeline_dialog_warns_when_minutely_data_missing():

--- a/tests/test_split_notification_timers.py
+++ b/tests/test_split_notification_timers.py
@@ -400,6 +400,7 @@ class TestNotificationEventHelpers:
         settings.notify_severe_risk_change = False
         settings.notify_minutely_precipitation_start = False
         settings.notify_minutely_precipitation_stop = False
+        settings.notify_precipitation_likelihood = False
         settings.notify_hwo_update = False
         settings.notify_sps_issued = False
         win.app.config_manager.get_settings.return_value = settings
@@ -615,7 +616,6 @@ class TestGetNotificationEventData:
         client._utcnow = MagicMock(
             side_effect=[
                 now,
-                now,
                 now + timedelta(minutes=1),
                 now + timedelta(minutes=31),
                 now + timedelta(minutes=31),
@@ -636,6 +636,7 @@ class TestGetNotificationEventData:
         settings.update_interval_minutes = 30
         settings.notify_minutely_precipitation_start = True
         settings.notify_minutely_precipitation_stop = True
+        settings.minutely_precipitation_fast_polling = True
         client.data_source = "pirateweather"
         client.pirate_weather_client = MagicMock()
         client.pirate_weather_client.get_current_conditions = AsyncMock(return_value=MagicMock())
@@ -660,8 +661,41 @@ class TestGetNotificationEventData:
                 now,
                 now,
                 now + timedelta(minutes=4),
+                now + timedelta(minutes=4),
                 now + timedelta(minutes=6),
                 now + timedelta(minutes=6),
+                now + timedelta(minutes=6),
+            ]
+        )
+
+        await client.get_notification_event_data(intl_location)
+        await client.get_notification_event_data(intl_location)
+        await client.get_notification_event_data(intl_location)
+
+        assert client._get_pirate_weather_minutely.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_minutely_precipitation_fetch_defaults_to_recommended_floor(
+        self, client, intl_location
+    ):
+        settings = client.settings
+        settings.update_interval_minutes = 10
+        settings.notify_minutely_precipitation_start = True
+        settings.notify_minutely_precipitation_stop = True
+        settings.minutely_precipitation_fast_polling = False
+        client.data_source = "pirateweather"
+        client.pirate_weather_client = MagicMock()
+        client.pirate_weather_client.get_current_conditions = AsyncMock(return_value=MagicMock())
+        client.pirate_weather_client.get_alerts = AsyncMock(return_value=WeatherAlerts(alerts=[]))
+        client._get_pirate_weather_minutely = AsyncMock(return_value=MagicMock())
+
+        now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+        client._utcnow = MagicMock(
+            side_effect=[
+                now,
+                now + timedelta(minutes=11),
+                now + timedelta(minutes=16),
+                now + timedelta(minutes=16),
             ]
         )
 


### PR DESCRIPTION
## Summary
- Normalize Pirate Weather minutely precipIntensity and precipIntensityError to canonical mm/hr before notification thresholds run.
- Display minutely intensity units and uncertainty in the precipitation timeline.
- Make sub-15-minute adaptive Pirate Weather minutely polling opt-in while still fetching minutely data for probability-based likelihood notifications.

## Verification
- uv run ruff format .
- uv run ruff check .
- uv run pyright
- uv run pytest -q -n 0 --tb=short