### PR TITLE
fix(pirate-weather): request v2 forecast data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Pirate Weather now requests API v2 data and carries v2 precipitation types like freezing rain and wintry mix into current, daily, and hourly forecasts.
 - Forecaster Notes now hides Hazardous Weather Outlook and Special Weather Statement tabs when NWS confirms there is no matching product for the selected office.
 - Nightly builds now report the dev package version consistently instead of using stale generated build metadata.
 

--- a/src/accessiweather/pirate_weather_client.py
+++ b/src/accessiweather/pirate_weather_client.py
@@ -44,6 +44,7 @@ from .weather_client_parsers import convert_f_to_c, degrees_to_cardinal
 logger = logging.getLogger(__name__)
 
 _BASE_URL = "https://api.pirateweather.net/forecast"
+_PIRATE_WEATHER_API_VERSION = "2"
 _PW_MIN_INCLUDED_SEVERITIES = frozenset({"Severe", "Extreme"})
 
 
@@ -72,6 +73,17 @@ _ICON_TO_CONDITION: dict[str, str] = {
     "thunderstorm": "Thunderstorm",
     "hail": "Hail",
     "tornado": "Tornado",
+    "ice": "Freezing Rain",
+    "mixed": "Wintry Mix",
+}
+
+_PRECIP_TYPE_TO_CONDITION: dict[str, str] = {
+    "rain": "Rain",
+    "snow": "Snow",
+    "sleet": "Sleet",
+    "hail": "Hail",
+    "ice": "Freezing Rain",
+    "mixed": "Wintry Mix",
 }
 
 
@@ -80,6 +92,49 @@ def _icon_to_condition(icon: str | None) -> str | None:
     if not icon:
         return None
     return _ICON_TO_CONDITION.get(icon, icon.replace("-", " ").title())
+
+
+def _normalize_precipitation_type(precip_type: object) -> list[str] | None:
+    """Normalize Pirate Weather precipType values for model fields."""
+    if isinstance(precip_type, str):
+        raw_types = [precip_type]
+    elif isinstance(precip_type, list | tuple | set):
+        raw_types = [str(value) for value in precip_type]
+    else:
+        return None
+
+    normalized: list[str] = []
+    for raw_type in raw_types:
+        name = raw_type.strip().lower()
+        if not name or name in {"none", "null"} or name in normalized:
+            continue
+        normalized.append(name)
+
+    return normalized or None
+
+
+def _precip_type_to_condition(precip_type: object) -> str | None:
+    """Return a plain-English condition from Pirate Weather precipType."""
+    normalized = _normalize_precipitation_type(precip_type)
+    if not normalized:
+        return None
+
+    return ", ".join(
+        _PRECIP_TYPE_TO_CONDITION.get(name, name.replace("-", " ").title()) for name in normalized
+    )
+
+
+def _data_point_condition(data_point: dict[str, object]) -> str | None:
+    """Resolve the best display condition for a Pirate Weather data point."""
+    summary = data_point.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        return summary
+
+    icon = data_point.get("icon")
+    if isinstance(icon, str):
+        return _icon_to_condition(icon)
+
+    return _precip_type_to_condition(data_point.get("precipType"))
 
 
 def _build_alert_id(alert_data: dict[str, object]) -> str:
@@ -211,6 +266,7 @@ class PirateWeatherClient:
         params = {
             "units": self.units,
             "extend": "hourly",
+            "version": _PIRATE_WEATHER_API_VERSION,
         }
         try:
             async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
@@ -420,7 +476,8 @@ class PirateWeatherClient:
             if ss:
                 sunset_time = datetime.fromtimestamp(ss, tz=location_tz)
 
-        condition_str = current.get("summary") or _icon_to_condition(current.get("icon"))
+        condition_str = _data_point_condition(current)
+        precipitation_type = _normalize_precipitation_type(current.get("precipType"))
 
         return CurrentConditions(
             temperature_f=temp_f,
@@ -444,6 +501,7 @@ class PirateWeatherClient:
             wind_gust_kph=wind_gust_kph,
             precipitation_in=precip_in,
             precipitation_mm=precip_mm,
+            precipitation_type=precipitation_type,
             sunrise_time=sunrise_time,
             sunset_time=sunset_time,
         )
@@ -519,7 +577,8 @@ class PirateWeatherClient:
 
             uv_index = day.get("uvIndex")
 
-            condition = day.get("summary") or _icon_to_condition(day.get("icon"))
+            condition = _data_point_condition(day)
+            precipitation_type = _normalize_precipitation_type(day.get("precipType"))
 
             period = ForecastPeriod(
                 name=name,
@@ -535,6 +594,7 @@ class PirateWeatherClient:
                 cloud_cover=cloud_cover,
                 wind_gust=wind_gust_str,
                 precipitation_amount=precip_amount,
+                precipitation_type=precipitation_type,
                 start_time=start_time,
             )
             periods.append(period)
@@ -652,7 +712,8 @@ class PirateWeatherClient:
                 feels_like_c = float(apparent) if apparent is not None else None
                 feels_like_f = (feels_like_c * 9 / 5 + 32) if feels_like_c is not None else None
 
