### PR TITLE
ci(build): add Linux Nuitka build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,10 +215,103 @@ jobs:
           path: .nuitka-cache
           key: nuitka-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'installer/build_nuitka.py') }}-${{ github.run_id }}
 
+  build-linux:
+    name: Linux
+    needs: prepare
+    if: needs.prepare.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/pip
+            ~/Library/Caches/pip
+            ~\AppData\Local\pip\Cache
+          key: pip-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            pip-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+            pip-${{ runner.os }}-
+
+      - uses: actions/cache/restore@v5
+        with:
+          path: .nuitka-cache
+          key: nuitka-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'installer/build_nuitka.py') }}-${{ github.run_id }}
+          restore-keys: |
+            nuitka-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'installer/build_nuitka.py') }}-
+            nuitka-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            ccache \
+            libgtk-3-dev \
+            libnotify-dev \
+            libsdl2-dev \
+            libwebkit2gtk-4.1-dev \
+            freeglut3-dev \
+            xvfb
+
+      - name: Install dependencies
+        run: |
+          pip install \
+            -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04 \
+            --only-binary wxPython \
+            wxPython
+          pip install -e .[build]
+
+      - name: Build
+        timeout-minutes: 55
+        run: |
+          python scripts/generate_build_meta.py ${{ needs.prepare.outputs.is_nightly == 'true' && needs.prepare.outputs.tag || '' }}
+          python installer/create_icons.py
+          python installer/build_nuitka.py --tag "${{ needs.prepare.outputs.is_nightly == 'true' && needs.prepare.outputs.tag || '' }}"
+
+      - name: Smoke test packaged app
+        env:
+          ACCESSIWEATHER_TEST_MODE: "1"
+          XDG_DATA_HOME: ${{ runner.temp }}/accessiweather-data
+          XDG_CONFIG_HOME: ${{ runner.temp }}/accessiweather-config
+        run: |
+          set +e
+          timeout 25s xvfb-run -a dist/AccessiWeather/AccessiWeather > linux-smoke.log 2>&1
+          status=$?
+          set -e
+          cat linux-smoke.log
+          if grep -E "cannot register existing type 'G(Task|AsyncResult|InputStream|Seekable|PollableInputStream)'|GLib-GObject-CRITICAL" linux-smoke.log; then
+            echo "Packaged Linux app hit the GLib/GIO duplicate type-registration crash."
+            exit 1
+          fi
+          if [ "$status" -ne 0 ] && [ "$status" -ne 124 ]; then
+            echo "Packaged Linux app exited unexpectedly with status $status."
+            exit "$status"
+          fi
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: linux
+          path: dist/AccessiWeather_Linux_*.zip
+
+      - uses: actions/cache/save@v5
+        if: always()
+        with:
+          path: .nuitka-cache
+          key: nuitka-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'installer/build_nuitka.py') }}-${{ github.run_id }}
+
   release:
     name: Release
-    needs: [prepare, build-windows, build-macos]
-    if: always() && needs.prepare.outputs.should_build == 'true' && (needs.build-windows.result == 'success' || needs.build-macos.result == 'success')
+    needs: [prepare, build-windows, build-macos, build-linux]
+    if: always() && needs.prepare.outputs.should_build == 'true' && (needs.build-windows.result == 'success' || needs.build-macos.result == 'success' || needs.build-linux.result == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -253,12 +346,14 @@ jobs:
                 *Setup*.exe) mv "$f" "assets/AccessiWeather-nightly-${TIMESTAMP}-windows-setup.exe" ;;
                 *Portable*.zip) mv "$f" "assets/AccessiWeather-nightly-${TIMESTAMP}-windows-portable.zip" ;;
                 *macOS*.zip) mv "$f" "assets/AccessiWeather-nightly-${TIMESTAMP}-macOS.zip" ;;
+                *Linux*.zip) mv "$f" "assets/AccessiWeather-nightly-${TIMESTAMP}-linux.zip" ;;
               esac
             else
               case "$name" in
                 *Setup*.exe) mv "$f" "assets/AccessiWeather-${VERSION}-windows-setup.exe" ;;
                 *Portable*.zip) mv "$f" "assets/AccessiWeather-${VERSION}-windows-portable.zip" ;;
                 *macOS*.zip) mv "$f" "assets/AccessiWeather-${VERSION}-macOS.zip" ;;
+                *Linux*.zip) mv "$f" "assets/AccessiWeather-${VERSION}-linux.zip" ;;
               esac
             fi
           done

--- a/installer/build_nuitka.py
+++ b/installer/build_nuitka.py
@@ -18,6 +18,13 @@ BUILD_DIR = ROOT / "build" / "nuitka"
 RESOURCES_DIR = SRC_DIR / "accessiweather" / "resources"
 SOUNDPACKS_DIR = ROOT / "soundpacks"
 APP_NAME = "AccessiWeather"
+LINUX_SYSTEM_DLL_EXCLUDES = (
+    "libgio-2.0.so*",
+    "libglib-2.0.so*",
+    "libgmodule-2.0.so*",
+    "libgobject-2.0.so*",
+    "libgthread-2.0.so*",
+)
 
 
 def _repo_path(path: Path) -> str:
