### PR TITLE
fix(ui): restore stale warning proxy import

### DIFF
--- a/src/accessiweather/ui/main_window_shared.py
+++ b/src/accessiweather/ui/main_window_shared.py
@@ -36,10 +36,22 @@ QUICK_ACTION_LABELS = {
 
 ALL_LOCATIONS_SENTINEL = "All Locations"
 
+
+class _StaleWarningProxy:
+    """Delegates SetLabel() calls to the second field of the wx.StatusBar."""
+
+    def __init__(self, window) -> None:
+        self._window = window
+
+    def SetLabel(self, text: str) -> None:
+        self._window.GetStatusBar().SetStatusText(text, 1)
+
+
 __all__ = [
     "ALL_LOCATIONS_SENTINEL",
     "QUICK_ACTION_LABELS",
     "SizedPanel",
+    "_StaleWarningProxy",
     "datetime",
     "format_temperature",
     "get_temperature_precision",


### PR DESCRIPTION
## Summary
- Expose the stale warning status-bar proxy through the shared main-window mixin imports.
- Fix the post-refactor startup crash in `MainWindowUIMixin._create_widgets`.

## Verification
- `uv run pytest -q -n 0 --tb=short tests/test_main_window_labels.py tests/test_main_window_refresh.py tests/test_main_window_precipitation_timeline.py` (8 passed)
- `uv run ruff check src tests scripts`
- `uv run pyright`
- `uv run accessiweather --debug` smoke launch stayed running and fetched weather data

## Notes
- Follow-up to PR #642 after the merged `dev` smoke run exposed the missing split-module import.