### PR TITLE
fix(audio): enable refresh success sound by default

### DIFF
--- a/src/accessiweather/app.py
+++ b/src/accessiweather/app.py
@@ -1287,7 +1287,7 @@ class AccessiWeatherApp(wx.App):
                 from .notifications.sound_player import play_startup_sound
 
                 sound_pack = getattr(settings, "sound_pack", "default")
-                muted_events = getattr(settings, "muted_sound_events", ["data_updated"])
+                muted_events = getattr(settings, "muted_sound_events", [])
                 play_startup_sound(sound_pack, muted_events=muted_events)
         except Exception as e:
             logger.debug(f"Could not play startup sound: {e}")
@@ -1315,7 +1315,7 @@ class AccessiWeatherApp(wx.App):
                 )
 
                 sound_pack = getattr(settings, "sound_pack", "default")
-                muted_events = getattr(settings, "muted_sound_events", ["data_updated"])
+                muted_events = getattr(settings, "muted_sound_events", [])
                 logger.debug(
                     "[packaging-diag] exit sound: compiled=%s sound_pack=%s sound_lib=%s playsound3=%s",
                     is_compiled_runtime(),
@@ -1378,7 +1378,7 @@ class AccessiWeatherApp(wx.App):
                 self._notifier.sound_enabled = bool(getattr(settings, "sound_enabled", True))
                 self._notifier.soundpack = getattr(settings, "sound_pack", "default")
                 self._notifier.muted_sound_events = list(
-                    getattr(settings, "muted_sound_events", ["data_updated"])
+                    getattr(settings, "muted_sound_events", [])
                 )
 
             if self.alert_notification_system:

--- a/src/accessiweather/app_initialization.py
+++ b/src/accessiweather/app_initialization.py
@@ -92,7 +92,7 @@ def initialize_components(app: AccessiWeatherApp) -> None:
     app._notifier = SafeDesktopNotifier(
         sound_enabled=bool(getattr(config.settings, "sound_enabled", True)),
         soundpack=getattr(config.settings, "sound_pack", "default"),
-        muted_sound_events=getattr(config.settings, "muted_sound_events", ["data_updated"]),
+        muted_sound_events=getattr(config.settings, "muted_sound_events", []),
     )
 
     # Initialize AI explanation cache (lazy import)

--- a/src/accessiweather/sound_events.py
+++ b/src/accessiweather/sound_events.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Collection
 from itertools import chain
 
-DEFAULT_MUTED_SOUND_EVENTS: tuple[str, ...] = ("data_updated",)
+DEFAULT_MUTED_SOUND_EVENTS: tuple[str, ...] = ()
 
 SOUND_EVENT_SECTIONS: tuple[tuple[str, str, tuple[tuple[str, str], ...]], ...] = (
     (

--- a/src/accessiweather/ui/dialogs/settings_tabs/audio.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/audio.py
@@ -190,7 +190,7 @@ class AudioTab:
         except (ValueError, AttributeError):
             controls["sound_pack"].SetSelection(0)
 
-        self.set_event_sound_states(getattr(settings, "muted_sound_events", ["data_updated"]))
+        self.set_event_sound_states(getattr(settings, "muted_sound_events", []))
 
     def save(self) -> dict:
         """Return Audio tab settings as a dict."""

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -940,7 +940,7 @@ class MainWindow(SizedFrame):
             app_name="AccessiWeather",
             sound_enabled=bool(getattr(settings, "sound_enabled", True)),
             soundpack=getattr(settings, "sound_pack", "default"),
-            muted_sound_events=getattr(settings, "muted_sound_events", ["data_updated"]),
+            muted_sound_events=getattr(settings, "muted_sound_events", []),
         )
         from ..notification_activation import (
             NotificationActivationRequest,
@@ -1541,17 +1541,17 @@ class MainWindow(SizedFrame):
             # any panels.  Silent (no screen-reader announcement).
             self._set_last_updated_status()
 
-            # Play data_updated sound on successful weather data refresh
+            # Play the weather-updated sound on successful refresh.
             try:
                 settings = self.app.config_manager.get_settings()
                 if getattr(settings, "sound_enabled", True):
                     from accessiweather.notifications.sound_player import play_data_updated_sound
 
                     sound_pack = getattr(settings, "sound_pack", "default")
-                    muted_events = getattr(settings, "muted_sound_events", ["data_updated"])
+                    muted_events = getattr(settings, "muted_sound_events", [])
                     play_data_updated_sound(sound_pack, muted_events=muted_events)
             except Exception as sound_exc:
-                logger.debug(f"Failed to play data_updated sound: {sound_exc}")
+                logger.debug(f"Failed to play weather-updated sound: {sound_exc}")
 
         except Exception as e:
             logger.error(f"Failed to update weather display: {e}")
@@ -1658,7 +1658,7 @@ class MainWindow(SizedFrame):
                 from accessiweather.notifications.sound_player import play_fetch_error_sound
 
                 sound_pack = getattr(settings, "sound_pack", "default")
-                muted_events = getattr(settings, "muted_sound_events", ["data_updated"])
+                muted_events = getattr(settings, "muted_sound_events", [])
                 play_fetch_error_sound(sound_pack, muted_events=muted_events)
         except Exception as sound_exc:
             logger.debug(f"Failed to play fetch_error sound: {sound_exc}")

--- a/tests/test_app_sounds.py
+++ b/tests/test_app_sounds.py
@@ -1,0 +1,23 @@
+"""Tests for application-level sound helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from accessiweather.app import AccessiWeatherApp
+
+
+def test_startup_sound_defaults_to_no_muted_events_when_setting_missing():
+    """Legacy settings without muted_sound_events should not mute startup sounds."""
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    app.config_manager = MagicMock()
+    app.config_manager.get_settings.return_value = SimpleNamespace(
+        sound_enabled=True,
+        sound_pack="default",
+    )
+
+    with patch("accessiweather.notifications.sound_player.play_startup_sound") as mock_play:
+        app._play_startup_sound()
+
+    mock_play.assert_called_once_with("default", muted_events=[])

--- a/tests/test_main_window_sounds.py
+++ b/tests/test_main_window_sounds.py
@@ -1,5 +1,5 @@
 """
-Tests for main window sound playback on data_updated and fetch_error events.
+Tests for main window sound playback on refresh success and fetch_error events.
 
 Covers lines in _on_weather_data_received and _on_weather_error that call
 play_data_updated_sound and play_fetch_error_sound when sound_enabled=True,
@@ -13,8 +13,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
-class TestMainWindowDataUpdatedSound:
-    """Tests for data_updated sound playback in _on_weather_data_received."""
+class TestMainWindowRefreshSuccessSound:
+    """Tests for weather-updated sound playback in _on_weather_data_received."""
 
     @pytest.fixture
     def mock_app(self):
@@ -72,7 +72,7 @@ class TestMainWindowDataUpdatedSound:
         app.presenter.present.return_value = presentation
         return win
 
-    def test_data_updated_sound_called_when_sound_enabled(self, mock_app):
+    def test_weather_updated_sound_called_when_sound_enabled(self, mock_app):
         """play_data_updated_sound is called when sound_enabled=True."""
         win = self._make_window(mock_app)
         weather_data = MagicMock()
@@ -85,7 +85,7 @@ class TestMainWindowDataUpdatedSound:
 
         mock_play.assert_called_once_with("default", muted_events=[])
 
-    def test_data_updated_sound_not_called_when_sound_disabled(self, mock_app_sound_disabled):
+    def test_weather_updated_sound_not_called_when_sound_disabled(self, mock_app_sound_disabled):
         """play_data_updated_sound is NOT called when sound_enabled=False."""
         win = self._make_window(mock_app_sound_disabled)
         weather_data = MagicMock()
@@ -98,8 +98,8 @@ class TestMainWindowDataUpdatedSound:
 
         mock_play.assert_not_called()
 
-    def test_data_updated_sound_not_called_when_event_muted(self, mock_app):
-        """play_data_updated_sound is skipped when the event is muted."""
+    def test_weather_updated_sound_called_with_muted_events(self, mock_app):
+        """play_data_updated_sound receives muted event overrides."""
         mock_app.config_manager.get_settings.return_value.muted_sound_events = ["data_updated"]
         win = self._make_window(mock_app)
         weather_data = MagicMock()
@@ -178,7 +178,7 @@ class TestMainWindowFetchErrorSound:
 
         mock_play.assert_called_once_with("default", muted_events=["data_updated"])
 
-    def test_data_updated_sound_exception_is_swallowed(self, mock_app):
+    def test_weather_updated_sound_exception_is_swallowed(self, mock_app):
         """Exceptions from play_data_updated_sound must not propagate."""
         from accessiweather.ui.main_window import MainWindow
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -388,10 +388,10 @@ class TestAppSettings:
         assert settings.forecast_time_reference == "location"
 
     def test_default_muted_sound_events(self):
-        """Weather refresh sound is muted by default."""
+        """Weather refresh sound is enabled by default."""
         settings = AppSettings()
 
-        assert settings.muted_sound_events == ["data_updated"]
+        assert settings.muted_sound_events == []
 
     def test_custom_settings(self):
         """Test custom settings."""

--- a/tests/test_toasted_windows_notifier.py
+++ b/tests/test_toasted_windows_notifier.py
@@ -141,7 +141,7 @@ class TestToastedWindowsNotifierSend:
         ):
             notifier = toast_notifier.ToastedWindowsNotifier(sound_enabled=True)
             notifier.send_notification("Title", "Body", play_sound=True)
-            mock_sound.assert_called_once_with("alert", "default", muted_events=["data_updated"])
+            mock_sound.assert_called_once_with("alert", "default", muted_events=[])
 
     def test_send_skips_sound_when_play_sound_false(self):
         """When play_sound=False, no sound is played."""
@@ -165,7 +165,7 @@ class TestToastedWindowsNotifierSend:
                 ["alert", "notify"],
                 "default",
                 logical_event="alert",
-                muted_events=["data_updated"],
+                muted_events=[],
             )
 
     def test_send_catches_exceptions(self):


### PR DESCRIPTION
## Summary
- Keep weather refresh completion on the data_updated sound event
- Enable the weather refresh sound by default by clearing the default muted sound-event list
- Remove stale data_updated fallback mutes from runtime/audio settings paths

## Verification
- uv run pytest -q -n 0 --tb=short tests/test_main_window_sounds.py tests/test_sound_player.py tests/test_settings_dialog_audio_events.py tests/test_models.py
- uv run ruff check src/accessiweather/sound_events.py src/accessiweather/ui/main_window.py src/accessiweather/app.py src/accessiweather/app_initialization.py src/accessiweather/ui/dialogs/settings_tabs/audio.py tests/test_main_window_sounds.py tests/test_models.py
- uv run pyright