### PR TITLE
fix(forecaster-notes): hide empty optional product tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Forecaster Notes now hides Hazardous Weather Outlook and Special Weather Statement tabs when NWS confirms there is no matching product for the selected office.
 - Nightly builds now report the dev package version consistently instead of using stale generated build metadata.
 
 ## [0.6.0] - 2026-04-24

--- a/src/accessiweather/ui/dialogs/forecast_product_panel.py
+++ b/src/accessiweather/ui/dialogs/forecast_product_panel.py
@@ -49,6 +49,7 @@ _EMPTY_COPY: dict[str, str] = {
 _NO_CWA_COPY = "NWS text products will populate after the next weather refresh."
 
 ProductLoader = Callable[[], Awaitable["TextProduct | list[TextProduct] | None"]]
+AvailabilityCallback = Callable[["ForecastProductPanel", bool], None]
 
 
 class ForecastProductPanel(wx.Panel):
@@ -63,6 +64,7 @@ class ForecastProductPanel(wx.Panel):
         cwa_office: str | None,
         location_name: str,
         app: object | None = None,
+        availability_callback: AvailabilityCallback | None = None,
     ) -> None:
         """
         Build the panel widgets.
@@ -81,6 +83,10 @@ class ForecastProductPanel(wx.Panel):
             app: Optional AccessiWeather app instance. When provided, async
                 loaders dispatch via ``app.run_async`` (the background asyncio
                 loop). Falls back to ``asyncio.ensure_future`` when absent.
+            availability_callback: Optional callback invoked after load
+                completes. ``False`` means the product fetch succeeded but
+                returned no products; errors are reported as available so the
+                dialog keeps the retry surface visible.
 
         """
         super().__init__(parent)
@@ -90,6 +96,7 @@ class ForecastProductPanel(wx.Panel):
         self._cwa_office = cwa_office
         self._location_name = location_name
         self._app = app
+        self._availability_callback = availability_callback
 
         # State
         self._current_text: str | None = None
@@ -340,12 +347,14 @@ class ForecastProductPanel(wx.Panel):
 
         if not products:
             self._render_empty_state()
+            self._notify_availability(False)
             return
 
         if self.product_type == "SPS":
             self._render_sps_products(products)
         else:
             self._render_single_product(products[0])
+        self._notify_availability(True)
 
     def _render_empty_state(self) -> None:
         """Render the 'no product available' state."""
@@ -412,6 +421,13 @@ class ForecastProductPanel(wx.Panel):
         self.explain_button.Disable()
         self._show_retry(True)
         self._current_text = None
