### PR TITLE
feat(weather): add pressure drop outlook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - **Faster Pirate Weather rain checks are opt-in** — a new notification setting lets you check minutely precipitation more often when rain is likely, while the default cadence stays closer to Pirate Weather's recommended update window
 - **Single combined alert view** — pick "Single combined view" in Settings > Display > Alert display to read the whole alert (headline, description, instruction, Issued, and Expires) in one scrollable edit box with a Close button. The original separate-fields layout is still the default
 - **Configurable date format** — choose how dates are shown: ISO (2026-04-18), US short (04/18/2026), US long (April 18, 2026), or EU (18/04/2026). Applies to timestamps in the new combined alert view for now
+- **Pressure outlook for fishing and planning** — pressure trends now say when a barometric pressure drop or rise is predicted, and Settings > Display lets you choose the pressure outlook range from 1 hour to 7 days
 
 ### Fixed
 - **Pirate Weather minutely precipitation units** — rain-start notifications now evaluate Pirate Weather minutely intensity in consistent mm/hr units, and the timeline shows the unit plus uncertainty when Pirate Weather provides it

--- a/src/accessiweather/display/presentation/current_conditions.py
+++ b/src/accessiweather/display/presentation/current_conditions.py
@@ -285,7 +285,12 @@ def _build_trend_metrics(
 
             if trend.sparkline:
                 summary = f"{summary} {trend.sparkline}".strip()
-            metrics.append(Metric(f"{trend.metric.replace('_', ' ').title()} trend", summary))
+            label = (
+                "Pressure outlook"
+                if is_pressure
+                else f"{trend.metric.replace('_', ' ').title()} trend"
+            )
+            metrics.append(Metric(label, summary))
             if is_pressure:
                 pressure_trend_present = True
 

--- a/src/accessiweather/ui/dialogs/settings_tabs/display.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/display.py
@@ -125,6 +125,22 @@ class DisplayTab:
             8,
         )
 
