### PR TITLE
refactor(config): split import export operations

### DIFF
--- a/src/accessiweather/config/import_export.py
+++ b/src/accessiweather/config/import_export.py
@@ -2,19 +2,17 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import shutil
-from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
 from ..models import Location
-from .portable_secrets import (
-    PortableSecretsError,
-    decrypt_secret_bundle,
-    encrypt_secret_bundle,
-)
+from .import_export_backup import BackupRestoreMixin
+from .import_export_locations import LocationImportExportMixin
+from .import_export_secrets import EncryptedApiKeyImportExportMixin
+from .import_export_settings import SettingsImportExportMixin
+from .portable_secrets import decrypt_secret_bundle, encrypt_secret_bundle
 from .secure_storage import SecureStorage
 
 if TYPE_CHECKING:
@@ -30,564 +28,45 @@ PORTABLE_API_SECRET_KEYS: Final[tuple[str, ...]] = (
 )
 
 
-class ImportExportOperations:
+class ImportExportOperations(
+    BackupRestoreMixin,
+    EncryptedApiKeyImportExportMixin,
+    LocationImportExportMixin,
+    SettingsImportExportMixin,
+):
     """
     Encapsulate config persistence utilities beyond the main file.
 
-    This class provides backup, restore, import, and export functionality for
-    AccessiWeather configuration data. It handles settings and location data
-    separately to allow selective migration.
-
-    Security Considerations:
-        - API keys and credentials are NEVER exported to files
-        - Sensitive data remains in the system keyring
-        - Import operations validate all input data before application
-        - File operations use secure paths to prevent directory traversal
+    Security-sensitive dependencies remain surfaced from this module for
+    compatibility with existing tests and callers that patch this facade.
     """
 
     def __init__(self, manager: ConfigManager) -> None:
-        """
-        Initialize import/export operations with a config manager.
-
-        Args:
-            manager: The ConfigManager instance to operate on
-
-        """
+        """Initialize import/export operations with a config manager."""
         self._manager = manager
 
     @property
     def logger(self) -> logging.Logger:
-        """
-        Access the configuration manager's logger instance.
-
-        Returns:
-            Logger instance configured for accessiweather.config
-
-        """
+        """Access the configuration manager's logger instance."""
         return self._manager._get_logger()
 
