### PR TITLE
fix(iem): show only active point products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - **Advanced Forecaster Notes lookup** — Forecaster Notes now has an Advanced Lookup path for current and historical NWS text products, preferring official NWS product history when available and falling back to IEM AFOS/SPC data for national products like SWODY1 and SPC mesoscale discussions (#641).
 
 ### Fixed
+- Forecaster Notes now starts with NWS discussion tabs only and adds IEM-backed tabs only when active SPC/WPC products apply to your selected location.
 - Pirate Weather now requests API v2 data and carries v2 precipitation types like freezing rain and wintry mix into current, daily, and hourly forecasts.
 - Forecaster Notes now hides Hazardous Weather Outlook and Special Weather Statement tabs when NWS confirms there is no matching product for the selected office.
 - Nightly builds now report the dev package version consistently instead of using stale generated build metadata.

--- a/src/accessiweather/iem_client.py
+++ b/src/accessiweather/iem_client.py
@@ -59,8 +59,103 @@ def _clean_iem_text(value: str) -> str:
     return "".join(char for char in value if char in "\n\r\t" or ord(char) >= 32).strip()
 
 
+def _describe_request_error(exc: Exception) -> str:
+    return str(exc) or exc.__class__.__name__
+
+
 def _format_iem_compact_datetime(value: datetime) -> str:
     return value.astimezone(UTC).strftime("%Y%m%d%H%M")
+
+
+def _now_utc() -> datetime:
+    return datetime.now(UTC)
+
+
+def _coerce_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _item_datetime(item: dict[str, Any], keys: tuple[str, ...]) -> datetime | None:
+    for key in keys:
+        parsed = _parse_datetime(item.get(key))
+        if parsed is not None:
+            return _coerce_utc(parsed)
+    return None
+
+
+def _is_active_at(
+    item: dict[str, Any],
+    valid_at: datetime,
+    *,
+    start_keys: tuple[str, ...],
+    end_keys: tuple[str, ...],
+) -> bool:
+    valid_at = _coerce_utc(valid_at)
+    starts = _item_datetime(item, start_keys)
+    ends = _item_datetime(item, end_keys)
+    if starts is not None and starts > valid_at:
+        return False
+    return not (ends is not None and ends <= valid_at)
+
+
+def _active_items(
+    items: list[Any],
+    valid_at: datetime,
+    *,
+    start_keys: tuple[str, ...],
+    end_keys: tuple[str, ...],
+) -> list[Any]:
+    active: list[Any] = []
+    for item in items:
+        if not isinstance(item, dict):
+            active.append(item)
+            continue
+        properties = item.get("properties")
+        item_data = properties if isinstance(properties, dict) else item
+        if _is_active_at(item_data, valid_at, start_keys=start_keys, end_keys=end_keys):
+            active.append(item)
+    return active
+
+
+def _items_in_time_window(
+    items: list[Any],
+    *,
+    start: datetime | None,
+    end: datetime | None,
+    time_keys: tuple[str, ...],
+) -> list[Any]:
+    if start is None and end is None:
+        return items
+    start_utc = _coerce_utc(start) if start is not None else None
+    end_utc = _coerce_utc(end) if end is not None else None
+    filtered: list[Any] = []
+    for item in items:
+        if not isinstance(item, dict):
+            filtered.append(item)
+            continue
+        properties = item.get("properties")
+        item_data = properties if isinstance(properties, dict) else item
+        item_time = _item_datetime(item_data, time_keys)
+        if item_time is None:
+            continue
+        if start_utc is not None and item_time < start_utc:
+            continue
+        if end_utc is not None and item_time >= end_utc:
+            continue
+        filtered.append(item)
+    return filtered
+
+
+def _payload_items(payload: dict[str, Any], item_keys: tuple[str, ...]) -> list[Any]:
+    for key in item_keys:
+        value = payload.get(key)
+        if isinstance(value, list):
+            return value
+        if isinstance(value, dict) and value:
+            return [value]
+    return []
 
 
 async def fetch_iem_afos_text(
@@ -146,6 +241,12 @@ def _spc_summary_lines(
     payload: Any,
     *,
     item_keys: tuple[str, ...],
+    active_at: datetime | None = None,
+    start_keys: tuple[str, ...] = (),
+    end_keys: tuple[str, ...] = (),
+    window_start: datetime | None = None,
+    window_end: datetime | None = None,
+    window_keys: tuple[str, ...] = (),
     max_items: int | None = None,
 ) -> list[str]:
     lines = [title, ""]
@@ -156,14 +257,21 @@ def _spc_summary_lines(
     if generated:
         lines.extend([f"Generated: {generated}", ""])
 
-    items: list[Any] = []
-    for key in item_keys:
-        value = payload.get(key)
-        if isinstance(value, list):
-            items = value
-            break
+    items = _payload_items(payload, item_keys)
+    if window_keys:
+        items = _items_in_time_window(
+            items,
+            start=window_start,
+            end=window_end,
+            time_keys=window_keys,
+        )
+    if active_at is not None and (start_keys or end_keys):
+        items = _active_items(items, active_at, start_keys=start_keys, end_keys=end_keys)
     if not items:
-        lines.append("No matching point-based products were returned for this location.")
+        if active_at is not None and (start_keys or end_keys):
+            lines.append("No active point-based products were returned for this location.")
+        else:
+            lines.append("No matching point-based products were returned for this location.")
         return lines
 
     visible_items, omitted = _limited_items(items, max_items)
@@ -194,6 +302,7 @@ async def fetch_iem_spc_outlook(
     *,
     day: int = 1,
     current: bool = True,
+    valid_at: datetime | None = None,
     max_items: int | None = 5,
     client: httpx.AsyncClient | None = None,
     iem_base_url: str = DEFAULT_IEM_BASE_URL,
@@ -209,6 +318,8 @@ async def fetch_iem_spc_outlook(
         "fmt": "json",
         "current": 1 if current else 0,
     }
+    if valid_at is not None and not current:
+        params["time"] = _format_iem_datetime(valid_at)
     url = f"{iem_base_url}/json/spcoutlook.py"
     headers = {"User-Agent": user_agent}
 
@@ -216,7 +327,9 @@ async def fetch_iem_spc_outlook(
         try:
             response = await _client_get(http_client, url, params=params, headers=headers)
         except (httpx.TimeoutException, httpx.TransportError, httpx.RequestError) as exc:
-            raise IemProductFetchError(f"IEM SPC outlook request failed: {exc}") from exc
+            raise IemProductFetchError(
+                f"IEM SPC outlook request failed: {_describe_request_error(exc)}"
+            ) from exc
         if response.status_code != 200:
             raise IemProductFetchError(f"IEM SPC outlook returned HTTP {response.status_code}")
         data = response.json()
@@ -231,7 +344,7 @@ async def fetch_iem_spc_outlook(
                 _spc_summary_lines(
                     title,
                     data,
-                    item_keys=("outlooks", "features"),
+                    item_keys=("outlooks", "outlook", "features"),
                     max_items=max_items,
                 )
             ),
@@ -248,6 +361,10 @@ async def fetch_iem_spc_mcds(
     latitude: float,
     longitude: float,
     *,
+    active_at: datetime | None = None,
+    active_only: bool = True,
+    start: datetime | None = None,
+    end: datetime | None = None,
     max_items: int | None = 5,
     client: httpx.AsyncClient | None = None,
     iem_base_url: str = DEFAULT_IEM_BASE_URL,
@@ -255,6 +372,7 @@ async def fetch_iem_spc_mcds(
     user_agent: str = DEFAULT_USER_AGENT,
 ) -> TextProduct:
     """Fetch and summarize IEM SPC mesoscale discussions near a point."""
+    active_at = active_at or _now_utc()
     params = {"lat": latitude, "lon": longitude, "fmt": "json"}
     url = f"{iem_base_url}/json/spcmcd.py"
     headers = {"User-Agent": user_agent}
@@ -263,11 +381,14 @@ async def fetch_iem_spc_mcds(
         try:
             response = await _client_get(http_client, url, params=params, headers=headers)
         except (httpx.TimeoutException, httpx.TransportError, httpx.RequestError) as exc:
-            raise IemProductFetchError(f"IEM SPC MCD request failed: {exc}") from exc
+            raise IemProductFetchError(
+                f"IEM SPC MCD request failed: {_describe_request_error(exc)}"
+            ) from exc
         if response.status_code != 200:
             raise IemProductFetchError(f"IEM SPC MCD returned HTTP {response.status_code}")
         data = response.json()
         title = "SPC Mesoscale Discussions"
+        item_filter_time = active_at if active_only else None
         return TextProduct(
             product_type="SPC_MCD",
             product_id="SPC_MCD",
@@ -278,6 +399,12 @@ async def fetch_iem_spc_mcds(
                     title,
                     data,
                     item_keys=("mcds", "features"),
+                    active_at=item_filter_time,
+                    start_keys=("utc_issue", "product_issue", "issue", "valid"),
+                    end_keys=("utc_expire", "product_expire", "expire", "expires"),
+                    window_start=start,
+                    window_end=end,
+                    window_keys=("utc_issue", "product_issue", "issue", "valid"),
                     max_items=max_items,
                 )
             ),
@@ -302,9 +429,9 @@ async def fetch_iem_spc_watches(
     user_agent: str = DEFAULT_USER_AGENT,
 ) -> TextProduct:
     """Fetch and summarize IEM SPC watches for a point."""
+    active_at = valid_at or _now_utc()
     params: dict[str, Any] = {"lat": latitude, "lon": longitude}
-    if valid_at is not None:
-        params["ts"] = _format_iem_compact_datetime(valid_at)
+    params["ts"] = _format_iem_compact_datetime(active_at)
     url = f"{iem_base_url}/json/spcwatch.py"
     headers = {"User-Agent": user_agent}
 
@@ -312,7 +439,9 @@ async def fetch_iem_spc_watches(
         try:
             response = await _client_get(http_client, url, params=params, headers=headers)
         except (httpx.TimeoutException, httpx.TransportError, httpx.RequestError) as exc:
-            raise IemProductFetchError(f"IEM SPC watches request failed: {exc}") from exc
+            raise IemProductFetchError(
+                f"IEM SPC watches request failed: {_describe_request_error(exc)}"
+            ) from exc
         if response.status_code != 200:
             raise IemProductFetchError(f"IEM SPC watches returned HTTP {response.status_code}")
         title = "SPC Watches"
@@ -322,7 +451,12 @@ async def fetch_iem_spc_watches(
             cwa_office="SPC",
             issuance_time=None,
             product_text="\n".join(
-                _spc_watch_summary_lines(title, response.json(), max_items=max_items)
+                _spc_watch_summary_lines(
+                    title,
+                    response.json(),
+                    active_at=active_at,
+                    max_items=max_items,
+                )
             ),
             headline=title,
         )
@@ -337,6 +471,7 @@ def _spc_watch_summary_lines(
     title: str,
     payload: Any,
     *,
+    active_at: datetime | None = None,
     max_items: int | None = None,
 ) -> list[str]:
     lines = [title, ""]
@@ -346,6 +481,15 @@ def _spc_watch_summary_lines(
     features = payload.get("features")
     if not isinstance(features, list) or not features:
         return [title, "", "No matching watches were returned."]
+    if active_at is not None:
+        features = _active_items(
+            features,
+            active_at,
+            start_keys=("issue", "utc_issue", "product_issue", "valid"),
+            end_keys=("expire", "utc_expire", "product_expire", "expires"),
+        )
+        if not features:
+            return [title, "", "No active watches were returned."]
 
     visible_features, omitted = _limited_items(features, max_items)
     for index, feature in enumerate(visible_features, start=1):
@@ -385,6 +529,7 @@ async def fetch_iem_wpc_outlook(
     user_agent: str = DEFAULT_USER_AGENT,
 ) -> TextProduct:
     """Fetch and summarize IEM WPC excessive rainfall outlooks for a point."""
+    active_at = valid_at or _now_utc()
     day = min(8, max(1, int(day)))
     params: dict[str, Any] = {
         "lat": latitude,
@@ -393,8 +538,7 @@ async def fetch_iem_wpc_outlook(
         "fmt": "json",
         "last": max(1, int(limit)),
     }
-    if valid_at is not None:
-        params["time"] = _format_iem_datetime(valid_at)
+    params["time"] = "current" if valid_at is None else _format_iem_datetime(active_at)
     url = f"{iem_base_url}/json/wpcoutlook.py"
     headers = {"User-Agent": user_agent}
 
@@ -402,7 +546,9 @@ async def fetch_iem_wpc_outlook(
         try:
             response = await _client_get(http_client, url, params=params, headers=headers)
         except (httpx.TimeoutException, httpx.TransportError, httpx.RequestError) as exc:
-            raise IemProductFetchError(f"IEM WPC outlook request failed: {exc}") from exc
+            raise IemProductFetchError(
+                f"IEM WPC outlook request failed: {_describe_request_error(exc)}"
+            ) from exc
         if response.status_code != 200:
             raise IemProductFetchError(f"IEM WPC outlook returned HTTP {response.status_code}")
         data = response.json()
@@ -413,7 +559,14 @@ async def fetch_iem_wpc_outlook(
             product_id=f"WPC_ERO_DAY{day}",
             cwa_office="WPC",
             issuance_time=_parse_datetime(issued),
-            product_text="\n".join(_wpc_outlook_summary_lines(title, data, max_items=max_items)),
+            product_text="\n".join(
+                _wpc_outlook_summary_lines(
+                    title,
+                    data,
+                    active_at=active_at,
+                    max_items=max_items,
+                )
+            ),
             headline=title,
         )
 
@@ -427,6 +580,7 @@ def _wpc_outlook_summary_lines(
     title: str,
     payload: Any,
     *,
+    active_at: datetime | None = None,
     max_items: int | None = None,
 ) -> list[str]:
     lines = [title, ""]
@@ -436,9 +590,18 @@ def _wpc_outlook_summary_lines(
     if generated:
         lines.extend([f"Generated: {generated}", ""])
 
-    outlooks = payload.get("outlooks")
-    if not isinstance(outlooks, list) or not outlooks:
+    outlooks = _payload_items(payload, ("outlooks", "outlook"))
+    if not outlooks:
         return [title, "", "No matching outlooks were returned."]
+    if active_at is not None:
+        outlooks = _active_items(
+            outlooks,
+            active_at,
+            start_keys=("utc_issue", "issue", "valid", "valid_begin"),
+            end_keys=("utc_expire", "expire", "expires", "valid_end"),
+        )
+        if not outlooks:
+            return [title, "", "No active outlooks were returned."]
 
     visible_outlooks, omitted = _limited_items(outlooks, max_items)
     for index, outlook in enumerate(visible_outlooks, start=1):
@@ -465,6 +628,10 @@ async def fetch_iem_wpc_mpds(
     latitude: float,
     longitude: float,
     *,
+    active_at: datetime | None = None,
+    active_only: bool = True,
+    start: datetime | None = None,
+    end: datetime | None = None,
     max_items: int | None = 5,
     client: httpx.AsyncClient | None = None,
     iem_base_url: str = DEFAULT_IEM_BASE_URL,
@@ -472,6 +639,7 @@ async def fetch_iem_wpc_mpds(
     user_agent: str = DEFAULT_USER_AGENT,
 ) -> TextProduct:
     """Fetch and summarize IEM WPC mesoscale precipitation discussions for a point."""
+    active_at = active_at or _now_utc()
     params = {"lat": latitude, "lon": longitude, "fmt": "json"}
     url = f"{iem_base_url}/json/wpcmpd.py"
     headers = {"User-Agent": user_agent}
@@ -480,17 +648,27 @@ async def fetch_iem_wpc_mpds(
         try:
             response = await _client_get(http_client, url, params=params, headers=headers)
         except (httpx.TimeoutException, httpx.TransportError, httpx.RequestError) as exc:
-            raise IemProductFetchError(f"IEM WPC MPD request failed: {exc}") from exc
+            raise IemProductFetchError(
+                f"IEM WPC MPD request failed: {_describe_request_error(exc)}"
+            ) from exc
         if response.status_code != 200:
             raise IemProductFetchError(f"IEM WPC MPD returned HTTP {response.status_code}")
         title = "WPC Mesoscale Precipitation Discussions"
+        item_filter_time = active_at if active_only else None
         return TextProduct(
             product_type="WPC_MPD",
             product_id="WPC_MPD",
             cwa_office="WPC",
             issuance_time=None,
             product_text="\n".join(
-                _wpc_mpd_summary_lines(title, response.json(), max_items=max_items)
+                _wpc_mpd_summary_lines(
+                    title,
+                    response.json(),
+                    active_at=item_filter_time,
+                    window_start=start,
+                    window_end=end,
+                    max_items=max_items,
+                )
             ),
             headline=title,
         )
@@ -505,6 +683,9 @@ def _wpc_mpd_summary_lines(
     title: str,
     payload: Any,
     *,
+    active_at: datetime | None = None,
+    window_start: datetime | None = None,
+    window_end: datetime | None = None,
     max_items: int | None = None,
 ) -> list[str]:
     lines = [title, ""]
@@ -514,6 +695,23 @@ def _wpc_mpd_summary_lines(
     mpds = payload.get("mpds")
     if not isinstance(mpds, list) or not mpds:
         return [title, "", "No matching discussions were returned."]
+    mpds = _items_in_time_window(
+        mpds,
+        start=window_start,
+        end=window_end,
+        time_keys=("utc_issue", "issue", "product_issue"),
+    )
+    if not mpds:
+        return [title, "", "No matching discussions were returned."]
+    if active_at is not None:
+        mpds = _active_items(
+            mpds,
+            active_at,
+            start_keys=("utc_issue", "issue", "product_issue"),
+            end_keys=("utc_expire", "expire", "product_expire", "expires"),
+        )
+        if not mpds:
+            return [title, "", "No active discussions were returned."]
 
     visible_mpds, omitted = _limited_items(mpds, max_items)
     for index, mpd in enumerate(visible_mpds, start=1):

--- a/src/accessiweather/services/forecast_product_service.py
+++ b/src/accessiweather/services/forecast_product_service.py
@@ -183,11 +183,15 @@ class ForecastProductService:
         *,
         day: int = 1,
         current: bool = True,
+        valid_at: datetime | None = None,
         max_items: int | None = 5,
         timeout: float = 10.0,
     ) -> TextProduct:
         """Fetch a structured IEM SPC convective outlook summary."""
-        key = self._iem_cache_key("SPC_OUTLOOK", latitude, longitude, day, current, max_items)
+        valid_key = valid_at.isoformat() if valid_at is not None else ""
+        key = self._iem_cache_key(
+            "SPC_OUTLOOK", latitude, longitude, day, current, valid_key, max_items
+        )
         cached = self._cache.get(key)
         if isinstance(cached, TextProduct):
             return cached
@@ -196,6 +200,7 @@ class ForecastProductService:
             longitude,
             day=day,
             current=current,
+            valid_at=valid_at,
             max_items=max_items,
             timeout=timeout,
         )
@@ -207,15 +212,30 @@ class ForecastProductService:
         latitude: float,
         longitude: float,
         *,
+        active_only: bool = True,
+        start: datetime | None = None,
+        end: datetime | None = None,
         max_items: int | None = 5,
         timeout: float = 10.0,
     ) -> TextProduct:
         """Fetch structured IEM SPC mesoscale discussion summaries."""
-        key = self._iem_cache_key("SPC_MCD", latitude, longitude, max_items)
+        start_key = start.isoformat() if start is not None else ""
+        end_key = end.isoformat() if end is not None else ""
+        key = self._iem_cache_key(
+            "SPC_MCD", latitude, longitude, active_only, start_key, end_key, max_items
+        )
         cached = self._cache.get(key)
         if isinstance(cached, TextProduct):
             return cached
-        result = await fetch_iem_spc_mcds(latitude, longitude, max_items=max_items, timeout=timeout)
+        result = await fetch_iem_spc_mcds(
+            latitude,
+            longitude,
+            active_only=active_only,
+            start=start,
+            end=end,
+            max_items=max_items,
+            timeout=timeout,
+        )
         self._cache.set(key, result, ttl=self._TTLS.get("SPS", 900))
         return result
 
@@ -278,14 +298,29 @@ class ForecastProductService:
         latitude: float,
         longitude: float,
         *,
+        active_only: bool = True,
+        start: datetime | None = None,
+        end: datetime | None = None,
         max_items: int | None = 5,
         timeout: float = 10.0,
     ) -> TextProduct:
         """Fetch structured IEM WPC mesoscale precipitation discussion summaries."""
-        key = self._iem_cache_key("WPC_MPD", latitude, longitude, max_items)
+        start_key = start.isoformat() if start is not None else ""
+        end_key = end.isoformat() if end is not None else ""
+        key = self._iem_cache_key(
+            "WPC_MPD", latitude, longitude, active_only, start_key, end_key, max_items
+        )
         cached = self._cache.get(key)
         if isinstance(cached, TextProduct):
             return cached
-        result = await fetch_iem_wpc_mpds(latitude, longitude, max_items=max_items, timeout=timeout)
+        result = await fetch_iem_wpc_mpds(
+            latitude,
+            longitude,
+            active_only=active_only,
+            start=start,
+            end=end,
+            max_items=max_items,
+            timeout=timeout,
+        )
         self._cache.set(key, result, ttl=self._TTLS.get("SPS", 900))
         return result

--- a/src/accessiweather/ui/dialogs/advanced_text_product_dialog.py
+++ b/src/accessiweather/ui/dialogs/advanced_text_product_dialog.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from datetime import UTC, datetime, time
+from datetime import UTC, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any
 
 import wx
@@ -20,6 +20,15 @@ _NWS_PRODUCT_TYPES = {"AFD", "HWO", "SPS", "CLI", "CF6", "RER", "LSR", "PNS"}
 _SOURCE_PREFER_NWS = "Prefer NWS when available"
 _SOURCE_IEM_ONLY = "IEM AFOS only"
 _SOURCE_NWS_ONLY = "NWS history only"
+_DATE_PRESETS = (
+    "Latest or current",
+    "Past 24 hours",
+    "Past 7 days",
+    "Past 30 days",
+    "Past 90 days",
+    "Past year",
+    "Custom dates below",
+)
 _SPC_OUTLOOK_RE = re.compile(r"(?:SPC\s*)?DAY\s*([1-8])\s*(?:CONVECTIVE\s*)?OUTLOOK", re.I)
 _WPC_OUTLOOK_RE = re.compile(
     r"(?:WPC\s*)?DAY\s*([1-8])\s*(?:EXCESSIVE\s*RAINFALL\s*)?OUTLOOK",
@@ -60,6 +69,8 @@ _LEFT = getattr(wx, "LEFT", wx.ALL)
 _RIGHT = getattr(wx, "RIGHT", wx.ALL)
 _TOP = getattr(wx, "TOP", wx.ALL)
 _EVT_CHOICE = getattr(wx, "EVT_CHOICE", wx.EVT_BUTTON)
+_COMBOBOX = getattr(wx, "ComboBox", wx.Choice)
+_CB_READONLY = getattr(wx, "CB_READONLY", 0)
 
 
 class AdvancedTextProductDialog(wx.Dialog):
@@ -127,9 +138,25 @@ class AdvancedTextProductDialog(wx.Dialog):
         self.limit_input = wx.TextCtrl(self, value="1")
         main_sizer.Add(self.limit_input, 0, wx.ALL | wx.EXPAND, 8)
 
+        self.date_preset_label = wx.StaticText(
+            self,
+            label="Date lookup preset:",
+        )
+        main_sizer.Add(self.date_preset_label, 0, _LEFT | _RIGHT | wx.EXPAND, 8)
+        self.date_preset_choice = _COMBOBOX(
+            self,
+            choices=list(_DATE_PRESETS),
+            style=_CB_READONLY,
+        )
+        self.date_preset_choice.SetSelection(0)
+        main_sizer.Add(self.date_preset_choice, 0, wx.ALL | wx.EXPAND, 8)
+
         self.start_label = wx.StaticText(
             self,
-            label="Start or valid time (optional, YYYY-MM-DD or ISO UTC):",
+            label=(
+                "Start or valid time in UTC (optional, YYYY-MM-DD or ISO timestamp). "
+                "For SPC/WPC outlooks and SPC watches, this is the valid time."
+            ),
         )
         main_sizer.Add(self.start_label, 0, _LEFT | _RIGHT | wx.EXPAND, 8)
         self.start_input = wx.TextCtrl(self, value="")
@@ -174,6 +201,7 @@ class AdvancedTextProductDialog(wx.Dialog):
     def _bind_events(self) -> None:
         """Bind buttons and Escape handling."""
         self.product_preset_choice.Bind(_EVT_CHOICE, self._on_product_preset)
+        self.date_preset_choice.Bind(_EVT_CHOICE, self._on_date_preset)
         self.lookup_button.Bind(wx.EVT_BUTTON, self._on_lookup)
         self.close_button.Bind(wx.EVT_BUTTON, self._on_close)
         self.Bind(wx.EVT_CHAR_HOOK, self._on_key)
@@ -236,16 +264,16 @@ class AdvancedTextProductDialog(wx.Dialog):
 
         spc_outlook_day = self._spc_outlook_day(product_id)
         if spc_outlook_day is not None:
-            return await self._lookup_spc_outlook(spc_outlook_day)
+            return await self._lookup_spc_outlook(spc_outlook_day, start)
         if product_id in {"SPC MCD", "MCD", "SPC MESOSCALE DISCUSSION"}:
-            return await self._lookup_spc_mcd()
+            return await self._lookup_spc_mcd(limit, start, end)
         if product_id in {"SPC WATCH", "SPC WATCHES", "WATCHES"}:
             return await self._lookup_spc_watches(start)
         wpc_outlook_day = self._wpc_outlook_day(product_id)
         if wpc_outlook_day is not None:
             return await self._lookup_wpc_outlook(wpc_outlook_day, start, limit)
         if product_id in {"WPC MPD", "MPD", "WPC MESOSCALE PRECIPITATION DISCUSSION"}:
-            return await self._lookup_wpc_mpd()
+            return await self._lookup_wpc_mpd(limit, start, end)
 
         if source != _SOURCE_IEM_ONLY and product_id in _NWS_PRODUCT_TYPES and location:
             products = await self._lookup_nws_history(product_id, location, limit, start, end)
@@ -283,15 +311,26 @@ class AdvancedTextProductDialog(wx.Dialog):
             return history
         return [history]
 
-    async def _lookup_spc_outlook(self, day: int) -> str:
+    async def _lookup_spc_outlook(self, day: int, valid_at: datetime | None) -> str:
         lat = getattr(self._location, "latitude", None)
         lon = getattr(self._location, "longitude", None)
         if lat is None or lon is None:
             return "SPC outlook lookup needs a location with latitude and longitude."
-        product = await self._service.get_iem_spc_outlook(lat, lon, day=day, current=True)
+        product = await self._service.get_iem_spc_outlook(
+            lat,
+            lon,
+            day=day,
+            current=valid_at is None,
+            valid_at=valid_at,
+        )
         return self._format_products("IEM", product)
 
-    async def _lookup_spc_mcd(self) -> str:
+    async def _lookup_spc_mcd(
+        self,
+        limit: int,
+        start: datetime | None,
+        end: datetime | None,
+    ) -> str:
         lat = getattr(self._location, "latitude", None)
         lon = getattr(self._location, "longitude", None)
         if lat is None or lon is None:
@@ -299,7 +338,14 @@ class AdvancedTextProductDialog(wx.Dialog):
                 "SPC MCD (Mesoscale Discussion) lookup needs a location with "
                 "latitude and longitude."
             )
-        product = await self._service.get_iem_spc_mcds(lat, lon)
+        product = await self._service.get_iem_spc_mcds(
+            lat,
+            lon,
+            active_only=False,
+            start=start,
+            end=end,
+            max_items=limit,
+        )
         return self._format_products("IEM", product)
 
     async def _lookup_spc_watches(self, valid_at: datetime | None) -> str:
@@ -329,7 +375,12 @@ class AdvancedTextProductDialog(wx.Dialog):
         )
         return self._format_products("IEM", product)
 
-    async def _lookup_wpc_mpd(self) -> str:
+    async def _lookup_wpc_mpd(
+        self,
+        limit: int,
+        start: datetime | None,
+        end: datetime | None,
+    ) -> str:
         lat = getattr(self._location, "latitude", None)
         lon = getattr(self._location, "longitude", None)
         if lat is None or lon is None:
@@ -337,7 +388,14 @@ class AdvancedTextProductDialog(wx.Dialog):
                 "WPC MPD (Mesoscale Precipitation Discussion) lookup needs a location "
                 "with latitude and longitude."
             )
-        product = await self._service.get_iem_wpc_mpds(lat, lon)
+        product = await self._service.get_iem_wpc_mpds(
+            lat,
+            lon,
+            active_only=False,
+            start=start,
+            end=end,
+            max_items=limit,
+        )
         return self._format_products("IEM", product)
 
     def _on_product_preset(self, event) -> None:
@@ -349,6 +407,14 @@ class AdvancedTextProductDialog(wx.Dialog):
             self.product_input.SetValue(product_id)
             if product_id not in _NWS_PRODUCT_TYPES:
                 self.source_choice.SetSelection(1)
+
+    def _on_date_preset(self, event) -> None:
+        """Apply a date preset to the start/end inputs."""
+        del event
+        preset = self.date_preset_choice.GetStringSelection()
+        start, end = self._date_range_for_preset(preset)
+        self.start_input.SetValue(self._format_form_datetime(start) if start is not None else "")
+        self.end_input.SetValue(self._format_form_datetime(end) if end is not None else "")
 
     @staticmethod
     def _parse_limit(value: str) -> int:
@@ -374,6 +440,27 @@ class AdvancedTextProductDialog(wx.Dialog):
         if parsed.tzinfo is None:
             return parsed.replace(tzinfo=UTC)
         return parsed
+
+    @staticmethod
+    def _date_range_for_preset(preset: str) -> tuple[datetime | None, datetime | None]:
+        if preset in {"", "Latest or current", "Custom dates below"}:
+            return None, None
+        now = datetime.now(UTC).replace(microsecond=0)
+        days_by_preset = {
+            "Past 24 hours": 1,
+            "Past 7 days": 7,
+            "Past 30 days": 30,
+            "Past 90 days": 90,
+            "Past year": 365,
+        }
+        days = days_by_preset.get(preset)
+        if days is None:
+            return None, None
+        return now - timedelta(days=days), now
+
+    @staticmethod
+    def _format_form_datetime(value: datetime) -> str:
+        return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
     @staticmethod
     def _spc_outlook_day(product_id: str) -> int | None:

--- a/src/accessiweather/ui/dialogs/forecast_products_dialog.py
+++ b/src/accessiweather/ui/dialogs/forecast_products_dialog.py
@@ -10,6 +10,7 @@ accessible notebook contract.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -17,10 +18,24 @@ from typing import TYPE_CHECKING
 
 import wx
 
+from ...iem_client import IemProductFetchError
 from .advanced_text_product_dialog import show_advanced_text_product_dialog
 from .forecast_product_panel import ForecastProductPanel
 
 ProductLoader = Callable[[], Awaitable[object]]
+
+_ACTIVE_IEM_LOADER_KINDS = {
+    "spc_outlook",
+    "spc_mcd",
+    "spc_watches_current",
+    "wpc_ero",
+    "wpc_mpd",
+}
+_INACTIVE_IEM_SUMMARY_PREFIXES = (
+    "No active ",
+    "No matching ",
+    "No structured data returned.",
+)
 
 if TYPE_CHECKING:
     from ...ai_explainer import AIExplainer
@@ -47,9 +62,6 @@ class ForecastProductsDialog(wx.Dialog):
         TextProductTab("AFD", "Area Forecast Discussion", "current", requires_cwa=True),
         TextProductTab("HWO", "Hazardous Weather Outlook", "current", requires_cwa=True),
         TextProductTab("SPS", "Special Weather Statement", "current", requires_cwa=True),
-        TextProductTab("LSR", "Local Storm Report", "nws_history", requires_cwa=True),
-        TextProductTab("PNS", "Public Information Statement", "nws_history", requires_cwa=True),
-        TextProductTab("CLI", "Daily Climate Report", "nws_history", requires_cwa=True),
         TextProductTab("SPC_OUTLOOK", "SPC Outlook (Storm Prediction Center)", "spc_outlook"),
         TextProductTab("SPC_MCD", "SPC MCD (Mesoscale Discussion)", "spc_mcd"),
         TextProductTab(
@@ -95,9 +107,11 @@ class ForecastProductsDialog(wx.Dialog):
         self._service = forecast_product_service
         self._ai_explainer = ai_explainer
         self._app = app
+        self._pending_iem_tabs: tuple[TextProductTab, ...] = ()
 
         self._create_widgets()
         self._bind_events()
+        self._schedule_active_iem_tab_check()
 
         self.SetSize(wx.Size(700, 600))
         self.CenterOnParent()
@@ -114,29 +128,23 @@ class ForecastProductsDialog(wx.Dialog):
         self.notebook = wx.Notebook(self)
 
         self.panels: list[ForecastProductPanel] = []
-        cwa_office = getattr(self._location, "cwa_office", None)
-        location_name = getattr(self._location, "name", "")
 
+        pending_iem_tabs: list[TextProductTab] = []
         for tab in self._TABS:
+            if tab.loader_kind in _ACTIVE_IEM_LOADER_KINDS:
+                pending_iem_tabs.append(tab)
+                continue
             is_first_tab = len(self.panels) == 0
-            loader = self._make_loader(tab)
-            panel_cwa = cwa_office if tab.requires_cwa else "IEM"
-            panel = ForecastProductPanel(
-                parent=self.notebook,
-                product_type=tab.product_type,
-                product_loader=loader,
-                ai_explainer=self._ai_explainer,
-                cwa_office=panel_cwa,
-                location_name=location_name,
-                app=self._app,
-                availability_callback=self._on_panel_availability_resolved,
-                advanced_lookup_opener=self._make_advanced_lookup_opener(tab.product_type),
-                autoload=is_first_tab,
-            )
-            self.notebook.AddPage(panel, tab.label)
-            self.panels.append(panel)
+            self._add_tab_panel(tab, autoload=is_first_tab)
+        self._pending_iem_tabs = tuple(pending_iem_tabs)
 
         main_sizer.Add(self.notebook, 1, wx.ALL | wx.EXPAND, 8)
+
+        self.active_iem_status = wx.StaticText(
+            self,
+            label="Checking active SPC and WPC products...",
+        )
+        main_sizer.Add(self.active_iem_status, 0, wx.LEFT | wx.RIGHT | wx.EXPAND, 8)
 
         # Close button row.
         button_sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -146,6 +154,40 @@ class ForecastProductsDialog(wx.Dialog):
         main_sizer.Add(button_sizer, 0, wx.ALL | wx.EXPAND, 8)
 
         self.SetSizer(main_sizer)
+
+    def _add_tab_panel(
+        self,
+        tab: TextProductTab,
+        *,
+        autoload: bool,
+        product_override: object | None = None,
+    ) -> ForecastProductPanel:
+        """Add a notebook page for a resolved tab."""
+        cwa_office = getattr(self._location, "cwa_office", None)
+        location_name = getattr(self._location, "name", "")
+        if product_override is None:
+            loader = self._make_loader(tab)
+        else:
+
+            async def loader():
+                return product_override
+
+        panel_cwa = cwa_office if tab.requires_cwa else "IEM"
+        panel = ForecastProductPanel(
+            parent=self.notebook,
+            product_type=tab.product_type,
+            product_loader=loader,
+            ai_explainer=self._ai_explainer,
+            cwa_office=panel_cwa,
+            location_name=location_name,
+            app=self._app,
+            availability_callback=self._on_panel_availability_resolved,
+            advanced_lookup_opener=self._make_advanced_lookup_opener(tab.product_type),
+            autoload=autoload,
+        )
+        self.notebook.AddPage(panel, tab.label)
+        self.panels.append(panel)
+        return panel
 
     def _bind_events(self) -> None:
         """
@@ -161,9 +203,82 @@ class ForecastProductsDialog(wx.Dialog):
         self.notebook.Bind(wx.EVT_NOTEBOOK_PAGE_CHANGED, self._on_page_changed)
         self.Bind(wx.EVT_CHAR_HOOK, self._on_key)
 
+    def _schedule_active_iem_tab_check(self) -> None:
+        """Check optional IEM tabs in the background and add only active ones."""
+        if not self._pending_iem_tabs:
+            self._finish_active_iem_tab_check()
+            return
+        coro = self._resolve_active_iem_tabs()
+        runner = getattr(self._app, "run_async", None) if self._app is not None else None
+        if runner is not None:
+            runner(coro)
+            return
+        try:
+            asyncio.ensure_future(coro)
+        except RuntimeError:
+            coro.close()
+            self._finish_active_iem_tab_check()
+
+    async def _resolve_active_iem_tabs(self) -> None:
+        """Resolve active IEM products without touching wx objects off-thread."""
+        resolved = await asyncio.gather(
+            *(self._resolve_active_iem_tab(tab) for tab in self._pending_iem_tabs),
+            return_exceptions=True,
+        )
+        wx.CallAfter(self._add_resolved_active_iem_tabs, resolved)
+
+    async def _resolve_active_iem_tab(
+        self, tab: TextProductTab
+    ) -> tuple[TextProductTab, object] | None:
+        product = await self._make_loader(tab)()
+        if product is None:
+            return None
+        return tab, product
+
+    def _add_resolved_active_iem_tabs(self, resolved: list[object]) -> None:
+        for item in resolved:
+            if isinstance(item, Exception):
+                logger.info("Optional active IEM tab check failed: %s", item)
+                continue
+            if item is None:
+                continue
+            tab, product = item
+            self._add_tab_panel(tab, autoload=False, product_override=product)
+        self._finish_active_iem_tab_check()
+
+    def _finish_active_iem_tab_check(self) -> None:
+        status = getattr(self, "active_iem_status", None)
+        if status is not None:
+            status.SetLabel("")
+            status.Hide()
+            self.Layout()
+
     # ------------------------------------------------------------------
     # Loader wiring
     # ------------------------------------------------------------------
+    @staticmethod
+    def _active_iem_tab_product_or_none(product):
+        """Return ``None`` when an active-tab IEM summary has no current product."""
+        text = getattr(product, "product_text", "")
+        if not isinstance(text, str):
+            return product
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith(("Generated:",)):
+                continue
+            if any(stripped.startswith(prefix) for prefix in _INACTIVE_IEM_SUMMARY_PREFIXES):
+                return None
+        return product
+
+    async def _load_active_iem_tab_product(self, product_awaitable: Awaitable[object]):
+        """Load an optional active IEM tab, hiding it when IEM is slow or empty."""
+        try:
+            product = await product_awaitable
+        except IemProductFetchError as exc:
+            logger.info("Optional active IEM tab lookup failed: %s", exc)
+            return None
+        return self._active_iem_tab_product_or_none(product)
+
     def _make_loader(self, tab: TextProductTab) -> ProductLoader:
         """Bind a zero-arg loader for a configured product tab."""
         cwa_office = getattr(self._location, "cwa_office", None)
@@ -180,43 +295,53 @@ class ForecastProductsDialog(wx.Dialog):
             if latitude is None or longitude is None:
                 return None
             if tab.loader_kind == "spc_outlook":
-                return await self._service.get_iem_spc_outlook(
-                    latitude,
-                    longitude,
-                    day=1,
-                    current=True,
-                    max_items=3,
-                    timeout=4.0,
+                return await self._load_active_iem_tab_product(
+                    self._service.get_iem_spc_outlook(
+                        latitude,
+                        longitude,
+                        day=1,
+                        current=True,
+                        max_items=3,
+                        timeout=10.0,
+                    )
                 )
             if tab.loader_kind == "spc_mcd":
-                return await self._service.get_iem_spc_mcds(
-                    latitude,
-                    longitude,
-                    max_items=3,
-                    timeout=4.0,
+                return await self._load_active_iem_tab_product(
+                    self._service.get_iem_spc_mcds(
+                        latitude,
+                        longitude,
+                        max_items=3,
+                        timeout=10.0,
+                    )
                 )
             if tab.loader_kind == "spc_watches_current":
-                return await self._service.get_iem_spc_watches(
-                    latitude,
-                    longitude,
-                    max_items=3,
-                    timeout=4.0,
+                return await self._load_active_iem_tab_product(
+                    self._service.get_iem_spc_watches(
+                        latitude,
+                        longitude,
+                        max_items=3,
+                        timeout=10.0,
+                    )
                 )
             if tab.loader_kind == "wpc_ero":
-                return await self._service.get_iem_wpc_outlook(
-                    latitude,
-                    longitude,
-                    day=1,
-                    limit=1,
-                    max_items=3,
-                    timeout=4.0,
+                return await self._load_active_iem_tab_product(
+                    self._service.get_iem_wpc_outlook(
+                        latitude,
+                        longitude,
+                        day=1,
+                        limit=1,
+                        max_items=3,
+                        timeout=10.0,
+                    )
                 )
             if tab.loader_kind == "wpc_mpd":
-                return await self._service.get_iem_wpc_mpds(
-                    latitude,
-                    longitude,
-                    max_items=3,
-                    timeout=4.0,
+                return await self._load_active_iem_tab_product(
+                    self._service.get_iem_wpc_mpds(
+                        latitude,
+                        longitude,
+                        max_items=3,
+                        timeout=10.0,
+                    )
                 )
             return None
 

--- a/tests/gui/test_advanced_text_product_dialog.py
+++ b/tests/gui/test_advanced_text_product_dialog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -21,6 +22,7 @@ for _attr, _val in {
     "WXK_ESCAPE": 27,
     "ID_CLOSE": 5107,
     "ID_OK": 5100,
+    "CB_READONLY": 16,
 }.items():
     if not hasattr(_wx, _attr):
         setattr(_wx, _attr, _val)
@@ -34,7 +36,7 @@ def _neutralize_wx():
         return None
 
     _wx.Dialog.__init__ = _noop
-    for name in ("StaticText", "TextCtrl", "Button", "Choice", "CheckBox"):
+    for name in ("StaticText", "TextCtrl", "Button", "Choice", "ComboBox", "CheckBox"):
         saved[name] = getattr(_wx, name)
         setattr(
             _wx,
@@ -55,7 +57,7 @@ def _neutralize_wx():
     yield
 
     _wx.Dialog.__init__ = saved["Dialog.__init__"]
-    for name in ("StaticText", "TextCtrl", "Button", "Choice", "CheckBox"):
+    for name in ("StaticText", "TextCtrl", "Button", "Choice", "ComboBox", "CheckBox"):
         setattr(_wx, name, saved[name])
     _wx.CallAfter = saved["CallAfter"]
 
@@ -160,7 +162,38 @@ def test_lookup_can_fetch_spc_outlook_summary():
 
     dlg._run_lookup_sync()
 
-    service.get_iem_spc_outlook.assert_awaited_once_with(35.78, -78.64, day=1, current=True)
+    service.get_iem_spc_outlook.assert_awaited_once_with(
+        35.78,
+        -78.64,
+        day=1,
+        current=True,
+        valid_at=None,
+    )
+
+
+def test_lookup_can_fetch_spc_outlook_for_valid_time():
+    service = MagicMock()
+    service.get_iem_spc_outlook = AsyncMock(return_value=_product("SPC_OUTLOOK_DAY1"))
+
+    dlg = AdvancedTextProductDialog(
+        parent=MagicMock(),
+        location=_location(),
+        forecast_product_service=service,
+        initial_product_type="SPC Day 1 Outlook",
+    )
+    dlg.product_input.GetValue.return_value = "SPC Day 1 Outlook"
+    dlg.limit_input.GetValue.return_value = "1"
+    dlg.start_input.GetValue.return_value = "2026-03-06T20:00:00Z"
+    dlg.end_input.GetValue.return_value = ""
+    dlg.source_choice.GetStringSelection.return_value = "Prefer NWS when available"
+
+    dlg._run_lookup_sync()
+
+    service.get_iem_spc_outlook.assert_awaited_once()
+    assert service.get_iem_spc_outlook.await_args.kwargs["current"] is False
+    assert service.get_iem_spc_outlook.await_args.kwargs["valid_at"].isoformat() == (
+        "2026-03-06T20:00:00+00:00"
+    )
 
 
 def test_product_preset_updates_product_input():
@@ -223,7 +256,14 @@ def test_lookup_can_fetch_wpc_mpd_summary():
 
     dlg._run_lookup_sync()
 
-    service.get_iem_wpc_mpds.assert_awaited_once_with(35.78, -78.64)
+    service.get_iem_wpc_mpds.assert_awaited_once_with(
+        35.78,
+        -78.64,
+        active_only=False,
+        start=None,
+        end=None,
+        max_items=1,
+    )
 
 
 def test_lookup_can_fetch_spc_watch_summary():
@@ -248,3 +288,29 @@ def test_lookup_can_fetch_spc_watch_summary():
     assert service.get_iem_spc_watches.await_args.kwargs["valid_at"].isoformat() == (
         "2026-03-16T15:00:00+00:00"
     )
+
+
+def test_date_preset_populates_start_and_end_inputs(monkeypatch):
+    service = MagicMock()
+    dlg = AdvancedTextProductDialog(
+        parent=MagicMock(),
+        location=_location(),
+        forecast_product_service=service,
+        initial_product_type="AFD",
+    )
+    dlg.date_preset_choice.GetStringSelection.return_value = "Past 7 days"
+    monkeypatch.setattr(
+        AdvancedTextProductDialog,
+        "_date_range_for_preset",
+        staticmethod(
+            lambda _preset: (
+                datetime(2026, 4, 27, 12, 0, tzinfo=UTC),
+                datetime(2026, 5, 4, 12, 0, tzinfo=UTC),
+            )
+        ),
+    )
+
+    dlg._on_date_preset(MagicMock())
+
+    dlg.start_input.SetValue.assert_called_once_with("2026-04-27T12:00:00Z")
+    dlg.end_input.SetValue.assert_called_once_with("2026-05-04T12:00:00Z")

--- a/tests/gui/test_forecast_products_dialog.py
+++ b/tests/gui/test_forecast_products_dialog.py
@@ -11,6 +11,7 @@ pattern.
 from __future__ import annotations
 
 import sys
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -77,7 +78,8 @@ for _meth in ("SetSizer", "GetSizer", "Bind", "Layout", "Show", "Hide"):
 # ---------------------------------------------------------------------------
 # Imports under test
 # ---------------------------------------------------------------------------
-from accessiweather.models import Location  # noqa: E402
+from accessiweather.iem_client import IemProductFetchError  # noqa: E402
+from accessiweather.models import Location, TextProduct  # noqa: E402
 from accessiweather.ui.dialogs.forecast_products_dialog import (  # noqa: E402
     ForecastProductsDialog,
 )
@@ -228,6 +230,38 @@ def sample_us_location():
 # Dialog-level tests
 # ---------------------------------------------------------------------------
 class TestForecastProductsDialog:
+    def test_inactive_iem_summary_counts_as_unavailable_for_active_tabs(self):
+        product = TextProduct(
+            product_type="WPC_ERO",
+            product_id="WPC_ERO_DAY1",
+            cwa_office="WPC",
+            issuance_time=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+            product_text=(
+                "WPC Day 1 Excessive Rainfall Outlook\n\n"
+                "Generated: 2026-05-01T12:00:00Z\n\n"
+                "No active outlooks were returned."
+            ),
+            headline="WPC Day 1 Excessive Rainfall Outlook",
+        )
+
+        result = ForecastProductsDialog._active_iem_tab_product_or_none(product)
+
+        assert result is None
+
+    def test_active_iem_summary_remains_available_for_active_tabs(self):
+        product = TextProduct(
+            product_type="SPC_WATCHES",
+            product_id="SPC_WATCHES",
+            cwa_office="SPC",
+            issuance_time=None,
+            product_text=("SPC Watches\n\nWatch 1:\nSEL: SEL8\nType: SVR\n"),
+            headline="SPC Watches",
+        )
+
+        result = ForecastProductsDialog._active_iem_tab_product_or_none(product)
+
+        assert result is product
+
     def test_dialog_builds_location_relevant_text_product_tabs(
         self, notebook_factory, panel_factory, sample_us_location
     ):
@@ -242,20 +276,8 @@ class TestForecastProductsDialog:
         )
 
         types = [entry["product_type"] for entry in panel_factory]
-        assert types == [
-            "AFD",
-            "HWO",
-            "SPS",
-            "LSR",
-            "PNS",
-            "CLI",
-            "SPC_OUTLOOK",
-            "SPC_MCD",
-            "SPC_WATCHES",
-            "WPC_ERO",
-            "WPC_MPD",
-        ]
-        assert len(dlg.panels) == 11
+        assert types == ["AFD", "HWO", "SPS"]
+        assert len(dlg.panels) == 3
 
         # Each panel got wired to the same service + explainer.
         for entry in panel_factory:
@@ -295,33 +317,6 @@ class TestForecastProductsDialog:
         finally:
             loop.close()
 
-    def test_loader_invokes_service_history_for_extra_local_products(
-        self, notebook_factory, panel_factory, sample_us_location
-    ):
-        """Extra local tabs use official NWS product history."""
-        import asyncio
-
-        service = MagicMock(name="ForecastProductService")
-
-        async def _fake_history(product_type, cwa_office, **kwargs):
-            return [SimpleNamespace(product_type=product_type, cwa=cwa_office, kwargs=kwargs)]
-
-        service.get_history.side_effect = _fake_history
-
-        ForecastProductsDialog(
-            parent=MagicMock(),
-            location=sample_us_location,
-            forecast_product_service=service,
-            ai_explainer=None,
-        )
-
-        lsr_entry = next(entry for entry in panel_factory if entry["product_type"] == "LSR")
-        result = asyncio.run(lsr_entry["product_loader"]())
-
-        assert result[0].product_type == "LSR"
-        assert result[0].cwa == "RAH"
-        assert result[0].kwargs == {"limit": 1}
-
     def test_loader_invokes_iem_for_point_based_tabs(
         self, notebook_factory, panel_factory, sample_us_location
     ):
@@ -340,21 +335,82 @@ class TestForecastProductsDialog:
 
         service.get_iem_spc_outlook.side_effect = _fake_spc_outlook
 
-        ForecastProductsDialog(
+        dlg = ForecastProductsDialog(
             parent=MagicMock(),
             location=sample_us_location,
             forecast_product_service=service,
             ai_explainer=None,
         )
 
-        spc_entry = next(entry for entry in panel_factory if entry["product_type"] == "SPC_OUTLOOK")
-        result = asyncio.run(spc_entry["product_loader"]())
+        spc_tab = next(
+            tab for tab in ForecastProductsDialog._TABS if tab.product_type == "SPC_OUTLOOK"
+        )
+        result = asyncio.run(dlg._make_loader(spc_tab)())
 
         assert result.product_type == "SPC_OUTLOOK"
         assert result.latitude == 35.7796
         assert result.longitude == -78.6382
-        assert result.kwargs == {"day": 1, "current": True, "max_items": 3, "timeout": 4.0}
+        assert result.kwargs == {"day": 1, "current": True, "max_items": 3, "timeout": 10.0}
         service.get_iem_afos.assert_not_called()
+
+    def test_point_based_loader_returns_none_for_inactive_iem_summary(
+        self, notebook_factory, panel_factory, sample_us_location
+    ):
+        """No-active IEM summaries disappear from the active tab strip."""
+        import asyncio
+
+        service = MagicMock(name="ForecastProductService")
+
+        async def _fake_wpc_outlook(latitude, longitude, **kwargs):
+            return TextProduct(
+                product_type="WPC_ERO",
+                product_id="WPC_ERO_DAY1",
+                cwa_office="WPC",
+                issuance_time=None,
+                product_text="WPC Day 1 Excessive Rainfall Outlook\n\nNo active outlooks were returned.",
+                headline="WPC Day 1 Excessive Rainfall Outlook",
+            )
+
+        service.get_iem_wpc_outlook.side_effect = _fake_wpc_outlook
+
+        dlg = ForecastProductsDialog(
+            parent=MagicMock(),
+            location=sample_us_location,
+            forecast_product_service=service,
+            ai_explainer=None,
+        )
+
+        wpc_tab = next(tab for tab in ForecastProductsDialog._TABS if tab.product_type == "WPC_ERO")
+        result = asyncio.run(dlg._make_loader(wpc_tab)())
+
+        assert result is None
+
+    def test_point_based_loader_returns_none_for_iem_fetch_error(
+        self, notebook_factory, panel_factory, sample_us_location
+    ):
+        """Optional active IEM tabs disappear when IEM is too slow or unavailable."""
+        import asyncio
+
+        service = MagicMock(name="ForecastProductService")
+
+        async def _fake_spc_outlook(latitude, longitude, **kwargs):
+            raise IemProductFetchError("IEM SPC outlook request failed: TimeoutException")
+
+        service.get_iem_spc_outlook.side_effect = _fake_spc_outlook
+
+        dlg = ForecastProductsDialog(
+            parent=MagicMock(),
+            location=sample_us_location,
+            forecast_product_service=service,
+            ai_explainer=None,
+        )
+
+        spc_tab = next(
+            tab for tab in ForecastProductsDialog._TABS if tab.product_type == "SPC_OUTLOOK"
+        )
+        result = asyncio.run(dlg._make_loader(spc_tab)())
+
+        assert result is None
 
     def test_dialog_passes_advanced_lookup_opener_to_panels(
         self, notebook_factory, panel_factory, sample_us_location
@@ -369,7 +425,7 @@ class TestForecastProductsDialog:
         )
 
         openers = [entry["advanced_lookup_opener"] for entry in panel_factory]
-        assert len(openers) == 11
+        assert len(openers) == 3
         for opener in openers:
             assert callable(opener)
 
@@ -396,12 +452,12 @@ class TestForecastProductsDialog:
             forecast_product_service=service,
             ai_explainer=None,
         )
-        notebook_factory["instance"].GetSelection.return_value = 4
+        notebook_factory["instance"].GetSelection.return_value = 2
         event = MagicMock()
 
         dlg._on_page_changed(event)
 
-        panel_factory[4]["instance"].ensure_loaded.assert_called_once()
+        panel_factory[2]["instance"].ensure_loaded.assert_called_once()
         event.Skip.assert_called_once()
 
     def test_page_change_does_not_steal_focus(
@@ -422,8 +478,14 @@ class TestForecastProductsDialog:
             forecast_product_service=service,
             ai_explainer=None,
         )
-        # _on_page_changed was removed — the handler must no longer exist.
-        assert not hasattr(dlg, "_on_page_changed")
+        notebook_factory["instance"].GetSelection.return_value = 1
+        event = MagicMock()
+
+        dlg._on_page_changed(event)
+
+        panel_factory[1]["instance"].ensure_loaded.assert_called_once()
+        panel_factory[1]["instance"].product_textctrl.SetFocus.assert_not_called()
+        event.Skip.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_forecast_product_service.py
+++ b/tests/test_forecast_product_service.py
@@ -226,7 +226,13 @@ class TestForecastProductServiceIemStructuredProducts:
         async def fake_wpc_mpds(lat, lon, **kwargs):
             assert lat == 35.78
             assert lon == -78.64
-            assert kwargs == {"max_items": 5, "timeout": 10.0}
+            assert kwargs == {
+                "active_only": True,
+                "start": None,
+                "end": None,
+                "max_items": 5,
+                "timeout": 10.0,
+            }
             return product
 
         monkeypatch.setattr(

--- a/tests/test_iem_text_products.py
+++ b/tests/test_iem_text_products.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
+from accessiweather import iem_client
 from accessiweather.iem_client import (
     IemProductFetchError,
     fetch_iem_afos_text,
@@ -140,6 +141,86 @@ async def test_spc_outlook_returns_accessible_summary():
 
 
 @pytest.mark.asyncio
+async def test_spc_outlook_accepts_current_singular_outlook_shape():
+    client = _client(
+        _resp(
+            {
+                "generated_at": "2026-05-01T12:00:00Z",
+                "outlook": {
+                    "category": "MRGL",
+                    "threshold": "CATEGORICAL",
+                    "valid": "2026-05-01T13:00:00Z",
+                },
+            }
+        )
+    )
+
+    result = await fetch_iem_spc_outlook(
+        38.907,
+        -77.037,
+        day=1,
+        current=True,
+        client=client,
+        iem_base_url=IEM_BASE,
+    )
+
+    assert "MRGL" in result.product_text
+    assert "CATEGORICAL" in result.product_text
+
+
+@pytest.mark.asyncio
+async def test_spc_outlook_valid_time_query_uses_time_parameter():
+    valid_at = datetime(2026, 3, 6, 20, 0, tzinfo=UTC)
+    client = _client(
+        _resp(
+            {
+                "generated_at": "2026-03-06T20:00:00Z",
+                "outlook": {
+                    "category": "SLGT",
+                    "threshold": "CATEGORICAL",
+                    "valid": "2026-03-06T20:00:00Z",
+                },
+            }
+        )
+    )
+
+    await fetch_iem_spc_outlook(
+        38.907,
+        -77.037,
+        day=2,
+        current=False,
+        valid_at=valid_at,
+        client=client,
+        iem_base_url=IEM_BASE,
+    )
+
+    assert client.get.call_args.kwargs["params"] == {
+        "lat": 38.907,
+        "lon": -77.037,
+        "day": 2,
+        "fmt": "json",
+        "current": 0,
+        "time": "2026-03-06T20:00:00Z",
+    }
+
+
+@pytest.mark.asyncio
+async def test_spc_outlook_timeout_error_names_exception():
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.get.side_effect = httpx.TimeoutException("")
+
+    with pytest.raises(IemProductFetchError, match="TimeoutException"):
+        await fetch_iem_spc_outlook(
+            38.907,
+            -77.037,
+            day=1,
+            current=True,
+            client=client,
+            iem_base_url=IEM_BASE,
+        )
+
+
+@pytest.mark.asyncio
 async def test_spc_mcd_returns_accessible_summary():
     client = _client(
         _resp(
@@ -194,7 +275,45 @@ async def test_spc_mcd_summary_can_limit_items():
 
 
 @pytest.mark.asyncio
+async def test_spc_mcd_advanced_lookup_can_filter_archive_window():
+    client = _client(
+        _resp(
+            {
+                "mcds": [
+                    {
+                        "mdnum": 1,
+                        "utc_issue": "2026-05-01T12:00:00Z",
+                        "utc_expire": "2026-05-01T14:00:00Z",
+                        "concerning": "inside",
+                    },
+                    {
+                        "mdnum": 2,
+                        "utc_issue": "2026-04-01T12:00:00Z",
+                        "utc_expire": "2026-04-01T14:00:00Z",
+                        "concerning": "outside",
+                    },
+                ]
+            }
+        )
+    )
+
+    result = await fetch_iem_spc_mcds(
+        42.0,
+        -95.0,
+        active_only=False,
+        start=datetime(2026, 5, 1, 0, 0, tzinfo=UTC),
+        end=datetime(2026, 5, 2, 0, 0, tzinfo=UTC),
+        client=client,
+        iem_base_url=IEM_BASE,
+    )
+
+    assert "inside" in result.product_text
+    assert "outside" not in result.product_text
+
+
+@pytest.mark.asyncio
 async def test_spc_watches_returns_accessible_summary():
+    valid_at = datetime(2026, 3, 16, 18, 0, tzinfo=UTC)
     client = _client(
         _resp(
             {
@@ -217,6 +336,7 @@ async def test_spc_watches_returns_accessible_summary():
     result = await fetch_iem_spc_watches(
         38.0,
         -77.0,
+        valid_at=valid_at,
         client=client,
         iem_base_url=IEM_BASE,
         max_items=3,
@@ -227,11 +347,56 @@ async def test_spc_watches_returns_accessible_summary():
     assert "SEL7" in result.product_text
     assert "TOR" in result.product_text
     client.get.assert_called_once()
-    assert client.get.call_args.kwargs["params"] == {"lat": 38.0, "lon": -77.0}
+    assert client.get.call_args.kwargs["params"] == {
+        "lat": 38.0,
+        "lon": -77.0,
+        "ts": "202603161800",
+    }
+
+
+@pytest.mark.asyncio
+async def test_spc_watches_filters_expired_matches():
+    valid_at = datetime(2026, 3, 16, 23, 30, tzinfo=UTC)
+    client = _client(
+        _resp(
+            {
+                "features": [
+                    {
+                        "properties": {
+                            "sel": "SEL7",
+                            "type": "TOR",
+                            "issue": "2026-03-16T14:50:00Z",
+                            "expire": "2026-03-16T23:13:00Z",
+                        }
+                    },
+                    {
+                        "properties": {
+                            "sel": "SEL8",
+                            "type": "SVR",
+                            "issue": "2026-03-16T23:00:00Z",
+                            "expire": "2026-03-17T04:00:00Z",
+                        }
+                    },
+                ]
+            }
+        )
+    )
+
+    result = await fetch_iem_spc_watches(
+        38.0,
+        -77.0,
+        valid_at=valid_at,
+        client=client,
+        iem_base_url=IEM_BASE,
+    )
+
+    assert "SEL7" not in result.product_text
+    assert "SEL8" in result.product_text
 
 
 @pytest.mark.asyncio
 async def test_wpc_outlook_returns_accessible_summary():
+    valid_at = datetime(2026, 3, 16, 18, 0, tzinfo=UTC)
     client = _client(
         _resp(
             {
@@ -254,6 +419,7 @@ async def test_wpc_outlook_returns_accessible_summary():
         38.907,
         -77.037,
         day=1,
+        valid_at=valid_at,
         client=client,
         iem_base_url=IEM_BASE,
     )
@@ -267,11 +433,55 @@ async def test_wpc_outlook_returns_accessible_summary():
         "day": 1,
         "fmt": "json",
         "last": 1,
+        "time": "2026-03-16T18:00:00Z",
+    }
+
+
+@pytest.mark.asyncio
+async def test_wpc_outlook_uses_current_keyword_for_active_lookup(monkeypatch):
+    monkeypatch.setattr(
+        iem_client,
+        "_now_utc",
+        lambda: datetime(2026, 5, 1, 18, 0, tzinfo=UTC),
+    )
+    client = _client(
+        _resp(
+            {
+                "generated_at": "2026-05-01T12:00:00Z",
+                "outlook": {
+                    "day": 1,
+                    "utc_product_issue": "2026-05-01T07:22:00Z",
+                    "utc_issue": "2026-05-01T12:00:00Z",
+                    "utc_expire": "2026-05-02T12:00:00Z",
+                    "threshold": "MRGL",
+                    "category": "CATEGORICAL",
+                },
+            }
+        )
+    )
+
+    result = await fetch_iem_wpc_outlook(
+        38.907,
+        -77.037,
+        day=1,
+        client=client,
+        iem_base_url=IEM_BASE,
+    )
+
+    assert "MRGL" in result.product_text
+    assert client.get.call_args.kwargs["params"] == {
+        "lat": 38.907,
+        "lon": -77.037,
+        "day": 1,
+        "fmt": "json",
+        "last": 1,
+        "time": "current",
     }
 
 
 @pytest.mark.asyncio
 async def test_wpc_mpd_returns_accessible_summary():
+    active_at = datetime(2025, 8, 14, 20, 0, tzinfo=UTC)
     client = _client(
         _resp(
             {
@@ -291,6 +501,7 @@ async def test_wpc_mpd_returns_accessible_summary():
     result = await fetch_iem_wpc_mpds(
         38.907,
         -77.037,
+        active_at=active_at,
         client=client,
         iem_base_url=IEM_BASE,
         max_items=3,
@@ -300,3 +511,31 @@ async def test_wpc_mpd_returns_accessible_summary():
     assert "WPC Mesoscale Precipitation Discussions" in result.product_text
     assert "934" in result.product_text
     assert "FLASH FLOODING POSSIBLE" in result.product_text
+
+
+@pytest.mark.asyncio
+async def test_wpc_mpd_filters_expired_discussions():
+    client = _client(
+        _resp(
+            {
+                "mpds": [
+                    {
+                        "product_num": 934,
+                        "utc_issue": "2025-08-14T19:27:00Z",
+                        "utc_expire": "2025-08-14T22:27:00Z",
+                    }
+                ]
+            }
+        )
+    )
+
+    result = await fetch_iem_wpc_mpds(
+        38.907,
+        -77.037,
+        active_at=datetime(2025, 8, 14, 23, 0, tzinfo=UTC),
+        client=client,
+        iem_base_url=IEM_BASE,
+    )
+
+    assert "934" not in result.product_text
+    assert "No active discussions were returned." in result.product_text


### PR DESCRIPTION
## Summary
- send current timestamps to IEM point-in-time watch and WPC outlook lookups
- filter SPC watches, SPC MCDs, WPC EROs, and WPC MPDs by valid/expire windows before showing active-tab content
- add regression coverage for expired SPC watches and WPC MPDs

## Verification
- uv run ruff check src tests
- uv run pytest -q -n 0 --tb=short tests/test_iem_text_products.py

## Notes
- Preserved the pre-existing local CHANGELOG edit in git stash: preserve local changelog before dev ff