### PR TITLE
fix(weather): surface conflicting precipitation sources

### DIFF
--- a/src/accessiweather/display/weather_presenter.py
+++ b/src/accessiweather/display/weather_presenter.py
@@ -648,6 +648,7 @@ class WeatherPresenter:
             "nws": "National Weather Service",
             "openmeteo": "Open-Meteo",
             "visualcrossing": "Visual Crossing",
+            "pirateweather": "Pirate Weather",
         }
 
         contributing = [
@@ -666,6 +667,10 @@ class WeatherPresenter:
         else:
             summary = ""
 
+        disagreement_note = self._build_source_disagreement_note(weather_data, source_names)
+        if disagreement_note:
+            summary = f"{summary}. {disagreement_note}" if summary else disagreement_note
+
         # Build accessible aria label
         aria_parts = []
         if contributing:
@@ -674,6 +679,8 @@ class WeatherPresenter:
             aria_parts.append(f"Data unavailable from {', '.join(failed)}")
         if incomplete:
             aria_parts.append(f"Missing sections: {', '.join(incomplete)}")
+        if disagreement_note:
+            aria_parts.append(disagreement_note)
         aria_label = ". ".join(aria_parts) if aria_parts else "Weather data source information"
 
         return SourceAttributionPresentation(
@@ -682,6 +689,59 @@ class WeatherPresenter:
             incomplete_sections=incomplete,
             summary_text=summary,
             aria_label=aria_label,
+        )
+
+    def _build_source_disagreement_note(
+        self, weather_data: WeatherData, source_names: dict[str, str]
+    ) -> str | None:
+        """Return a short note when obvious condition sources disagree."""
+        attribution = weather_data.source_attribution
+        if attribution is None or weather_data.current is None:
+            return None
+
+        current_text = _clean_condition_text(weather_data.current.condition)
+        current_state = _precipitation_state(current_text)
+        if current_text is None or current_state is None:
+            return None
+
+        hourly_period = (
+            weather_data.hourly_forecast.periods[0]
+            if weather_data.hourly_forecast and weather_data.hourly_forecast.periods
+            else None
+        )
+        hourly_text = _clean_condition_text(
+            getattr(hourly_period, "short_forecast", None) if hourly_period else None
+        )
+        hourly_state = _precipitation_state(hourly_text)
+
+        minutely = weather_data.minutely_precipitation
+        minutely_text = _clean_condition_text(getattr(minutely, "summary", None))
+        minutely_state = _minutely_precipitation_state(minutely)
+
+        parts: list[str] = []
+        field_sources = attribution.field_sources
+        current_source = _format_source_name(field_sources.get("condition"), source_names)
+        hourly_source = _format_source_name(field_sources.get("hourly_source"), source_names)
+        minutely_source = _format_source_name(
+            field_sources.get("minutely_precipitation") or field_sources.get("hourly_summary"),
+            source_names,
+        )
+
+        if hourly_text and hourly_state is not None and hourly_state != current_state:
+            parts.append(f"hourly forecast from {hourly_source} says {hourly_text}")
+
+        if minutely_text and minutely_state is not None and minutely_state != current_state:
+            parts.append(
+                f"minute-by-minute precipitation outlook from {minutely_source} says "
+                f"{minutely_text}"
+            )
+
+        if not parts:
+            return None
+
+        return (
+            f"Data note: current conditions from {current_source} report {current_text}; "
+            f"{'; '.join(parts)}."
         )
 
     def _resolve_unit_preferences(
@@ -704,6 +764,72 @@ class WeatherPresenter:
             use_12hour=use_12hour,
             show_timezone=show_timezone,
         )
+
+
+_WET_CONDITION_MARKERS = (
+    "thunderstorm",
+    "t-storm",
+    "rain",
+    "shower",
+    "drizzle",
+    "snow",
+    "sleet",
+    "hail",
+    "freezing rain",
+)
+_DRY_CONDITION_MARKERS = (
+    "clear",
+    "sunny",
+    "cloudy",
+    "overcast",
+    "fair",
+)
+
+
+def _clean_condition_text(value: str | None) -> str | None:
+    """Normalize condition text for display while preserving user-facing wording."""
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned.rstrip(".") if cleaned else None
+
+
+def _precipitation_state(value: str | None) -> str | None:
+    """Classify obvious wet/dry condition wording; return None when ambiguous."""
+    if value is None:
+        return None
+    normalized = value.casefold()
+    if any(marker in normalized for marker in _WET_CONDITION_MARKERS):
+        return "wet"
+    if any(marker in normalized for marker in _DRY_CONDITION_MARKERS):
+        return "dry"
+    return None
+
+
+def _minutely_precipitation_state(minutely: object | None) -> str | None:
+    """Classify minutely precipitation data from explicit points or summary text."""
+    if minutely is None:
+        return None
+
+    points = getattr(minutely, "points", None)
+    if points:
+        for point in points:
+            intensity = getattr(point, "precipitation_intensity", None)
+            probability = getattr(point, "precipitation_probability", None)
+            if (isinstance(intensity, int | float) and intensity > 0) or (
+                isinstance(probability, int | float) and probability > 0
+            ):
+                return "wet"
+        return "dry"
+
+    return _precipitation_state(_clean_condition_text(getattr(minutely, "summary", None)))
+
+
+def _format_source_name(source: str | None, source_names: dict[str, str]) -> str:
+    """Return a readable source label, falling back to a generic label."""
+    if not source:
+        return "another source"
+    return source_names.get(source, source.title())
 
 
 from .presentation.alerts import build_alerts  # noqa: E402

--- a/src/accessiweather/weather_client_nws.py
+++ b/src/accessiweather/weather_client_nws.py
@@ -1708,6 +1708,7 @@ def parse_nws_forecast(data: dict) -> Forecast:
             icon=period_data.get("icon"),
             start_time=start_time,
             end_time=end_time,
+            precipitation_probability=_extract_float(period_data.get("probabilityOfPrecipitation")),
         )
         periods.append(period)
 