-            condition = hour.get("summary") or _icon_to_condition(hour.get("icon"))
+            condition = _data_point_condition(hour)
+            precipitation_type = _normalize_precipitation_type(hour.get("precipType"))
 
             period = HourlyForecastPeriod(
                 start_time=start_time,
@@ -672,6 +733,7 @@ class PirateWeatherClient:
                 cloud_cover=cloud_cover,
                 wind_gust_mph=wind_gust_mph,
                 precipitation_amount=precip_amount,
+                precipitation_type=precipitation_type,
                 feels_like=feels_like_f,
                 visibility_miles=visibility_miles,
                 visibility_km=visibility_km,

--- a/tests/test_pirate_weather_client.py
+++ b/tests/test_pirate_weather_client.py
@@ -133,6 +133,10 @@ class TestIconToCondition:
         assert _icon_to_condition("rain") == "Rain"
         assert _icon_to_condition("partly-cloudy-night") == "Partly Cloudy"
 
+    def test_v2_precipitation_icons(self):
+        assert _icon_to_condition("ice") == "Freezing Rain"
+        assert _icon_to_condition("mixed") == "Wintry Mix"
+
     def test_unknown_icon_title_cases(self):
         result = _icon_to_condition("sleet-hail")
         assert result == "Sleet Hail"
@@ -212,6 +216,20 @@ class TestParseCurrentConditions:
         # daily block has sunriseTime / sunsetTime
         assert result.sunrise_time is not None
         assert result.sunset_time is not None
+
+    def test_v2_precipitation_type_populated(self, client, sample_forecast_payload):
+        payload = dict(sample_forecast_payload)
+        payload["currently"] = {
+            **sample_forecast_payload["currently"],
+            "summary": None,
+            "icon": "ice",
+            "precipType": "ice",
+        }
+
+        result = client._parse_current_conditions(payload)
+
+        assert result.condition == "Freezing Rain"
+        assert result.precipitation_type == ["ice"]
 
     def test_current_sunrise_uses_response_timezone_name(self, client, sample_forecast_payload):
         """IANA timezone from PW should override the fixed offset fallback."""
@@ -357,6 +375,21 @@ class TestParseForecast:
         assert result.summary == "Possible drizzle on Thursday."
         assert result.periods == []
 
+    def test_v2_daily_precipitation_type_populated(self, client, sample_forecast_payload):
+        day = {
+            **sample_forecast_payload["daily"]["data"][0],
+            "summary": None,
+            "icon": "mixed",
+            "precipType": "mixed",
+        }
+        payload = dict(sample_forecast_payload)
+        payload["daily"] = {"data": [day]}
+
+        result = client._parse_forecast(payload)
+
+        assert result.periods[0].short_forecast == "Wintry Mix"
+        assert result.periods[0].precipitation_type == ["mixed"]
+
     def test_uses_timezone_name_to_normalize_london_dst_daily_dates(self, client):
         """Europe/London daily periods should normalize to consecutive local noon dates."""
         start_dates = [
@@ -494,6 +527,21 @@ class TestParseHourlyForecast:
         payload["hourly"] = {"data": []}
         result = client._parse_hourly_forecast(payload)
         assert result.periods == []
+
+    def test_v2_hourly_precipitation_type_populated(self, client, sample_forecast_payload):
+        hour = {
+            **sample_forecast_payload["hourly"]["data"][0],
+            "summary": None,
+            "icon": "ice",
+            "precipType": "ice",
+        }
+        payload = dict(sample_forecast_payload)
+        payload["hourly"] = {"data": [hour]}
+
+        result = client._parse_hourly_forecast(payload)
+
+        assert result.periods[0].short_forecast == "Freezing Rain"
+        assert result.periods[0].precipitation_type == ["ice"]
 
     # ------------------------------------------------------------------
     # Regression tests – wind_speed_mph unit normalisation (bug fix)
@@ -654,6 +702,22 @@ class TestParseAlerts:
 
 
 class TestPirateWeatherHttpLayer:
+    @pytest.mark.asyncio
+    async def test_forecast_request_uses_api_version_2(self, client, sample_forecast_payload):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = sample_forecast_payload
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_http = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_http
+            mock_http.get.return_value = mock_resp
+
+            await client.get_forecast_data(Location("NYC", 40.7128, -74.006))
+
+        request_params = mock_http.get.call_args.kwargs["params"]
+        assert request_params["version"] == "2"
+
     @pytest.mark.asyncio
     async def test_get_current_conditions_success(self, client, sample_forecast_payload):
         mock_resp = MagicMock()


### PR DESCRIPTION
## Summary
- Request Pirate Weather forecast data with `version=2`.
- Normalize v2 `ice` and `mixed` precipitation values into plain-English conditions.
- Preserve v2 `precipType` values on current, daily, and hourly forecast models.

## Validation
- `uv run pytest -q -n 0 --tb=short tests/test_pirate_weather_client.py` — 70 passed
- `uv run pytest -q -n auto --tb=short` — 3791 passed, 38 skipped
- `uv run ruff check src tests`
- `uv run ruff format --check .`
- `uv run pyright`