### PR TITLE
test(pytest): stabilize local parallel suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,12 +119,12 @@ jobs:
       run: |
         if [ "${{ matrix.primary }}" = "true" ]; then
           mkdir -p reports
-          xvfb-run -a pytest tests/ -n auto -v --tb=short -m "not integration" \
+          xvfb-run -a pytest tests/ -n 8 -v --tb=short -m "not integration" \
             --cov=src/accessiweather \
             --cov-report=xml:reports/coverage.xml \
             --cov-report=term-missing
         else
-          xvfb-run -a pytest tests/ -n auto -v --tb=short -m "not integration"
+          xvfb-run -a pytest tests/ -n 8 -v --tb=short -m "not integration"
         fi
 
     - name: Install diff-cover

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ For the same validation CI enforces on pull requests, run:
 ```bash
 ruff format --check .
 ruff check .
-ACCESSIWEATHER_TEST_MODE=1 HYPOTHESIS_PROFILE=ci pytest tests/ -n auto -v --tb=short -m "not integration"
+ACCESSIWEATHER_TEST_MODE=1 HYPOTHESIS_PROFILE=ci pytest tests/ -n 8 -v --tb=short -m "not integration"
 ```
 
 ## Accessibility Requirements

--- a/TESTING.md
+++ b/TESTING.md
@@ -42,8 +42,11 @@ LIVE_WEATHER_TESTS=1 pytest tests/integration/ -v
 # Run a specific provider's tests
 pytest tests/integration/test_nws_integration.py
 
-# Run all tests in parallel (faster)
-pytest -n auto
+# Run all tests with the stable parallel default
+pytest
+
+# Run all tests with an explicit worker count
+pytest -n 8
 
 # Run tests matching a pattern
 pytest -k "test_name" -v

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -536,8 +536,8 @@ api_key = keyring.get_password("accessiweather", "visual_crossing_api_key")
 **Dialog Creation:** Dialogs created when needed, not at app init
 
 ### 5. Test Parallelization
