### PR TITLE
test(settings): import dialog module by package

### DIFF
--- a/tests/test_settings_dialog_api_key_guard.py
+++ b/tests/test_settings_dialog_api_key_guard.py
@@ -23,22 +23,9 @@ def _make_dialog(
     original_or="",
 ):
     """Create a minimal SettingsDialogSimple stand-in with the guard logic."""
-    import importlib.util
-    from pathlib import Path
+    from accessiweather.ui.dialogs import settings_dialog
 
-    module_path = (
-        Path(__file__).resolve().parents[1]
-        / "src"
-        / "accessiweather"
-        / "ui"
-        / "dialogs"
-        / "settings_dialog.py"
-    )
-    spec = importlib.util.spec_from_file_location("sdmod", module_path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-
-    dlg = mod.SettingsDialogSimple.__new__(mod.SettingsDialogSimple)
+    dlg = settings_dialog.SettingsDialogSimple.__new__(settings_dialog.SettingsDialogSimple)
     dlg._original_vc_key = original_vc
     dlg._original_pirate_weather_key = original_pirate
     dlg._original_openrouter_key = original_or

--- a/tests/test_settings_dialog_portable_copy.py
+++ b/tests/test_settings_dialog_portable_copy.py
@@ -1,25 +1,14 @@
 from __future__ import annotations
 
-import importlib.util
 import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
 
 def _load_settings_dialog_module():
-    module_path = (
-        Path(__file__).resolve().parents[1]
-        / "src"
-        / "accessiweather"
-        / "ui"
-        / "dialogs"
-        / "settings_dialog.py"
-    )
-    spec = importlib.util.spec_from_file_location("test_settings_dialog_copy_module", module_path)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    from accessiweather.ui.dialogs import settings_dialog
+
+    return settings_dialog
 
 
 module = _load_settings_dialog_module()


### PR DESCRIPTION
## Summary
- Backport settings dialog tests to import the dialog module through the package instead of loading the file directly.
- Unblocks main-based Dependabot PR CI, where direct file imports fail package-relative imports.

## Verification
- uv run pytest -q -n 0 --tb=short tests/test_settings_dialog_api_key_guard.py tests/test_settings_dialog_portable_copy.py