+        self._notify_availability(True)
+
+    def _notify_availability(self, has_product: bool) -> None:
+        """Tell the parent dialog whether this product has confirmed content."""
+        if self._availability_callback is None:
+            return
+        self._availability_callback(self, has_product)
 
     def _update_explain_button_state(self) -> None:
         """

--- a/src/accessiweather/ui/dialogs/forecast_products_dialog.py
+++ b/src/accessiweather/ui/dialogs/forecast_products_dialog.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 class ForecastProductsDialog(wx.Dialog):
-    """Tabbed dialog showing NWS AFD, HWO, and SPS for a US location."""
+    """Tabbed dialog showing available NWS AFD, HWO, and SPS products."""
 
     _TABS: tuple[tuple[str, str], ...] = (
         ("AFD", "Area Forecast Discussion"),
@@ -99,6 +99,7 @@ class ForecastProductsDialog(wx.Dialog):
                 cwa_office=cwa_office,
                 location_name=location_name,
                 app=self._app,
+                availability_callback=self._on_panel_availability_resolved,
             )
             self.notebook.AddPage(panel, tab_label)
             self.panels.append(panel)
@@ -140,6 +141,42 @@ class ForecastProductsDialog(wx.Dialog):
             return await self._service.get(product_type, cwa_office)
 
         return _loader
+
+    def _on_panel_availability_resolved(
+        self,
+        panel: ForecastProductPanel,
+        has_product: bool,
+    ) -> None:
+        """
+        Remove optional tabs whose product lookup completed with no content.
+
+        AFD stays visible even when empty because it is the primary forecaster
+        notes product and gives users a stable place to retry/read status.
+        HWO and SPS are supplemental; when NWS confirms there is no product for
+        the office, hiding those tabs avoids advertising unavailable content.
+        Fetch errors report ``has_product=True`` so the tab remains available
+        with its retry button.
+        """
+        if has_product or getattr(panel, "product_type", None) == "AFD":
+            return
+
+        try:
+            index = self.panels.index(panel)
+        except ValueError:
+            return
+
+        if len(self.panels) <= 1:
+            return
+
+        deleted = self.notebook.DeletePage(index)
+        if deleted is False:
+            logger.debug(
+                "Notebook refused to remove empty %s page",
+                getattr(panel, "product_type", "unknown"),
+            )
+            return
+
+        del self.panels[index]
 
     # ------------------------------------------------------------------
     # Key events

--- a/tests/test_forecast_product_panel_availability.py
+++ b/tests/test_forecast_product_panel_availability.py
@@ -1,0 +1,80 @@
+"""Pure unit tests for ForecastProductPanel availability notifications."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from accessiweather.models import TextProduct
+from accessiweather.ui.dialogs.forecast_product_panel import ForecastProductPanel
+
+
+def _panel_stub(product_type: str = "HWO"):
+    calls: list[bool] = []
+    panel = SimpleNamespace(
+        product_type=product_type,
+        _availability_callback=lambda _panel, has_product: calls.append(has_product),
+        _is_loading=True,
+        _show_retry=MagicMock(),
+        _render_empty_state=MagicMock(),
+        _render_sps_products=MagicMock(),
+        _render_single_product=MagicMock(),
+    )
+    panel._notify_availability = lambda has_product: ForecastProductPanel._notify_availability(
+        panel, has_product
+    )
+    return panel, calls
+
+
+def _product(product_type: str = "HWO") -> TextProduct:
+    return TextProduct(
+        product_type=product_type,  # type: ignore[arg-type]
+        product_id="product-1",
+        cwa_office="FWD",
+        issuance_time=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        product_text="Product text",
+        headline=None,
+    )
+
+
+def test_empty_result_reports_unavailable_after_rendering_empty_state():
+    panel, calls = _panel_stub()
+
+    ForecastProductPanel._on_load_complete(panel, None)
+
+    panel._render_empty_state.assert_called_once()
+    assert calls == [False]
+
+
+def test_single_product_reports_available_after_rendering_product():
+    panel, calls = _panel_stub()
+
+    ForecastProductPanel._on_load_complete(panel, _product())
+
+    panel._render_single_product.assert_called_once()
+    assert calls == [True]
+
+
+def test_load_error_reports_available_to_keep_retry_tab_visible():
+    calls: list[bool] = []
+    panel = SimpleNamespace(
+        product_type="HWO",
+        _availability_callback=lambda _panel, has_product: calls.append(has_product),
+        _is_loading=True,
+        _show_retry=MagicMock(),
+        _show_sps_chooser=MagicMock(),
+        _hide_ai_summary_section=MagicMock(),
+        product_textctrl=MagicMock(),
+        issuance_label=MagicMock(),
+        explain_button=MagicMock(),
+        _current_text="old text",
+    )
+    panel._notify_availability = lambda has_product: ForecastProductPanel._notify_availability(
+        panel, has_product
+    )
+
+    ForecastProductPanel._on_load_error(panel, RuntimeError("boom"))
+
+    panel._show_retry.assert_called_once_with(True)
+    assert calls == [True]

--- a/tests/test_forecast_products_dialog_availability.py
+++ b/tests/test_forecast_products_dialog_availability.py
@@ -1,0 +1,40 @@
+"""Pure unit tests for ForecastProductsDialog tab availability handling."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from accessiweather.ui.dialogs.forecast_products_dialog import ForecastProductsDialog
+
+
+def _dialog_stub(product_types: list[str]):
+    panels = [SimpleNamespace(product_type=product_type) for product_type in product_types]
+    return SimpleNamespace(notebook=MagicMock(name="Notebook"), panels=panels), panels
+
+
+def test_empty_optional_product_removes_tab():
+    dlg, panels = _dialog_stub(["AFD", "HWO", "SPS"])
+
+    ForecastProductsDialog._on_panel_availability_resolved(dlg, panels[1], False)
+
+    dlg.notebook.DeletePage.assert_called_once_with(1)
+    assert [panel.product_type for panel in dlg.panels] == ["AFD", "SPS"]
+
+
+def test_empty_afd_product_keeps_tab():
+    dlg, panels = _dialog_stub(["AFD", "HWO", "SPS"])
+
+    ForecastProductsDialog._on_panel_availability_resolved(dlg, panels[0], False)
+
+    dlg.notebook.DeletePage.assert_not_called()
+    assert [panel.product_type for panel in dlg.panels] == ["AFD", "HWO", "SPS"]
+
+
+def test_available_optional_product_keeps_tab():
+    dlg, panels = _dialog_stub(["AFD", "HWO", "SPS"])
+
+    ForecastProductsDialog._on_panel_availability_resolved(dlg, panels[2], True)
+
+    dlg.notebook.DeletePage.assert_not_called()
+    assert [panel.product_type for panel in dlg.panels] == ["AFD", "HWO", "SPS"]


### PR DESCRIPTION
## Summary
- Hide supplemental Forecaster Notes tabs when the NWS product fetch succeeds with no HWO or SPS content.
- Keep AFD visible as the primary notes surface, and keep optional tabs visible on fetch errors so users retain the retry path.
- Add pure unit coverage for the panel availability callback and dialog tab-removal behavior.

## Verification
- `uv run ruff check src tests`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -q -n 0 --tb=short`

## Notes
Root cause: the dialog always created HWO and SPS tabs before knowing whether NWS had products for the selected CWA office, so offices like FWD could show a misleading Hazardous Weather Outlook tab even when the official text-product endpoint returned no product.