### PR TITLE
ci(tests): run wx app tests serially

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,12 +121,29 @@ jobs:
       run: |
         if [ "${{ matrix.primary }}" = "true" ]; then
           mkdir -p reports
-          xvfb-run -a pytest tests/ -n 8 --dist=loadgroup -v --tb=short -m "not integration" \
+          xvfb-run -a pytest tests/ \
+            --ignore=tests/test_alert_dialog_copy_integration.py \
+            --ignore=tests/test_alert_dialog_dispatch.py \
+            -n 8 --dist=loadgroup -v --tb=short -m "not integration" \
             --cov=src/accessiweather \
+            --cov-report=
+          xvfb-run -a pytest \
+            tests/test_alert_dialog_copy_integration.py \
+            tests/test_alert_dialog_dispatch.py \
+            -n 0 -v --tb=short -m "not integration" \
+            --cov=src/accessiweather \
+            --cov-append \
             --cov-report=xml:reports/coverage.xml \
             --cov-report=term-missing
         else
-          xvfb-run -a pytest tests/ -n 8 --dist=loadgroup -v --tb=short -m "not integration"
+          xvfb-run -a pytest tests/ \
+            --ignore=tests/test_alert_dialog_copy_integration.py \
+            --ignore=tests/test_alert_dialog_dispatch.py \
+            -n 8 --dist=loadgroup -v --tb=short -m "not integration"
+          xvfb-run -a pytest \
+            tests/test_alert_dialog_copy_integration.py \
+            tests/test_alert_dialog_dispatch.py \
+            -n 0 -v --tb=short -m "not integration"
         fi
 
     - name: Install diff-cover


### PR DESCRIPTION
## Summary
- keep the large non-integration suite parallelized
- exclude the real wx.App alert dialog tests from xdist
- run those wx tests serially in a separate xvfb pytest command
- preserve coverage output on the primary matrix job with cov-append

## Verification
- targeted wx pytest command passed locally
- pre-commit hooks: check yaml