@@ -68,7 +75,13 @@ def _find_nuitka_output_dir() -> tuple[Path, str]:
 def stage_nuitka_distribution() -> Path:
     """Copy Nuitka standalone output into the layout expected by Inno and ZIP code."""
     source_dir, output_kind = _find_nuitka_output_dir()
-    target_dir = DIST_DIR / ("AccessiWeather.app" if output_kind == "app" else "AccessiWeather_dir")
+    if output_kind == "app":
+        target_name = "AccessiWeather.app"
+    elif platform.system() == "Linux":
+        target_name = "AccessiWeather"
+    else:
+        target_name = "AccessiWeather_dir"
+    target_dir = DIST_DIR / target_name
     if target_dir.exists():
         shutil.rmtree(target_dir)
     DIST_DIR.mkdir(parents=True, exist_ok=True)
@@ -173,6 +186,11 @@ def build_nuitka_command(
                 f"--macos-app-icon={_repo_path(icon)}",
             ]
         )
+    elif system == "Linux":
+        # GTK loads the host GLib/GIO stack. Shipping another copy can trigger
+        # duplicate GType registration crashes such as "cannot register existing
+        # type 'GTask'" when wx/GTK and other GLib consumers initialize.
+        command.extend(f"--noinclude-dlls={pattern}" for pattern in LINUX_SYSTEM_DLL_EXCLUDES)
 
     return command
 

