### PR TITLE
fix(notifications): improve AFD update summaries

### DIFF
--- a/src/accessiweather/notifications/notification_event_manager.py
+++ b/src/accessiweather/notifications/notification_event_manager.py
@@ -145,6 +145,28 @@ def _extract_section(text: str, start_marker: str, end_markers: tuple[str, ...])
     return content if content else None
 
 
+def _normalize_discussion_summary(text: str | None) -> str:
+    """Normalize extracted AFD summary text for comparison."""
+    if not text:
+        return ""
+    return " ".join(text.split()).casefold().strip(" .")
+
+
+def _is_no_change_summary(text: str | None) -> bool:
+    """Return True when a WHAT HAS CHANGED section explicitly says nothing changed."""
+    normalized = _normalize_discussion_summary(text)
+    if not normalized:
+        return False
+    return normalized in {
+        "no change",
+        "no changes",
+        "no significant change",
+        "no significant changes",
+        "no significant changes made to forecast",
+        "no significant changes made to the forecast",
+    }
+
+
 def summarize_discussion_change(previous_text: str | None, current_text: str | None) -> str | None:
     """
     Return a short human-friendly summary of what changed in the discussion text.
@@ -159,23 +181,38 @@ def summarize_discussion_change(previous_text: str | None, current_text: str | N
     if not current_text:
         return None
 
-    # 1. Try .WHAT HAS CHANGED... section
-    section = _extract_section(
+    # 1. Try .WHAT HAS CHANGED... section. If it explicitly says there were no
+    # changes, keep looking for changed key messages before giving up.
+    what_changed_section = _extract_section(
         current_text,
         start_marker=".WHAT HAS CHANGED",
         end_markers=(".", "&&"),
     )
-    if section:
-        return section[:300]
+    current_declares_no_changes = _is_no_change_summary(what_changed_section)
+    if what_changed_section and not current_declares_no_changes:
+        return what_changed_section[:300]
 
     # 2. Try .KEY MESSAGES... section
     section = _extract_section(
         current_text,
         start_marker=".KEY MESSAGES",
-        end_markers=("&&",),
+        end_markers=(".", "&&"),
     )
     if section:
-        return section[:300]
+        previous_section = _extract_section(
+            previous_text or "",
+            start_marker=".KEY MESSAGES",
+            end_markers=(".", "&&"),
+        )
+        if not previous_section or _normalize_discussion_summary(
+            section
+        ) != _normalize_discussion_summary(previous_section):
+            return section[:300]
+        if current_declares_no_changes:
+            return None
+
+    if current_declares_no_changes:
+        return None
 
     # 3. Fall back to first new line not present in previous text
     previous_lines = {
@@ -521,6 +558,20 @@ class NotificationEventManager:
             )
             self.state.last_discussion_issuance_time = issuance_time
             self.state.last_discussion_text = discussion_text
+
+            if change_summary is None and _is_no_change_summary(
+                _extract_section(
+                    discussion_text or "",
+                    start_marker=".WHAT HAS CHANGED",
+                    end_markers=(".", "&&"),
+                )
+            ):
+                logger.info(
+                    "Discussion issuance advanced for %s, but AFD says no changes; "
+                    "state updated without notification",
+                    location_name,
+                )
+                return None
 
             issued_label = _extract_discussion_issued_time_label(discussion_text)
             if not issued_label:

--- a/src/accessiweather/weather_client_nws.py
+++ b/src/accessiweather/weather_client_nws.py
@@ -996,11 +996,19 @@ async def get_nws_text_product(
             )
             return products
 
-        # AFD or HWO: newest @graph entry only, or None if empty.
+        # AFD or HWO: newest @graph entry only, or None if empty. The API is
+        # usually newest-first, but live listings can contain out-of-order
+        # entries, so select by issuanceTime defensively.
         if not graph:
             return None
 
-        latest = graph[0]
+        latest = max(
+            (entry for entry in graph if isinstance(entry, dict)),
+            key=lambda entry: (
+                _parse_iso_datetime(entry.get("issuanceTime")) or datetime.min.replace(tzinfo=UTC)
+            ),
+            default=None,
+        )
         if not isinstance(latest, dict):
             return None
 

--- a/tests/test_notification_event_manager.py
+++ b/tests/test_notification_event_manager.py
@@ -210,14 +210,53 @@ class TestNotificationEventManager:
             "National Weather Service New York NY\n"
             "935 AM EST Tue Jan 20 2026\n\n"
             ".WHAT HAS CHANGED...\n"
-            "No significant changes made to forecast."
+            "Rain arrives earlier than previously forecast."
         )
         weather_data.discussion_issuance_time = first_time + timedelta(hours=1)
         events = manager.check_for_events(weather_data, settings_with_discussion, "Test Location")
 
         assert len(events) == 1
         assert "9:35 AM EST" in events[0].message
-        assert "No significant changes made to forecast." in events[0].message
+        assert "Rain arrives earlier than previously forecast." in events[0].message
+
+    def test_discussion_update_with_no_changes_updates_state_without_notification(
+        self, manager, settings_with_discussion
+    ):
+        """AFD products that explicitly say no changes should not notify users."""
+        weather_data = MagicMock(spec=WeatherData)
+        weather_data.current = None
+        weather_data.discussion = (
+            "\n000\nFXUS61 KPHI 290645\nAFDPHI\n\n"
+            "Area Forecast Discussion\n"
+            "National Weather Service Mount Holly NJ\n"
+            "245 AM EDT Wed Apr 29 2026\n\n"
+            ".WHAT HAS CHANGED...\n"
+            "Rainfall totals have lowered a bit.\n\n"
+            "&&\n"
+        )
+        weather_data.minutely_precipitation = None
+
+        first_time = datetime(2026, 4, 29, 6, 45, 0, tzinfo=UTC)
+        weather_data.discussion_issuance_time = first_time
+        manager.check_for_events(weather_data, settings_with_discussion, "Lumberton")
+
+        weather_data.discussion = (
+            "\n000\nFXUS61 KPHI 291732\nAFDPHI\n\n"
+            "Area Forecast Discussion\n"
+            "National Weather Service Mount Holly NJ\n"
+            "132 PM EDT Wed Apr 29 2026\n\n"
+            ".WHAT HAS CHANGED...\n"
+            "No changes.\n\n"
+            "&&\n"
+        )
+        newer_time = datetime(2026, 4, 29, 17, 32, 0, tzinfo=UTC)
+        weather_data.discussion_issuance_time = newer_time
+
+        events = manager.check_for_events(weather_data, settings_with_discussion, "Lumberton")
+
+        assert events == []
+        assert manager.state.last_discussion_issuance_time == newer_time
+        assert manager.state.last_discussion_text == weather_data.discussion
 
     def test_discussion_update_falls_back_to_metadata_time(self, manager, settings_with_discussion):
         """Use the metadata timestamp when the AFD text has no parseable issued line."""

--- a/tests/test_split_notification_timers.py
+++ b/tests/test_split_notification_timers.py
@@ -101,6 +101,67 @@ class TestSummarizeDiscussionChange:
         assert "Flash flood watch in effect" in result
         assert "Short term text" not in result
 
+    def test_key_messages_stop_at_next_dot_section(self):
+        """KEY MESSAGES must not absorb UPDATE/SHORT TERM text before &&."""
+        afd = (
+            ".KEY MESSAGES...\n"
+            "- Heavy rain expected Tuesday.\n"
+            "- Flash flood watch in effect.\n"
+            ".UPDATE...\n"
+            "Only aviation wording changed.\n"
+            ".SHORT TERM...\n"
+            "Short term text.\n"
+            "&&\n"
+        )
+        result = summarize_discussion_change(None, afd)
+        assert result is not None
+        assert "Heavy rain expected Tuesday" in result
+        assert "Flash flood watch in effect" in result
+        assert "Only aviation wording changed" not in result
+        assert "Short term text" not in result
+
+    def test_key_messages_diff_prefers_new_messages_when_changed(self):
+        """When KEY MESSAGES change, the toast summary should use the current messages."""
+        previous = (
+            ".KEY MESSAGES...\n"
+            "1. Rain arrives later today.\n"
+            "2. Saturday storm potential remains.\n"
+            "&&\n"
+        )
+        current = (
+            ".KEY MESSAGES...\n"
+            "1. Rain arrives late this afternoon.\n"
+            "2. Saturday storm potential remains.\n"
+            "&&\n"
+        )
+        result = summarize_discussion_change(previous, current)
+        assert result is not None
+        assert "late this afternoon" in result
+        assert "later today" not in result
+
+    def test_no_changes_section_defers_to_changed_key_messages(self):
+        """A no-change marker should not hide materially changed KEY MESSAGES."""
+        previous = (
+            ".WHAT HAS CHANGED...\n"
+            "Rainfall totals have lowered a bit.\n"
+            "&&\n"
+            ".KEY MESSAGES...\n"
+            "1. Rain arrives later today.\n"
+            "&&\n"
+        )
+        current = (
+            ".WHAT HAS CHANGED...\n"
+            "No changes.\n"
+            "&&\n"
+            ".KEY MESSAGES...\n"
+            "1. Rain arrives late this afternoon.\n"
+            "&&\n"
+        )
+        result = summarize_discussion_change(previous, current)
+        assert result is not None
+        assert "late this afternoon" in result
+        assert "No changes" not in result
+
     def test_first_new_line_fallback_when_no_special_sections(self):
         """Path 3: falls back to first new line when no special sections exist."""
         previous = "line one\nline two\n"

--- a/tests/test_weather_client_nws_text_product.py
+++ b/tests/test_weather_client_nws_text_product.py
@@ -105,6 +105,32 @@ class TestGetNwsTextProductAFD:
 
         assert result is None
 
+    @pytest.mark.asyncio
+    async def test_afd_uses_newest_issuance_time_when_listing_is_unsorted(self):
+        """NWS product listings are not guaranteed to be perfectly sorted."""
+        graph = {
+            "@graph": [
+                {"id": "afd-old", "issuanceTime": "2026-04-16T06:45:00+00:00"},
+                {"id": "afd-new", "issuanceTime": "2026-04-16T17:32:00+00:00"},
+            ]
+        }
+        client = _client_for(
+            {
+                f"{NWS_BASE}/products/types/AFD/locations/{OFFICE}": _resp(graph),
+                f"{NWS_BASE}/products/afd-new": _resp(
+                    {
+                        "productText": "NEW AREA FORECAST DISCUSSION",
+                        "issuanceTime": "2026-04-16T17:32:00+00:00",
+                    }
+                ),
+            }
+        )
+
+        result = await get_nws_text_product("AFD", OFFICE, nws_base_url=NWS_BASE, client=client)
+
+        assert isinstance(result, TextProduct)
+        assert result.product_id == "afd-new"
+
 
 # ---------------------------------------------------------------------------
 # HWO happy path


### PR DESCRIPTION
## Summary
- Improve AFD update summaries so `.KEY MESSAGES...` stops at the next section header and changed key messages use the current product text.
- Suppress AFD notifications when `.WHAT HAS CHANGED...` explicitly says there are no changes and key messages did not materially change, while still updating stored notification state.
- Select the newest AFD/HWO product by `issuanceTime` instead of assuming the NWS listing is always sorted.

## Root cause
Some NWS offices issue AFDs without a meaningful `.WHAT HAS CHANGED...` section, or with `No changes.` while still reissuing the product for routine package updates. The fallback summary could also over-read `.KEY MESSAGES...` into following sections and reuse stale previous key-message text.

## Validation
- `uv run pytest -q -n 0 --tb=short tests/test_split_notification_timers.py tests/test_notification_event_manager.py tests/test_weather_client_nws_text_product.py tests/test_nws_afd_notification.py tests/test_split_update_timers.py`
- `uv run ruff check src tests`
- `uv run pyright`