-**Tool:** `pytest-xdist` with `-n auto` flag
-**Result:** ~4x faster test suite execution
+**Tool:** `pytest-xdist` with a conservative default worker cap
+**Result:** Faster test suite execution without overwhelming local Windows runs
 
 ---
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -461,7 +461,7 @@ cat build/accessiweather/{platform}/app/logs/*.log
 
 ### Pre-Release
 
-- [ ] All tests passing (`pytest -n auto`)
+- [ ] All tests passing (`pytest`)
 - [ ] Code formatted (`ruff format .`)
 - [ ] Linting clean (`ruff check .`)
 - [ ] Version updated in `pyproject.toml`

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -135,8 +135,11 @@ git push origin feature/my-feature
 # Run all tests (serial)
 pytest -v
 
-# Run all tests (parallel - ~4x faster)
-pytest -n auto
+# Run all tests with the stable parallel default
+pytest
+
+# Run all tests with an explicit worker count
+pytest -n 8
 
 # Run specific test file
 pytest tests/test_weather_client.py -v
@@ -551,7 +554,7 @@ git push origin v0.4.3
 ### Development Performance
 
 - Use `briefcase dev` for fast iteration (no full build)
-- Run tests in parallel: `pytest -n auto`
+- Run tests with the stable parallel default: `pytest`
 - Use `--lf --ff` flags for faster test feedback
 - Cache API responses during development
 
@@ -658,7 +661,7 @@ python -c "import keyring; print(keyring.get_password('accessiweather', 'visual_
 ## Next Steps
 
 1. **Read architecture docs** to understand system design
-2. **Run tests** to verify setup: `pytest -n auto`
+2. **Run tests** to verify setup: `pytest`
 3. **Make a small change** to get familiar with workflow
 4. **Check existing issues** on GitHub for contribution ideas
 5. **Join community** via BeeWare Discord for questions

--- a/docs/index.md
+++ b/docs/index.md
@@ -239,8 +239,8 @@ Cache Check
 ### Test Commands
 
 ```bash
-# Run all tests (parallel)
-pytest -n auto
+# Run all tests with the stable parallel default
+pytest
 
 # Run unit tests only
 pytest -m "unit" -v

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -356,7 +356,7 @@ See [deployment-guide.md](deployment-guide.md) for complete pipeline docs.
 - **Coverage:** >70% target
 - **Backend:** `toga_dummy` (no real UI)
 - **Speed:** Fast (~1-2 minutes for full suite)
-- **Execution:** `pytest -n auto` (parallel)
+- **Execution:** `pytest` (parallel, stable default)
 
 ### Integration Tests
 - **Marker:** `@pytest.mark.integration`

--- a/docs/source-tree-analysis.md
+++ b/docs/source-tree-analysis.md
@@ -365,7 +365,7 @@ tests/
 
 **Test Execution:**
 - **Serial:** `pytest -v`
-- **Parallel:** `pytest -n auto` (~4x faster)
+- **Parallel:** `pytest` (stable default worker cap)
 - **Last Failed:** `pytest --lf --ff`
 - **Unit Only:** `pytest -m "unit"`
 

--- a/docs/technology-stack.md
+++ b/docs/technology-stack.md
@@ -215,7 +215,7 @@ See [ACCESSIBILITY.md](ACCESSIBILITY.md) for complete guidelines.
 
 ### Testing Performance
 - Parallel test execution with `pytest-xdist`
-- Test suite runs ~4x faster with `-n auto` flag
+- Test suite uses a conservative default pytest-xdist worker cap for local stability
 
 ---
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,9 @@
 [pytest]
-# Test configuration optimized for speed
-# - Parallel execution enabled (-n auto)
+# Test configuration optimized for local stability
+# - Parallel execution enabled with a conservative worker cap (-n 8)
 # - Verbose output with short tracebacks
 # - pytest-asyncio in auto mode
-addopts = -v --strict-markers -p no:asyncio -p pytest_asyncio.plugin -n auto --dist loadscope --tb=short -m "not live_only"
+addopts = -v --strict-markers -p no:asyncio -p pytest_asyncio.plugin -n 8 --dist loadscope --tb=short -m "not live_only"
 
 # =============================================================================
 # QUICK REFERENCE
@@ -21,6 +21,7 @@ python_classes = Test*
 python_functions = test_*
 testpaths = tests
 pythonpath = src
+cache_dir = .tmp/pytest_cache
 
 # Async mode for pytest-asyncio
 asyncio_mode = auto

--- a/tests/test_toasted_windows_notifier.py
+++ b/tests/test_toasted_windows_notifier.py
@@ -287,16 +287,7 @@ class TestToastedWindowsNotifierWorker:
             notifier._ensure_worker = MagicMock(return_value=True)
 
             def _run_immediately(coro, _loop):
-                class _CompletedTask:
-                    def add_done_callback(self, callback):
-                        callback(self)
-
-                def _create_task(task_coro):
-                    task_coro.close()
-                    return _CompletedTask()
-
-                with patch.object(toast_notifier.asyncio, "create_task", _create_task):
-                    asyncio.run(coro)
+                asyncio.run(coro)
                 return MagicMock()
 
             with patch.object(toast_notifier.asyncio, "run_coroutine_threadsafe", _run_immediately):
@@ -370,16 +361,7 @@ class TestToastedActivationCallback:
             notifier._ensure_worker = MagicMock(return_value=True)
 
             def _run_immediately(coro, _loop):
-                class _CompletedTask:
-                    def add_done_callback(self, callback):
-                        callback(self)
-
-                def _create_task(task_coro):
-                    task_coro.close()
-                    return _CompletedTask()
-
-                with patch.object(toast_notifier.asyncio, "create_task", _create_task):
-                    asyncio.run(coro)
+                asyncio.run(coro)
                 return MagicMock()
 
             with patch.object(toast_notifier.asyncio, "run_coroutine_threadsafe", _run_immediately):


### PR DESCRIPTION
## Summary
- cap the default pytest-xdist run at 8 workers instead of unbounded auto worker creation
- move pytest cache writes to .tmp/pytest_cache to avoid stale or unwritable .pytest_cache state
- clean up toast notifier test async handling so it no longer leaks an unawaited coroutine warning
- update active contributor/testing docs to use the stable default or explicit -n 8

## Why 8 workers
The suite has over 3K tests, so 4 workers was stable but conservative. I verified the full suite with 8 workers locally, and it completed cleanly in about 23 seconds while avoiding the 20-worker pressure from -n auto.

## Verification
- uv run pytest --tb=short --color=no: 3739 passed, 38 skipped
- uv run ruff check .
- uv run pyright