-    def backup_config(self, backup_path: Path | None = None) -> bool:
-        """
-        Create a backup copy of the current configuration file.
+    @property
+    def _location_cls(self):
+        return Location
 
-        Creates a timestamped backup of the entire configuration file, including
-        settings and locations. This is useful before performing risky operations
-        like imports or manual edits.
+    @property
+    def _secure_storage_cls(self):
+        return SecureStorage
 
-        Security Considerations:
-            - Backup files contain all settings but NOT API keys (keys are in keyring)
-            - Uses shutil.copy2 to preserve file metadata and permissions
-            - Backup path should be user-controlled to prevent directory traversal
-            - Original file permissions are preserved on the backup
+    @property
+    def _portable_api_secret_keys(self) -> tuple[str, ...]:
+        return PORTABLE_API_SECRET_KEYS
 
-        Args:
-            backup_path: Optional custom path for the backup file.
-                        Defaults to <config_file>.json.backup
+    def _copy_file(self, source: Path, target: Path) -> None:
+        shutil.copy2(source, target)
 
-        Returns:
-            True if backup was created successfully, False otherwise
+    def _encrypt_secret_bundle(self, secrets: dict[str, str], passphrase: str) -> dict:
+        return encrypt_secret_bundle(secrets, passphrase)
 
-        """
-        backup_target = backup_path or self._manager.config_file.with_suffix(".json.backup")
-
-        try:
-            if not self._manager.config_file.exists():
-                self.logger.warning("No config file to backup")
-                return False
-
-            # SECURITY: shutil.copy2 preserves original file permissions
-            shutil.copy2(self._manager.config_file, backup_target)
-            self.logger.info(f"Config backed up to {backup_target}")
-            return True
-        except Exception as exc:
-            self.logger.error(f"Failed to backup config: {exc}")
-            return False
-
-    def restore_config(self, backup_path: Path) -> bool:
-        """
-        Restore configuration from the provided backup file.
-
-        Replaces the current configuration file with a backup copy and reloads
-        the configuration. This operation is destructive and should only be used
-        when recovering from a corrupted or unwanted configuration state.
-
-        Security Considerations:
-            - Validates backup file exists before attempting restore
-            - Uses ConfigManager.load_config() for JSON validation
-            - Invalid JSON in backup file will cause restore to fail safely
-            - Original config file is overwritten (consider backing up first)
-            - API keys are NOT affected (they remain in system keyring)
-
-        Args:
-            backup_path: Path to the backup file to restore from
-
-        Returns:
-            True if configuration was restored successfully, False otherwise
-
-        """
-        try:
-            # SECURITY: Validate backup file exists to prevent path traversal errors
-            if not backup_path.exists():
-                self.logger.error(f"Backup file not found: {backup_path}")
-                return False
-
-            # Replace current config file with backup
-            shutil.copy2(backup_path, self._manager.config_file)
-
-            # SECURITY: Clear cached config and reload to validate JSON structure
-            # This ensures corrupted or malicious backup files are rejected
-            self._manager._config = None
-            self._manager.load_config()
-
-            self.logger.info(f"Config restored from {backup_path}")
-            return True
-        except Exception as exc:
-            self.logger.error(f"Failed to restore config: {exc}")
-            return False
-
-    def export_settings(self, export_path: Path) -> bool:
-        """
-        Export application settings to a standalone JSON file.
-
-        Exports user preferences and configuration options (like units, data sources,
-        update intervals) to a portable JSON file that can be imported on another
-        system or shared with other users.
-
-        Security Considerations:
-            - API keys and credentials are NEVER exported to files
-            - Sensitive keys remain in the system keyring only
-            - Export file contains only non-sensitive configuration preferences
-            - No personally identifiable information (PII) is included
-            - File is written with UTF-8 encoding to prevent injection attacks
-
-        Args:
-            export_path: Path where the settings JSON file will be written
-
-        Returns:
-            True if settings were exported successfully, False otherwise
-
-        Note:
-            After importing these settings on another system, API keys must be
-            configured separately through the settings dialog.
-
-        """
-        try:
-            config = self._manager.get_config()
-
-            # SECURITY: Only export non-sensitive settings (API keys stay in keyring)
-            settings_data = {
-                "settings": config.settings.to_dict(),
-                "locations": [
-                    {
-                        "name": location.name,
-                        "latitude": location.latitude,
-                        "longitude": location.longitude,
-                        **(
-                            {"country_code": location.country_code} if location.country_code else {}
-                        ),
-                    }
-                    for location in config.locations
-                ],
-                "exported_at": str(datetime.now()),
-            }
-
-            # SECURITY: Use UTF-8 encoding and ensure_ascii=False for safe serialization
-            with open(export_path, "w", encoding="utf-8") as outfile:
-                json.dump(settings_data, outfile, indent=2, ensure_ascii=False)
-
-            self.logger.info(f"Settings exported to {export_path}")
-            return True
-        except Exception as exc:
-            self.logger.error(f"Failed to export settings: {exc}")
-            return False
-
-    def export_encrypted_api_keys(self, export_path: Path, passphrase: str) -> bool:
-        """
-        Export API keys to an encrypted portable bundle file.
-
-        Checks in-memory settings first (covers portable mode where keys are
-        not in keyring), then falls back to keyring (covers installed mode).
-        LazySecureStorage values are resolved via ``str()``.
-        """
-        try:
-            secrets: dict[str, str] = {}
-            for key_name in PORTABLE_API_SECRET_KEYS:
-                value: str | None = None
-                # 1. Try in-memory settings (covers portable mode)
-                if self._manager._config is not None:
-                    raw = getattr(self._manager._config.settings, key_name, None)
-                    if raw is not None:
-                        resolved = str(raw)  # resolves LazySecureStorage
-                        if resolved:
-                            value = resolved
-                # 2. Fall back to keyring (covers installed mode)
-                if not value:
-                    value = SecureStorage.get_password(key_name)
-                if value:
-                    secrets[key_name] = value
-
-            if not secrets:
-                self.logger.warning("No API keys available in secure storage to export")
-                return False
-
-            envelope = encrypt_secret_bundle(secrets, passphrase)
-            with open(export_path, "w", encoding="utf-8") as outfile:
-                json.dump(envelope, outfile, indent=2, ensure_ascii=False)
-
-            self.logger.info(f"Encrypted API keys exported to {export_path}")
-            return True
-        except PortableSecretsError as exc:
-            self.logger.error(f"Failed to export encrypted API keys: {exc}")
-            return False
-        except Exception as exc:
-            self.logger.error(f"Failed to export encrypted API keys: {exc}")
-            return False
-
-    def import_encrypted_api_keys(self, import_path: Path, passphrase: str) -> bool:
-        """Import encrypted API keys bundle into current machine keyring."""
-        try:
-            with open(import_path, encoding="utf-8") as infile:
-                envelope = json.load(infile)
-
-            if not isinstance(envelope, dict):
-                self.logger.error("Invalid encrypted API key bundle format")
-                return False
-
-            secrets = decrypt_secret_bundle(envelope, passphrase)
-
-            imported = 0
-            failed = []
-            for key_name in PORTABLE_API_SECRET_KEYS:
-                value = secrets.get(key_name)
-                if not value:
-                    continue
-                if not SecureStorage.set_password(key_name, value):
-                    self.logger.error(f"Failed to import API key into secure storage: {key_name}")
-                    failed.append(key_name)
-                else:
-                    imported += 1
-
-            if imported == 0 and not failed:
-                self.logger.warning("Encrypted API key bundle did not contain supported keys")
-                return False
-
-            self.logger.info("Imported %d API keys into secure storage", imported)
-
-            # In portable mode, set keys directly on in-memory settings so they
-            # are active immediately (keyring may not be available).
-            is_portable = getattr(self._manager, "app", None) and getattr(
-                self._manager.app, "_portable_mode", False
-            )
-            if is_portable and self._manager._config is not None:
-                for key_name in PORTABLE_API_SECRET_KEYS:
-                    value = secrets.get(key_name)
-                    if value:
-                        setattr(self._manager._config.settings, key_name, value)
-                        self.logger.debug(f"Set in-memory key for portable mode: {key_name}")
-            else:
-                # Refresh in-memory config so keys are active without a restart
-                self._manager._load_secure_keys()
-
-            return not failed
-        except PortableSecretsError as exc:
-            self.logger.error(f"Failed to import encrypted API keys: {exc}")
-            return False
-        except Exception as exc:
-            self.logger.error(f"Failed to import encrypted API keys: {exc}")
-            return False
-
-    def export_locations(self, export_path: Path) -> bool:
-        """
-        Export configured locations to a standalone JSON file.
-
-        Exports all saved locations (name, latitude, longitude) to a portable
-        JSON file that can be shared or imported on another system.
-
-        Security Considerations:
-            - Location data may contain PII (home address, work location, etc.)
-            - Users should be aware that exported location files contain GPS coordinates
-            - Exported file should be treated as potentially sensitive information
-            - File is written with UTF-8 encoding to prevent injection attacks
-            - No validation is performed on location names during export
-
-        Args:
-            export_path: Path where the locations JSON file will be written
-
-        Returns:
-            True if locations were exported successfully, False otherwise
-
-        Privacy Note:
-            Location names and coordinates may reveal personal information about
-            places you frequently check. Store exported files securely.
-
-        """
-        try:
-            config = self._manager.get_config()
-
-            # SECURITY: Location data may contain PII - handle carefully
-            locations_data = {
-                "locations": [
-                    {
-                        "name": location.name,
-                        "latitude": location.latitude,
-                        "longitude": location.longitude,
-                    }
-                    for location in config.locations
-                ],
-                "exported_at": str(datetime.now()),
-            }
-
-            # SECURITY: Use UTF-8 encoding for safe serialization
-            with open(export_path, "w", encoding="utf-8") as outfile:
-                json.dump(locations_data, outfile, indent=2, ensure_ascii=False)
-
-            self.logger.info(f"Locations exported to {export_path}")
-            return True
-        except Exception as exc:
-            self.logger.error(f"Failed to export locations: {exc}")
-            return False
-
-    def import_locations(self, import_path: Path) -> bool:
-        """
-        Import locations from an exported JSON file.
-
-        Reads location data from a JSON file and adds new locations to the current
-        configuration. Existing locations (by name) are skipped to prevent duplicates.
-        All imported data is validated before being added.
-
-        Security Considerations:
-            - Validates JSON structure before processing (protects against malformed input)
-            - Type-checks all location entries (dict validation)
-            - Validates required fields presence (name, latitude, longitude)
-            - Validates coordinate data types (must be numeric)
-            - Validates coordinate ranges via Location model (-90 to 90, -180 to 180)
-            - Skips invalid entries gracefully without crashing
-            - No code execution from imported data (safe JSON parsing only)
-            - Prevents duplicate locations (name-based collision detection)
-
-        Args:
-            import_path: Path to the JSON file containing location data
-
-        Returns:
-            True if at least one location was imported successfully or if all were
-            duplicates, False if all entries were invalid or file couldn't be read
-
-        Note:
-            Invalid or malformed location entries are skipped with warnings logged.
-            The import continues processing remaining valid entries.
-
-        """
-        try:
-            # SECURITY: Use UTF-8 encoding to prevent encoding-based attacks
-            with open(import_path, encoding="utf-8") as infile:
-                data = json.load(infile)
-
-            config = self._manager.get_config()
-            imported_count = 0
-            skipped_invalid = 0
-
-            # SECURITY: Validate each location entry thoroughly before adding
-            for entry in data.get("locations", []):
-                # SECURITY: Type check - must be a dictionary
-                if not isinstance(entry, dict):
-                    skipped_invalid += 1
-                    self.logger.warning("Skipped invalid location entry (not a mapping): %s", entry)
-                    continue
-
-                name = entry.get("name")
-                latitude = entry.get("latitude")
-                longitude = entry.get("longitude")
-
-                # SECURITY: Validate required fields are present
-                if not name or latitude is None or longitude is None:
-                    skipped_invalid += 1
-                    self.logger.warning(
-                        "Skipped invalid location entry (missing fields): %s", entry
-                    )
-                    continue
-
-                # SECURITY: Validate coordinates are numeric (prevents injection)
-                try:
-                    latitude_value = float(latitude)
-                    longitude_value = float(longitude)
-                except (TypeError, ValueError):
-                    skipped_invalid += 1
-                    self.logger.warning(
-                        "Skipped invalid location entry (non-numeric coordinates): %s", entry
-                    )
-                    continue
-
-                # SECURITY: Prevent duplicate locations (name-based collision detection)
-                if any(location.name == name for location in config.locations):
-                    self.logger.info(f"Skipped existing location: {name}")
-                    continue
-
-                # SECURITY: Location model validates coordinate ranges (-90/90, -180/180)
-                config.locations.append(
-                    Location(name=name, latitude=latitude_value, longitude=longitude_value)
-                )
-                imported_count += 1
-                self.logger.info(f"Imported location: {name}")
-
-            success = True
-            if imported_count > 0:
-                self._manager.save_config()
-            elif skipped_invalid > 0:
-                success = False
-
-            self.logger.info(
-                "Imported %d new locations; skipped %d invalid entries",
-                imported_count,
-                skipped_invalid,
-            )
-
-            return success
-        except json.JSONDecodeError as exc:
-            # SECURITY: Catch malformed JSON separately for better error reporting
-            self.logger.error(f"Failed to parse locations file (invalid JSON): {exc}")
-            return False
-        except Exception as exc:
-            self.logger.error(f"Failed to import locations: {exc}")
-            return False
-
-    def import_settings(self, import_path: Path) -> bool:
-        """
-        Import application settings from an exported JSON file.
-
-        Imports user preferences and configuration options from a JSON file,
-        merging them with the current configuration while preserving locations.
-        All imported data is validated before being applied.
-
-        Security Considerations:
-            - API keys and credentials are NEVER imported from files
-            - Sensitive keys must be configured separately (stored in keyring)
-            - Validates file existence before attempting to read
-            - Validates JSON structure at multiple levels (root, settings object)
-            - Type-checks all imported values before application
-            - Validates enum values (data_source) against allowed list
-            - Uses AppSettings.from_dict() for centralized validation
-            - Rejects invalid settings gracefully without partial application
-            - No code execution from imported data (safe JSON parsing only)
-            - Preserves existing locations (settings-only import)
-
-        Args:
-            import_path: Path to the JSON file containing exported settings
-
-        Returns:
-            True if settings were imported successfully, False otherwise
-
-        Note:
-            After importing settings, API keys must be configured separately
-            through the settings dialog, as they are never stored in export files.
-
-        """
-        try:
-            # SECURITY: Validate file exists to prevent path-based errors
-            if not import_path.exists():
-                self.logger.error(f"Import file not found: {import_path}")
-                return False
-
-            # SECURITY: Use UTF-8 encoding to prevent encoding-based attacks
-            with open(import_path, encoding="utf-8") as infile:
-                data = json.load(infile)
-
-            # SECURITY: Validate JSON structure - root must be a dict
-            if not isinstance(data, dict):
-                self.logger.error("Invalid settings file: root element must be a JSON object")
-                return False
-
-            # SECURITY: Validate settings key exists and is a dict
-            settings_data = data.get("settings")
-            if not isinstance(settings_data, dict):
-                self.logger.error(
-                    "Invalid settings file: missing or invalid 'settings' key (expected object)"
-                )
-                return False
-
-            # SECURITY: Validate data_source enum if present (prevent invalid values)
-            valid_sources = ["auto", "nws", "openmeteo", "visualcrossing"]
-            data_source = settings_data.get("data_source")
-            if data_source is not None and data_source not in valid_sources:
-                self.logger.warning(
-                    f"Invalid data_source '{data_source}' in imported settings, "
-                    f"will use 'auto'. Valid values: {', '.join(valid_sources)}"
-                )
-                settings_data["data_source"] = "auto"
-
-            # SECURITY: Use AppSettings.from_dict() for centralized validation
-            # This ensures all type checking, range validation, and defaults are applied
-            try:
-                from ..models import AppSettings
-
-                imported_settings = AppSettings.from_dict(settings_data)
-            except Exception as exc:
-                self.logger.error(f"Failed to deserialize settings: {exc}")
-                return False
-
-            # SECURITY: Merge settings while preserving existing locations
-            config = self._manager.get_config()
-            config.settings = imported_settings
-
-            # Import locations if present in export file (skip duplicates by name)
-            locations_imported = 0
-            for entry in data.get("locations", []):
-                if not isinstance(entry, dict):
-                    continue
-                name = entry.get("name")
-                latitude = entry.get("latitude")
-                longitude = entry.get("longitude")
-                if not name or latitude is None or longitude is None:
-                    continue
-                try:
-                    latitude_value = float(latitude)
-                    longitude_value = float(longitude)
-                except (TypeError, ValueError):
-                    continue
-                if any(loc.name == name for loc in config.locations):
-                    self.logger.info(f"Skipped existing location: {name}")
-                    continue
-                config.locations.append(
-                    Location(
-                        name=name,
-                        latitude=latitude_value,
-                        longitude=longitude_value,
-                        country_code=entry.get("country_code"),
-                    )
-                )
-                locations_imported += 1
-                self.logger.info(f"Imported location: {name}")
-
-            if locations_imported:
-                self.logger.info("Imported %d locations from settings file", locations_imported)
-
-            # Save the updated configuration
-            if not self._manager.save_config():
-                self.logger.error("Failed to save imported settings")
-                return False
-
-            # Count imported settings for logging
-            imported_count = len(settings_data)
-            self.logger.info(f"Successfully imported {imported_count} settings")
-
-            # Log if imported from older export (missing newer fields)
-            current_settings_dict = imported_settings.to_dict()
-            missing_fields = []
-            for key in current_settings_dict:
-                if key not in settings_data:
-                    missing_fields.append(key)
-
-            if missing_fields:
-                self.logger.info(
-                    f"Used defaults for {len(missing_fields)} fields not present in import: "
-                    f"{', '.join(missing_fields[:5])}" + ("..." if len(missing_fields) > 5 else "")
-                )
-
-            return True
-
-        except json.JSONDecodeError as exc:
-            # SECURITY: Catch malformed JSON separately for better error reporting
-            self.logger.error(f"Failed to parse settings file (invalid JSON): {exc}")
-            return False
-        except Exception as exc:
-            self.logger.error(f"Failed to import settings: {exc}")
-            return False
+    def _decrypt_secret_bundle(self, envelope: dict, passphrase: str) -> dict[str, str]:
+        return decrypt_secret_bundle(envelope, passphrase)

