### PR TITLE
ci(build): experiment with Nuitka packaging

### DIFF
--- a/.github/workflows/nuitka-build.yml
+++ b/.github/workflows/nuitka-build.yml
@@ -1,0 +1,77 @@
+name: Nuitka Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_tag:
+        description: "Optional build tag, e.g. nightly-20260427"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  build-windows:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install --only-binary wxPython wxPython
+          pip install -e .[build]
+
+      - name: Build with Nuitka
+        run: |
+          python scripts/generate_build_meta.py ${{ inputs.build_tag }}
+          python installer/create_icons.py
+          python installer/build_nuitka.py --tag "${{ inputs.build_tag }}"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: nuitka-windows
+          path: |
+            dist/AccessiWeather_dir/**
+            dist/AccessiWeather_Portable_*.zip
+            build/nuitka/**/*.exe
+            dist/version.txt
+
+  build-macos:
+    name: macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install --only-binary wxPython wxPython
+          pip install -e .[build]
+
+      - name: Build with Nuitka
+        run: |
+          python scripts/generate_build_meta.py ${{ inputs.build_tag }}
+          python installer/create_icons.py
+          python installer/build_nuitka.py --tag "${{ inputs.build_tag }}"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: nuitka-macos
+          path: |
+            dist/AccessiWeather_macOS_*.zip
+            build/nuitka/**/*.app/**
+            dist/version.txt

--- a/installer/build_nuitka.py
+++ b/installer/build_nuitka.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Experimental Nuitka build path for AccessiWeather."""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = ROOT / "src"
+DIST_DIR = ROOT / "dist"
+BUILD_DIR = ROOT / "build" / "nuitka"
+RESOURCES_DIR = SRC_DIR / "accessiweather" / "resources"
+SOUNDPACKS_DIR = ROOT / "soundpacks"
+APP_NAME = "AccessiWeather"
+
+
+def _repo_path(path: Path) -> str:
+    """Return a POSIX-style path relative to the repository root."""
+    return path.relative_to(ROOT).as_posix()
+
+
+def get_version() -> str:
+    """Read the package version from pyproject.toml."""
+    with (ROOT / "pyproject.toml").open("rb") as f:
+        return tomllib.load(f)["project"]["version"]
+
+
+def _nuitka_version(version: str) -> str:
+    """Convert a PEP 440-ish version into Nuitka's numeric Windows version format."""
+    base = version.split("+", 1)[0].split(".dev", 1)[0].split("a", 1)[0].split("b", 1)[0]
+    parts = [part for part in base.split(".") if part.isdigit()]
+    return ".".join((parts + ["0", "0", "0", "0"])[:4])
+
+
+def write_inno_version_file() -> Path:
+    """Write the version handoff consumed by Inno Setup."""
+    DIST_DIR.mkdir(parents=True, exist_ok=True)
+    version_file = DIST_DIR / "version.txt"
+    version_file.write_text(f"[version]\nvalue={get_version()}\n", encoding="utf-8")
+    return version_file
+
+
+def _find_nuitka_dist_dir() -> Path:
+    """Find the standalone folder produced by Nuitka."""
+    candidates = sorted(BUILD_DIR.glob("*.dist"))
+    for candidate in candidates:
+        if (candidate / f"{APP_NAME}.exe").exists() or (candidate / APP_NAME).exists():
+            return candidate
+
+    raise FileNotFoundError(f"Nuitka standalone output was not found under {BUILD_DIR}")
+
+
+def stage_nuitka_distribution() -> Path:
+    """Copy Nuitka standalone output into the layout expected by Inno and ZIP code."""
+    source_dir = _find_nuitka_dist_dir()
+    target_dir = DIST_DIR / "AccessiWeather_dir"
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
+    DIST_DIR.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source_dir, target_dir)
+    return target_dir
+
+
+def create_portable_zip() -> bool:
+    """Create a portable ZIP from the staged Nuitka standalone folder."""
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+
+    from installer import build
+
+    original_dist_dir = build.DIST_DIR
+    try:
+        build.DIST_DIR = DIST_DIR
+        return build.create_portable_zip()
+    finally:
+        build.DIST_DIR = original_dist_dir
+
+
+def build_nuitka_command(
+    *,
+    output_dir: Path,
+    build_tag: str | None,
+    assume_platform: str | None = None,
+) -> list[str]:
+    """Build the Nuitka command for the current platform."""
+    system = assume_platform or platform.system()
+    version = get_version()
+    numeric_version = _nuitka_version(version)
+
+    mode = "--mode=app" if system == "Darwin" else "--mode=standalone"
+    command = [
+        sys.executable,
+        "-m",
+        "nuitka",
+        mode,
+        "--assume-yes-for-downloads",
+        "--deployment",
+        "--enable-plugin=anti-bloat",
+        "--noinclude-pytest-mode=nofollow",
+        "--noinclude-unittest-mode=nofollow",
+        "--include-package=accessiweather",
+        "--include-package-data=desktop_notifier",
+        "--include-package-data=tzdata",
+        "--include-package-data=toasted",
+        "--include-package-data=playsound3",
+        f"--include-data-dir={_repo_path(RESOURCES_DIR)}=accessiweather/resources",
+        f"--output-dir={output_dir.as_posix()}",
+        f"--output-filename={APP_NAME}",
+        f"--product-name={APP_NAME}",
+        f"--file-description={APP_NAME}",
+        f"--product-version={numeric_version}",
+        f"--file-version={numeric_version}",
+        _repo_path(SRC_DIR / "accessiweather" / "__main__.py"),
+    ]
+
+    if (SOUNDPACKS_DIR / "default").exists():
+        command.insert(
+            -1,
+            f"--include-data-dir={_repo_path(SOUNDPACKS_DIR / 'default')}=soundpacks/default",
+        )
+
+    if build_tag:
+        command.insert(-1, f"--company-name=Orinks ({build_tag})")
+    else:
+        command.insert(-1, "--company-name=Orinks")
+
+    if system == "Windows":
+        icon = RESOURCES_DIR / "app.ico"
+        command.extend([
+            "--windows-console-mode=disable",
+            f"--windows-icon-from-ico={_repo_path(icon)}",
+        ])
+    elif system == "Darwin":
+        icon = RESOURCES_DIR / "app.icns"
+        command.extend([
+            "--macos-create-app-bundle",
+            f"--macos-app-name={APP_NAME}",
+            f"--macos-app-icon={_repo_path(icon)}",
+        ])
+
+    return command
+
+
+def run_command(command: list[str]) -> None:
+    """Run a command from the project root."""
+    print("Running:", " ".join(command))
+    subprocess.run(command, cwd=ROOT, check=True)
+
+
+def ensure_nuitka_available() -> None:
+    """Fail early with a useful message if Nuitka is not installed."""
+    if shutil.which("nuitka") is None:
+        try:
+            subprocess.run(
+                [sys.executable, "-m", "nuitka", "--version"],
+                cwd=ROOT,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            raise RuntimeError("Nuitka is not installed. Run: pip install nuitka") from exc
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build AccessiWeather with Nuitka.")
+    parser.add_argument("--tag", default=None, help="Build tag, e.g. nightly-20260427.")
+    parser.add_argument("--skip-compile", action="store_true", help="Only write version metadata.")
+    args = parser.parse_args()
+
+    print(f"AccessiWeather Nuitka build, version {get_version()}")
+    write_inno_version_file()
+
+    if args.skip_compile:
+        return 0
+
+    ensure_nuitka_available()
+    run_command(build_nuitka_command(output_dir=BUILD_DIR, build_tag=args.tag))
+    stage_nuitka_distribution()
+    if not create_portable_zip():
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/installer/build_nuitka.py
+++ b/installer/build_nuitka.py
@@ -132,17 +132,21 @@ def build_nuitka_command(
 
     if system == "Windows":
         icon = RESOURCES_DIR / "app.ico"
-        command.extend([
-            "--windows-console-mode=disable",
-            f"--windows-icon-from-ico={_repo_path(icon)}",
-        ])
+        command.extend(
+            [
+                "--windows-console-mode=disable",
+                f"--windows-icon-from-ico={_repo_path(icon)}",
+            ]
+        )
     elif system == "Darwin":
         icon = RESOURCES_DIR / "app.icns"
-        command.extend([
-            "--macos-create-app-bundle",
-            f"--macos-app-name={APP_NAME}",
-            f"--macos-app-icon={_repo_path(icon)}",
-        ])
+        command.extend(
+            [
+                "--macos-create-app-bundle",
+                f"--macos-app-name={APP_NAME}",
+                f"--macos-app-icon={_repo_path(icon)}",
+            ]
+        )
 
     return command
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
 ]
 build = [
     "pyinstaller>=6.0.0",
+    "nuitka>=4.0.8",
     "pillow>=10.0.0",
 ]
 [project.scripts]

--- a/tests/test_nuitka_build.py
+++ b/tests/test_nuitka_build.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from installer import build_nuitka
+
+
+def test_get_version_reads_pyproject() -> None:
+    assert build_nuitka.get_version() == "0.6.1.dev0"
+
+
+def test_write_inno_version_file_uses_pyproject_version(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(build_nuitka, "DIST_DIR", tmp_path)
+
+    version_file = build_nuitka.write_inno_version_file()
+
+    assert version_file == tmp_path / "version.txt"
+    assert version_file.read_text(encoding="utf-8") == "[version]\nvalue=0.6.1.dev0\n"
+
+
+def test_windows_nuitka_command_uses_standalone_dir_and_pyproject_version() -> None:
+    command = build_nuitka.build_nuitka_command(
+        output_dir=Path("dist"),
+        build_tag="nightly-20260427",
+        assume_platform="Windows",
+    )
+
+    assert command[:3] == [build_nuitka.sys.executable, "-m", "nuitka"]
+    assert "--mode=standalone" in command
+    assert "--windows-console-mode=disable" in command
+    assert "--output-filename=AccessiWeather" in command
+    assert "--product-version=0.6.1.0" in command
+    assert "--file-version=0.6.1.0" in command
+    assert "--include-data-dir=soundpacks/default=soundpacks/default" in command
+    assert "--include-package-data=tzdata" in command
+    assert "--include-package=accessiweather" in command
+    assert "src/accessiweather/__main__.py" in command
+    assert "--mode=onefile" not in command
+
+
+def test_macos_nuitka_command_uses_app_mode() -> None:
+    command = build_nuitka.build_nuitka_command(
+        output_dir=Path("dist"),
+        build_tag=None,
+        assume_platform="Darwin",
+    )
+
+    assert "--mode=app" in command
+    assert "--macos-create-app-bundle" in command
+    assert "--macos-app-name=AccessiWeather" in command
+
+
+def test_nuitka_is_available_as_build_extra() -> None:
+    pyproject = (build_nuitka.ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert '"nuitka' in pyproject
+
+
+def test_experimental_nuitka_workflow_uses_binary_wxpython_install() -> None:
+    workflow = (build_nuitka.ROOT / ".github" / "workflows" / "nuitka-build.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "workflow_dispatch:" in workflow
+    assert "--only-binary wxPython" in workflow
+    assert "python installer/build_nuitka.py" in workflow
+    assert "scripts/generate_build_meta.py" in workflow
+
+
+def test_stage_nuitka_distribution_copies_output_to_dist_shape(tmp_path, monkeypatch) -> None:
+    build_dir = tmp_path / "build" / "nuitka"
+    nuitka_dist = build_dir / "__main__.dist"
+    nuitka_dist.mkdir(parents=True)
+    (nuitka_dist / "AccessiWeather.exe").write_bytes(b"fake-exe")
+    (nuitka_dist / "wx").mkdir()
+
+    dist_dir = tmp_path / "dist"
+    monkeypatch.setattr(build_nuitka, "BUILD_DIR", build_dir)
+    monkeypatch.setattr(build_nuitka, "DIST_DIR", dist_dir)
+
+    staged = build_nuitka.stage_nuitka_distribution()
+
+    assert staged == dist_dir / "AccessiWeather_dir"
+    assert (staged / "AccessiWeather.exe").read_bytes() == b"fake-exe"
+    assert (staged / "wx").is_dir()
+
+
+def test_stage_nuitka_distribution_fails_when_output_missing(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(build_nuitka, "BUILD_DIR", tmp_path / "build" / "nuitka")
+
+    with pytest.raises(FileNotFoundError, match="Nuitka standalone output"):
+        build_nuitka.stage_nuitka_distribution()


### PR DESCRIPTION
## Summary
- Add a manual experimental Nuitka build workflow for Windows and macOS
- Add installer/build_nuitka.py to build from pyproject.toml version metadata, stage standalone output, and create portable ZIPs
- Force binary wxPython install in the workflow to avoid source builds

## Verification
- uv run pytest -q -n 0 --tb=short tests/test_nuitka_build.py tests/test_installer_build.py tests/test_installer_version_metadata.py
- uv run ruff check installer tests
- uv run pyright
- Local Windows Nuitka compile succeeded; portable ZIP created without PyInstaller

## Notes
GitHub cannot workflow_dispatch a workflow file that only exists on this branch, so the macOS Nuitka job needs this workflow to be present on dev/default before manual dispatch.