+        pressure_outlook_row = wx.BoxSizer(wx.HORIZONTAL)
+        pressure_outlook_row.Add(
+            wx.StaticText(panel, label="Pressure outlook range (hours):"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            10,
+        )
+        controls["trend_hours"] = wx.SpinCtrl(panel, min=1, max=168, initial=24)
+        pressure_outlook_row.Add(controls["trend_hours"], 0)
+        forecast_section.Add(
+            pressure_outlook_row,
+            0,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
+            8,
+        )
+
         details_section = self.dialog.create_section(
             panel,
             sizer,
@@ -295,6 +311,7 @@ class DisplayTab:
             _FORECAST_DURATION_MAP.get(forecast_duration_days, 2)
         )
         controls["hourly_forecast_hours"].SetValue(getattr(settings, "hourly_forecast_hours", 6))
+        controls["trend_hours"].SetValue(getattr(settings, "trend_hours", 24))
 
         forecast_time_reference = getattr(settings, "forecast_time_reference", "location")
         controls["forecast_time_reference"].SetSelection(
@@ -339,6 +356,7 @@ class DisplayTab:
                 controls["forecast_duration_days"].GetSelection()
             ],
             "hourly_forecast_hours": controls["hourly_forecast_hours"].GetValue(),
+            "trend_hours": controls["trend_hours"].GetValue(),
             "forecast_time_reference": _FORECAST_TIME_REF_VALUES[
                 controls["forecast_time_reference"].GetSelection()
             ],
@@ -374,6 +392,7 @@ class DisplayTab:
             "round_values": "Show values as whole numbers when possible",
             "forecast_duration_days": "Daily forecast range",
             "hourly_forecast_hours": "Hourly forecast range in hours",
+            "trend_hours": "Pressure outlook range in hours",
             "forecast_time_reference": "Forecast time reference",
             "time_display_mode": "Time display mode",
             "time_format_12hour": "Use 12-hour time format",

--- a/src/accessiweather/weather_client_base.py
+++ b/src/accessiweather/weather_client_base.py
@@ -378,6 +378,7 @@ class WeatherClient:
             # Use retry wrapper for the parallel fetch
             try:
                 forecast_days = self._get_forecast_days_for_source(location, source="openmeteo")
+                requested_hours = self._get_hourly_hours_for_pressure_outlook()
                 return await retry_with_backoff(
                     openmeteo_client.get_openmeteo_all_data_parallel,
                     location,
@@ -385,6 +386,8 @@ class WeatherClient:
                     self.timeout,
                     client,
                     forecast_days,
+                    "best_match",
+                    requested_hours,
                     max_retries=1,
                     initial_delay=1.0,
                 )
@@ -1612,8 +1615,18 @@ class WeatherClient:
     async def _get_openmeteo_hourly_forecast(self, location: Location) -> HourlyForecast | None:
         """Delegate to the Open-Meteo client module."""
         return await openmeteo_client.get_openmeteo_hourly_forecast(
-            location, self.openmeteo_base_url, self.timeout, self._get_http_client()
+            location,
+            self.openmeteo_base_url,
+            self.timeout,
+            self._get_http_client(),
+            hours=self._get_hourly_hours_for_pressure_outlook(),
         )
+
+    def _get_hourly_hours_for_pressure_outlook(self) -> int:
+        """Return enough hourly data for display and pressure trend windows."""
+        hourly_hours = int(getattr(self.settings, "hourly_forecast_hours", 6) or 6)
+        trend_hours = int(getattr(self.settings, "trend_hours", 24) or 24)
+        return max(1, min(max(hourly_hours, trend_hours), 384))
 
     async def _augment_current_with_openmeteo(
         self,

--- a/src/accessiweather/weather_client_fusion.py
+++ b/src/accessiweather/weather_client_fusion.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import fields, replace
+from datetime import UTC, datetime
 from typing import Any
 
 from accessiweather.config.source_priority import SourcePriorityConfig
@@ -786,6 +787,21 @@ class DataFusionEngine:
         if hourly_forecast and hourly_forecast.summary is None and pirate_summary:
             hourly_forecast = replace(hourly_forecast, summary=pirate_summary)
 
+        pressure_source = self._select_hourly_pressure_source(valid_sources, selected_source)
+        if (
+            hourly_forecast
+            and pressure_source
+            and pressure_source.hourly_forecast
+            and pressure_source.source != source_name
+        ):
+            overlaid_hourly = self._overlay_hourly_pressure(
+                hourly_forecast,
+                pressure_source.hourly_forecast,
+            )
+            if overlaid_hourly is not hourly_forecast:
+                hourly_forecast = overlaid_hourly
+                field_sources["hourly_pressure_source"] = pressure_source.source
+
         # Track attribution
         field_sources["hourly_source"] = source_name
         if pirate_summary and hourly_forecast and hourly_forecast.summary == pirate_summary:
@@ -793,3 +809,104 @@ class DataFusionEngine:
         logger.debug(f"Using {source_name} for hourly forecast (location: {location.name})")
 
         return hourly_forecast, field_sources
+
+    def _select_hourly_pressure_source(
+        self,
+        valid_sources: list[SourceData],
+        selected_source: SourceData,
+    ) -> SourceData | None:
+        """Return the selected hourly source or best alternate source with pressure data."""
+        if self._hourly_has_pressure(selected_source.hourly_forecast):
+            return selected_source
+
+        pressure_priority = ["openmeteo", "visualcrossing", "pirateweather"]
+        pressure_sources = [
+            s for s in valid_sources if self._hourly_has_pressure(s.hourly_forecast)
+        ]
+        if not pressure_sources:
+            return None
+
+        pressure_sources.sort(
+            key=lambda source: self._source_priority_index(source.source, pressure_priority)
+        )
+        return pressure_sources[0]
+
+    def _hourly_has_pressure(self, hourly: HourlyForecast | None) -> bool:
+        """Return True when any hourly period includes pressure."""
+        if hourly is None:
+            return False
+        return any(p.pressure_in is not None or p.pressure_mb is not None for p in hourly.periods)
+
+    def _overlay_hourly_pressure(
+        self,
+        display_hourly: HourlyForecast,
+        pressure_hourly: HourlyForecast,
+    ) -> HourlyForecast:
+        """Copy pressure-only fields from a pressure-capable hourly source by nearest time."""
+        pressure_periods = [
+            period
+            for period in pressure_hourly.periods
+            if period.pressure_in is not None or period.pressure_mb is not None
+        ]
+        if not pressure_periods:
+            return display_hourly
+
+        overlaid_periods = []
+        changed = False
+        for display_period in display_hourly.periods:
+            if display_period.pressure_in is not None or display_period.pressure_mb is not None:
+                overlaid_periods.append(display_period)
+                continue
+
+            pressure_period = self._nearest_hourly_pressure_period(
+                display_period.start_time,
+                pressure_periods,
+            )
+            if pressure_period is None:
+                overlaid_periods.append(display_period)
+                continue
+
+            overlaid_periods.append(
+                replace(
+                    display_period,
+                    pressure_in=pressure_period.pressure_in,
+                    pressure_mb=pressure_period.pressure_mb,
+                )
+            )
+            changed = True
+
+        if not changed:
+            return display_hourly
+        return replace(display_hourly, periods=overlaid_periods)
+
+    def _nearest_hourly_pressure_period(
+        self,
+        target: datetime,
+        pressure_periods: list,
+    ):
+        """Find a pressure period close enough to the target display hour."""
+        target_ts = self._datetime_timestamp(target)
+        if target_ts is None:
+            return None
+
+        closest = None
+        best_delta = None
+        for period in pressure_periods:
+            period_ts = self._datetime_timestamp(period.start_time)
+            if period_ts is None:
+                continue
+            delta = abs(period_ts - target_ts)
+            if best_delta is None or delta < best_delta:
+                closest = period
+                best_delta = delta
+
+        if best_delta is None or best_delta > 90 * 60:
+            return None
+        return closest
+
+    def _datetime_timestamp(self, value: datetime | None) -> float | None:
+        """Normalize aware and naive datetimes to comparable timestamps."""
+        if value is None:
+            return None
+        value = value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+        return value.timestamp()

--- a/src/accessiweather/weather_client_nws.py
+++ b/src/accessiweather/weather_client_nws.py
@@ -6,6 +6,7 @@ import asyncio
 import inspect
 import logging
 import re
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 
@@ -1306,7 +1307,13 @@ async def get_nws_hourly_forecast(
             response.raise_for_status()
             hourly_data = response.json()
 
-            return parse_nws_hourly_forecast(hourly_data, location)
+            hourly = parse_nws_hourly_forecast(hourly_data, location)
+            pressure_data = await _fetch_nws_gridpoint_pressure(
+                grid_data,
+                client,
+                headers,
+            )
+            return apply_nws_gridpoint_pressure(hourly, pressure_data)
         grid_url = f"{nws_base_url}/points/{location.latitude},{location.longitude}"
 
         async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as new_client:
@@ -1323,13 +1330,40 @@ async def get_nws_hourly_forecast(
             response.raise_for_status()
             hourly_data = response.json()
 
-            return parse_nws_hourly_forecast(hourly_data, location)
+            hourly = parse_nws_hourly_forecast(hourly_data, location)
+            pressure_data = await _fetch_nws_gridpoint_pressure(
+                grid_data,
+                new_client,
+                headers,
+            )
+            return apply_nws_gridpoint_pressure(hourly, pressure_data)
 
     except Exception as exc:  # noqa: BLE001
         logger.error(f"Failed to get NWS hourly forecast: {exc}")
         if isinstance(exc, RETRYABLE_EXCEPTIONS) or is_retryable_http_error(exc):
             raise
         return None
+
+
+async def _fetch_nws_gridpoint_pressure(
+    point_data: dict[str, Any],
+    client: httpx.AsyncClient,
+    headers: dict[str, str],
+) -> dict[datetime, tuple[float | None, float | None]]:
+    """Fetch and parse the NWS gridpoint pressure layer for hourly pressure outlooks."""
+    gridpoint_url = point_data.get("properties", {}).get("forecastGridData")
+    if not gridpoint_url:
+        return {}
+
+    try:
+        response = await _client_get(client, gridpoint_url, headers=headers)
+        response.raise_for_status()
+        return parse_nws_gridpoint_pressure(response.json())
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("NWS gridpoint pressure fetch failed: %s", exc)
+        if isinstance(exc, RETRYABLE_EXCEPTIONS) or is_retryable_http_error(exc):
+            raise
+        return {}
 
 
 @async_retry_with_backoff(max_attempts=3, base_delay=1.0, timeout=20.0)
@@ -1842,3 +1876,99 @@ def parse_nws_hourly_forecast(data: dict, location: Location | None = None) -> H
         periods.append(period)
 
     return HourlyForecast(periods=periods, generated_at=datetime.now())
+
+
+def parse_nws_gridpoint_pressure(data: dict) -> dict[datetime, tuple[float | None, float | None]]:
+    """Parse NWS gridpoint pressure values keyed by valid-time start."""
+    pressure = data.get("properties", {}).get("pressure", {})
+    values = pressure.get("values", []) if isinstance(pressure, dict) else []
+    pressure_by_time: dict[datetime, tuple[float | None, float | None]] = {}
+
+    for item in values:
+        if not isinstance(item, dict):
+            continue
+        start_time = _parse_valid_time_start(item.get("validTime"))
+        pressure_pa = item.get("value")
+        if start_time is None or pressure_pa is None:
+            continue
+        pressure_by_time[start_time] = (
+            convert_pa_to_inches(pressure_pa),
+            convert_pa_to_mb(pressure_pa),
+        )
+
+    return pressure_by_time
+
+
+def apply_nws_gridpoint_pressure(
+    hourly: HourlyForecast,
+    pressure_by_time: dict[datetime, tuple[float | None, float | None]],
+) -> HourlyForecast:
+    """Populate NWS hourly periods with pressure from the gridpoint pressure layer."""
+    if not pressure_by_time:
+        return hourly
+
+    updated_periods: list[HourlyForecastPeriod] = []
+    changed = False
+    for period in hourly.periods:
+        if period.pressure_in is not None or period.pressure_mb is not None:
+            updated_periods.append(period)
+            continue
+
+        pressure_pair = _nearest_pressure_pair(period.start_time, pressure_by_time)
+        if pressure_pair is None:
+            updated_periods.append(period)
+            continue
+
+        updated_periods.append(
+            replace(
+                period,
+                pressure_in=pressure_pair[0],
+                pressure_mb=pressure_pair[1],
+            )
+        )
+        changed = True
+
+    if not changed:
+        return hourly
+    return HourlyForecast(
+        periods=updated_periods,
+        generated_at=hourly.generated_at,
+        summary=hourly.summary,
+    )
+
+
+def _nearest_pressure_pair(
+    start_time: datetime,
+    pressure_by_time: dict[datetime, tuple[float | None, float | None]],
+) -> tuple[float | None, float | None] | None:
+    """Return pressure from the closest gridpoint valid time within 90 minutes."""
+    target_ts = _timestamp_utc(start_time)
+    best_pair = None
+    best_delta = None
+    for valid_time, pressure_pair in pressure_by_time.items():
+        delta = abs(_timestamp_utc(valid_time) - target_ts)
+        if best_delta is None or delta < best_delta:
+            best_delta = delta
+            best_pair = pressure_pair
+
+    if best_delta is None or best_delta > 90 * 60:
+        return None
+    return best_pair
+
+
+def _parse_valid_time_start(valid_time: str | None) -> datetime | None:
+    """Parse the start timestamp from an NWS ISO interval validTime value."""
+    if not valid_time:
+        return None
+    start = valid_time.split("/", 1)[0]
+    try:
+        return datetime.fromisoformat(start.replace("Z", "+00:00"))
+    except ValueError:
+        logger.debug("Failed to parse NWS gridpoint validTime: %s", valid_time)
+        return None
+
+
+def _timestamp_utc(value: datetime) -> float:
+    """Normalize aware and naive datetimes to UTC timestamps."""
+    value = value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+    return value.timestamp()

--- a/src/accessiweather/weather_client_openmeteo.py
+++ b/src/accessiweather/weather_client_openmeteo.py
@@ -166,6 +166,7 @@ async def get_openmeteo_all_data_parallel(
     client: httpx.AsyncClient,
     forecast_days: int = 7,
     model: str = "best_match",
+    hourly_hours: int = 48,
 ) -> tuple[CurrentConditions | None, Forecast | None, HourlyForecast | None]:
     """
     Fetch all Open-Meteo data in parallel.
@@ -188,7 +189,14 @@ async def get_openmeteo_all_data_parallel(
             )
         )
         hourly_task = asyncio.create_task(
-            get_openmeteo_hourly_forecast(location, openmeteo_base_url, timeout, client, model)
+            get_openmeteo_hourly_forecast(
+                location,
+                openmeteo_base_url,
+                timeout,
+                client,
+                model,
+                hours=hourly_hours,
+            )
         )
 
         # Gather all results
@@ -320,6 +328,7 @@ async def get_openmeteo_hourly_forecast(
     timeout: float,
     client: httpx.AsyncClient | None = None,
     model: str = "best_match",
+    hours: int = 48,
 ) -> HourlyForecast | None:
     """Fetch hourly forecast from the Open-Meteo API."""
     try:
@@ -337,7 +346,7 @@ async def get_openmeteo_hourly_forecast(
             "wind_speed_unit": "mph",
             "precipitation_unit": "inch",
             "timezone": "auto",
-            "forecast_days": 2,
+            "forecast_hours": min(max(hours, 1), 384),
         }
 
         # Add model parameter if not using default

--- a/src/accessiweather/weather_client_trends.py
+++ b/src/accessiweather/weather_client_trends.py
@@ -34,6 +34,10 @@ def apply_trend_insights(
         pressure_insight = compute_pressure_trend(weather_data, trend_hours)
         if pressure_insight:
             insights.append(pressure_insight)
+        else:
+            pressure_unavailable = compute_pressure_outlook_unavailable(weather_data, trend_hours)
+            if pressure_unavailable:
+                insights.append(pressure_unavailable)
 
     daily_insight = compute_daily_trend(weather_data)
     if daily_insight:
@@ -98,7 +102,11 @@ def compute_pressure_trend(
 
     base_mb = current.pressure_mb
     base_in = current.pressure_in
-    target_period = period_for_hours_ahead(hourly, trend_hours)
+    target_period = period_for_hours_ahead(
+        hourly,
+        trend_hours,
+        max_delta_hours=_pressure_target_tolerance_hours(trend_hours),
+    )
     if not target_period:
         logger.debug("No target period available for pressure trend calculation")
         return None
@@ -122,7 +130,7 @@ def compute_pressure_trend(
         minor=0.5 if unit == "mb" else 0.02,
         strong=1.5 if unit == "mb" else 0.05,
     )
-    summary = f"Pressure {direction} {change:+.2f}{unit} over {trend_hours}h"
+    summary = pressure_trend_summary(direction, change, unit, trend_hours)
     return TrendInsight(
         metric="pressure",
         direction=direction,
@@ -132,6 +140,87 @@ def compute_pressure_trend(
         summary=summary,
         sparkline=sparkline,
     )
+
+
+def compute_pressure_outlook_unavailable(
+    weather_data: WeatherData,
+    trend_hours: int,
+) -> TrendInsight | None:
+    """Explain why a pressure outlook cannot be calculated for the selected data."""
+    current = weather_data.current
+    if current is None or not current.has_data():
+        return None
+
+    if current.pressure_mb is None and current.pressure_in is None:
+        summary = "Pressure outlook unavailable: current pressure data is missing."
+        return _pressure_unavailable_insight(summary, trend_hours)
+
+    hourly = weather_data.hourly_forecast
+    if hourly is None or not hourly.has_data():
+        summary = "Pressure outlook unavailable: hourly forecast data is missing."
+        return _pressure_unavailable_insight(summary, trend_hours)
+
+    hourly_source = None
+    if weather_data.source_attribution is not None:
+        hourly_source = weather_data.source_attribution.field_sources.get("hourly_source")
+
+    if not any(p.pressure_mb is not None or p.pressure_in is not None for p in hourly.periods):
+        source_label = _format_source_name(hourly_source)
+        summary = (
+            f"Pressure outlook unavailable: {source_label} hourly forecast "
+            "does not include pressure data."
+            if source_label
+            else "Pressure outlook unavailable: hourly forecast does not include pressure data."
+        )
+        return _pressure_unavailable_insight(summary, trend_hours)
+
+    summary = (
+        "Pressure outlook unavailable: not enough hourly pressure data "
+        f"for the next {trend_hours}h."
+    )
+    return _pressure_unavailable_insight(summary, trend_hours)
+
+
+def _pressure_unavailable_insight(summary: str, trend_hours: int) -> TrendInsight:
+    """Create a pressure insight that explains an unavailable outlook."""
+    return TrendInsight(
+        metric="pressure",
+        direction="unavailable",
+        change=None,
+        unit=None,
+        timeframe_hours=trend_hours,
+        summary=summary,
+        sparkline=None,
+    )
+
+
+def _format_source_name(source: str | None) -> str | None:
+    """Return a user-facing source name for short pressure availability messages."""
+    if not source:
+        return None
+    source_names = {
+        "nws": "NWS",
+        "openmeteo": "Open-Meteo",
+        "visualcrossing": "Visual Crossing",
+        "pirateweather": "Pirate Weather",
+    }
+    return source_names.get(source, source)
+
+
+def _pressure_target_tolerance_hours(trend_hours: int) -> float:
+    """Return the acceptable distance from the requested pressure outlook target."""
+    return max(3.0, min(12.0, trend_hours * 0.25))
+
+
+def pressure_trend_summary(direction: str, change: float, unit: str, trend_hours: int) -> str:
+    """Build the user-facing pressure outlook summary."""
+    if direction == "falling":
+        action = "drop predicted"
+    elif direction == "rising":
+        action = "rise predicted"
+    else:
+        action = "steady"
+    return f"Pressure {action}: {change:+.2f} {unit} over next {trend_hours}h"
 
 
 def trend_descriptor(change: float, *, minor: float, strong: float) -> tuple[str, str]:
@@ -150,6 +239,8 @@ def trend_descriptor(change: float, *, minor: float, strong: float) -> tuple[str
 def period_for_hours_ahead(
     periods: Sequence[HourlyForecastPeriod],
     hours_ahead: int,
+    *,
+    max_delta_hours: float | None = None,
 ) -> HourlyForecastPeriod | None:
     """Return the forecast period closest to the target number of hours ahead."""
     if not periods:
@@ -161,7 +252,7 @@ def period_for_hours_ahead(
     target = target + timedelta(hours=hours_ahead)
 
     closest = None
-    best_delta = None
+    best_delta: float | None = None
     for period in periods:
         start = normalize_datetime(period.start_time)
         if start is None:
@@ -174,6 +265,12 @@ def period_for_hours_ahead(
         if best_delta is None or delta < best_delta:
             closest = period
             best_delta = delta
+    if (
+        max_delta_hours is not None
+        and best_delta is not None
+        and best_delta > max_delta_hours * 3600
+    ):
+        return None
     return closest
 
 

--- a/tests/test_current_conditions.py
+++ b/tests/test_current_conditions.py
@@ -528,6 +528,23 @@ class TestBuildTrendMetrics:
         metrics = _build_trend_metrics(trends, current, None, show_pressure_trend=False)
         assert len(metrics) == 0
 
+    def test_pressure_trend_label_reads_as_outlook(self):
+        trends = [
+            TrendInsight(
+                metric="pressure",
+                direction="falling",
+                summary="Pressure drop predicted: -0.08 inHg over next 24h",
+            ),
+        ]
+        metrics = _build_trend_metrics(
+            trends,
+            CurrentConditions(),
+            None,
+            show_pressure_trend=True,
+        )
+        assert metrics[0].label == "Pressure outlook"
+        assert "drop predicted" in metrics[0].value
+
     def test_no_trends(self):
         metrics = _build_trend_metrics(None, CurrentConditions(), None, show_pressure_trend=True)
         assert len(metrics) == 0

--- a/tests/test_nws_high_low.py
+++ b/tests/test_nws_high_low.py
@@ -1,6 +1,11 @@
-"""Tests for NWS high/low temperature pairing in parse_nws_forecast."""
+"""Tests for NWS high/low temperature pairing and hourly pressure parsing."""
 
-from accessiweather.weather_client_nws import parse_nws_forecast
+from accessiweather.weather_client_nws import (
+    apply_nws_gridpoint_pressure,
+    parse_nws_forecast,
+    parse_nws_gridpoint_pressure,
+    parse_nws_hourly_forecast,
+)
 
 
 def _make_period(name, temp, unit="F", is_daytime=True):
@@ -100,3 +105,68 @@ class TestNwsHighLowPairing:
         forecast = parse_nws_forecast(data)
         assert forecast.periods[0].temperature_low is None
         assert forecast.periods[1].temperature_low is None
+
+
+def _hourly_payload(start_time: str = "2026-04-26T10:00:00-04:00"):
+    return {
+        "properties": {
+            "periods": [
+                {
+                    "startTime": start_time,
+                    "endTime": "2026-04-26T11:00:00-04:00",
+                    "temperature": 60,
+                    "temperatureUnit": "F",
+                    "shortForecast": "Cloudy",
+                    "windSpeed": "5 mph",
+                    "windDirection": "N",
+                }
+            ]
+        }
+    }
+
+
+class TestNwsHourlyPressure:
+    def test_gridpoint_pressure_applies_to_hourly_periods(self):
+        hourly = parse_nws_hourly_forecast(_hourly_payload())
+        pressure = parse_nws_gridpoint_pressure(
+            {
+                "properties": {
+                    "pressure": {
+                        "uom": "wmoUnit:Pa",
+                        "values": [
+                            {
+                                "validTime": "2026-04-26T10:00:00-04:00/PT1H",
+                                "value": 101325,
+                            }
+                        ],
+                    }
+                }
+            }
+        )
+
+        result = apply_nws_gridpoint_pressure(hourly, pressure)
+
+        assert result.periods[0].pressure_mb == 1013.25
+        assert result.periods[0].pressure_in is not None
+
+    def test_gridpoint_pressure_ignores_far_valid_times(self):
+        hourly = parse_nws_hourly_forecast(_hourly_payload())
+        pressure = parse_nws_gridpoint_pressure(
+            {
+                "properties": {
+                    "pressure": {
+                        "values": [
+                            {
+                                "validTime": "2026-04-26T15:00:00-04:00/PT1H",
+                                "value": 101325,
+                            }
+                        ]
+                    }
+                }
+            }
+        )
+
+        result = apply_nws_gridpoint_pressure(hourly, pressure)
+
+        assert result.periods[0].pressure_mb is None
+        assert result.periods[0].pressure_in is None

--- a/tests/test_nws_high_low.py
+++ b/tests/test_nws_high_low.py
@@ -1,7 +1,13 @@
 """Tests for NWS high/low temperature pairing and hourly pressure parsing."""
 
+import httpx
+import pytest
+
+from accessiweather.models import Location
 from accessiweather.weather_client_nws import (
+    _fetch_nws_gridpoint_pressure,
     apply_nws_gridpoint_pressure,
+    get_nws_hourly_forecast,
     parse_nws_forecast,
     parse_nws_gridpoint_pressure,
     parse_nws_hourly_forecast,
@@ -126,6 +132,70 @@ def _hourly_payload(start_time: str = "2026-04-26T10:00:00-04:00"):
 
 
 class TestNwsHourlyPressure:
+    @pytest.mark.asyncio
+    async def test_get_nws_hourly_forecast_applies_gridpoint_pressure(self):
+        location = Location(name="Test", latitude=40.0, longitude=-74.0)
+        grid_data = {
+            "properties": {
+                "forecastHourly": "https://example.test/hourly",
+                "forecastGridData": "https://example.test/grid",
+            }
+        }
+
+        def handler(request):
+            if str(request.url) == "https://example.test/hourly":
+                return httpx.Response(200, json=_hourly_payload())
+            if str(request.url) == "https://example.test/grid":
+                return httpx.Response(
+                    200,
+                    json={
+                        "properties": {
+                            "pressure": {
+                                "values": [
+                                    {
+                                        "validTime": "2026-04-26T10:00:00-04:00/PT1H",
+                                        "value": 101325,
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                )
+            return httpx.Response(404)
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            result = await get_nws_hourly_forecast(
+                location,
+                "https://api.weather.gov",
+                "AccessiWeather tests",
+                10,
+                client,
+                grid_data,
+            )
+
+        assert result is not None
+        assert result.periods[0].pressure_mb == 1013.25
+
+    @pytest.mark.asyncio
+    async def test_fetch_gridpoint_pressure_returns_empty_when_url_missing(self):
+        async with httpx.AsyncClient(transport=httpx.MockTransport(lambda request: None)) as client:
+            result = await _fetch_nws_gridpoint_pressure({"properties": {}}, client, {})
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_fetch_gridpoint_pressure_ignores_nonretryable_errors(self):
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda request: httpx.Response(404))
+        ) as client:
+            result = await _fetch_nws_gridpoint_pressure(
+                {"properties": {"forecastGridData": "https://example.test/grid"}},
+                client,
+                {},
+            )
+
+        assert result == {}
+
     def test_gridpoint_pressure_applies_to_hourly_periods(self):
         hourly = parse_nws_hourly_forecast(_hourly_payload())
         pressure = parse_nws_gridpoint_pressure(
@@ -170,3 +240,51 @@ class TestNwsHourlyPressure:
 
         assert result.periods[0].pressure_mb is None
         assert result.periods[0].pressure_in is None
+
+    def test_gridpoint_pressure_parser_skips_invalid_values(self):
+        pressure = parse_nws_gridpoint_pressure(
+            {
+                "properties": {
+                    "pressure": {
+                        "values": [
+                            None,
+                            {"validTime": None, "value": 101325},
+                            {"validTime": "not-a-time/PT1H", "value": 101325},
+                            {"validTime": "2026-04-26T10:00:00-04:00/PT1H", "value": None},
+                        ]
+                    }
+                }
+            }
+        )
+
+        assert pressure == {}
+
+    def test_gridpoint_pressure_keeps_existing_hourly_pressure(self):
+        hourly = parse_nws_hourly_forecast(_hourly_payload())
+        hourly.periods[0].pressure_mb = 1000.0
+        pressure = parse_nws_gridpoint_pressure(
+            {
+                "properties": {
+                    "pressure": {
+                        "values": [
+                            {
+                                "validTime": "2026-04-26T10:00:00-04:00/PT1H",
+                                "value": 101325,
+                            }
+                        ]
+                    }
+                }
+            }
+        )
+
+        result = apply_nws_gridpoint_pressure(hourly, pressure)
+
+        assert result is hourly
+        assert result.periods[0].pressure_mb == 1000.0
+
+    def test_gridpoint_pressure_returns_original_when_no_pressure_available(self):
+        hourly = parse_nws_hourly_forecast(_hourly_payload())
+
+        result = apply_nws_gridpoint_pressure(hourly, {})
+
+        assert result is hourly

--- a/tests/test_weather_client_fusion.py
+++ b/tests/test_weather_client_fusion.py
@@ -671,9 +671,16 @@ class TestMergeForecasts:
 
 
 class TestMergeHourlyForecasts:
-    def _make_hourly(self):
+    def _make_hourly(self, *, start_time=None, pressure_mb=None, pressure_in=None):
         return HourlyForecast(
-            periods=[HourlyForecastPeriod(start_time=datetime.now(UTC), temperature=65.0)]
+            periods=[
+                HourlyForecastPeriod(
+                    start_time=start_time or datetime.now(UTC),
+                    temperature=65.0,
+                    pressure_mb=pressure_mb,
+                    pressure_in=pressure_in,
+                )
+            ]
         )
 
     def test_no_sources(self, engine, us_location):
@@ -743,6 +750,81 @@ class TestMergeHourlyForecasts:
         assert result.summary == "Light rain developing overnight."
         assert field_sources["hourly_source"] == "openmeteo"
         assert field_sources["hourly_summary"] == "pirateweather"
+
+    def test_selected_hourly_source_keeps_own_pressure(self, engine, us_location):
+        nws_hourly = self._make_hourly(pressure_mb=1012.0)
+        om_hourly = self._make_hourly(pressure_mb=1008.0)
+        sources = [
+            _make_source("openmeteo", hourly=om_hourly),
+            _make_source("nws", hourly=nws_hourly),
+        ]
+
+        result, field_sources = engine.merge_hourly_forecasts(sources, us_location)
+
+        assert result is not None
+        assert result.periods[0].pressure_mb == 1012.0
+        assert field_sources["hourly_source"] == "nws"
+        assert "hourly_pressure_source" not in field_sources
+
+    def test_overlays_pressure_from_alternate_hourly_source(self, engine, us_location):
+        now = datetime(2026, 4, 26, 10, tzinfo=UTC)
+        nws_hourly = self._make_hourly(start_time=now)
+        om_hourly = self._make_hourly(
+            start_time=now + timedelta(minutes=30),
+            pressure_mb=1007.5,
+            pressure_in=29.75,
+        )
+        sources = [
+            _make_source("openmeteo", hourly=om_hourly),
+            _make_source("nws", hourly=nws_hourly),
+        ]
+
+        result, field_sources = engine.merge_hourly_forecasts(sources, us_location)
+
+        assert result is not None
+        assert result is not nws_hourly
+        assert result.periods[0].temperature == 65.0
+        assert result.periods[0].pressure_mb == 1007.5
+        assert result.periods[0].pressure_in == 29.75
+        assert field_sources["hourly_source"] == "nws"
+        assert field_sources["hourly_pressure_source"] == "openmeteo"
+
+    def test_overlay_pressure_returns_original_when_source_has_no_pressure(self, engine):
+        display_hourly = self._make_hourly()
+        pressure_hourly = self._make_hourly()
+
+        result = engine._overlay_hourly_pressure(display_hourly, pressure_hourly)
+
+        assert result is display_hourly
+
+    def test_overlay_pressure_skips_existing_unmatched_and_invalid_times(self, engine):
+        now = datetime(2026, 4, 26, 10, tzinfo=UTC)
+        existing = HourlyForecastPeriod(
+            start_time=now,
+            temperature=65.0,
+            pressure_mb=1010.0,
+        )
+        unmatched = HourlyForecastPeriod(
+            start_time=now + timedelta(hours=4),
+            temperature=66.0,
+        )
+        invalid_time = HourlyForecastPeriod(
+            start_time=None,
+            temperature=67.0,
+        )
+        display_hourly = HourlyForecast(periods=[existing, unmatched, invalid_time])
+        pressure_hourly = HourlyForecast(
+            periods=[
+                HourlyForecastPeriod(start_time=None, pressure_mb=1009.0),
+                HourlyForecastPeriod(start_time=now, pressure_mb=1008.0),
+            ]
+        )
+
+        result = engine._overlay_hourly_pressure(display_hourly, pressure_hourly)
+
+        assert result is display_hourly
+        assert engine._hourly_has_pressure(None) is False
+        assert engine._nearest_hourly_pressure_period(None, pressure_hourly.periods) is None
 
 
 # --- DataFusionEngine init ---

--- a/tests/test_weather_client_trends.py
+++ b/tests/test_weather_client_trends.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 
+import pytest
+
+from accessiweather import weather_client_base
 from accessiweather.models import AppSettings
 from accessiweather.models.weather import (
     CurrentConditions,
@@ -12,6 +15,7 @@ from accessiweather.models.weather import (
     HourlyForecast,
     HourlyForecastPeriod,
     Location,
+    SourceAttribution,
     TrendInsight,
     WeatherData,
 )
@@ -19,6 +23,7 @@ from accessiweather.weather_client_base import WeatherClient
 from accessiweather.weather_client_trends import (
     apply_trend_insights,
     compute_daily_trend,
+    compute_pressure_outlook_unavailable,
     compute_pressure_trend,
     compute_temperature_trend,
     normalize_datetime,
@@ -320,8 +325,83 @@ class TestComputePressureTrend:
 
         assert compute_pressure_trend(wd, 168) is None
 
+    def test_unavailable_when_current_pressure_missing(self):
+        periods = _make_hourly_periods(
+            hours=12,
+            pressure_mb=1013.0,
+            pressure_change_mb=1.0,
+        )
+        wd = _make_weather_data(temp_f=70.0, hourly_periods=periods)
+
+        result = compute_pressure_outlook_unavailable(wd, 24)
+
+        assert result is not None
+        assert result.direction == "unavailable"
+        assert result.summary == "Pressure outlook unavailable: current pressure data is missing."
+
+    def test_unavailable_when_hourly_forecast_missing(self):
+        wd = _make_weather_data(temp_f=70.0, pressure_mb=1013.0)
+
+        result = compute_pressure_outlook_unavailable(wd, 24)
+
+        assert result is not None
+        assert result.summary == "Pressure outlook unavailable: hourly forecast data is missing."
+
+    def test_unavailable_names_hourly_source_without_pressure_data(self):
+        wd = _make_weather_data(
+            temp_f=70.0,
+            pressure_mb=1013.0,
+            hourly_periods=_make_hourly_periods(hours=12),
+        )
+        wd.source_attribution = SourceAttribution(field_sources={"hourly_source": "nws"})
+
+        result = compute_pressure_outlook_unavailable(wd, 24)
+
+        assert result is not None
+        assert result.summary == (
+            "Pressure outlook unavailable: NWS hourly forecast does not include pressure data."
+        )
+
+    def test_unavailable_uses_unknown_source_name_as_label(self):
+        wd = _make_weather_data(
+            temp_f=70.0,
+            pressure_mb=1013.0,
+            hourly_periods=_make_hourly_periods(hours=12),
+        )
+        wd.source_attribution = SourceAttribution(field_sources={"hourly_source": "custom"})
+
+        result = compute_pressure_outlook_unavailable(wd, 24)
+
+        assert result is not None
+        assert result.summary == (
+            "Pressure outlook unavailable: custom hourly forecast does not include pressure data."
+        )
+
+    def test_unavailable_when_pressure_data_is_shorter_than_requested_window(self):
+        periods = _make_hourly_periods(
+            hours=12,
+            pressure_mb=1013.0,
+            pressure_change_mb=-1.0,
+        )
+        wd = _make_weather_data(
+            temp_f=70.0,
+            pressure_mb=1013.0,
+            hourly_periods=periods,
+        )
+
+        result = compute_pressure_outlook_unavailable(wd, 48)
+
+        assert result is not None
+        assert result.summary == (
+            "Pressure outlook unavailable: not enough hourly pressure data for the next 48h."
+        )
+
 
 class TestPressureTrendSummary:
+    def test_steady_pressure_uses_steady_language(self):
+        result = pressure_trend_summary("steady", 0.0, "mb", 24)
+        assert result == "Pressure steady: +0.00 mb over next 24h"
+
     def test_falling_pressure_uses_drop_language(self):
         result = pressure_trend_summary("falling", -0.08, "inHg", 24)
         assert result == "Pressure drop predicted: -0.08 inHg over next 24h"
@@ -510,3 +590,33 @@ class TestPressureOutlookHourlyWindow:
         client = WeatherClient(settings=settings)
 
         assert client._get_hourly_hours_for_pressure_outlook() == 96
+
+    @pytest.mark.asyncio
+    async def test_openmeteo_parallel_fetch_receives_pressure_outlook_window(self, monkeypatch):
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        settings = AppSettings(hourly_forecast_hours=6, trend_hours=72)
+        client = WeatherClient(settings=settings)
+        client._test_mode = False
+        captured = {}
+
+        async def fake_parallel_fetch(
+            location,
+            base_url,
+            timeout,
+            http_client,
+            forecast_days,
+            model,
+            requested_hours,
+        ):
+            captured["requested_hours"] = requested_hours
+            return CurrentConditions(), Forecast(periods=[]), HourlyForecast(periods=[])
+
+        monkeypatch.setattr(
+            weather_client_base.openmeteo_client,
+            "get_openmeteo_all_data_parallel",
+            fake_parallel_fetch,
+        )
+
+        await client._fetch_openmeteo_data(_make_location())
+
+        assert captured["requested_hours"] == 72

--- a/tests/test_weather_client_trends.py
+++ b/tests/test_weather_client_trends.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 
+from accessiweather.models import AppSettings
 from accessiweather.models.weather import (
     CurrentConditions,
     Forecast,
@@ -14,6 +15,7 @@ from accessiweather.models.weather import (
     TrendInsight,
     WeatherData,
 )
+from accessiweather.weather_client_base import WeatherClient
 from accessiweather.weather_client_trends import (
     apply_trend_insights,
     compute_daily_trend,
@@ -21,6 +23,7 @@ from accessiweather.weather_client_trends import (
     compute_temperature_trend,
     normalize_datetime,
     period_for_hours_ahead,
+    pressure_trend_summary,
     trend_descriptor,
 )
 
@@ -300,6 +303,32 @@ class TestComputePressureTrend:
         result = compute_pressure_trend(wd, 6)
         assert result is not None
         assert result.direction == "falling"
+        assert result.summary is not None
+        assert "drop predicted" in result.summary
+
+    def test_does_not_report_pressure_outlook_when_requested_window_exceeds_data(self):
+        periods = _make_hourly_periods(
+            hours=24,
+            pressure_mb=1013.0,
+            pressure_change_mb=-4.0,
+        )
+        wd = _make_weather_data(
+            temp_f=70.0,
+            pressure_mb=1013.0,
+            hourly_periods=periods,
+        )
+
+        assert compute_pressure_trend(wd, 168) is None
+
+
+class TestPressureTrendSummary:
+    def test_falling_pressure_uses_drop_language(self):
+        result = pressure_trend_summary("falling", -0.08, "inHg", 24)
+        assert result == "Pressure drop predicted: -0.08 inHg over next 24h"
+
+    def test_rising_pressure_uses_rise_language(self):
+        result = pressure_trend_summary("rising", 2.25, "mb", 48)
+        assert result == "Pressure rise predicted: +2.25 mb over next 48h"
 
 
 # --- compute_daily_trend ---
@@ -467,3 +496,17 @@ class TestApplyTrendInsights:
         wd = WeatherData(location=_make_location(), current=None)
         apply_trend_insights(wd, trend_insights_enabled=True, trend_hours=6)
         assert wd.trend_insights == []
+
+
+class TestPressureOutlookHourlyWindow:
+    def test_openmeteo_hourly_request_covers_pressure_outlook_window(self):
+        settings = AppSettings(hourly_forecast_hours=6, trend_hours=72)
+        client = WeatherClient(settings=settings)
+
+        assert client._get_hourly_hours_for_pressure_outlook() == 72
+
+    def test_openmeteo_hourly_request_covers_display_window_when_larger(self):
+        settings = AppSettings(hourly_forecast_hours=96, trend_hours=24)
+        client = WeatherClient(settings=settings)
+
+        assert client._get_hourly_hours_for_pressure_outlook() == 96


### PR DESCRIPTION
## Summary
- Add a configurable pressure outlook range in Display settings for 1 hour through 7 days.
- Normalize pressure outlooks across NWS, Open-Meteo, Pirate Weather, and Visual Crossing hourly data.
- Populate NWS hourly pressure from the NWS gridpoint pressure layer and preserve pressure outlooks in auto mode source fusion.
- Surface pressure drop/rise prediction wording and clear unavailable states when pressure data is missing or too short for the requested window.

## Verification
- uv run pytest -q -n 0 --tb=short tests/test_nws_high_low.py tests/test_weather_client_trends.py tests/test_current_conditions.py tests/test_weather_client_fusion.py tests/test_source_priority_pirateweather.py tests/test_auto_mode_api_budget.py
- uv run ruff check src tests
- uv run ruff format --check src tests
- uv run pyright

Note: a previous full-suite run reached about 82% before a Windows access violation in audio/notification/thread tests; rerunning the implicated notifier/thread tests separately passed.