--- a/src/accessiweather/config/import_export_backup.py
+++ b/src/accessiweather/config/import_export_backup.py
@@ -1,0 +1,42 @@
+"""Backup and restore helpers for configuration import/export operations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class BackupRestoreMixin:
+    """Provide configuration backup and restore operations."""
+
+    def backup_config(self, backup_path: Path | None = None) -> bool:
+        """Create a backup copy of the current configuration file."""
+        backup_target = backup_path or self._manager.config_file.with_suffix(".json.backup")
+
+        try:
+            if not self._manager.config_file.exists():
+                self.logger.warning("No config file to backup")
+                return False
+
+            self._copy_file(self._manager.config_file, backup_target)
+            self.logger.info(f"Config backed up to {backup_target}")
+            return True
+        except Exception as exc:
+            self.logger.error(f"Failed to backup config: {exc}")
+            return False
+
+    def restore_config(self, backup_path: Path) -> bool:
+        """Restore configuration from the provided backup file."""
+        try:
+            if not backup_path.exists():
+                self.logger.error(f"Backup file not found: {backup_path}")
+                return False
+
+            self._copy_file(backup_path, self._manager.config_file)
+            self._manager._config = None
+            self._manager.load_config()
+
+            self.logger.info(f"Config restored from {backup_path}")
+            return True
+        except Exception as exc:
+            self.logger.error(f"Failed to restore config: {exc}")
+            return False

--- a/src/accessiweather/config/import_export_locations.py
+++ b/src/accessiweather/config/import_export_locations.py
@@ -1,0 +1,108 @@
+"""Location import/export helpers for configuration operations."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+
+class LocationImportExportMixin:
+    """Provide location export and import operations."""
+
+    def export_locations(self, export_path: Path) -> bool:
+        """Export configured locations to a standalone JSON file."""
+        try:
+            config = self._manager.get_config()
+            locations_data = {
+                "locations": [
+                    {
+                        "name": location.name,
+                        "latitude": location.latitude,
+                        "longitude": location.longitude,
+                    }
+                    for location in config.locations
+                ],
+                "exported_at": str(datetime.now()),
+            }
+
+            with open(export_path, "w", encoding="utf-8") as outfile:
+                json.dump(locations_data, outfile, indent=2, ensure_ascii=False)
+
+            self.logger.info(f"Locations exported to {export_path}")
+            return True
+        except Exception as exc:
+            self.logger.error(f"Failed to export locations: {exc}")
+            return False
+
+    def import_locations(self, import_path: Path) -> bool:
+        """Import locations from an exported JSON file."""
+        try:
+            with open(import_path, encoding="utf-8") as infile:
+                data = json.load(infile)
+
+            config = self._manager.get_config()
+            imported_count = 0
+            skipped_invalid = 0
+
+            for entry in data.get("locations", []):
+                result = self._coerce_location_entry(entry)
+                if result is None:
+                    skipped_invalid += 1
+                    self.logger.warning("Skipped invalid location entry: %s", entry)
+                    continue
+
+                name, latitude_value, longitude_value, country_code = result
+                if any(location.name == name for location in config.locations):
+                    self.logger.info(f"Skipped existing location: {name}")
+                    continue
+
+                kwargs = {
+                    "name": name,
+                    "latitude": latitude_value,
+                    "longitude": longitude_value,
+                }
+                if country_code is not None:
+                    kwargs["country_code"] = country_code
+                config.locations.append(self._location_cls(**kwargs))
+                imported_count += 1
+                self.logger.info(f"Imported location: {name}")
+
+            success = True
+            if imported_count > 0:
+                self._manager.save_config()
+            elif skipped_invalid > 0:
+                success = False
+
+            self.logger.info(
+                "Imported %d new locations; skipped %d invalid entries",
+                imported_count,
+                skipped_invalid,
+            )
+            return success
+        except json.JSONDecodeError as exc:
+            self.logger.error(f"Failed to parse locations file (invalid JSON): {exc}")
+            return False
+        except Exception as exc:
+            self.logger.error(f"Failed to import locations: {exc}")
+            return False
+
+    def _coerce_location_entry(self, entry: object) -> tuple[str, float, float, str | None] | None:
+        """Validate and coerce a JSON location entry."""
+        if not isinstance(entry, dict):
+            return None
+
+        name = entry.get("name")
+        latitude = entry.get("latitude")
+        longitude = entry.get("longitude")
+        if not name or latitude is None or longitude is None:
+            return None
+
+        try:
+            latitude_value = float(latitude)
+            longitude_value = float(longitude)
+        except (TypeError, ValueError):
+            return None
+
+        country_code = entry.get("country_code")
+        return str(name), latitude_value, longitude_value, country_code

