### PR TITLE
fix(build): split Windows portable staging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ startsWith(github.ref, 'refs/tags/') && github.ref || 'dev' }}
+          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
           fetch-depth: 0
 
       - name: Check build conditions
@@ -101,7 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ needs.prepare.outputs.is_nightly == 'true' && 'dev' || github.ref }}
+          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
           fetch-depth: 0
 
       - uses: actions/setup-python@v6
@@ -154,7 +154,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ needs.prepare.outputs.is_nightly == 'true' && 'dev' || github.ref }}
+          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
           fetch-depth: 0
 
       - uses: actions/setup-python@v6
@@ -205,7 +205,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ needs.prepare.outputs.is_nightly == 'true' && 'dev' || github.ref }}
+          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
           fetch-depth: 0
 
       - uses: actions/download-artifact@v8

--- a/installer/accessiweather.iss
+++ b/installer/accessiweather.iss
@@ -52,7 +52,7 @@ SetupIconFile=app.ico
 UninstallDisplayIcon={app}\{#MyAppExeName}
 
 ; Compression
-Compression=lzma2/ultra64
+Compression=lzma2/normal
 SolidCompression=yes
 LZMAUseSeparateProcess=yes
 LZMANumBlockThreads=4

--- a/installer/build.py
+++ b/installer/build.py
@@ -337,14 +337,16 @@ def create_portable_zip() -> bool:
 
     if IS_WINDOWS:
         # Look for directory distribution first, then single exe
-        source_dir = DIST_DIR / "AccessiWeather_dir"
-        if not source_dir.exists():
+        app_source_dir = DIST_DIR / "AccessiWeather_dir"
+        source_dir = DIST_DIR / "AccessiWeather"
+        if source_dir.exists():
+            shutil.rmtree(source_dir)
+        if app_source_dir.exists():
+            shutil.copytree(app_source_dir, source_dir)
+        else:
             # Single exe - create a directory for it
             exe_path = DIST_DIR / "AccessiWeather.exe"
             if exe_path.exists():
-                source_dir = DIST_DIR / "AccessiWeather_portable"
-                if source_dir.exists():
-                    shutil.rmtree(source_dir)
                 source_dir.mkdir(exist_ok=True)
                 shutil.copy2(exe_path, source_dir / "AccessiWeather.exe")
             else:

--- a/tests/test_installer_build.py
+++ b/tests/test_installer_build.py
@@ -36,10 +36,10 @@ def test_create_portable_zip_from_single_exe_includes_default_soundpack(
     with zipfile.ZipFile(zip_path) as archive:
         names = set(archive.namelist())
 
-    assert "AccessiWeather_portable/AccessiWeather.exe" in names
-    assert "AccessiWeather_portable/.portable" in names
-    assert "AccessiWeather_portable/data/soundpacks/default/pack.json" in names
-    assert "AccessiWeather_portable/data/soundpacks/default/startup.wav" in names
+    assert "AccessiWeather/AccessiWeather.exe" in names
+    assert "AccessiWeather/.portable" in names
+    assert "AccessiWeather/data/soundpacks/default/pack.json" in names
+    assert "AccessiWeather/data/soundpacks/default/startup.wav" in names
 
 
 def test_create_portable_zip_from_dir_distribution_uses_staged_bundled_soundpack(
@@ -62,15 +62,16 @@ def test_create_portable_zip_from_dir_distribution_uses_staged_bundled_soundpack
     monkeypatch.setattr(build, "get_version", lambda: "9.9.9")
 
     assert build.create_portable_zip() is True
-    assert (source_dir / "data" / "soundpacks" / "default" / "pack.json").exists()
+    portable_stage_dir = dist_dir / "AccessiWeather"
+    assert (portable_stage_dir / "data" / "soundpacks" / "default" / "pack.json").exists()
 
     zip_path = dist_dir / "AccessiWeather_Portable_v9.9.9.zip"
     with zipfile.ZipFile(zip_path) as archive:
         names = set(archive.namelist())
 
-    assert "AccessiWeather_dir/data/soundpacks/default/pack.json" in names
-    assert "AccessiWeather_dir/data/soundpacks/default/startup.wav" in names
-    assert "AccessiWeather_dir/.portable" in names
+    assert "AccessiWeather/data/soundpacks/default/pack.json" in names
+    assert "AccessiWeather/data/soundpacks/default/startup.wav" in names
+    assert "AccessiWeather/.portable" in names
 
 
 def test_create_portable_zip_fails_when_default_soundpack_manifest_missing(

--- a/tests/test_installer_version_metadata.py
+++ b/tests/test_installer_version_metadata.py
@@ -13,6 +13,13 @@ def test_inno_installer_has_no_stale_version_fallback():
     assert 'ReadIni("..\\dist\\version.txt"' in script
 
 
+def test_inno_installer_avoids_ultra_compression_for_ci_runtime():
+    script = (ROOT / "installer" / "accessiweather.iss").read_text()
+
+    assert "Compression=lzma2/normal" in script
+    assert "Compression=lzma2/ultra" not in script
+
+
 def test_build_workflow_uses_nuitka_builder_for_windows_installer_metadata():
     workflow = (ROOT / ".github" / "workflows" / "build.yml").read_text()
 
@@ -20,6 +27,13 @@ def test_build_workflow_uses_nuitka_builder_for_windows_installer_metadata():
     assert "python installer/build_nuitka.py" in workflow
     assert "dist/AccessiWeather_Setup_*.exe" in workflow
     assert "echo value=${{ needs.prepare.outputs.version }}" not in workflow
+
+
+def test_build_workflow_dispatch_uses_selected_ref_for_branch_testing():
+    workflow = (ROOT / ".github" / "workflows" / "build.yml").read_text()
+
+    assert "${{ github.event_name == 'schedule' && 'dev' || github.ref }}" in workflow
+    assert "needs.prepare.outputs.is_nightly == 'true' && 'dev' || github.ref" not in workflow
 
 
 def test_build_workflow_uses_nuitka_for_macos_artifacts():

--- a/tests/test_nuitka_build.py
+++ b/tests/test_nuitka_build.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import os
+import zipfile
 from pathlib import Path
 
 import pytest
 
-from installer import build_nuitka
+from installer import build, build_nuitka
 
 
 def test_get_version_reads_pyproject() -> None:
@@ -194,3 +195,37 @@ def test_nuitka_windows_main_builds_installer_before_portable_zip(monkeypatch) -
 
     assert build_nuitka.main() == 0
     assert calls == ["compile", "stage", "installer", "portable"]
+
+
+def test_windows_portable_zip_uses_separate_staging_dir(tmp_path, monkeypatch) -> None:
+    dist_dir = tmp_path / "dist"
+    installer_stage = dist_dir / "AccessiWeather_dir"
+    bundled_soundpack = installer_stage / "soundpacks" / "default"
+    bundled_soundpack.mkdir(parents=True)
+    (installer_stage / "AccessiWeather.exe").write_bytes(b"fake-exe")
+    (bundled_soundpack / "pack.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(build, "DIST_DIR", dist_dir)
+    monkeypatch.setattr(build, "IS_WINDOWS", True)
+    monkeypatch.setattr(build, "IS_MACOS", False)
+    monkeypatch.setattr(build, "IS_LINUX", False)
+
+    assert build.create_portable_zip() is True
+
+    portable_stage = dist_dir / "AccessiWeather"
+    zip_path = dist_dir / f"AccessiWeather_Portable_v{build.get_version()}.zip"
+    assert portable_stage.is_dir()
+    assert (portable_stage / ".portable").is_file()
+    assert (portable_stage / "config").is_dir()
+    assert (portable_stage / "data" / "soundpacks" / "default" / "pack.json").is_file()
+
+    assert not (installer_stage / ".portable").exists()
+    assert not (installer_stage / "config").exists()
+    assert not (installer_stage / "data").exists()
+
+    with zipfile.ZipFile(zip_path) as archive:
+        names = set(archive.namelist())
+
+    assert "AccessiWeather/AccessiWeather.exe" in names
+    assert "AccessiWeather/.portable" in names
+    assert "AccessiWeather/data/soundpacks/default/pack.json" in names

--- a/tests/test_settings_dialog_api_key_guard.py
+++ b/tests/test_settings_dialog_api_key_guard.py
@@ -23,22 +23,9 @@ def _make_dialog(
     original_or="",
 ):
     """Create a minimal SettingsDialogSimple stand-in with the guard logic."""
-    import importlib.util
-    from pathlib import Path
+    from accessiweather.ui.dialogs import settings_dialog
 
-    module_path = (
-        Path(__file__).resolve().parents[1]
-        / "src"
-        / "accessiweather"
-        / "ui"
-        / "dialogs"
-        / "settings_dialog.py"
-    )
-    spec = importlib.util.spec_from_file_location("sdmod", module_path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-
-    dlg = mod.SettingsDialogSimple.__new__(mod.SettingsDialogSimple)
+    dlg = settings_dialog.SettingsDialogSimple.__new__(settings_dialog.SettingsDialogSimple)
     dlg._original_vc_key = original_vc
     dlg._original_pirate_weather_key = original_pirate
     dlg._original_openrouter_key = original_or

--- a/tests/test_settings_dialog_portable_copy.py
+++ b/tests/test_settings_dialog_portable_copy.py
@@ -1,25 +1,14 @@
 from __future__ import annotations
 
-import importlib.util
 import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
 
 def _load_settings_dialog_module():
-    module_path = (
-        Path(__file__).resolve().parents[1]
-        / "src"
-        / "accessiweather"
-        / "ui"
-        / "dialogs"
-        / "settings_dialog.py"
-    )
-    spec = importlib.util.spec_from_file_location("test_settings_dialog_copy_module", module_path)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    from accessiweather.ui.dialogs import settings_dialog
+
+    return settings_dialog
 
 
 module = _load_settings_dialog_module()


### PR DESCRIPTION
## Summary
- Build Windows portable ZIPs from a separate staging directory so installer staging stays clean
- Reduce Inno Setup compression from lzma2/ultra64 to lzma2/normal for faster Windows packaging
- Let manual Build workflow dispatches test the selected branch/ref while scheduled nightlies still build dev

## Verification
- uv run pytest -q -n 0 --tb=short tests/test_nuitka_build.py tests/test_installer_version_metadata.py tests/test_simple_update.py
- uv run ruff check installer/build.py installer/build_nuitka.py tests/test_nuitka_build.py tests/test_installer_version_metadata.py tests/test_simple_update.py
- uv run pyright
- actionlint
- Dry-run Build workflow on this branch: https://github.com/Orinks/AccessiWeather/actions/runs/25108689136
  - Windows job: ~21m 19s
  - Windows Build step: ~19m 15s
  - macOS job: ~4m 44s
  - whole workflow: ~22m