### PR TITLE
ci(tests): group wx tests under xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,12 +121,12 @@ jobs:
       run: |
         if [ "${{ matrix.primary }}" = "true" ]; then
           mkdir -p reports
-          xvfb-run -a pytest tests/ -n 8 -v --tb=short -m "not integration" \
+          xvfb-run -a pytest tests/ -n 8 --dist=loadgroup -v --tb=short -m "not integration" \
             --cov=src/accessiweather \
             --cov-report=xml:reports/coverage.xml \
             --cov-report=term-missing
         else
-          xvfb-run -a pytest tests/ -n 8 -v --tb=short -m "not integration"
+          xvfb-run -a pytest tests/ -n 8 --dist=loadgroup -v --tb=short -m "not integration"
         fi
 
     - name: Install diff-cover

--- a/tests/test_alert_dialog_copy_integration.py
+++ b/tests/test_alert_dialog_copy_integration.py
@@ -11,6 +11,8 @@ import wx
 from accessiweather.models.config import AppSettings
 from accessiweather.ui.dialogs.alert_dialog import AlertDialog
 
+pytestmark = pytest.mark.xdist_group("wx")
+
 
 @pytest.fixture(scope="module")
 def wx_app():

--- a/tests/test_alert_dialog_dispatch.py
+++ b/tests/test_alert_dialog_dispatch.py
@@ -11,6 +11,8 @@ import wx
 from accessiweather.models.config import AppSettings
 from accessiweather.ui.dialogs.alert_dialog import AlertDialog
 
+pytestmark = pytest.mark.xdist_group("wx")
+
 
 @pytest.fixture(scope="module")
 def wx_app():


### PR DESCRIPTION
## Summary
- group wx-based alert dialog tests onto one xdist worker
- enable pytest-xdist loadgroup scheduling in the CI test command

## Verification
- uv run ruff check tests/test_alert_dialog_copy_integration.py tests/test_alert_dialog_dispatch.py
- uv run pytest -q -n 0 --tb=short tests/test_alert_dialog_copy_integration.py tests/test_alert_dialog_dispatch.py
- pre-commit hooks: check yaml, ruff, ruff-format