--- a/src/accessiweather/services/simple_update.py
+++ b/src/accessiweather/services/simple_update.py
@@ -220,9 +220,10 @@ def select_asset(
                 if asset.get("name", "").lower().endswith(ext):
                     return asset
     else:
-        for ext in (".appimage", ".deb", ".rpm", ".tar.gz"):
+        for ext in (".appimage", ".deb", ".rpm", ".tar.gz", ".zip"):
             for asset in filtered:
-                if asset.get("name", "").lower().endswith(ext):
+                name = asset.get("name", "").lower()
+                if name.endswith(ext) and ("linux" in name or ext != ".zip"):
                     return asset
 
     return filtered[0] if filtered else (assets[0] if assets else None)

--- a/tests/test_installer_build.py
+++ b/tests/test_installer_build.py
@@ -92,3 +92,27 @@ def test_create_portable_zip_fails_when_default_soundpack_manifest_missing(
 
     assert build.create_portable_zip() is False
     assert not (dist_dir / "AccessiWeather_Portable_v9.9.9.zip").exists()
+
+
+def test_create_linux_zip_from_nuitka_distribution(tmp_path, monkeypatch) -> None:
+    """Linux Nuitka builds stage as dist/AccessiWeather and zip that directory."""
+    dist_dir = tmp_path / "dist"
+    source_dir = dist_dir / "AccessiWeather"
+    source_dir.mkdir(parents=True)
+    (source_dir / "AccessiWeather").write_bytes(b"fake-linux-exe")
+
+    monkeypatch.setattr(build, "IS_WINDOWS", False)
+    monkeypatch.setattr(build, "IS_MACOS", False)
+    monkeypatch.setattr(build, "IS_LINUX", True)
+    monkeypatch.setattr(build, "DIST_DIR", dist_dir)
+    monkeypatch.setattr(build, "get_version", lambda: "9.9.9")
+
+    assert build.create_portable_zip() is True
+
+    zip_path = dist_dir / "AccessiWeather_Linux_v9.9.9.zip"
+    assert zip_path.exists()
+
+    with zipfile.ZipFile(zip_path) as archive:
+        names = set(archive.namelist())
+
+    assert "AccessiWeather/AccessiWeather" in names

--- a/tests/test_installer_version_metadata.py
+++ b/tests/test_installer_version_metadata.py
@@ -45,3 +45,14 @@ def test_build_workflow_uses_nuitka_for_macos_artifacts():
     assert "python installer/build_nuitka.py" in workflow
     assert "dist/AccessiWeather_macOS_*.zip" in workflow
     assert 'zip -r "AccessiWeather_v${VERSION}_macOS.zip"' not in workflow
+
+
+def test_build_workflow_uses_nuitka_for_linux_artifacts():
+    workflow = (ROOT / ".github" / "workflows" / "build.yml").read_text()
+
+    assert "build-linux:" in workflow
+    assert "libwebkit2gtk-4.1-dev" in workflow
+    assert "xvfb-run -a dist/AccessiWeather/AccessiWeather" in workflow
+    assert "dist/AccessiWeather_Linux_*.zip" in workflow
+    assert "AccessiWeather-nightly-${TIMESTAMP}-linux.zip" in workflow
+    assert "AccessiWeather-${VERSION}-linux.zip" in workflow

--- a/tests/test_nuitka_build.py
+++ b/tests/test_nuitka_build.py
@@ -66,6 +66,19 @@ def test_macos_nuitka_command_uses_app_mode() -> None:
     assert "--include-data-dir=src/accessiweather/resources=accessiweather/resources" not in command
 
 
+def test_linux_nuitka_command_excludes_host_glib_stack() -> None:
+    command = build_nuitka.build_nuitka_command(
+        output_dir=Path("dist"),
+        build_tag=None,
+        assume_platform="Linux",
+    )
+
+    assert "--mode=standalone" in command
+    assert "--include-data-dir=src/accessiweather/resources=accessiweather/resources" in command
+    for pattern in build_nuitka.LINUX_SYSTEM_DLL_EXCLUDES:
+        assert f"--noinclude-dlls={pattern}" in command
+
+
 def test_nuitka_is_available_as_build_extra() -> None:
     pyproject = (build_nuitka.ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
@@ -85,8 +98,11 @@ def test_production_build_workflow_uses_nuitka() -> None:
     assert "--only-binary wxPython" in workflow
     assert "dist/AccessiWeather_Setup_*.exe" in workflow
     assert "dist/AccessiWeather_macOS_*.zip" in workflow
+    assert "dist/AccessiWeather_Linux_*.zip" in workflow
     assert "python installer/build_nuitka.py" in workflow
     assert "scripts/generate_build_meta.py" in workflow
+    assert "Smoke test packaged app" in workflow
+    assert "GLib-GObject-CRITICAL" in workflow
 
 
 def test_stage_nuitka_distribution_copies_output_to_dist_shape(tmp_path, monkeypatch) -> None:
@@ -99,6 +115,7 @@ def test_stage_nuitka_distribution_copies_output_to_dist_shape(tmp_path, monkeyp
     dist_dir = tmp_path / "dist"
     monkeypatch.setattr(build_nuitka, "BUILD_DIR", build_dir)
     monkeypatch.setattr(build_nuitka, "DIST_DIR", dist_dir)
+    monkeypatch.setattr(build_nuitka.platform, "system", lambda: "Windows")
 
     staged = build_nuitka.stage_nuitka_distribution()
 
@@ -143,6 +160,25 @@ def test_stage_nuitka_distribution_copies_macos_app_to_dist_shape(tmp_path, monk
 
     assert staged == dist_dir / "AccessiWeather.app"
     assert (staged / "Contents" / "MacOS" / "AccessiWeather").read_bytes() == b"fake-app"
+
+
+def test_stage_nuitka_distribution_copies_linux_output_to_zip_source_shape(
+    tmp_path, monkeypatch
+) -> None:
+    build_dir = tmp_path / "build" / "nuitka"
+    nuitka_dist = build_dir / "__main__.dist"
+    nuitka_dist.mkdir(parents=True)
+    (nuitka_dist / "AccessiWeather").write_bytes(b"fake-linux-exe")
+
+    dist_dir = tmp_path / "dist"
+    monkeypatch.setattr(build_nuitka, "BUILD_DIR", build_dir)
+    monkeypatch.setattr(build_nuitka, "DIST_DIR", dist_dir)
+    monkeypatch.setattr(build_nuitka.platform, "system", lambda: "Linux")
+
+    staged = build_nuitka.stage_nuitka_distribution()
+
+    assert staged == dist_dir / "AccessiWeather"
+    assert (staged / "AccessiWeather").read_bytes() == b"fake-linux-exe"
 
 
 def test_stage_nuitka_distribution_fails_when_output_missing(tmp_path, monkeypatch) -> None:

--- a/tests/test_simple_update.py
+++ b/tests/test_simple_update.py
@@ -108,6 +108,20 @@ def test_select_asset_windows_portable():
     assert asset["name"].endswith(".zip")
 
 
+def test_select_asset_linux_prefers_linux_zip():
+    release = _release(
+        assets=[
+            {"name": "AccessiWeather-nightly-20260505-windows-portable.zip"},
+            {"name": "AccessiWeather-nightly-20260505-linux.zip"},
+            {"name": "checksums.txt"},
+        ]
+    )
+
+    asset = select_asset(release, portable=False, platform_system="Linux")
+
+    assert asset["name"] == "AccessiWeather-nightly-20260505-linux.zip"
+
+
 def test_build_portable_update_script_contains_extract_and_restart():
     script = build_portable_update_script(
         Path("C:/temp/update.zip"),


### PR DESCRIPTION
## Summary
- add a Linux Nuitka build job that produces a Linux ZIP artifact
- smoke-test the packaged Linux app under xvfb and fail on the GLib/GIO duplicate type-registration crash from the user log
- avoid bundling Linux GLib/GIO runtime libraries so wx/GTK uses the host stack
- let the updater choose Linux ZIP assets without grabbing Windows portable ZIPs

## Verification
- python -m pytest tests/test_nuitka_build.py tests/test_installer_build.py tests/test_installer_version_metadata.py tests/test_simple_update.py -q
- python -m ruff check installer/build_nuitka.py installer/build.py src/accessiweather/services/simple_update.py tests/test_nuitka_build.py tests/test_installer_build.py tests/test_installer_version_metadata.py tests/test_simple_update.py
- git --no-pager diff --check