--- a/src/accessiweather/config/import_export_secrets.py
+++ b/src/accessiweather/config/import_export_secrets.py
@@ -1,0 +1,112 @@
+"""Encrypted API key import/export helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .portable_secrets import PortableSecretsError
+
+
+class EncryptedApiKeyImportExportMixin:
+    """Provide encrypted portable API key bundle operations."""
+
+    def export_encrypted_api_keys(self, export_path: Path, passphrase: str) -> bool:
+        """
+        Export API keys to an encrypted portable bundle file.
+
+        Checks in-memory settings first (covers portable mode where keys are
+        not in keyring), then falls back to keyring (covers installed mode).
+        LazySecureStorage values are resolved via ``str()``.
+        """
+        try:
+            secrets = self._collect_api_key_secrets()
+            if not secrets:
+                self.logger.warning("No API keys available in secure storage to export")
+                return False
+
+            envelope = self._encrypt_secret_bundle(secrets, passphrase)
+            with open(export_path, "w", encoding="utf-8") as outfile:
+                json.dump(envelope, outfile, indent=2, ensure_ascii=False)
+
+            self.logger.info(f"Encrypted API keys exported to {export_path}")
+            return True
+        except PortableSecretsError as exc:
+            self.logger.error(f"Failed to export encrypted API keys: {exc}")
+            return False
+        except Exception as exc:
+            self.logger.error(f"Failed to export encrypted API keys: {exc}")
+            return False
+
+    def import_encrypted_api_keys(self, import_path: Path, passphrase: str) -> bool:
+        """Import encrypted API keys bundle into current machine keyring."""
+        try:
+            with open(import_path, encoding="utf-8") as infile:
+                envelope = json.load(infile)
+
+            if not isinstance(envelope, dict):
+                self.logger.error("Invalid encrypted API key bundle format")
+                return False
+
+            secrets = self._decrypt_secret_bundle(envelope, passphrase)
+            imported, failed = self._write_api_key_secrets(secrets)
+
+            if imported == 0 and not failed:
+                self.logger.warning("Encrypted API key bundle did not contain supported keys")
+                return False
+
+            self.logger.info("Imported %d API keys into secure storage", imported)
+            self._activate_imported_api_keys(secrets)
+            return not failed
+        except PortableSecretsError as exc:
+            self.logger.error(f"Failed to import encrypted API keys: {exc}")
+            return False
+        except Exception as exc:
+            self.logger.error(f"Failed to import encrypted API keys: {exc}")
+            return False
+
+    def _collect_api_key_secrets(self) -> dict[str, str]:
+        """Collect supported API keys from memory first, then secure storage."""
+        secrets: dict[str, str] = {}
+        for key_name in self._portable_api_secret_keys:
+            value: str | None = None
+            if self._manager._config is not None:
+                raw = getattr(self._manager._config.settings, key_name, None)
+                if raw is not None:
+                    resolved = str(raw)
+                    if resolved:
+                        value = resolved
+            if not value:
+                value = self._secure_storage_cls.get_password(key_name)
+            if value:
+                secrets[key_name] = value
+        return secrets
+
+    def _write_api_key_secrets(self, secrets: dict[str, str]) -> tuple[int, list[str]]:
+        """Write supported API keys into secure storage."""
+        imported = 0
+        failed = []
+        for key_name in self._portable_api_secret_keys:
+            value = secrets.get(key_name)
+            if not value:
+                continue
+            if not self._secure_storage_cls.set_password(key_name, value):
+                self.logger.error(f"Failed to import API key into secure storage: {key_name}")
+                failed.append(key_name)
+            else:
+                imported += 1
+        return imported, failed
+
+    def _activate_imported_api_keys(self, secrets: dict[str, str]) -> None:
+        """Refresh imported keys into the active config or portable settings."""
+        is_portable = getattr(self._manager, "app", None) and getattr(
+            self._manager.app, "_portable_mode", False
+        )
+        if is_portable and self._manager._config is not None:
+            for key_name in self._portable_api_secret_keys:
+                value = secrets.get(key_name)
+                if value:
+                    setattr(self._manager._config.settings, key_name, value)
+                    self.logger.debug(f"Set in-memory key for portable mode: {key_name}")
+        else:
+            self._manager._load_secure_keys()

--- a/src/accessiweather/config/import_export_settings.py
+++ b/src/accessiweather/config/import_export_settings.py
@@ -1,0 +1,141 @@
+"""Settings import/export helpers for configuration operations."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+
+class SettingsImportExportMixin:
+    """Provide settings import and export operations."""
+
+    def export_settings(self, export_path: Path) -> bool:
+        """Export application settings to a standalone JSON file."""
+        try:
+            config = self._manager.get_config()
+            settings_data = {
+                "settings": config.settings.to_dict(),
+                "locations": [
+                    {
+                        "name": location.name,
+                        "latitude": location.latitude,
+                        "longitude": location.longitude,
+                        **(
+                            {"country_code": location.country_code} if location.country_code else {}
+                        ),
+                    }
+                    for location in config.locations
+                ],
+                "exported_at": str(datetime.now()),
+            }
+
+            with open(export_path, "w", encoding="utf-8") as outfile:
+                json.dump(settings_data, outfile, indent=2, ensure_ascii=False)
+
+            self.logger.info(f"Settings exported to {export_path}")
+            return True
+        except Exception as exc:
+            self.logger.error(f"Failed to export settings: {exc}")
+            return False
+
+    def import_settings(self, import_path: Path) -> bool:
+        """Import application settings from an exported JSON file."""
+        try:
+            if not import_path.exists():
+                self.logger.error(f"Import file not found: {import_path}")
+                return False
+
+            with open(import_path, encoding="utf-8") as infile:
+                data = json.load(infile)
+
+            if not isinstance(data, dict):
+                self.logger.error("Invalid settings file: root element must be a JSON object")
+                return False
+
+            settings_data = data.get("settings")
+            if not isinstance(settings_data, dict):
+                self.logger.error(
+                    "Invalid settings file: missing or invalid 'settings' key (expected object)"
+                )
+                return False
+
+            self._normalize_imported_settings(settings_data)
+            imported_settings = self._deserialize_imported_settings(settings_data)
+            if imported_settings is None:
+                return False
+
+            config = self._manager.get_config()
+            config.settings = imported_settings
+            locations_imported = self._import_settings_locations(data, config.locations)
+            if locations_imported:
+                self.logger.info("Imported %d locations from settings file", locations_imported)
+
+            if not self._manager.save_config():
+                self.logger.error("Failed to save imported settings")
+                return False
+
+            self.logger.info(f"Successfully imported {len(settings_data)} settings")
+            self._log_missing_import_fields(imported_settings, settings_data)
+            return True
+        except json.JSONDecodeError as exc:
+            self.logger.error(f"Failed to parse settings file (invalid JSON): {exc}")
+            return False
+        except Exception as exc:
+            self.logger.error(f"Failed to import settings: {exc}")
+            return False
+
+    def _normalize_imported_settings(self, settings_data: dict) -> None:
+        """Normalize imported settings before deserialization."""
+        valid_sources = ["auto", "nws", "openmeteo", "visualcrossing"]
+        data_source = settings_data.get("data_source")
+        if data_source is not None and data_source not in valid_sources:
+            self.logger.warning(
+                f"Invalid data_source '{data_source}' in imported settings, "
+                f"will use 'auto'. Valid values: {', '.join(valid_sources)}"
+            )
+            settings_data["data_source"] = "auto"
+
+    def _deserialize_imported_settings(self, settings_data: dict):
+        """Deserialize imported settings through AppSettings validation."""
+        try:
+            from ..models import AppSettings
+
+            return AppSettings.from_dict(settings_data)
+        except Exception as exc:
+            self.logger.error(f"Failed to deserialize settings: {exc}")
+            return None
+
+    def _import_settings_locations(self, data: dict, locations: list) -> int:
+        """Import optional locations included with settings exports."""
+        locations_imported = 0
+        for entry in data.get("locations", []):
+            result = self._coerce_location_entry(entry)
+            if result is None:
+                continue
+
+            name, latitude_value, longitude_value, country_code = result
+            if any(location.name == name for location in locations):
+                self.logger.info(f"Skipped existing location: {name}")
+                continue
+
+            locations.append(
+                self._location_cls(
+                    name=name,
+                    latitude=latitude_value,
+                    longitude=longitude_value,
+                    country_code=country_code,
+                )
+            )
+            locations_imported += 1
+            self.logger.info(f"Imported location: {name}")
+        return locations_imported
+
+    def _log_missing_import_fields(self, imported_settings, settings_data: dict) -> None:
+        """Log defaulted fields that were absent from an older export."""
+        missing_fields = [key for key in imported_settings.to_dict() if key not in settings_data]
+        if missing_fields:
+            self.logger.info(
+                f"Used defaults for {len(missing_fields)} fields not present in import: "
+                f"{', '.join(missing_fields[:5])}" + ("..." if len(missing_fields) > 5 else "")
+            )


### PR DESCRIPTION
## Summary
- Split backup/restore, location import/export, settings import/export, and encrypted API key bundle logic out of the oversized import_export module.
- Kept ImportExportOperations as the public facade and preserved patchable compatibility names for Location and SecureStorage.
- Brings the import/export config files well under the 500-line target.

## Verification
- uv run pytest -q -n 0 --tb=short tests/test_import_export.py tests/test_portable_secrets.py tests/test_config_manager.py
- uv run ruff check src tests scripts
- uv run pyright
- uv run pytest -q -n 0 --tb=short

## Notes
- Stacked on #644; retarget to dev after the earlier refactor PRs merge.