### PR TITLE
fix(notifications): filter SPS products by location zone

### DIFF
--- a/src/accessiweather/ui/main_window_notification_events.py
+++ b/src/accessiweather/ui/main_window_notification_events.py
@@ -8,6 +8,7 @@ This keeps lightweight polling and event notification logic out of
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING
 
 import wx
@@ -21,6 +22,10 @@ if TYPE_CHECKING:
     from .main_window import MainWindow
 
 logger = logging.getLogger(__name__)
+
+_UGC_LINE_RE = re.compile(
+    r"^\s*([A-Z]{2}[CZ])(\d{3}(?:[->]\d{3})?(?:-\d{3}(?:[->]\d{3})?)*)-\d{6}-?\s*$"
+)
 
 
 def _log_reviewable_event_text(window: MainWindow, title: str, message: str) -> None:
@@ -202,10 +207,76 @@ def _check_sps_from_cache(
         else:
             products = [raw]
 
+        products = _filter_sps_products_for_location(products, location)
         active_alerts = _active_alerts_for_current_location(window)
         manager._check_sps_new(location, products, active_alerts, settings)
     except Exception as e:  # noqa: BLE001
         logger.debug("[events] SPS check skipped: %s", e)
+
+
+def _filter_sps_products_for_location(products: list, location) -> list:
+    """
+    Keep only SPS products whose UGC zones include the saved location zones.
+
+    ``/products/types/SPS/locations/{CWA}`` is an office-wide feed. Unlike the
+    active-alert point/county endpoints, it can include statements for any zone
+    in the forecast office. Filter by the product UGC line before running the
+    SPS notification heuristic so county/zone alert settings do not receive
+    other-county office products.
+    """
+    location_zone_ids = _location_zone_ids(location)
+    if not location_zone_ids:
+        return products
+
+    filtered = []
+    for product in products:
+        product_zone_ids = _sps_product_zone_ids(getattr(product, "product_text", None))
+        if not product_zone_ids or product_zone_ids & location_zone_ids:
+            filtered.append(product)
+    return filtered
+
+
+def _location_zone_ids(location) -> set[str]:
+    """Return normalized NWS zone IDs available on a saved location."""
+    zone_ids: set[str] = set()
+    for attr in ("forecast_zone_id", "fire_zone_id", "county_zone_id"):
+        zone_id = _zone_id_tail(getattr(location, attr, None))
+        if zone_id:
+            zone_ids.add(zone_id)
+    return zone_ids
+
+
+def _zone_id_tail(value: str | None) -> str | None:
+    """Normalize a full NWS zone URL or bare zone code to its uppercase ID."""
+    if not value:
+        return None
+    return str(value).rstrip("/").rsplit("/", 1)[-1].upper()
+
+
+def _sps_product_zone_ids(product_text: str | None) -> set[str]:
+    """Extract UGC zone codes such as ``TXZ118`` or ``TXZ105>107`` from SPS text."""
+    if not product_text:
+        return set()
+
+    zone_ids: set[str] = set()
+    for raw_line in product_text.splitlines()[:20]:
+        match = _UGC_LINE_RE.match(raw_line)
+        if not match:
+            continue
+        prefix, encoded_zones = match.groups()
+        for token in encoded_zones.split("-"):
+            if not token:
+                continue
+            if ">" in token:
+                start_text, end_text = token.split(">", 1)
+                start = int(start_text)
+                end = int(end_text)
+                step = 1 if end >= start else -1
+                for value in range(start, end + step, step):
+                    zone_ids.add(f"{prefix}{value:03d}")
+            else:
+                zone_ids.add(f"{prefix}{int(token):03d}")
+    return zone_ids
 
 
 def _active_alerts_for_current_location(window: MainWindow) -> list:

--- a/tests/test_split_notification_timers.py
+++ b/tests/test_split_notification_timers.py
@@ -20,10 +20,14 @@ from accessiweather.models import (
     HourlyForecast,
     HourlyForecastPeriod,
     Location,
+    TextProduct,
     WeatherAlerts,
     WeatherData,
 )
 from accessiweather.notifications.notification_event_manager import summarize_discussion_change
+from accessiweather.ui.main_window_notification_events import (
+    _filter_sps_products_for_location,
+)
 
 # ---------------------------------------------------------------------------
 # summarize_discussion_change (notification_event_manager.py lines 54, 64)
@@ -551,6 +555,69 @@ class TestNotificationEventHelpers:
             "Summary",
             category="Updated discussion",
         )
+
+
+class TestSpsProductLocationFiltering:
+    """SPS product notifications must honor the user's saved NWS zones."""
+
+    def _product(self, product_text: str, product_id: str = "SPS-FWD") -> TextProduct:
+        return TextProduct(
+            product_type="SPS",
+            product_id=product_id,
+            cwa_office="FWD",
+            issuance_time=datetime(2026, 4, 29, 18, 10, tzinfo=UTC),
+            product_text=product_text,
+            headline="Special Weather Statement",
+        )
+
+    def test_drops_office_sps_for_other_forecast_zones(self):
+        location = Location(
+            name="Copperas Cove",
+            latitude=31.1241,
+            longitude=-97.9031,
+            country_code="US",
+            cwa_office="FWD",
+            forecast_zone_id="TXZ157",
+            county_zone_id="TXC099",
+            fire_zone_id="TXZ157",
+        )
+        dallas_sps = self._product(
+            "\n"
+            "TXZ118-119-291900-\n"
+            "Tarrant TX-Dallas TX-\n"
+            "110 PM CDT Wed Apr 29 2026\n"
+            "...A strong thunderstorm will impact portions of southeastern Tarrant\n"
+            "and Dallas Counties through 200 PM CDT...\n",
+            product_id="SPS-DALLAS",
+        )
+
+        result = _filter_sps_products_for_location([dallas_sps], location)
+
+        assert result == []
+
+    def test_keeps_sps_for_location_forecast_zone(self):
+        location = Location(
+            name="Copperas Cove",
+            latitude=31.1241,
+            longitude=-97.9031,
+            country_code="US",
+            cwa_office="FWD",
+            forecast_zone_id="TXZ157",
+            county_zone_id="TXC099",
+            fire_zone_id="TXZ157",
+        )
+        local_sps = self._product(
+            "\n"
+            "TXZ157-291900-\n"
+            "Coryell TX-\n"
+            "110 PM CDT Wed Apr 29 2026\n"
+            "...A strong thunderstorm will impact portions of Coryell County...\n",
+            product_id="SPS-CORYELL",
+        )
+
+        result = _filter_sps_products_for_location([local_sps], location)
+
+        assert result == [local_sps]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Filter office-wide Special Weather Statement products by the saved location's NWS zone IDs before notification evaluation.
- Parse UGC zone lines, including ranged forms such as `TXZ105>107`, and compare them with the location's forecast, fire, and county zone IDs.
- Add regression coverage for Copperas Cove (`TXZ157`) not receiving Dallas/Tarrant (`TXZ118-119`) SPS products while still keeping a local `TXZ157` SPS.

## Root cause
The active alert path honors the user's alert area setting, but the SPS product path reads the CWA-wide `/products/types/SPS/locations/{office}` cache. For offices like FWD, that feed includes Dallas-area statements even when a Copperas Cove point has no active alert. Without a zone filter, those office products could be treated as informational SPS notifications for the current location.

## Validation
- `uv run pytest -q -n 0 --tb=short tests/test_split_notification_timers.py::TestSpsProductLocationFiltering tests/test_notification_sps_dedupe.py`
- latest Ruff: `ruff format --check .`
- `uv run ruff check src tests`
- `uv run pyright`