@@ -1872,6 +1873,7 @@ def parse_nws_hourly_forecast(data: dict, location: Location | None = None) -> H
             wind_speed=_format_wind_speed(period_data.get("windSpeed")),
             wind_direction=wind_direction,
             icon=period_data.get("icon"),
+            precipitation_probability=_extract_float(period_data.get("probabilityOfPrecipitation")),
         )
         periods.append(period)
 

--- a/tests/test_nws_high_low.py
+++ b/tests/test_nws_high_low.py
@@ -96,6 +96,22 @@ class TestNwsHighLowPairing:
             == "Sunny, with a high near 34. Northwest wind 10 mph."
         )
 
+    def test_probability_of_precipitation_preserved(self):
+        """NWS probabilityOfPrecipitation.value is mapped to the forecast period."""
+        data = _wrap(
+            [
+                {
+                    **_make_period("Today", 34, is_daytime=True),
+                    "probabilityOfPrecipitation": {
+                        "unitCode": "wmoUnit:percent",
+                        "value": 52,
+                    },
+                }
+            ]
+        )
+        forecast = parse_nws_forecast(data)
+        assert forecast.periods[0].precipitation_probability == 52
+
     def test_empty_periods(self):
         forecast = parse_nws_forecast({"properties": {"periods": []}})
         assert len(forecast.periods) == 0
@@ -125,6 +141,10 @@ def _hourly_payload(start_time: str = "2026-04-26T10:00:00-04:00"):
                     "shortForecast": "Cloudy",
                     "windSpeed": "5 mph",
                     "windDirection": "N",
+                    "probabilityOfPrecipitation": {
+                        "unitCode": "wmoUnit:percent",
+                        "value": 14,
+                    },
                 }
             ]
         }
@@ -132,6 +152,11 @@ def _hourly_payload(start_time: str = "2026-04-26T10:00:00-04:00"):
 
 
 class TestNwsHourlyPressure:
+    def test_probability_of_precipitation_preserved(self):
+        """NWS hourly probabilityOfPrecipitation.value is mapped to the hourly period."""
+        hourly = parse_nws_hourly_forecast(_hourly_payload())
+        assert hourly.periods[0].precipitation_probability == 14
+
     @pytest.mark.asyncio
     async def test_get_nws_hourly_forecast_applies_gridpoint_pressure(self):
         location = Location(name="Test", latitude=40.0, longitude=-74.0)

--- a/tests/test_weather_presenter_mobility_briefing.py
+++ b/tests/test_weather_presenter_mobility_briefing.py
@@ -13,6 +13,7 @@ from accessiweather.models import (
     Location,
     MinutelyPrecipitationForecast,
     MinutelyPrecipitationPoint,
+    SourceAttribution,
     WeatherData,
 )
 
