### PR TITLE
refactor(display): split presentation builders

### DIFF
--- a/src/accessiweather/display/presentation/alerts.py
+++ b/src/accessiweather/display/presentation/alerts.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ...models import AppSettings, Location, WeatherAlert, WeatherAlerts
-from ..weather_presenter import AlertPresentation, AlertsPresentation
 from .formatters import format_display_datetime, truncate, wrap_text
+from .models import AlertPresentation, AlertsPresentation
 
 if TYPE_CHECKING:
     from accessiweather.alert_lifecycle import AlertLifecycleDiff

--- a/src/accessiweather/display/presentation/aviation.py
+++ b/src/accessiweather/display/presentation/aviation.py
@@ -1,0 +1,197 @@
+"""Aviation weather presentation helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime
+from typing import Any
+
+from ...models import AviationData, Location
+from ...utils import decode_taf_text
+from .models import AviationPresentation
+
+
+def build_aviation(
+    aviation: AviationData | None,
+    location: Location,
+    format_timestamp: Callable[[datetime], str],
+) -> AviationPresentation | None:
+    """Build an aviation presentation from METAR/TAF advisory data."""
+    if aviation is None:
+        return None
+
+    has_advisories = bool(aviation.active_sigmets or aviation.active_cwas)
+    taf_available = bool(
+        (aviation.raw_taf and aviation.raw_taf.strip())
+        or (aviation.decoded_taf and aviation.decoded_taf.strip())
+    )
+    if not (taf_available or has_advisories):
+        return None
+
+    station_label = aviation.airport_name or aviation.station_id
+    header_location = (
+        f"{station_label} near {location.name}"
+        if station_label and station_label.lower() != location.name.lower()
+        else station_label or location.name
+    )
+    header = f"Aviation weather for {header_location}."
+
+    taf_summary = aviation.decoded_taf
+    if not taf_summary and aviation.raw_taf:
+        taf_summary = decode_taf_text(aviation.raw_taf)
+
+    sigmet_lines = [
+        summary
+        for summary in (
+            _summarize_sigmet(entry, format_timestamp) for entry in aviation.active_sigmets[:5]
+        )
+        if summary
+    ]
+    cwa_lines = [
+        summary
+        for summary in (
+            _summarize_cwa(entry, format_timestamp) for entry in aviation.active_cwas[:5]
+        )
+        if summary
+    ]
+
+    fallback_lines: list[str] = [header]
+    if taf_summary:
+        fallback_lines.append("Terminal Aerodrome Forecast:")
+        fallback_lines.append(taf_summary)
+        if aviation.raw_taf and aviation.raw_taf.strip():
+            fallback_lines.append("Raw TAF message:")
+            fallback_lines.append(aviation.raw_taf.strip())
+    elif aviation.raw_taf and aviation.raw_taf.strip():
+        fallback_lines.append("Raw Terminal Aerodrome Forecast:")
+        fallback_lines.append(aviation.raw_taf.strip())
+    else:
+        fallback_lines.append("No Terminal Aerodrome Forecast available.")
+
+    if sigmet_lines:
+        fallback_lines.append("SIGMET and AIRMET advisories:")
+        fallback_lines.extend(f"• {line}" for line in sigmet_lines)
+    if cwa_lines:
+        fallback_lines.append("Center Weather Advisories:")
+        fallback_lines.extend(f"• {line}" for line in cwa_lines)
+
+    return AviationPresentation(
+        title="Aviation Weather",
+        airport_name=aviation.airport_name,
+        station_id=aviation.station_id,
+        taf_summary=taf_summary,
+        raw_taf=aviation.raw_taf,
+        sigmets=sigmet_lines,
+        cwas=cwa_lines,
+        fallback_text="\n".join(fallback_lines),
+    )
+
+
+def _format_aviation_time(
+    value: str | None,
+    format_timestamp: Callable[[datetime], str],
+) -> str | None:
+    if not value:
+        return None
+    try:
+        sanitized = value.replace("Z", "+00:00") if value.endswith("Z") else value
+        timestamp = datetime.fromisoformat(sanitized)
+    except ValueError:
+        return value
+    return format_timestamp(timestamp)
+
+
+def _summarize_sigmet(data: Any, format_timestamp: Callable[[datetime], str]) -> str | None:
+    if not isinstance(data, dict):
+        return None
+
+    name = (
+        data.get("name")
+        or data.get("event")
+        or data.get("hazard")
+        or data.get("phenomenon")
+        or "SIGMET"
+    )
+    severity = data.get("severity") or data.get("intensity")
+    area = data.get("fir") or data.get("area") or data.get("regions") or data.get("airspace")
+    if isinstance(area, list):
+        area = ", ".join(str(item) for item in area if item)
+
+    start = _format_aviation_time(
+        data.get("startTime")
+        or data.get("beginTime")
+        or data.get("validTimeStart")
+        or data.get("issueTime"),
+        format_timestamp,
+    )
+    end = _format_aviation_time(
+        data.get("endTime")
+        or data.get("expires")
+        or data.get("validTimeEnd")
+        or data.get("validUntil"),
+        format_timestamp,
+    )
+    description = data.get("description") or data.get("text") or data.get("summary")
+
+    summary_parts = [name]
+    if severity:
+        summary_parts.append(f"severity {severity}")
+    summary = " ".join(summary_parts)
+
+    detail_parts: list[str] = []
+    if area:
+        detail_parts.append(f"Area: {area}")
+    if start or end:
+        if start and end:
+            detail_parts.append(f"Valid {start} to {end}")
+        elif end:
+            detail_parts.append(f"Valid until {end}")
+        elif start:
+            detail_parts.append(f"Effective {start}")
+    if description:
+        detail_parts.append(description)
+
+    details = "; ".join(detail_parts)
+    return f"{summary}; {details}" if details else summary
+
+
+def _summarize_cwa(data: Any, format_timestamp: Callable[[datetime], str]) -> str | None:
+    if not isinstance(data, dict):
+        return None
+
+    name = (
+        data.get("event")
+        or data.get("phenomenon")
+        or data.get("hazard")
+        or data.get("productType")
+        or "Center Weather Advisory"
+    )
+    cwsu = data.get("cwsu") or data.get("issuingOffice")
+    area = data.get("area") or data.get("regions") or data.get("airspace") or cwsu
+    if isinstance(area, list):
+        area = ", ".join(str(item) for item in area if item)
+
+    start = _format_aviation_time(data.get("startTime") or data.get("issueTime"), format_timestamp)
+    end = _format_aviation_time(data.get("endTime") or data.get("expires"), format_timestamp)
+    description = data.get("description") or data.get("text") or data.get("summary")
+
+    summary_parts = [name]
+    if cwsu and cwsu not in summary_parts:
+        summary_parts.append(f"({cwsu})")
+    summary = " ".join(summary_parts)
+
+    detail_parts: list[str] = []
+    if area and area not in summary:
+        detail_parts.append(f"Area: {area}")
+    if start or end:
+        if start and end:
+            detail_parts.append(f"Valid {start} to {end}")
+        elif end:
+            detail_parts.append(f"Valid until {end}")
+        elif start:
+            detail_parts.append(f"Issued {start}")
+    if description:
+        detail_parts.append(description)
+
+    details = "; ".join(detail_parts)
+    return f"{summary}; {details}" if details else summary

--- a/src/accessiweather/display/presentation/current_condition_seasonal.py
+++ b/src/accessiweather/display/presentation/current_condition_seasonal.py
@@ -1,0 +1,129 @@
+"""Seasonal metric helpers for current conditions presentation."""
+
+from __future__ import annotations
+
+from ...models import CurrentConditions
+from ...utils import TemperatureUnit
+from .models import Metric
+
+
+def _build_seasonal_metrics(
+    current: CurrentConditions,
+    unit_pref: TemperatureUnit,
+    precision: int,
+) -> list[Metric]:
+    """Build seasonal weather metrics (snow depth, wind chill, heat index, etc.)."""
+    metrics: list[Metric] = []
+
+    if current.snow_depth_in is not None and current.snow_depth_in > 0:
+        if unit_pref == TemperatureUnit.CELSIUS:
+            snow_depth_cm = current.snow_depth_cm or current.snow_depth_in * 2.54
+            metrics.append(Metric("Snow on ground", f"{snow_depth_cm:.{precision}f} cm"))
+        elif unit_pref == TemperatureUnit.FAHRENHEIT:
+            metrics.append(Metric("Snow on ground", f"{current.snow_depth_in:.{precision}f} in"))
+        else:
+            snow_depth_cm = current.snow_depth_cm or current.snow_depth_in * 2.54
+            metrics.append(
+                Metric(
+                    "Snow on ground",
+                    f"{current.snow_depth_in:.{precision}f} in ({snow_depth_cm:.{precision}f} cm)",
+                )
+            )
+
+    if current.wind_chill_f is not None:
+        temp_f = current.temperature_f
+        if temp_f is None or abs(current.wind_chill_f - temp_f) >= 3:
+            wind_chill_c = current.wind_chill_c
+            if wind_chill_c is None and current.wind_chill_f is not None:
+                wind_chill_c = (current.wind_chill_f - 32) * 5 / 9
+            wc_str = format_temperature_value(
+                current.wind_chill_f, wind_chill_c, unit_pref, precision
+            )
+            if wc_str:
+                metrics.append(Metric("Wind chill", wc_str))
+
+    if current.freezing_level_ft is not None:
+        if unit_pref == TemperatureUnit.CELSIUS:
+            freezing_m = current.freezing_level_m or current.freezing_level_ft * 0.3048
+            metrics.append(Metric("Freezing level", f"{freezing_m:.0f} m"))
+        elif unit_pref == TemperatureUnit.FAHRENHEIT:
+            metrics.append(Metric("Freezing level", f"{current.freezing_level_ft:.0f} ft"))
+        else:
+            freezing_m = current.freezing_level_m or current.freezing_level_ft * 0.3048
+            metrics.append(
+                Metric("Freezing level", f"{current.freezing_level_ft:.0f} ft ({freezing_m:.0f} m)")
+            )
+
+    if current.heat_index_f is not None:
+        temp_f = current.temperature_f
+        if temp_f is None or abs(current.heat_index_f - temp_f) >= 3:
+            heat_index_c = current.heat_index_c
+            if heat_index_c is None and current.heat_index_f is not None:
+                heat_index_c = (current.heat_index_f - 32) * 5 / 9
+            hi_str = format_temperature_value(
+                current.heat_index_f, heat_index_c, unit_pref, precision
+            )
+            if hi_str:
+                metrics.append(Metric("Heat index", hi_str))
+
+    if current.frost_risk is not None and current.frost_risk.lower() != "none":
+        metrics.append(Metric("Frost risk", current.frost_risk))
+
+    has_active_precip = False
+    if current.precipitation_type and len(current.precipitation_type) > 0:
+        condition_lower = (current.condition or "").lower()
+        precip_keywords = ["rain", "snow", "drizzle", "shower", "storm", "sleet", "hail", "precip"]
+        has_active_precip = any(keyword in condition_lower for keyword in precip_keywords)
+
+    if has_active_precip and current.precipitation_type:
+        precip_types = ", ".join(current.precipitation_type)
+        metrics.append(Metric("Precipitation type", precip_types.title()))
+
+    if current.severe_weather_risk is not None and current.severe_weather_risk > 0:
+        risk_level = _get_severe_risk_description(current.severe_weather_risk)
+        metrics.append(
+            Metric("Severe weather risk", f"{current.severe_weather_risk}% ({risk_level})")
+        )
+
+    return metrics
+
+
+def format_temperature_value(
+    temp_f: float | None,
+    temp_c: float | None,
+    unit_pref: TemperatureUnit,
+    precision: int,
+) -> str | None:
+    """Format a temperature value based on unit preference."""
+    if temp_f is None and temp_c is None:
+        return None
+
+    if unit_pref == TemperatureUnit.FAHRENHEIT:
+        if temp_f is not None:
+            return f"{temp_f:.{precision}f}°F"
+        return None
+    if unit_pref == TemperatureUnit.CELSIUS:
+        if temp_c is not None:
+            return f"{temp_c:.{precision}f}°C"
+        if temp_f is not None:
+            temp_c = (temp_f - 32) * 5 / 9
+            return f"{temp_c:.{precision}f}°C"
+        return None
+    if temp_f is not None:
+        if temp_c is None:
+            temp_c = (temp_f - 32) * 5 / 9
+        return f"{temp_f:.{precision}f}°F ({temp_c:.{precision}f}°C)"
+    return None
+
+
+def _get_severe_risk_description(risk: int) -> str:
+    """Get a description for severe weather risk percentage."""
+    if risk >= 80:
+        return "Extreme"
+    if risk >= 60:
+        return "High"
+    if risk >= 40:
+        return "Moderate"
+    if risk >= 20:
+        return "Low"
+    return "Minimal"

--- a/src/accessiweather/display/presentation/current_condition_trends.py
+++ b/src/accessiweather/display/presentation/current_condition_trends.py
@@ -1,0 +1,174 @@
+"""Trend helpers for current conditions presentation."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from ...models import CurrentConditions, HourlyForecast, HourlyForecastPeriod, TrendInsight
+from ...utils import TemperatureUnit
+
+
+def _adapt_temperature_trend_summary(trend: TrendInsight, unit_pref: TemperatureUnit) -> str:
+    """Return a temperature-trend summary adapted to the user's unit preference."""
+    if trend.change is None or trend.unit not in {"°F", "°C"}:
+        return trend.summary or describe_trend(trend)
+
+    src_unit = trend.unit
+    direction = trend.direction or "steady"
+    hours = trend.timeframe_hours or 24
+
+    if src_unit == "°F":
+        change_f = trend.change
+        change_c = change_f * 5.0 / 9.0
+        if unit_pref == TemperatureUnit.CELSIUS:
+            return f"Temperature {direction} {change_c:+.1f}°C over {hours}h"
+        if unit_pref == TemperatureUnit.BOTH:
+            return f"Temperature {direction} {change_f:+.1f}°F ({change_c:+.1f}°C) over {hours}h"
+        return trend.summary or describe_trend(trend)
+
+    change_c = trend.change
+    change_f = change_c * 9.0 / 5.0
+    if unit_pref == TemperatureUnit.FAHRENHEIT:
+        return f"Temperature {direction} {change_f:+.1f}°F over {hours}h"
+    if unit_pref == TemperatureUnit.BOTH:
+        return f"Temperature {direction} {change_f:+.1f}°F ({change_c:+.1f}°C) over {hours}h"
+    return trend.summary or describe_trend(trend)
+
+
+def format_trend_lines(
+    trends: Iterable[TrendInsight] | None,
+    *,
+    current: CurrentConditions | None = None,
+    hourly_forecast: HourlyForecast | None = None,
+    include_pressure: bool = True,
+    unit_pref: TemperatureUnit = TemperatureUnit.FAHRENHEIT,
+) -> list[str]:
+    """Generate human readable summaries for trend insights."""
+    lines: list[str] = []
+    pressure_present = False
+
+    if trends:
+        for trend in trends:
+            metric_name = getattr(trend, "metric", "")
+            if isinstance(metric_name, str) and metric_name.lower() == "daily_trend":
+                continue
+            is_pressure = isinstance(metric_name, str) and metric_name.lower() == "pressure"
+            if is_pressure and not include_pressure:
+                continue
+
+            is_temperature = isinstance(metric_name, str) and metric_name.lower() == "temperature"
+            if is_temperature:
+                summary = _adapt_temperature_trend_summary(trend, unit_pref)
+            else:
+                summary = trend.summary or describe_trend(trend)
+
+            if trend.sparkline:
+                summary = f"{summary} {trend.sparkline}".strip()
+            if summary:
+                lines.append(summary)
+            if is_pressure:
+                pressure_present = True
+
+    if include_pressure and (not pressure_present) and current and hourly_forecast:
+        legacy_pressure = compute_pressure_trend_from_hourly(current, hourly_forecast)
+        if legacy_pressure:
+            summary = legacy_pressure["summary"]
+            if summary and summary not in lines:
+                lines.append(summary)
+
+    return lines
+
+
+def describe_trend(trend: TrendInsight) -> str:
+    """Describe a trend insight when it lacks a canned summary."""
+    direction = (trend.direction or "steady").capitalize()
+    timeframe = trend.timeframe_hours or 24
+    change_text = ""
+    if trend.change is not None:
+        if trend.unit in {"°F", "°C"}:
+            change_text = f"{trend.change:+.1f}{trend.unit}"
+        elif trend.unit:
+            change_text = f"{trend.change:+.2f}{trend.unit}"
+        else:
+            change_text = f"{trend.change:+.1f}"
+    pieces = [direction]
+    if change_text:
+        pieces.append(change_text)
+    pieces.append(f"over {timeframe}h")
+    return " ".join(pieces)
+
+
+def compute_pressure_trend_from_hourly(
+    current: CurrentConditions,
+    hourly_forecast: HourlyForecast | None,
+) -> dict[str, str] | None:
+    """Approximate a pressure trend using upcoming hourly data."""
+    if not hourly_forecast or not hourly_forecast.has_data():
+        return None
+
+    next_hours = hourly_forecast.get_next_hours(6)
+    if not next_hours:
+        return None
+
+    target: HourlyForecastPeriod | None = None
+    for period in reversed(next_hours):
+        if not period:
+            continue
+        if period.pressure_in is not None or period.pressure_mb is not None:
+            target = period
+            break
+
+    if target is None:
+        return None
+
+    base_in = current.pressure_in
+    base_mb = current.pressure_mb
+    future_in = target.pressure_in
+    future_mb = target.pressure_mb
+
+    descriptor: str | None = None
+    magnitude: str | None = None
+    change: float | None = None
+
+    if base_in is not None and future_in is not None:
+        change = future_in - base_in
+        descriptor = direction_descriptor(change, minor=0.02, strong=0.05)
+        magnitude = f"{change:+.2f} inHg"
+    elif base_mb is not None and future_mb is not None:
+        change = future_mb - base_mb
+        descriptor = direction_descriptor(change, minor=0.5, strong=1.5)
+        magnitude = f"{change:+.1f} mb"
+
+    if descriptor is None or magnitude is None or change is None:
+        return None
+
+    direction_word, arrow = split_direction_descriptor(descriptor)
+    window_hours = 6
+    arrow_part = f" {arrow}" if arrow else ""
+    value = f"{direction_word.title()}{arrow_part} {magnitude} over next {window_hours}h".strip()
+    summary = f"Pressure {descriptor} {magnitude} over next {window_hours}h".strip()
+
+    return {"summary": summary, "value": value}
+
+
+def direction_descriptor(change: float, *, minor: float, strong: float) -> str:
+    """Classify change magnitude into rising/falling/steady buckets with arrows."""
+    if change >= strong:
+        return "rising ⬆⬆"
+    if change >= minor:
+        return "rising ⬆"
+    if change <= -strong:
+        return "falling ⬇⬇"
+    if change <= -minor:
+        return "falling ⬇"
+    return "steady →"
+
+
+def split_direction_descriptor(descriptor: str) -> tuple[str, str]:
+    """Return the textual direction and accompanying arrow glyphs."""
+    if not descriptor:
+        return "steady", ""
+    if " " in descriptor:
+        direction, arrow = descriptor.split(" ", 1)
+        return direction, arrow.strip()
+    return descriptor, ""