@@ -76,3 +77,94 @@ def test_weather_presenter_populates_forecast_mobility_briefing():
     assert presentation.forecast.hourly_section_text.startswith(
         "Hourly forecast:\nMobility briefing:"
     )
+
+
+def test_weather_presenter_source_attribution_notes_current_hourly_minutely_disagreement():
+    now = datetime(2026, 4, 27, 20, 0, tzinfo=UTC)
+    weather_data = WeatherData(
+        location=Location(name="Carrollton, Texas", latitude=32.95373, longitude=-96.89028),
+        current=CurrentConditions(condition="Thunderstorms", temperature_f=91.0),
+        forecast=Forecast(periods=[ForecastPeriod(name="Tonight", short_forecast="Partly Cloudy")]),
+        hourly_forecast=HourlyForecast(
+            periods=[
+                HourlyForecastPeriod(
+                    start_time=now,
+                    temperature=91.0,
+                    temperature_unit="F",
+                    short_forecast="Mostly Clear",
+                    precipitation_probability=14,
+                )
+            ],
+            summary="Thunderstorms starting later this evening.",
+        ),
+        minutely_precipitation=MinutelyPrecipitationForecast(
+            summary="Clear for the hour.",
+            points=[
+                MinutelyPrecipitationPoint(
+                    time=now + timedelta(minutes=i),
+                    precipitation_intensity=0.0,
+                    precipitation_probability=0.0,
+                    precipitation_type="none",
+                )
+                for i in range(3)
+            ],
+        ),
+        source_attribution=SourceAttribution(
+            field_sources={
+                "condition": "nws",
+                "hourly_source": "nws",
+                "hourly_summary": "pirateweather",
+            },
+            contributing_sources={"nws", "pirateweather"},
+        ),
+    )
+
+    presenter = WeatherPresenter(AppSettings(hourly_forecast_hours=1))
+    presentation = presenter.present(weather_data)
+
+    assert presentation.source_attribution is not None
+    assert (
+        "Data note: current conditions from National Weather Service report Thunderstorms; "
+        "hourly forecast from National Weather Service says Mostly Clear; "
+        "minute-by-minute precipitation outlook from Pirate Weather says Clear for the hour."
+        in presentation.source_attribution.summary_text
+    )
+
+
+def test_weather_presenter_source_attribution_omits_note_when_sources_agree():
+    now = datetime(2026, 4, 27, 20, 0, tzinfo=UTC)
+    weather_data = WeatherData(
+        location=Location(name="Carrollton, Texas", latitude=32.95373, longitude=-96.89028),
+        current=CurrentConditions(condition="Mostly Clear", temperature_f=91.0),
+        forecast=Forecast(periods=[ForecastPeriod(name="Tonight", short_forecast="Partly Cloudy")]),
+        hourly_forecast=HourlyForecast(
+            periods=[
+                HourlyForecastPeriod(
+                    start_time=now,
+                    temperature=91.0,
+                    temperature_unit="F",
+                    short_forecast="Mostly Clear",
+                )
+            ]
+        ),
+        minutely_precipitation=MinutelyPrecipitationForecast(
+            summary="Clear for the hour.",
+            points=[
+                MinutelyPrecipitationPoint(
+                    time=now,
+                    precipitation_intensity=0.0,
+                    precipitation_probability=0.0,
+                )
+            ],
+        ),
+        source_attribution=SourceAttribution(
+            field_sources={"condition": "nws", "hourly_source": "nws"},
+            contributing_sources={"nws", "pirateweather"},
+        ),
+    )
+
+    presenter = WeatherPresenter(AppSettings(hourly_forecast_hours=1))
+    presentation = presenter.present(weather_data)
+
+    assert presentation.source_attribution is not None
+    assert "Data note:" not in presentation.source_attribution.summary_text


### PR DESCRIPTION
## Summary
- Add a source-attribution data note when current conditions, hourly forecast, and minute-by-minute precipitation outlook clearly disagree.
- Preserve NWS `probabilityOfPrecipitation.value` in daily and hourly forecast models so the UI can show NWS PoP.
- Add regression coverage for the NWS PoP parser and source-disagreement attribution behavior.

## Verification
- `uv run pytest -q -n 0 --tb=short`
- `uv run ruff check src tests`
- `uv run ruff format --check .`
- `uv run pyright`

## Notes
The disagreement cue is intentionally conservative: it only appears for obvious wet/dry wording conflicts, so ambiguous condition text remains quiet.