--- a/src/accessiweather/display/presentation/current_conditions.py
+++ b/src/accessiweather/display/presentation/current_conditions.py
@@ -11,7 +11,6 @@ from ...models import (
     CurrentConditions,
     EnvironmentalConditions,
     HourlyForecast,
-    HourlyForecastPeriod,
     Location,
     MinutelyPrecipitationForecast,
     TrendInsight,
@@ -22,7 +21,19 @@ from ...utils import TemperatureUnit
 from ...utils.unit_utils import format_precipitation, format_wind_speed
 from ...weather_anomaly import AnomalyCallout
 from ..priority_engine import PriorityEngine, WeatherCategory
-from ..weather_presenter import CurrentConditionsPresentation, Metric
+from .current_condition_seasonal import (
+    _build_seasonal_metrics,
+    _get_severe_risk_description,
+    format_temperature_value,
+)
+from .current_condition_trends import (
+    _adapt_temperature_trend_summary,
+    compute_pressure_trend_from_hourly,
+    describe_trend,
+    direction_descriptor,
+    format_trend_lines,
+    split_direction_descriptor,
+)
 from .environmental import AirQualityPresentation
 from .formatters import (
     format_dewpoint,
@@ -34,8 +45,21 @@ from .formatters import (
     get_temperature_precision,
     get_uv_description,
 )
+from .models import CurrentConditionsPresentation, Metric
 
 logger = logging.getLogger(__name__)
+
+__all__ = [
+    "_build_seasonal_metrics",
+    "_get_severe_risk_description",
+    "build_current_conditions",
+    "compute_pressure_trend_from_hourly",
+    "describe_trend",
+    "direction_descriptor",
+    "format_temperature_value",
+    "format_trend_lines",
+    "split_direction_descriptor",
+]
 
 
 def _normalize_metric_wind_units(value: str, *, unit_system: DisplayUnitSystem | str | None) -> str:
@@ -229,34 +253,6 @@ def _build_environmental_metrics(
     return metrics
 
 
-def _adapt_temperature_trend_summary(trend: TrendInsight, unit_pref: TemperatureUnit) -> str:
-    """Return a temperature-trend summary adapted to the user's unit preference."""
-    if trend.change is None or trend.unit not in {"°F", "°C"}:
-        return trend.summary or describe_trend(trend)
-
-    src_unit = trend.unit
-    direction = trend.direction or "steady"
-    hours = trend.timeframe_hours or 24
-
-    if src_unit == "°F":
-        change_f = trend.change
-        change_c = change_f * 5.0 / 9.0
-        if unit_pref == TemperatureUnit.CELSIUS:
-            return f"Temperature {direction} {change_c:+.1f}°C over {hours}h"
-        if unit_pref == TemperatureUnit.BOTH:
-            return f"Temperature {direction} {change_f:+.1f}°F ({change_c:+.1f}°C) over {hours}h"
-        return trend.summary or describe_trend(trend)  # FAHRENHEIT – already correct
-
-    # src_unit == "°C"
-    change_c = trend.change
-    change_f = change_c * 9.0 / 5.0
-    if unit_pref == TemperatureUnit.FAHRENHEIT:
-        return f"Temperature {direction} {change_f:+.1f}°F over {hours}h"
-    if unit_pref == TemperatureUnit.BOTH:
-        return f"Temperature {direction} {change_f:+.1f}°F ({change_c:+.1f}°C) over {hours}h"
-    return trend.summary or describe_trend(trend)  # CELSIUS – already correct
-
-
 def _build_trend_metrics(
     trends: Iterable[TrendInsight] | None,
     current: CurrentConditions,
@@ -300,137 +296,6 @@ def _build_trend_metrics(
             metrics.append(Metric("Pressure trend", legacy_pressure_trend["value"]))
 
     return metrics
-
-
-def _build_seasonal_metrics(
-    current: CurrentConditions,
-    unit_pref: TemperatureUnit,
-    precision: int,
-) -> list[Metric]:
-    """Build seasonal weather metrics (snow depth, wind chill, heat index, etc.)."""
-    metrics: list[Metric] = []
-
-    # Winter metrics
-    if current.snow_depth_in is not None and current.snow_depth_in > 0:
-        if unit_pref == TemperatureUnit.CELSIUS:
-            snow_depth_cm = current.snow_depth_cm or current.snow_depth_in * 2.54
-            metrics.append(Metric("Snow on ground", f"{snow_depth_cm:.{precision}f} cm"))
-        elif unit_pref == TemperatureUnit.FAHRENHEIT:
-            metrics.append(Metric("Snow on ground", f"{current.snow_depth_in:.{precision}f} in"))
-        else:
-            snow_depth_cm = current.snow_depth_cm or current.snow_depth_in * 2.54
-            metrics.append(
-                Metric(
-                    "Snow on ground",
-                    f"{current.snow_depth_in:.{precision}f} in ({snow_depth_cm:.{precision}f} cm)",
-                )
-            )
-
-    if current.wind_chill_f is not None:
-        # Only show wind chill if significantly different from temperature
-        temp_f = current.temperature_f
-        if temp_f is None or abs(current.wind_chill_f - temp_f) >= 3:
-            wind_chill_c = current.wind_chill_c
-            if wind_chill_c is None and current.wind_chill_f is not None:
-                wind_chill_c = (current.wind_chill_f - 32) * 5 / 9
-            wc_str = format_temperature_value(
-                current.wind_chill_f, wind_chill_c, unit_pref, precision
-            )
-            if wc_str:
-                metrics.append(Metric("Wind chill", wc_str))
-
-    if current.freezing_level_ft is not None:
-        if unit_pref == TemperatureUnit.CELSIUS:
-            freezing_m = current.freezing_level_m or current.freezing_level_ft * 0.3048
-            metrics.append(Metric("Freezing level", f"{freezing_m:.0f} m"))
-        elif unit_pref == TemperatureUnit.FAHRENHEIT:
-            metrics.append(Metric("Freezing level", f"{current.freezing_level_ft:.0f} ft"))
-        else:
-            freezing_m = current.freezing_level_m or current.freezing_level_ft * 0.3048
-            metrics.append(
-                Metric("Freezing level", f"{current.freezing_level_ft:.0f} ft ({freezing_m:.0f} m)")
-            )
-
-    # Summer metrics
-    if current.heat_index_f is not None:
-        # Only show heat index if significantly different from temperature
-        temp_f = current.temperature_f
-        if temp_f is None or abs(current.heat_index_f - temp_f) >= 3:
-            heat_index_c = current.heat_index_c
-            if heat_index_c is None and current.heat_index_f is not None:
-                heat_index_c = (current.heat_index_f - 32) * 5 / 9
-            hi_str = format_temperature_value(
-                current.heat_index_f, heat_index_c, unit_pref, precision
-            )
-            if hi_str:
-                metrics.append(Metric("Heat index", hi_str))
-
-    # Spring/Fall metrics
-    if current.frost_risk is not None and current.frost_risk.lower() != "none":
-        metrics.append(Metric("Frost risk", current.frost_risk))
-
-    # Year-round metrics - only show precipitation type when there's active precipitation
-    # Check for active precipitation indicators: precipitation amount, or condition suggests precip
-    has_active_precip = False
-    if current.precipitation_type and len(current.precipitation_type) > 0:
-        # Check if condition indicates active precipitation
-        condition_lower = (current.condition or "").lower()
-        precip_keywords = ["rain", "snow", "drizzle", "shower", "storm", "sleet", "hail", "precip"]
-        has_active_precip = any(keyword in condition_lower for keyword in precip_keywords)
-
-    if has_active_precip and current.precipitation_type:
-        precip_types = ", ".join(current.precipitation_type)
-        metrics.append(Metric("Precipitation type", precip_types.title()))
-
-    if current.severe_weather_risk is not None and current.severe_weather_risk > 0:
-        risk_level = _get_severe_risk_description(current.severe_weather_risk)
-        metrics.append(
-            Metric("Severe weather risk", f"{current.severe_weather_risk}% ({risk_level})")
-        )
-
-    return metrics
-
-
-def format_temperature_value(
-    temp_f: float | None,
-    temp_c: float | None,
-    unit_pref: TemperatureUnit,
-    precision: int,
-) -> str | None:
-    """Format a temperature value based on unit preference."""
-    if temp_f is None and temp_c is None:
-        return None
-
-    if unit_pref == TemperatureUnit.FAHRENHEIT:
-        if temp_f is not None:
-            return f"{temp_f:.{precision}f}°F"
-        return None
-    if unit_pref == TemperatureUnit.CELSIUS:
-        if temp_c is not None:
-            return f"{temp_c:.{precision}f}°C"
-        if temp_f is not None:
-            temp_c = (temp_f - 32) * 5 / 9
-            return f"{temp_c:.{precision}f}°C"
-        return None
-    # BOTH
-    if temp_f is not None:
-        if temp_c is None:
-            temp_c = (temp_f - 32) * 5 / 9
-        return f"{temp_f:.{precision}f}°F ({temp_c:.{precision}f}°C)"
-    return None
-
-
-def _get_severe_risk_description(risk: int) -> str:
-    """Get a description for severe weather risk percentage."""
-    if risk >= 80:
-        return "Extreme"
-    if risk >= 60:
-        return "High"
-    if risk >= 40:
-        return "Moderate"
-    if risk >= 20:
-        return "Low"
-    return "Minimal"
 
 
 def _categorize_metric(label: str) -> WeatherCategory:
@@ -609,142 +474,3 @@ def build_current_conditions(
         trends=trend_lines,
         impact_summary=impact,
     )
-
-
-def format_trend_lines(
-    trends: Iterable[TrendInsight] | None,
-    *,
-    current: CurrentConditions | None = None,
-    hourly_forecast: HourlyForecast | None = None,
-    include_pressure: bool = True,
-    unit_pref: TemperatureUnit = TemperatureUnit.FAHRENHEIT,
-) -> list[str]:
-    """Generate human readable summaries for trend insights."""
-    lines: list[str] = []
-    pressure_present = False
-
-    if trends:
-        for trend in trends:
-            metric_name = getattr(trend, "metric", "")
-            if isinstance(metric_name, str) and metric_name.lower() == "daily_trend":
-                continue
-            is_pressure = isinstance(metric_name, str) and metric_name.lower() == "pressure"
-            if is_pressure and not include_pressure:
-                continue
-
-            is_temperature = isinstance(metric_name, str) and metric_name.lower() == "temperature"
-            if is_temperature:
-                summary = _adapt_temperature_trend_summary(trend, unit_pref)
-            else:
-                summary = trend.summary or describe_trend(trend)
-
-            if trend.sparkline:
-                summary = f"{summary} {trend.sparkline}".strip()
-            if summary:
-                lines.append(summary)
-            if is_pressure:
-                pressure_present = True
-
-    if include_pressure and (not pressure_present) and current and hourly_forecast:
-        legacy_pressure = compute_pressure_trend_from_hourly(current, hourly_forecast)
-        if legacy_pressure:
-            summary = legacy_pressure["summary"]
-            if summary and summary not in lines:
-                lines.append(summary)
-
-    return lines
-
-
-def describe_trend(trend: TrendInsight) -> str:
-    """Describe a trend insight when it lacks a canned summary."""
-    direction = (trend.direction or "steady").capitalize()
-    timeframe = trend.timeframe_hours or 24
-    change_text = ""
-    if trend.change is not None:
-        if trend.unit in {"°F", "°C"}:
-            change_text = f"{trend.change:+.1f}{trend.unit}"
-        elif trend.unit:
-            change_text = f"{trend.change:+.2f}{trend.unit}"
-        else:
-            change_text = f"{trend.change:+.1f}"
-    pieces = [direction]
-    if change_text:
-        pieces.append(change_text)
-    pieces.append(f"over {timeframe}h")
-    return " ".join(pieces)
-
-
-def compute_pressure_trend_from_hourly(
-    current: CurrentConditions,
-    hourly_forecast: HourlyForecast | None,
-) -> dict[str, str] | None:
-    """Approximate a pressure trend using upcoming hourly data."""
-    if not hourly_forecast or not hourly_forecast.has_data():
-        return None
-
-    next_hours = hourly_forecast.get_next_hours(6)
-    if not next_hours:
-        return None
-
-    target: HourlyForecastPeriod | None = None
-    for period in reversed(next_hours):
-        if not period:
-            continue
-        if period.pressure_in is not None or period.pressure_mb is not None:
-            target = period
-            break
-
-    if target is None:
-        return None
-
-    base_in = current.pressure_in
-    base_mb = current.pressure_mb
-    future_in = target.pressure_in
-    future_mb = target.pressure_mb
-
-    descriptor: str | None = None
-    magnitude: str | None = None
-    change: float | None = None
-
-    if base_in is not None and future_in is not None:
-        change = future_in - base_in
-        descriptor = direction_descriptor(change, minor=0.02, strong=0.05)
-        magnitude = f"{change:+.2f} inHg"
-    elif base_mb is not None and future_mb is not None:
-        change = future_mb - base_mb
-        descriptor = direction_descriptor(change, minor=0.5, strong=1.5)
-        magnitude = f"{change:+.1f} mb"
-
-    if descriptor is None or magnitude is None or change is None:
-        return None
-
-    direction_word, arrow = split_direction_descriptor(descriptor)
-    window_hours = 6
-    arrow_part = f" {arrow}" if arrow else ""
-    value = f"{direction_word.title()}{arrow_part} {magnitude} over next {window_hours}h".strip()
-    summary = f"Pressure {descriptor} {magnitude} over next {window_hours}h".strip()
-
-    return {"summary": summary, "value": value}
-
-
-def direction_descriptor(change: float, *, minor: float, strong: float) -> str:
-    """Classify change magnitude into rising/falling/steady buckets with arrows."""
-    if change >= strong:
-        return "rising ⬆⬆"
-    if change >= minor:
-        return "rising ⬆"
-    if change <= -strong:
-        return "falling ⬇⬇"
-    if change <= -minor:
-        return "falling ⬇"
-    return "steady →"
-
-
-def split_direction_descriptor(descriptor: str) -> tuple[str, str]:
-    """Return the textual direction and accompanying arrow glyphs."""
-    if not descriptor:
-        return "steady", ""
-    if " " in descriptor:
-        direction, arrow = descriptor.split(" ", 1)
-        return direction, arrow.strip()
-    return descriptor, ""

--- a/src/accessiweather/display/presentation/environmental.py
+++ b/src/accessiweather/display/presentation/environmental.py
@@ -8,10 +8,9 @@ from datetime import datetime
 from ...models import (
     AppSettings,
     EnvironmentalConditions,
-    HourlyAirQuality,
-    HourlyUVIndex,
     Location,
 )
+from .environmental_hourly import _format_time, format_hourly_air_quality, format_hourly_uv_index
 from .formatters import format_display_datetime
 
 _AIR_QUALITY_GUIDANCE: dict[str, str] = {
@@ -286,141 +285,6 @@ def _build_updated_line(
         show_timezone=show_timezone_suffix,
     )
     return f"Updated {timestamp}"
-
-
-def format_hourly_air_quality(
-    hourly_data: list[HourlyAirQuality],
-    settings: AppSettings | None = None,
-    max_hours: int = 24,
-) -> str | None:
-    """
-    Format hourly air quality forecast into readable text.
-
-    Args:
-        hourly_data: List of hourly air quality forecasts.
-        settings: App settings for time formatting.
-        max_hours: Maximum number of hours to include.
-
-    Returns:
-        Formatted string describing the hourly forecast, or None if no data.
-
-    """
-    if not hourly_data:
-        return None
-
-    time_format_12hour = getattr(settings, "time_format_12hour", True) if settings else True
-    data = hourly_data[:max_hours]
-
-    current = data[0]
-    peak = max(data, key=lambda h: h.aqi)
-    best = min(data, key=lambda h: h.aqi)
-
-    lines = []
-    lines.append(f"Current: AQI {current.aqi} ({current.category})")
-
-    if len(data) >= 3:
-        trend_start = data[0].aqi
-        trend_end = data[2].aqi
-        diff = trend_end - trend_start
-
-        if diff > 20:
-            lines.append(f"Trend: Worsening (AQI {trend_start} → {trend_end})")
-        elif diff < -20:
-            lines.append(f"Trend: Improving (AQI {trend_start} → {trend_end})")
-        else:
-            lines.append("Trend: Stable")
-
-    if peak.aqi != current.aqi:
-        peak_time = _format_time(peak.timestamp, time_format_12hour)
-        lines.append(f"Peak: AQI {peak.aqi} ({peak.category}) at {peak_time}")
-
-    if best.aqi < 100 and best.aqi != current.aqi:
-        best_time = _format_time(best.timestamp, time_format_12hour)
-        lines.append(f"Best time: AQI {best.aqi} at {best_time}")
-
-    # Add individual hourly entries (show up to 12 hours)
-    hourly_entries = data[:12]
-    if hourly_entries:
-        lines.append("")
-        lines.append("Hourly Forecast:")
-        for entry in hourly_entries:
-            entry_time = _format_time(entry.timestamp, time_format_12hour)
-            lines.append(f"  {entry_time}: AQI {entry.aqi} ({entry.category})")
-
-    return "\n".join(lines)
-
-
-def format_hourly_uv_index(
-    hourly_data: list[HourlyUVIndex],
-    settings: AppSettings | None = None,
-    max_hours: int = 24,
-) -> str | None:
-    """
-    Format hourly UV index forecast into readable text.
-
-    Args:
-        hourly_data: List of hourly UV index forecasts.
-        settings: App settings for time formatting.
-        max_hours: Maximum number of hours to include.
-
-    Returns:
-        Formatted string describing the hourly forecast, or None if no data.
-
-    """
-    if not hourly_data:
-        return None
-
-    time_format_12hour = getattr(settings, "time_format_12hour", True) if settings else True
-    data = hourly_data[:max_hours]
-
-    current = data[0]
-    peak = max(data, key=lambda h: h.uv_index)
-    lowest = min(data, key=lambda h: h.uv_index)
-
-    lines = []
-    lines.append(f"Current: UV Index {current.uv_index:.1f} ({current.category})")
-
-    if len(data) >= 3:
-        trend_start = data[0].uv_index
-        trend_end = data[2].uv_index
-        diff = trend_end - trend_start
-
-        if diff > 2:
-            lines.append(f"Trend: Rising (UV {trend_start:.1f} → {trend_end:.1f})")
-        elif diff < -2:
-            lines.append(f"Trend: Falling (UV {trend_start:.1f} → {trend_end:.1f})")
-        else:
-            lines.append("Trend: Stable")
-
-    if peak.uv_index != current.uv_index:
-        peak_time = _format_time(peak.timestamp, time_format_12hour)
-        lines.append(
-            f"Peak: UV Index {peak.uv_index:.1f} ({peak.category}) at {peak_time}"
-        )
-
-    if lowest.uv_index < 3 and lowest.uv_index != current.uv_index:
-        lowest_time = _format_time(lowest.timestamp, time_format_12hour)
-        lines.append(f"Lowest UV: {lowest.uv_index:.1f} at {lowest_time}")
-
-    # Add individual hourly entries (show up to 12 hours)
-    hourly_entries = data[:12]
-    if hourly_entries:
-        lines.append("")
-        lines.append("Hourly Forecast:")
-        for entry in hourly_entries:
-            entry_time = _format_time(entry.timestamp, time_format_12hour)
-            lines.append(
-                f"  {entry_time}: UV Index {entry.uv_index:.1f} ({entry.category})"
-            )
-
-    return "\n".join(lines)
-
-
-def _format_time(dt: datetime, use_12hour: bool = True) -> str:
-    """Format a datetime as a simple time string."""
-    if use_12hour:
-        return dt.strftime("%I:%M %p").lstrip("0")
-    return dt.strftime("%H:%M")
 
 
 def format_air_quality_summary(

--- a/src/accessiweather/display/presentation/environmental_hourly.py
+++ b/src/accessiweather/display/presentation/environmental_hourly.py
@@ -1,0 +1,136 @@
+"""Hourly environmental forecast formatting helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from ...models import AppSettings, HourlyAirQuality, HourlyUVIndex
+
+
+def format_hourly_air_quality(
+    hourly_data: list[HourlyAirQuality],
+    settings: AppSettings | None = None,
+    max_hours: int = 24,
+) -> str | None:
+    """
+    Format hourly air quality forecast into readable text.
+
+    Args:
+        hourly_data: List of hourly air quality forecasts.
+        settings: App settings for time formatting.
+        max_hours: Maximum number of hours to include.
+
+    Returns:
+        Formatted string describing the hourly forecast, or None if no data.
+
+    """
+    if not hourly_data:
+        return None
+
+    time_format_12hour = getattr(settings, "time_format_12hour", True) if settings else True
+    data = hourly_data[:max_hours]
+
+    current = data[0]
+    peak = max(data, key=lambda h: h.aqi)
+    best = min(data, key=lambda h: h.aqi)
+
+    lines = []
+    lines.append(f"Current: AQI {current.aqi} ({current.category})")
+
+    if len(data) >= 3:
+        trend_start = data[0].aqi
+        trend_end = data[2].aqi
+        diff = trend_end - trend_start
+
+        if diff > 20:
+            lines.append(f"Trend: Worsening (AQI {trend_start} → {trend_end})")
+        elif diff < -20:
+            lines.append(f"Trend: Improving (AQI {trend_start} → {trend_end})")
+        else:
+            lines.append("Trend: Stable")
+
+    if peak.aqi != current.aqi:
+        peak_time = _format_time(peak.timestamp, time_format_12hour)
+        lines.append(f"Peak: AQI {peak.aqi} ({peak.category}) at {peak_time}")
+
+    if best.aqi < 100 and best.aqi != current.aqi:
+        best_time = _format_time(best.timestamp, time_format_12hour)
+        lines.append(f"Best time: AQI {best.aqi} at {best_time}")
+
+    hourly_entries = data[:12]
+    if hourly_entries:
+        lines.append("")
+        lines.append("Hourly Forecast:")
+        for entry in hourly_entries:
+            entry_time = _format_time(entry.timestamp, time_format_12hour)
+            lines.append(f"  {entry_time}: AQI {entry.aqi} ({entry.category})")
+
+    return "\n".join(lines)
+
+
+def format_hourly_uv_index(
+    hourly_data: list[HourlyUVIndex],
+    settings: AppSettings | None = None,
+    max_hours: int = 24,
+) -> str | None:
+    """
+    Format hourly UV index forecast into readable text.
+
+    Args:
+        hourly_data: List of hourly UV index forecasts.
+        settings: App settings for time formatting.
+        max_hours: Maximum number of hours to include.
+
+    Returns:
+        Formatted string describing the hourly forecast, or None if no data.
+
+    """
+    if not hourly_data:
+        return None
+
+    time_format_12hour = getattr(settings, "time_format_12hour", True) if settings else True
+    data = hourly_data[:max_hours]
+
+    current = data[0]
+    peak = max(data, key=lambda h: h.uv_index)
+    lowest = min(data, key=lambda h: h.uv_index)
+
+    lines = []
+    lines.append(f"Current: UV Index {current.uv_index:.1f} ({current.category})")
+
+    if len(data) >= 3:
+        trend_start = data[0].uv_index
+        trend_end = data[2].uv_index
+        diff = trend_end - trend_start
+
+        if diff > 2:
+            lines.append(f"Trend: Rising (UV {trend_start:.1f} → {trend_end:.1f})")
+        elif diff < -2:
+            lines.append(f"Trend: Falling (UV {trend_start:.1f} → {trend_end:.1f})")
+        else:
+            lines.append("Trend: Stable")
+
+    if peak.uv_index != current.uv_index:
+        peak_time = _format_time(peak.timestamp, time_format_12hour)
+        lines.append(f"Peak: UV Index {peak.uv_index:.1f} ({peak.category}) at {peak_time}")
+
+    if lowest.uv_index < 3 and lowest.uv_index != current.uv_index:
+        lowest_time = _format_time(lowest.timestamp, time_format_12hour)
+        lines.append(f"Lowest UV: {lowest.uv_index:.1f} at {lowest_time}")
+
+    hourly_entries = data[:12]
+    if hourly_entries:
+        lines.append("")
+        lines.append("Hourly Forecast:")
+        for entry in hourly_entries:
+            entry_time = _format_time(entry.timestamp, time_format_12hour)
+            lines.append(f"  {entry_time}: UV Index {entry.uv_index:.1f} ({entry.category})")
+
+    return "\n".join(lines)
+
+
+def _format_time(dt: datetime, use_12hour: bool = True) -> str:
+    """Format a datetime as a simple time string."""
+    if use_12hour:
+        return dt.strftime("%I:%M %p").lstrip("0")
+    return dt.strftime("%H:%M")

--- a/src/accessiweather/display/presentation/forecast.py
+++ b/src/accessiweather/display/presentation/forecast.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from datetime import UTC, date, datetime, tzinfo
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -16,25 +15,28 @@ from ...models import (
     Location,
     MarineForecast,
 )
-from ...utils import TemperatureUnit, calculate_dewpoint
-from ...utils.unit_utils import format_precipitation, format_wind_speed
-from ..weather_presenter import (
-    ForecastPeriodPresentation,
-    ForecastPresentation,
-    HourlyPeriodPresentation,
-)
+from ...utils import TemperatureUnit
+from ...utils.unit_utils import format_precipitation
+from .forecast_hourly import build_hourly_section_text, build_hourly_summary, render_hourly_fallback
+from .forecast_time import _resolve_forecast_display_time
 from .formatters import (
-    format_display_time,
     format_forecast_temperature,
-    format_hourly_wind,
-    format_period_temperature,
     format_period_wind,
-    format_temperature,
     format_timestamp,
     get_temperature_precision,
     get_uv_description,
     wrap_text,
 )
+from .models import ForecastPeriodPresentation, ForecastPresentation
+
+__all__ = [
+    "_resolve_forecast_display_time",
+    "_select_periods_by_day_window",
+    "build_forecast",
+    "build_hourly_section_text",
+    "build_hourly_summary",
+    "render_hourly_fallback",
+]
 
 
 def _is_us_location(location: Location) -> bool:
@@ -410,243 +412,4 @@ def build_forecast(
         confidence_label=confidence_label,
         summary=summary_line,
         impact_summary=forecast_impact,
-    )
-
-
-def build_hourly_summary(
-    hourly_forecast: HourlyForecast,
-    unit_pref: TemperatureUnit,
-    settings: AppSettings | None = None,
-    *,
-    location_timezone: tzinfo | None = None,
-) -> list[HourlyPeriodPresentation]:
-    """Generate the next six hours of simplified forecast data."""
-    round_values = getattr(settings, "round_values", False) if settings else False
-    precision = 0 if round_values else get_temperature_precision(unit_pref)
-    summary: list[HourlyPeriodPresentation] = []
-
-    # Extract time display preferences and verbosity from settings
-    if settings:
-        time_display_mode = getattr(settings, "time_display_mode", "local")
-        time_format_12hour = getattr(settings, "time_format_12hour", True)
-        show_timezone_suffix = getattr(settings, "show_timezone_suffix", False)
-        forecast_time_reference = getattr(settings, "forecast_time_reference", "location")
-        verbosity_level = getattr(settings, "verbosity_level", "standard")
-    else:
-        time_display_mode = "local"
-        time_format_12hour = True
-        show_timezone_suffix = False
-        forecast_time_reference = "location"
-        verbosity_level = "standard"
-
-    # Determine which fields to include based on verbosity level
-    # minimal: temperature, conditions only
-    # standard: temperature, conditions, wind, precipitation
-    # detailed: all available fields
-    include_wind = verbosity_level in ("standard", "detailed")
-    include_precipitation = verbosity_level in ("standard", "detailed")
-    include_humidity = verbosity_level in ("standard", "detailed")
-    include_dewpoint = verbosity_level in ("standard", "detailed")
-    include_uv = verbosity_level == "detailed"
-    include_snowfall = verbosity_level == "detailed"
-    include_cloud_cover = verbosity_level == "detailed"
-    include_wind_gust = verbosity_level == "detailed"
-
-    hourly_hours = getattr(settings, "hourly_forecast_hours", 6) if settings else 6
-    hourly_hours = max(1, min(hourly_hours, 168))
-    for period in hourly_forecast.get_next_hours(hourly_hours):
-        if not period.has_data():
-            continue
-        temperature = format_period_temperature(period, unit_pref, precision)
-        wind = format_hourly_wind(period, unit_pref) if include_wind else None
-
-        # Use enhanced time formatter with user preferences
-        display_time = _resolve_forecast_display_time(
-            period.start_time,
-            forecast_time_reference=forecast_time_reference,
-            location_timezone=location_timezone,
-        )
-        time_str = format_display_time(
-            display_time,
-            time_display_mode=time_display_mode,
-            use_12hour=time_format_12hour,
-            show_timezone=show_timezone_suffix,
-        )
-
-        # Format extended fields based on verbosity
-        precip_prob = (
-            f"{int(period.precipitation_probability)}%"
-            if include_precipitation and period.precipitation_probability is not None
-            else None
-        )
-        humidity_val = (
-            f"{period.humidity:.0f}%" if include_humidity and period.humidity is not None else None
-        )
-        dewpoint_val = (
-            _format_hourly_dewpoint(period, unit_pref, precision) if include_dewpoint else None
-        )
-        snowfall_val = (
-            f"{period.snowfall:.{precision}f} in"
-            if include_snowfall and period.snowfall is not None and period.snowfall > 0
-            else None
-        )
-        uv_val = (
-            f"{period.uv_index:.0f} ({get_uv_description(period.uv_index)})"
-            if include_uv and period.uv_index is not None
-            else None
-        )
-        cloud_val = (
-            f"{period.cloud_cover:.0f}%"
-            if include_cloud_cover and period.cloud_cover is not None
-            else None
-        )
-        gust_val = (
-            format_wind_speed(period.wind_gust_mph, unit_pref, precision=0)
-            if include_wind_gust and period.wind_gust_mph is not None
-            else None
-        )
-        precip_amt = (
-            format_precipitation(
-                period.precipitation_amount,
-                unit_pref,
-                precipitation_mm=period.precipitation_amount * 25.4,
-                precision=precision,
-            )
-            if include_precipitation
-            and period.precipitation_amount is not None
-            and period.precipitation_amount > 0
-            else None
-        )
-
-        summary.append(
-            HourlyPeriodPresentation(
-                time=time_str,
-                temperature=temperature,
-                conditions=period.short_forecast,
-                wind=wind,
-                humidity=humidity_val,
-                dewpoint=dewpoint_val,
-                precipitation_probability=precip_prob,
-                snowfall=snowfall_val,
-                uv_index=uv_val,
-                cloud_cover=cloud_val,
-                wind_gust=gust_val,
-                precipitation_amount=precip_amt,
-            )
-        )
-    return summary
-
-
-def _resolve_forecast_display_time(
-    start_time: datetime,
-    *,
-    forecast_time_reference: str,
-    location_timezone: tzinfo | None = None,
-    local_timezone: tzinfo | None = None,
-) -> datetime:
-    """
-    Resolve forecast hour display time to the configured timezone reference.
-
-    Location mode keeps the source timestamp unchanged. My-local mode converts
-    timezone-aware values to the system's local timezone.
-    """
-    if start_time.tzinfo is None:
-        return start_time
-
-    if forecast_time_reference != "user_local":
-        if location_timezone is None:
-            return start_time
-        return start_time.astimezone(location_timezone)
-
-    target_tz = local_timezone or datetime.now().astimezone().tzinfo
-    if target_tz is None:
-        return start_time.astimezone()
-    return start_time.astimezone(target_tz)
-
-
-def render_hourly_fallback(hourly: Iterable[HourlyPeriodPresentation], hours: int = 6) -> str:
-    """Render hourly periods into fallback text."""
-    lines = [f"Next {hours} Hours:"]
-    for period in hourly:
-        parts = [period.time]
-        if period.temperature:
-            parts.append(period.temperature)
-        if period.conditions:
-            parts.append(period.conditions)
-        # Bug 5: compact wind – combine speed and gust on one line
-        if period.wind and period.wind_gust:
-            parts.append(f"Wind {period.wind}, gusting to {period.wind_gust}")
-        elif period.wind:
-            parts.append(f"Wind {period.wind}")
-        elif period.wind_gust:
-            parts.append(f"Gusts {period.wind_gust}")
-        if period.humidity:
-            parts.append(f"Humidity {period.humidity}")
-        if period.dewpoint:
-            parts.append(f"Dewpoint {period.dewpoint}")
-        # Bug 6: compact precip – combine amount and chance on one line
-        precip_parts: list[str] = []
-        if period.precipitation_amount:
-            precip_parts.append(period.precipitation_amount)
-        if period.precipitation_probability:
-            precip_parts.append(f"{period.precipitation_probability} chance")
-        if precip_parts:
-            parts.append(f"Precip {', '.join(precip_parts)}")
-        if period.snowfall:
-            parts.append(f"Snow {period.snowfall}")
-        if period.cloud_cover:
-            parts.append(f"Clouds {period.cloud_cover}")
-        if period.uv_index:
-            parts.append(f"UV {period.uv_index}")
-        lines.append("  " + " - ".join(parts))
-    return "\n".join(lines)
-
-
-def build_hourly_section_text(
-    hourly: Iterable[HourlyPeriodPresentation],
-    *,
-    hours: int,
-    summary_line: str | None = None,
-) -> str:
-    """Render hourly forecast as a separate accessibility section."""
-    hourly_periods = list(hourly)
-    if not hourly_periods and not summary_line:
-        return ""
-
-    lines = ["Hourly forecast:"]
-    if summary_line:
-        lines.append(summary_line)
-
-    rendered = render_hourly_fallback(hourly_periods, hours=hours)
-    if rendered:
-        lines.append(rendered)
-
-    return "\n".join(lines).rstrip()
-
-
-def _format_hourly_dewpoint(
-    period,
-    unit_pref: TemperatureUnit,
-    precision: int,
-) -> str | None:
-    dewpoint_f = period.dewpoint_f
-    dewpoint_c = period.dewpoint_c
-
-    if dewpoint_f is None and dewpoint_c is None:
-        if period.temperature is None or period.humidity is None:
-            return None
-        unit = (period.temperature_unit or "F").upper()
-        temp_f = period.temperature if unit == "F" else (period.temperature * 9 / 5) + 32
-        dewpoint_f = calculate_dewpoint(
-            temp_f,
-            period.humidity,
-            unit=TemperatureUnit.FAHRENHEIT,
-        )
-        dewpoint_c = (dewpoint_f - 32) * 5 / 9 if dewpoint_f is not None else None
-
-    return format_temperature(
-        dewpoint_f,
-        unit_pref,
-        temperature_c=dewpoint_c,
-        precision=precision,
     )

--- a/src/accessiweather/display/presentation/forecast_hourly.py
+++ b/src/accessiweather/display/presentation/forecast_hourly.py
@@ -1,0 +1,231 @@
+"""Hourly forecast presentation builders."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import tzinfo
+
+from ...models import AppSettings, HourlyForecast
+from ...utils import TemperatureUnit, calculate_dewpoint, format_temperature
+from ...utils.unit_utils import format_precipitation, format_wind_speed
+from .forecast_time import _resolve_forecast_display_time
+from .formatters import (
+    format_display_time,
+    format_hourly_wind,
+    format_period_temperature,
+    get_temperature_precision,
+    get_uv_description,
+)
+from .models import HourlyPeriodPresentation
+
+
+def build_hourly_summary(
+    hourly_forecast: HourlyForecast,
+    unit_pref: TemperatureUnit,
+    settings: AppSettings | None = None,
+    *,
+    location_timezone: tzinfo | None = None,
+) -> list[HourlyPeriodPresentation]:
+    """Generate the next six hours of simplified forecast data."""
+    round_values = getattr(settings, "round_values", False) if settings else False
+    precision = 0 if round_values else get_temperature_precision(unit_pref)
+    summary: list[HourlyPeriodPresentation] = []
+
+    # Extract time display preferences and verbosity from settings
+    if settings:
+        time_display_mode = getattr(settings, "time_display_mode", "local")
+        time_format_12hour = getattr(settings, "time_format_12hour", True)
+        show_timezone_suffix = getattr(settings, "show_timezone_suffix", False)
+        forecast_time_reference = getattr(settings, "forecast_time_reference", "location")
+        verbosity_level = getattr(settings, "verbosity_level", "standard")
+    else:
+        time_display_mode = "local"
+        time_format_12hour = True
+        show_timezone_suffix = False
+        forecast_time_reference = "location"
+        verbosity_level = "standard"
+
+    # Determine which fields to include based on verbosity level
+    # minimal: temperature, conditions only
+    # standard: temperature, conditions, wind, precipitation
+    # detailed: all available fields
+    include_wind = verbosity_level in ("standard", "detailed")
+    include_precipitation = verbosity_level in ("standard", "detailed")
+    include_humidity = verbosity_level in ("standard", "detailed")
+    include_dewpoint = verbosity_level in ("standard", "detailed")
+    include_uv = verbosity_level == "detailed"
+    include_snowfall = verbosity_level == "detailed"
+    include_cloud_cover = verbosity_level == "detailed"
+    include_wind_gust = verbosity_level == "detailed"
+
+    hourly_hours = getattr(settings, "hourly_forecast_hours", 6) if settings else 6
+    hourly_hours = max(1, min(hourly_hours, 168))
+    for period in hourly_forecast.get_next_hours(hourly_hours):
+        if not period.has_data():
+            continue
+        temperature = format_period_temperature(period, unit_pref, precision)
+        wind = format_hourly_wind(period, unit_pref) if include_wind else None
+
+        # Use enhanced time formatter with user preferences
+        display_time = _resolve_forecast_display_time(
+            period.start_time,
+            forecast_time_reference=forecast_time_reference,
+            location_timezone=location_timezone,
+        )
+        time_str = format_display_time(
+            display_time,
+            time_display_mode=time_display_mode,
+            use_12hour=time_format_12hour,
+            show_timezone=show_timezone_suffix,
+        )
+
+        # Format extended fields based on verbosity
+        precip_prob = (
+            f"{int(period.precipitation_probability)}%"
+            if include_precipitation and period.precipitation_probability is not None
+            else None
+        )
+        humidity_val = (
+            f"{period.humidity:.0f}%" if include_humidity and period.humidity is not None else None
+        )
+        dewpoint_val = (
+            _format_hourly_dewpoint(period, unit_pref, precision) if include_dewpoint else None
+        )
+        snowfall_val = (
+            f"{period.snowfall:.{precision}f} in"
+            if include_snowfall and period.snowfall is not None and period.snowfall > 0
+            else None
+        )
+        uv_val = (
+            f"{period.uv_index:.0f} ({get_uv_description(period.uv_index)})"
+            if include_uv and period.uv_index is not None
+            else None
+        )
+        cloud_val = (
+            f"{period.cloud_cover:.0f}%"
+            if include_cloud_cover and period.cloud_cover is not None
+            else None
+        )
+        gust_val = (
+            format_wind_speed(period.wind_gust_mph, unit_pref, precision=0)
+            if include_wind_gust and period.wind_gust_mph is not None
+            else None
+        )
+        precip_amt = (
+            format_precipitation(
+                period.precipitation_amount,
+                unit_pref,
+                precipitation_mm=period.precipitation_amount * 25.4,
+                precision=precision,
+            )
+            if include_precipitation
+            and period.precipitation_amount is not None
+            and period.precipitation_amount > 0
+            else None
+        )
+
+        summary.append(
+            HourlyPeriodPresentation(
+                time=time_str,
+                temperature=temperature,
+                conditions=period.short_forecast,
+                wind=wind,
+                humidity=humidity_val,
+                dewpoint=dewpoint_val,
+                precipitation_probability=precip_prob,
+                snowfall=snowfall_val,
+                uv_index=uv_val,
+                cloud_cover=cloud_val,
+                wind_gust=gust_val,
+                precipitation_amount=precip_amt,
+            )
+        )
+    return summary
+
+
+def render_hourly_fallback(hourly: Iterable[HourlyPeriodPresentation], hours: int = 6) -> str:
+    """Render hourly periods into fallback text."""
+    lines = [f"Next {hours} Hours:"]
+    for period in hourly:
+        parts = [period.time]
+        if period.temperature:
+            parts.append(period.temperature)
+        if period.conditions:
+            parts.append(period.conditions)
+        # Bug 5: compact wind – combine speed and gust on one line
+        if period.wind and period.wind_gust:
+            parts.append(f"Wind {period.wind}, gusting to {period.wind_gust}")
+        elif period.wind:
+            parts.append(f"Wind {period.wind}")
+        elif period.wind_gust:
+            parts.append(f"Gusts {period.wind_gust}")
+        if period.humidity:
+            parts.append(f"Humidity {period.humidity}")
+        if period.dewpoint:
+            parts.append(f"Dewpoint {period.dewpoint}")
+        # Bug 6: compact precip – combine amount and chance on one line
+        precip_parts: list[str] = []
+        if period.precipitation_amount:
+            precip_parts.append(period.precipitation_amount)
+        if period.precipitation_probability:
+            precip_parts.append(f"{period.precipitation_probability} chance")
+        if precip_parts:
+            parts.append(f"Precip {', '.join(precip_parts)}")
+        if period.snowfall:
+            parts.append(f"Snow {period.snowfall}")
+        if period.cloud_cover:
+            parts.append(f"Clouds {period.cloud_cover}")
+        if period.uv_index:
+            parts.append(f"UV {period.uv_index}")
+        lines.append("  " + " - ".join(parts))
+    return "\n".join(lines)
+
+
+def build_hourly_section_text(
+    hourly: Iterable[HourlyPeriodPresentation],
+    *,
+    hours: int,
+    summary_line: str | None = None,
+) -> str:
+    """Render hourly forecast as a separate accessibility section."""
+    hourly_periods = list(hourly)
+    if not hourly_periods and not summary_line:
+        return ""
+
+    lines = ["Hourly forecast:"]
+    if summary_line:
+        lines.append(summary_line)
+
+    rendered = render_hourly_fallback(hourly_periods, hours=hours)
+    if rendered:
+        lines.append(rendered)
+
+    return "\n".join(lines).rstrip()
+
+
+def _format_hourly_dewpoint(
+    period,
+    unit_pref: TemperatureUnit,
+    precision: int,
+) -> str | None:
+    dewpoint_f = period.dewpoint_f
+    dewpoint_c = period.dewpoint_c
+
+    if dewpoint_f is None and dewpoint_c is None:
+        if period.temperature is None or period.humidity is None:
+            return None
+        unit = (period.temperature_unit or "F").upper()
+        temp_f = period.temperature if unit == "F" else (period.temperature * 9 / 5) + 32
+        dewpoint_f = calculate_dewpoint(
+            temp_f,
+            period.humidity,
+            unit=TemperatureUnit.FAHRENHEIT,
+        )
+        dewpoint_c = (dewpoint_f - 32) * 5 / 9 if dewpoint_f is not None else None
+
+    return format_temperature(
+        dewpoint_f,
+        unit_pref,
+        temperature_c=dewpoint_c,
+        precision=precision,
+    )

--- a/src/accessiweather/display/presentation/forecast_time.py
+++ b/src/accessiweather/display/presentation/forecast_time.py
@@ -1,0 +1,32 @@
+"""Forecast time-resolution helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, tzinfo
+
+
+def _resolve_forecast_display_time(
+    start_time: datetime,
+    *,
+    forecast_time_reference: str,
+    location_timezone: tzinfo | None = None,
+    local_timezone: tzinfo | None = None,
+) -> datetime:
+    """
+    Resolve forecast hour display time to the configured timezone reference.
+
+    Location mode keeps the source timestamp unchanged. My-local mode converts
+    timezone-aware values to the system's local timezone.
+    """
+    if start_time.tzinfo is None:
+        return start_time
+
+    if forecast_time_reference != "user_local":
+        if location_timezone is None:
+            return start_time
+        return start_time.astimezone(location_timezone)
+
+    target_tz = local_timezone or datetime.now().astimezone().tzinfo
+    if target_tz is None:
+        return start_time.astimezone()
+    return start_time.astimezone(target_tz)

--- a/src/accessiweather/display/presentation/models.py
+++ b/src/accessiweather/display/presentation/models.py
@@ -1,0 +1,169 @@
+"""Presentation view models for weather display surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from .environmental import AirQualityPresentation
+
+if TYPE_CHECKING:
+    from ...impact_summary import ImpactSummary
+
+
+@dataclass(slots=True)
+class Metric:
+    """Key-value pair used for presenting weather measurements."""
+
+    label: str
+    value: str
+
+
+@dataclass(slots=True)
+class HourlyPeriodPresentation:
+    """Simplified hourly forecast period for structured display."""
+
+    time: str
+    temperature: str | None
+    conditions: str | None
+    wind: str | None
+    humidity: str | None = None
+    dewpoint: str | None = None
+    precipitation_probability: str | None = None
+    snowfall: str | None = None
+    uv_index: str | None = None
+    cloud_cover: str | None = None
+    wind_gust: str | None = None
+    precipitation_amount: str | None = None
+
+
+@dataclass(slots=True)
+class ForecastPeriodPresentation:
+    """Daily forecast period presentation."""
+
+    name: str
+    temperature: str | None
+    conditions: str | None
+    wind: str | None
+    details: str | None
+    precipitation_probability: str | None = None
+    snowfall: str | None = None
+    uv_index: str | None = None
+    cloud_cover: str | None = None
+    wind_gust: str | None = None
+    precipitation_amount: str | None = None
+
+
+@dataclass(slots=True)
+class CurrentConditionsPresentation:
+    """Structured view of the current conditions."""
+
+    title: str
+    description: str
+    metrics: list[Metric] = field(default_factory=list)
+    fallback_text: str = ""
+    trends: list[str] = field(default_factory=list)
+    impact_summary: ImpactSummary | None = None
+
+    @property
+    def trend_summary(self) -> list[str]:  # pragma: no cover - backward compatibility
+        """Alias for legacy callers expecting ``trend_summary``."""
+        return self.trends
+
+
+@dataclass(slots=True)
+class ForecastPresentation:
+    """Structured forecast view including hourly highlights."""
+
+    title: str
+    periods: list[ForecastPeriodPresentation] = field(default_factory=list)
+    hourly_periods: list[HourlyPeriodPresentation] = field(default_factory=list)
+    hourly_summary: str | None = None
+    generated_at: str | None = None
+    fallback_text: str = ""
+    daily_section_text: str = ""
+    hourly_section_text: str = ""
+    mobility_briefing: str | None = None
+    marine_section_text: str = ""
+    marine_summary: str | None = None
+    marine_highlights: list[str] = field(default_factory=list)
+    confidence_label: str | None = None
+    summary: str | None = None
+    impact_summary: ImpactSummary | None = None
+
+
+@dataclass(slots=True)
+class AviationPresentation:
+    """Structured aviation weather presentation."""
+
+    title: str
+    airport_name: str | None = None
+    station_id: str | None = None
+    taf_summary: str | None = None
+    raw_taf: str | None = None
+    sigmets: list[str] = field(default_factory=list)
+    cwas: list[str] = field(default_factory=list)
+    fallback_text: str = ""
+
+
+@dataclass(slots=True)
+class AlertPresentation:
+    """Structured weather alert presentation."""
+
+    title: str
+    severity: str | None = None
+    urgency: str | None = None
+    event: str | None = None
+    areas: list[str] = field(default_factory=list)
+    expires: str | None = None
+    description: str | None = None
+    instructions: str | None = None
+    fallback_text: str = ""
+
+
+@dataclass(slots=True)
+class AlertsPresentation:
+    """Collection of alert presentations with fallback text."""
+
+    title: str
+    alerts: list[AlertPresentation] = field(default_factory=list)
+    fallback_text: str = ""
+    change_summary: str | None = None
+
+
+@dataclass(slots=True)
+class SourceAttributionPresentation:
+    """Presentation of data source attribution for transparency."""
+
+    contributing_sources: list[str] = field(default_factory=list)
+    failed_sources: list[str] = field(default_factory=list)
+    incomplete_sections: list[str] = field(default_factory=list)
+    summary_text: str = ""
+    aria_label: str = ""
+
+
+@dataclass(slots=True)
+class WeatherPresentation:
+    """Top-level presentation for all weather content."""
+
+    location_name: str
+    summary_text: str
+    current_conditions: CurrentConditionsPresentation | None = None
+    forecast: ForecastPresentation | None = None
+    alerts: AlertsPresentation | None = None
+    air_quality: AirQualityPresentation | None = None
+    aviation: AviationPresentation | None = None
+    trend_summary: list[str] = field(default_factory=list)
+    status_messages: list[str] = field(default_factory=list)
+    source_attribution: SourceAttributionPresentation | None = None
+
+    @property
+    def current(self) -> CurrentConditionsPresentation | None:  # pragma: no cover - compat
+        """Backward-compatible alias for older presentation attribute name."""
+        return self.current_conditions
+
+    @current.setter
+    def current(
+        self, value: CurrentConditionsPresentation | None
+    ) -> None:  # pragma: no cover - compat
+        self.current_conditions = value

--- a/src/accessiweather/display/presentation/source_attribution.py
+++ b/src/accessiweather/display/presentation/source_attribution.py
@@ -1,0 +1,179 @@
+"""Source attribution presentation helpers."""
+
+from __future__ import annotations
+
+from ...models import WeatherData
+from .models import SourceAttributionPresentation
+
+_WET_CONDITION_MARKERS = (
+    "thunderstorm",
+    "t-storm",
+    "rain",
+    "shower",
+    "drizzle",
+    "snow",
+    "sleet",
+    "hail",
+    "freezing rain",
+)
+_DRY_CONDITION_MARKERS = (
+    "clear",
+    "sunny",
+    "cloudy",
+    "overcast",
+    "fair",
+)
+
+
+def build_source_attribution(weather_data: WeatherData) -> SourceAttributionPresentation | None:
+    """Build source attribution presentation for transparency."""
+    attribution = weather_data.source_attribution
+    if not attribution:
+        return None
+
+    source_names = {
+        "nws": "National Weather Service",
+        "openmeteo": "Open-Meteo",
+        "visualcrossing": "Visual Crossing",
+        "pirateweather": "Pirate Weather",
+    }
+
+    contributing = [
+        source_names.get(source, source.title())
+        for source in sorted(attribution.contributing_sources)
+    ]
+    failed = [
+        source_names.get(source, source.title()) for source in sorted(attribution.failed_sources)
+    ]
+    incomplete = list(weather_data.incomplete_sections)
+
+    if contributing:
+        summary = f"Data from: {', '.join(contributing)}"
+        if failed:
+            summary += f". Unavailable: {', '.join(failed)}"
+    elif failed:
+        summary = f"Sources unavailable: {', '.join(failed)}"
+    else:
+        summary = ""
+
+    disagreement_note = _build_source_disagreement_note(weather_data, source_names)
+    if disagreement_note:
+        summary = f"{summary}. {disagreement_note}" if summary else disagreement_note
+
+    aria_parts = []
+    if contributing:
+        aria_parts.append(f"Weather data provided by {', '.join(contributing)}")
+    if failed:
+        aria_parts.append(f"Data unavailable from {', '.join(failed)}")
+    if incomplete:
+        aria_parts.append(f"Missing sections: {', '.join(incomplete)}")
+    if disagreement_note:
+        aria_parts.append(disagreement_note)
+    aria_label = ". ".join(aria_parts) if aria_parts else "Weather data source information"
+
+    return SourceAttributionPresentation(
+        contributing_sources=contributing,
+        failed_sources=failed,
+        incomplete_sections=incomplete,
+        summary_text=summary,
+        aria_label=aria_label,
+    )
+
+
+def _build_source_disagreement_note(
+    weather_data: WeatherData, source_names: dict[str, str]
+) -> str | None:
+    """Return a short note when obvious condition sources disagree."""
+    attribution = weather_data.source_attribution
+    if attribution is None or weather_data.current is None:
+        return None
+
+    current_text = _clean_condition_text(weather_data.current.condition)
+    current_state = _precipitation_state(current_text)
+    if current_text is None or current_state is None:
+        return None
+
+    hourly_period = (
+        weather_data.hourly_forecast.periods[0]
+        if weather_data.hourly_forecast and weather_data.hourly_forecast.periods
+        else None
+    )
+    hourly_text = _clean_condition_text(
+        getattr(hourly_period, "short_forecast", None) if hourly_period else None
+    )
+    hourly_state = _precipitation_state(hourly_text)
+
+    minutely = weather_data.minutely_precipitation
+    minutely_text = _clean_condition_text(getattr(minutely, "summary", None))
+    minutely_state = _minutely_precipitation_state(minutely)
+
+    parts: list[str] = []
+    field_sources = attribution.field_sources
+    current_source = _format_source_name(field_sources.get("condition"), source_names)
+    hourly_source = _format_source_name(field_sources.get("hourly_source"), source_names)
+    minutely_source = _format_source_name(
+        field_sources.get("minutely_precipitation") or field_sources.get("hourly_summary"),
+        source_names,
+    )
+
+    if hourly_text and hourly_state is not None and hourly_state != current_state:
+        parts.append(f"hourly forecast from {hourly_source} says {hourly_text}")
+
+    if minutely_text and minutely_state is not None and minutely_state != current_state:
+        parts.append(
+            f"minute-by-minute precipitation outlook from {minutely_source} says {minutely_text}"
+        )
+
+    if not parts:
+        return None
+
+    return (
+        f"Data note: current conditions from {current_source} report {current_text}; "
+        f"{'; '.join(parts)}."
+    )
+
+
+def _clean_condition_text(value: str | None) -> str | None:
+    """Normalize condition text for display while preserving user-facing wording."""
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned.rstrip(".") if cleaned else None
+
+
+def _precipitation_state(value: str | None) -> str | None:
+    """Classify obvious wet/dry condition wording; return None when ambiguous."""
+    if value is None:
+        return None
+    normalized = value.casefold()
+    if any(marker in normalized for marker in _WET_CONDITION_MARKERS):
+        return "wet"
+    if any(marker in normalized for marker in _DRY_CONDITION_MARKERS):
+        return "dry"
+    return None
+
+
+def _minutely_precipitation_state(minutely: object | None) -> str | None:
+    """Classify minutely precipitation data from explicit points or summary text."""
+    if minutely is None:
+        return None
+
+    points = getattr(minutely, "points", None)
+    if points:
+        for point in points:
+            intensity = getattr(point, "precipitation_intensity", None)
+            probability = getattr(point, "precipitation_probability", None)
+            if (isinstance(intensity, int | float) and intensity > 0) or (
+                isinstance(probability, int | float) and probability > 0
+            ):
+                return "wet"
+        return "dry"
+
+    return _precipitation_state(_clean_condition_text(getattr(minutely, "summary", None)))
+
+
+def _format_source_name(source: str | None, source_names: dict[str, str]) -> str:
+    """Return a readable source label, falling back to a generic label."""
+    if not source:
+        return "another source"
+    return source_names.get(source, source.title())

--- a/src/accessiweather/display/weather_presenter.py
+++ b/src/accessiweather/display/weather_presenter.py
@@ -8,15 +8,13 @@ maintaining accessible fallback text for screen reader users.
 from __future__ import annotations
 
 from collections.abc import Iterable
-from dataclasses import dataclass, field
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from accessiweather.alert_lifecycle import AlertLifecycleDiff
 
     from ..forecast_confidence import ForecastConfidence
-    from ..impact_summary import ImpactSummary
 
 from ..models import (
     AppSettings,
@@ -33,166 +31,36 @@ from ..models import (
 )
 from ..services.mobility_briefing import build_mobility_briefing
 from ..units import resolve_display_unit_system, resolve_temperature_unit_preference
-from ..utils import TemperatureUnit, decode_taf_text
+from ..utils import TemperatureUnit
+from .presentation.aviation import build_aviation
 from .presentation.environmental import AirQualityPresentation, build_air_quality_panel
+from .presentation.models import (
+    AlertPresentation,
+    AlertsPresentation,
+    AviationPresentation,
+    CurrentConditionsPresentation,
+    ForecastPeriodPresentation,
+    ForecastPresentation,
+    HourlyPeriodPresentation,
+    Metric,
+    SourceAttributionPresentation,
+    WeatherPresentation,
+)
+from .presentation.source_attribution import build_source_attribution
 
-
-@dataclass(slots=True)
-class Metric:
-    """Key-value pair used for presenting weather measurements."""
-
-    label: str
-    value: str
-
-
-@dataclass(slots=True)
-class HourlyPeriodPresentation:
-    """Simplified hourly forecast period for structured display."""
-
-    time: str
-    temperature: str | None
-    conditions: str | None
-    wind: str | None
-    humidity: str | None = None
-    dewpoint: str | None = None
-    precipitation_probability: str | None = None
-    snowfall: str | None = None
-    uv_index: str | None = None
-    cloud_cover: str | None = None
-    wind_gust: str | None = None
-    precipitation_amount: str | None = None
-
-
-@dataclass(slots=True)
-class ForecastPeriodPresentation:
-    """Daily forecast period presentation."""
-
-    name: str
-    temperature: str | None
-    conditions: str | None
-    wind: str | None
-    details: str | None
-    precipitation_probability: str | None = None
-    snowfall: str | None = None
-    uv_index: str | None = None
-    cloud_cover: str | None = None
-    wind_gust: str | None = None
-    precipitation_amount: str | None = None
-
-
-@dataclass(slots=True)
-class CurrentConditionsPresentation:
-    """Structured view of the current conditions."""
-
-    title: str
-    description: str
-    metrics: list[Metric] = field(default_factory=list)
-    fallback_text: str = ""
-    trends: list[str] = field(default_factory=list)
-    impact_summary: ImpactSummary | None = None
-
-    @property
-    def trend_summary(self) -> list[str]:  # pragma: no cover - backward compatibility
-        """Alias for legacy callers expecting ``trend_summary``."""
-        return self.trends
-
-
-@dataclass(slots=True)
-class ForecastPresentation:
-    """Structured forecast view including hourly highlights."""
-
-    title: str
-    periods: list[ForecastPeriodPresentation] = field(default_factory=list)
-    hourly_periods: list[HourlyPeriodPresentation] = field(default_factory=list)
-    hourly_summary: str | None = None
-    generated_at: str | None = None
-    fallback_text: str = ""
-    daily_section_text: str = ""
-    hourly_section_text: str = ""
-    mobility_briefing: str | None = None
-    marine_section_text: str = ""
-    marine_summary: str | None = None
-    marine_highlights: list[str] = field(default_factory=list)
-    confidence_label: str | None = None
-    summary: str | None = None
-    impact_summary: ImpactSummary | None = None
-
-
-@dataclass(slots=True)
-class AviationPresentation:
-    """Structured aviation weather presentation."""
-
-    title: str
-    airport_name: str | None = None
-    station_id: str | None = None
-    taf_summary: str | None = None
-    raw_taf: str | None = None
-    sigmets: list[str] = field(default_factory=list)
-    cwas: list[str] = field(default_factory=list)
-    fallback_text: str = ""
-
-
-@dataclass(slots=True)
-class AlertPresentation:
-    """Structured weather alert presentation."""
-
-    title: str
-    severity: str | None = None
-    urgency: str | None = None
-    event: str | None = None
-    areas: list[str] = field(default_factory=list)
-    expires: str | None = None
-    description: str | None = None
-    instructions: str | None = None
-    fallback_text: str = ""
-
-
-@dataclass(slots=True)
-class AlertsPresentation:
-    """Collection of alert presentations with fallback text."""
-
-    title: str
-    alerts: list[AlertPresentation] = field(default_factory=list)
-    fallback_text: str = ""
-    change_summary: str | None = None
-
-
-@dataclass(slots=True)
-class SourceAttributionPresentation:
-    """Presentation of data source attribution for transparency."""
-
-    contributing_sources: list[str] = field(default_factory=list)
-    failed_sources: list[str] = field(default_factory=list)
-    incomplete_sections: list[str] = field(default_factory=list)
-    summary_text: str = ""
-    aria_label: str = ""
-
-
-@dataclass(slots=True)
-class WeatherPresentation:
-    """Top-level presentation for all weather content."""
-
-    location_name: str
-    summary_text: str
-    current_conditions: CurrentConditionsPresentation | None = None
-    forecast: ForecastPresentation | None = None
-    alerts: AlertsPresentation | None = None
-    air_quality: AirQualityPresentation | None = None
-    aviation: AviationPresentation | None = None
-    trend_summary: list[str] = field(default_factory=list)
-    status_messages: list[str] = field(default_factory=list)
-    source_attribution: SourceAttributionPresentation | None = None
-
-    @property
-    def current(self) -> CurrentConditionsPresentation | None:  # pragma: no cover - compat
-        """Backward-compatible alias for older presentation attribute name."""
-        return self.current_conditions
-
-    @current.setter
-    def current(
-        self, value: CurrentConditionsPresentation | None
-    ) -> None:  # pragma: no cover - compat
-        self.current_conditions = value
+__all__ = [
+    "AlertPresentation",
+    "AlertsPresentation",
+    "AviationPresentation",
+    "CurrentConditionsPresentation",
+    "ForecastPeriodPresentation",
+    "ForecastPresentation",
+    "HourlyPeriodPresentation",
+    "Metric",
+    "SourceAttributionPresentation",
+    "WeatherPresentation",
+    "WeatherPresenter",
+]
 
 
 class WeatherPresenter:
@@ -410,176 +278,11 @@ class WeatherPresenter:
     def _build_aviation(
         self, aviation: AviationData | None, location: Location
     ) -> AviationPresentation | None:
-        if aviation is None:
-            return None
-
-        has_advisories = bool(aviation.active_sigmets or aviation.active_cwas)
-        taf_available = bool(
-            (aviation.raw_taf and aviation.raw_taf.strip())
-            or (aviation.decoded_taf and aviation.decoded_taf.strip())
-        )
-        if not (taf_available or has_advisories):
-            return None
-
-        station_label = aviation.airport_name or aviation.station_id
-        header_location = (
-            f"{station_label} near {location.name}"
-            if station_label and station_label.lower() != location.name.lower()
-            else station_label or location.name
-        )
-        header = f"Aviation weather for {header_location}."
-
-        taf_summary = aviation.decoded_taf
-        if not taf_summary and aviation.raw_taf:
-            taf_summary = decode_taf_text(aviation.raw_taf)
-
-        sigmet_lines = [
-            summary
-            for summary in (self._summarize_sigmet(entry) for entry in aviation.active_sigmets[:5])
-            if summary
-        ]
-        cwa_lines = [
-            summary
-            for summary in (self._summarize_cwa(entry) for entry in aviation.active_cwas[:5])
-            if summary
-        ]
-
-        fallback_lines: list[str] = [header]
-        if taf_summary:
-            fallback_lines.append("Terminal Aerodrome Forecast:")
-            fallback_lines.append(taf_summary)
-            if aviation.raw_taf and aviation.raw_taf.strip():
-                fallback_lines.append("Raw TAF message:")
-                fallback_lines.append(aviation.raw_taf.strip())
-        elif aviation.raw_taf and aviation.raw_taf.strip():
-            fallback_lines.append("Raw Terminal Aerodrome Forecast:")
-            fallback_lines.append(aviation.raw_taf.strip())
-        else:
-            fallback_lines.append("No Terminal Aerodrome Forecast available.")
-
-        if sigmet_lines:
-            fallback_lines.append("SIGMET and AIRMET advisories:")
-            fallback_lines.extend(f"• {line}" for line in sigmet_lines)
-        if cwa_lines:
-            fallback_lines.append("Center Weather Advisories:")
-            fallback_lines.extend(f"• {line}" for line in cwa_lines)
-
-        return AviationPresentation(
-            title="Aviation Weather",
-            airport_name=aviation.airport_name,
-            station_id=aviation.station_id,
-            taf_summary=taf_summary,
-            raw_taf=aviation.raw_taf,
-            sigmets=sigmet_lines,
-            cwas=cwa_lines,
-            fallback_text="\n".join(fallback_lines),
-        )
+        return build_aviation(aviation, location, self._format_timestamp)
 
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
-
-    def _format_aviation_time(self, value: str | None) -> str | None:
-        if not value:
-            return None
-        try:
-            sanitized = value.replace("Z", "+00:00") if value.endswith("Z") else value
-            timestamp = datetime.fromisoformat(sanitized)
-        except ValueError:
-            return value
-        return self._format_timestamp(timestamp)
-
-    def _summarize_sigmet(self, data: Any) -> str | None:
-        if not isinstance(data, dict):
-            return None
-
-        name = (
-            data.get("name")
-            or data.get("event")
-            or data.get("hazard")
-            or data.get("phenomenon")
-            or "SIGMET"
-        )
-        severity = data.get("severity") or data.get("intensity")
-        area = data.get("fir") or data.get("area") or data.get("regions") or data.get("airspace")
-        if isinstance(area, list):
-            area = ", ".join(str(item) for item in area if item)
-
-        start = self._format_aviation_time(
-            data.get("startTime")
-            or data.get("beginTime")
-            or data.get("validTimeStart")
-            or data.get("issueTime")
-        )
-        end = self._format_aviation_time(
-            data.get("endTime")
-            or data.get("expires")
-            or data.get("validTimeEnd")
-            or data.get("validUntil")
-        )
-        description = data.get("description") or data.get("text") or data.get("summary")
-
-        summary_parts = [name]
-        if severity:
-            summary_parts.append(f"severity {severity}")
-        summary = " ".join(summary_parts)
-
-        detail_parts: list[str] = []
-        if area:
-            detail_parts.append(f"Area: {area}")
-        if start or end:
-            if start and end:
-                detail_parts.append(f"Valid {start} to {end}")
-            elif end:
-                detail_parts.append(f"Valid until {end}")
-            elif start:
-                detail_parts.append(f"Effective {start}")
-        if description:
-            detail_parts.append(description)
-
-        details = "; ".join(detail_parts)
-        return f"{summary}; {details}" if details else summary
-
-    def _summarize_cwa(self, data: Any) -> str | None:
-        if not isinstance(data, dict):
-            return None
-
-        name = (
-            data.get("event")
-            or data.get("phenomenon")
-            or data.get("hazard")
-            or data.get("productType")
-            or "Center Weather Advisory"
-        )
-        cwsu = data.get("cwsu") or data.get("issuingOffice")
-        area = data.get("area") or data.get("regions") or data.get("airspace") or cwsu
-        if isinstance(area, list):
-            area = ", ".join(str(item) for item in area if item)
-
-        start = self._format_aviation_time(data.get("startTime") or data.get("issueTime"))
-        end = self._format_aviation_time(data.get("endTime") or data.get("expires"))
-        description = data.get("description") or data.get("text") or data.get("summary")
-
-        summary_parts = [name]
-        if cwsu and cwsu not in summary_parts:
-            summary_parts.append(f"({cwsu})")
-        summary = " ".join(summary_parts)
-
-        detail_parts: list[str] = []
-        if area and area not in summary:
-            detail_parts.append(f"Area: {area}")
-        if start or end:
-            if start and end:
-                detail_parts.append(f"Valid {start} to {end}")
-            elif end:
-                detail_parts.append(f"Valid until {end}")
-            elif start:
-                detail_parts.append(f"Issued {start}")
-        if description:
-            detail_parts.append(description)
-
-        details = "; ".join(detail_parts)
-        return f"{summary}; {details}" if details else summary
 
     def _build_summary(self, weather_data: WeatherData, unit_pref: TemperatureUnit) -> str:
         if not weather_data.has_any_data():
@@ -638,111 +341,7 @@ class WeatherPresenter:
     def _build_source_attribution(
         self, weather_data: WeatherData
     ) -> SourceAttributionPresentation | None:
-        """Build source attribution presentation for transparency."""
-        attribution = weather_data.source_attribution
-        if not attribution:
-            return None
-
-        # Format source names for display
-        source_names = {
-            "nws": "National Weather Service",
-            "openmeteo": "Open-Meteo",
-            "visualcrossing": "Visual Crossing",
-            "pirateweather": "Pirate Weather",
-        }
-
-        contributing = [
-            source_names.get(s, s.title()) for s in sorted(attribution.contributing_sources)
-        ]
-        failed = [source_names.get(s, s.title()) for s in sorted(attribution.failed_sources)]
-        incomplete = list(weather_data.incomplete_sections)
-
-        # Build summary text
-        if contributing:
-            summary = f"Data from: {', '.join(contributing)}"
-            if failed:
-                summary += f". Unavailable: {', '.join(failed)}"
-        elif failed:
-            summary = f"Sources unavailable: {', '.join(failed)}"
-        else:
-            summary = ""
-
-        disagreement_note = self._build_source_disagreement_note(weather_data, source_names)
-        if disagreement_note:
-            summary = f"{summary}. {disagreement_note}" if summary else disagreement_note
-
-        # Build accessible aria label
-        aria_parts = []
-        if contributing:
-            aria_parts.append(f"Weather data provided by {', '.join(contributing)}")
-        if failed:
-            aria_parts.append(f"Data unavailable from {', '.join(failed)}")
-        if incomplete:
-            aria_parts.append(f"Missing sections: {', '.join(incomplete)}")
-        if disagreement_note:
-            aria_parts.append(disagreement_note)
-        aria_label = ". ".join(aria_parts) if aria_parts else "Weather data source information"
-
-        return SourceAttributionPresentation(
-            contributing_sources=contributing,
-            failed_sources=failed,
-            incomplete_sections=incomplete,
-            summary_text=summary,
-            aria_label=aria_label,
-        )
-
-    def _build_source_disagreement_note(
-        self, weather_data: WeatherData, source_names: dict[str, str]
-    ) -> str | None:
-        """Return a short note when obvious condition sources disagree."""
-        attribution = weather_data.source_attribution
-        if attribution is None or weather_data.current is None:
-            return None
-
-        current_text = _clean_condition_text(weather_data.current.condition)
-        current_state = _precipitation_state(current_text)
-        if current_text is None or current_state is None:
-            return None
-
-        hourly_period = (
-            weather_data.hourly_forecast.periods[0]
-            if weather_data.hourly_forecast and weather_data.hourly_forecast.periods
-            else None
-        )
-        hourly_text = _clean_condition_text(
-            getattr(hourly_period, "short_forecast", None) if hourly_period else None
-        )
-        hourly_state = _precipitation_state(hourly_text)
-
-        minutely = weather_data.minutely_precipitation
-        minutely_text = _clean_condition_text(getattr(minutely, "summary", None))
-        minutely_state = _minutely_precipitation_state(minutely)
-
-        parts: list[str] = []
-        field_sources = attribution.field_sources
-        current_source = _format_source_name(field_sources.get("condition"), source_names)
-        hourly_source = _format_source_name(field_sources.get("hourly_source"), source_names)
-        minutely_source = _format_source_name(
-            field_sources.get("minutely_precipitation") or field_sources.get("hourly_summary"),
-            source_names,
-        )
-
-        if hourly_text and hourly_state is not None and hourly_state != current_state:
-            parts.append(f"hourly forecast from {hourly_source} says {hourly_text}")
-
-        if minutely_text and minutely_state is not None and minutely_state != current_state:
-            parts.append(
-                f"minute-by-minute precipitation outlook from {minutely_source} says "
-                f"{minutely_text}"
-            )
-
-        if not parts:
-            return None
-
-        return (
-            f"Data note: current conditions from {current_source} report {current_text}; "
-            f"{'; '.join(parts)}."
-        )
+        return build_source_attribution(weather_data)
 
     def _resolve_unit_preferences(
         self, location: Location
@@ -764,72 +363,6 @@ class WeatherPresenter:
             use_12hour=use_12hour,
             show_timezone=show_timezone,
         )
-
-
-_WET_CONDITION_MARKERS = (
-    "thunderstorm",
-    "t-storm",
-    "rain",
-    "shower",
-    "drizzle",
-    "snow",
-    "sleet",
-    "hail",
-    "freezing rain",
-)
-_DRY_CONDITION_MARKERS = (
-    "clear",
-    "sunny",
-    "cloudy",
-    "overcast",
-    "fair",
-)
-
-
-def _clean_condition_text(value: str | None) -> str | None:
-    """Normalize condition text for display while preserving user-facing wording."""
-    if not isinstance(value, str):
-        return None
-    cleaned = value.strip()
-    return cleaned.rstrip(".") if cleaned else None
-
-
-def _precipitation_state(value: str | None) -> str | None:
-    """Classify obvious wet/dry condition wording; return None when ambiguous."""
-    if value is None:
-        return None
-    normalized = value.casefold()
-    if any(marker in normalized for marker in _WET_CONDITION_MARKERS):
-        return "wet"
-    if any(marker in normalized for marker in _DRY_CONDITION_MARKERS):
-        return "dry"
-    return None
-
-
-def _minutely_precipitation_state(minutely: object | None) -> str | None:
-    """Classify minutely precipitation data from explicit points or summary text."""
-    if minutely is None:
-        return None
-
-    points = getattr(minutely, "points", None)
-    if points:
-        for point in points:
-            intensity = getattr(point, "precipitation_intensity", None)
-            probability = getattr(point, "precipitation_probability", None)
-            if (isinstance(intensity, int | float) and intensity > 0) or (
-                isinstance(probability, int | float) and probability > 0
-            ):
-                return "wet"
-        return "dry"
-
-    return _precipitation_state(_clean_condition_text(getattr(minutely, "summary", None)))
-
-
-def _format_source_name(source: str | None, source_names: dict[str, str]) -> str:
-    """Return a readable source label, falling back to a generic label."""
-    if not source:
-        return "another source"
-    return source_names.get(source, source.title())
 
 
 from .presentation.alerts import build_alerts  # noqa: E402


### PR DESCRIPTION
## Summary
- Split oversized display presentation modules into focused builders for forecast, current conditions, environmental hourly formatting, aviation, source attribution, and shared presentation view models.
- Kept existing public imports from display.weather_presenter and presentation facade modules stable via explicit compatibility exports.
- Brings the display package Python files under the 500-line target.

## Verification
- uv run ruff check src tests scripts
- uv run pyright
- uv run pytest -q -n 0 --tb=short tests/test_current_conditions.py tests/test_round_values_setting.py tests/test_presentation_environmental.py tests/test_weather_presenter_mobility_briefing.py tests/test_impact_summary.py tests/test_hourly_forecast_presentation.py tests/test_forecast_confidence_presentation.py tests/test_forecast_time_reference.py tests/test_openmeteo_forecast_timezone.py tests/test_show_impact_summaries_setting.py tests/test_unit_preference_bugs.py tests/test_alert_lifecycle_presentation.py tests/test_main_window_forecast_sections.py
- uv run pytest -q -n 0 --tb=short

## Notes
- Stacked on #643; retarget to dev after the earlier refactor PRs merge.