### PR TITLE
fix(build): ship Linux builds as tarballs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -27,7 +27,7 @@ This directory contains the GitHub Actions workflows for AccessiWeather. Below i
 - Manual dispatch (with optional version override)
 
 **What it does**:
-- Builds Windows installer + portable ZIP and macOS DMG
+- Builds Windows installer + portable ZIP, macOS ZIP, and Linux tarball
 - Creates nightly or stable GitHub releases
 
 ---

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,7 +300,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: linux
-          path: dist/AccessiWeather_Linux_*.zip
+          path: dist/AccessiWeather_Linux_*.tar.gz
 
       - uses: actions/cache/save@v5
         if: always()
@@ -338,7 +338,7 @@ jobs:
           TIMESTAMP=$(date -u +%Y%m%d)
 
           # Rename assets based on release type
-          for f in dist/*.exe dist/*.zip; do
+          for f in dist/*.exe dist/*.zip dist/*.tar.gz; do
             [ -f "$f" ] || continue
             name=$(basename "$f")
             if [ "$IS_NIGHTLY" = "true" ]; then
@@ -346,14 +346,14 @@ jobs:
                 *Setup*.exe) mv "$f" "assets/AccessiWeather-nightly-${TIMESTAMP}-windows-setup.exe" ;;
                 *Portable*.zip) mv "$f" "assets/AccessiWeather-nightly-${TIMESTAMP}-windows-portable.zip" ;;
                 *macOS*.zip) mv "$f" "assets/AccessiWeather-nightly-${TIMESTAMP}-macOS.zip" ;;
-                *Linux*.zip) mv "$f" "assets/AccessiWeather-nightly-${TIMESTAMP}-linux.zip" ;;
+                *Linux*.tar.gz) mv "$f" "assets/AccessiWeather-nightly-${TIMESTAMP}-linux.tar.gz" ;;
               esac
             else
               case "$name" in
                 *Setup*.exe) mv "$f" "assets/AccessiWeather-${VERSION}-windows-setup.exe" ;;
                 *Portable*.zip) mv "$f" "assets/AccessiWeather-${VERSION}-windows-portable.zip" ;;
                 *macOS*.zip) mv "$f" "assets/AccessiWeather-${VERSION}-macOS.zip" ;;
-                *Linux*.zip) mv "$f" "assets/AccessiWeather-${VERSION}-linux.zip" ;;
+                *Linux*.tar.gz) mv "$f" "assets/AccessiWeather-${VERSION}-linux.tar.gz" ;;
               esac
             fi
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - **Advanced Forecaster Notes lookup** — Forecaster Notes now has an Advanced Lookup path for current and historical NWS text products, preferring official NWS product history when available and falling back to IEM AFOS/SPC data for national products like SWODY1 and SPC mesoscale discussions (#641).
 
+### Changed
+- Linux nightly and release downloads now ship as `.tar.gz` tarballs instead of ZIP files.
+
 ### Fixed
 - Forecaster Notes now starts with NWS discussion tabs only and adds IEM-backed tabs only when active SPC/WPC products apply to your selected location.
 - Pirate Weather now requests API v2 data and carries v2 precipitation types like freezing rain and wintry mix into current, daily, and hourly forecasts.

--- a/installer/README.md
+++ b/installer/README.md
@@ -11,7 +11,7 @@ pip install nuitka pillow
 # Generate icons (optional - will be auto-generated if missing)
 python installer/create_icons.py
 
-# Full Nuitka build (app + installer/portable ZIP where supported)
+# Full Nuitka build (app + installer/portable archive where supported)
 python installer/build_nuitka.py
 
 # Build app only (no installer)
@@ -40,6 +40,10 @@ All outputs are placed in the `dist/` directory:
 ### macOS
 - `AccessiWeather_macOS_vX.X.X.zip` - macOS app ZIP
 - `AccessiWeather.app` - Application bundle
+
+### Linux
+- `AccessiWeather_Linux_vX.X.X.tar.gz` - Linux portable tarball
+- `AccessiWeather/` - Staged application directory
 
 ## Requirements
 
@@ -132,7 +136,7 @@ The GitHub Actions workflow `.github/workflows/build.yml` automates:
 
 1. Building on Windows and macOS
 2. Creating installers (Inno Setup / DMG)
-3. Creating portable ZIPs
+3. Creating portable archives
 4. Uploading artifacts
 5. Creating releases (on tags)
 

--- a/installer/build.py
+++ b/installer/build.py
@@ -6,7 +6,7 @@ This script handles the complete build process:
 - Generates app icons if needed
 - Builds the application with PyInstaller
 - Creates installers (Inno Setup on Windows, DMG on macOS)
-- Creates portable ZIP archives
+- Creates portable archives
 
 Usage:
     python installer/build.py                    # Full build for current platform
@@ -23,6 +23,7 @@ import platform
 import shutil
 import subprocess
 import sys
+import tarfile
 import zipfile
 from pathlib import Path
 
@@ -328,9 +329,9 @@ def create_macos_dmg() -> bool:
 
 
 def create_portable_zip() -> bool:
-    """Create a portable ZIP archive."""
+    """Create a portable archive."""
     print("\n" + "=" * 60)
-    print("Creating portable ZIP...")
+    print("Creating portable archive...")
     print("=" * 60 + "\n")
 
     version = get_version()
@@ -367,7 +368,7 @@ def create_portable_zip() -> bool:
             return False
         zip_name = f"AccessiWeather_Linux_v{version}"
 
-    zip_path = DIST_DIR / zip_name
+    archive_path = DIST_DIR / zip_name
 
     # Ensure portable marker directory for Windows portable artifacts.
     if IS_WINDOWS:
@@ -380,22 +381,28 @@ def create_portable_zip() -> bool:
             print(f"Error: {exc}")
             return False
 
-    # Remove existing zip
-    zip_file = Path(f"{zip_path}.zip")
-    if zip_file.exists():
-        zip_file.unlink()
+    if IS_LINUX:
+        archive_file = Path(f"{archive_path}.tar.gz")
+        if archive_file.exists():
+            archive_file.unlink()
 
-    # Create zip
-    shutil.make_archive(str(zip_path), "zip", source_dir.parent, source_dir.name)
+        with tarfile.open(archive_file, "w:gz") as archive:
+            archive.add(source_dir, arcname=source_dir.name)
+    else:
+        archive_file = Path(f"{archive_path}.zip")
+        if archive_file.exists():
+            archive_file.unlink()
+
+        shutil.make_archive(str(archive_path), "zip", source_dir.parent, source_dir.name)
 
     if IS_WINDOWS:
         try:
-            _assert_portable_zip_has_soundpack(zip_file)
+            _assert_portable_zip_has_soundpack(archive_file)
         except RuntimeError as exc:
             print(f"Error: {exc}")
             return False
 
-    print(f"\nOK: Portable ZIP created: {zip_file}")
+    print(f"\nOK: Portable archive created: {archive_file}")
     return True
 
 
@@ -583,12 +590,12 @@ def main() -> int:
     parser.add_argument(
         "--no-zip",
         action="store_true",
-        help="Skip portable ZIP creation",
+        help="Skip portable archive creation",
     )
     parser.add_argument(
         "--portable-zip-only",
         action="store_true",
-        help="Create and validate the portable ZIP from an existing dist/ build",
+        help="Create and validate the portable archive from an existing dist/ build",
     )
     parser.add_argument(
         "--nightly",
@@ -648,7 +655,7 @@ def main() -> int:
         elif IS_MACOS:
             create_macos_dmg()
 
-    # Create portable ZIP
+    # Create portable archive
     if not args.no_zip and not create_portable_zip():
         return 1
 

--- a/installer/build_nuitka.py
+++ b/installer/build_nuitka.py
@@ -132,7 +132,7 @@ def stage_nuitka_distribution() -> Path:
 
 
 def create_portable_zip() -> bool:
-    """Create a portable ZIP from the staged Nuitka standalone folder."""
+    """Create a portable archive from the staged Nuitka standalone folder."""
     if str(ROOT) not in sys.path:
         sys.path.insert(0, str(ROOT))
 

--- a/tests/test_installer_build.py
+++ b/tests/test_installer_build.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import tarfile
 import zipfile
 
 from installer import build
@@ -94,8 +95,8 @@ def test_create_portable_zip_fails_when_default_soundpack_manifest_missing(
     assert not (dist_dir / "AccessiWeather_Portable_v9.9.9.zip").exists()
 
 
-def test_create_linux_zip_from_nuitka_distribution(tmp_path, monkeypatch) -> None:
-    """Linux Nuitka builds stage as dist/AccessiWeather and zip that directory."""
+def test_create_linux_tarball_from_nuitka_distribution(tmp_path, monkeypatch) -> None:
+    """Linux Nuitka builds stage as dist/AccessiWeather and archive that directory."""
     dist_dir = tmp_path / "dist"
     source_dir = dist_dir / "AccessiWeather"
     source_dir.mkdir(parents=True)
@@ -109,10 +110,11 @@ def test_create_linux_zip_from_nuitka_distribution(tmp_path, monkeypatch) -> Non
 
     assert build.create_portable_zip() is True
 
-    zip_path = dist_dir / "AccessiWeather_Linux_v9.9.9.zip"
-    assert zip_path.exists()
+    tarball_path = dist_dir / "AccessiWeather_Linux_v9.9.9.tar.gz"
+    assert tarball_path.exists()
+    assert not (dist_dir / "AccessiWeather_Linux_v9.9.9.zip").exists()
 
-    with zipfile.ZipFile(zip_path) as archive:
-        names = set(archive.namelist())
+    with tarfile.open(tarball_path, "r:gz") as archive:
+        names = set(archive.getnames())
 
     assert "AccessiWeather/AccessiWeather" in names

--- a/tests/test_installer_version_metadata.py
+++ b/tests/test_installer_version_metadata.py
@@ -53,6 +53,6 @@ def test_build_workflow_uses_nuitka_for_linux_artifacts():
     assert "build-linux:" in workflow
     assert "libwebkit2gtk-4.1-dev" in workflow
     assert "xvfb-run -a dist/AccessiWeather/AccessiWeather" in workflow
-    assert "dist/AccessiWeather_Linux_*.zip" in workflow
-    assert "AccessiWeather-nightly-${TIMESTAMP}-linux.zip" in workflow
-    assert "AccessiWeather-${VERSION}-linux.zip" in workflow
+    assert "dist/AccessiWeather_Linux_*.tar.gz" in workflow
+    assert "AccessiWeather-nightly-${TIMESTAMP}-linux.tar.gz" in workflow
+    assert "AccessiWeather-${VERSION}-linux.tar.gz" in workflow

--- a/tests/test_nuitka_build.py
+++ b/tests/test_nuitka_build.py
@@ -98,7 +98,7 @@ def test_production_build_workflow_uses_nuitka() -> None:
     assert "--only-binary wxPython" in workflow
     assert "dist/AccessiWeather_Setup_*.exe" in workflow
     assert "dist/AccessiWeather_macOS_*.zip" in workflow
-    assert "dist/AccessiWeather_Linux_*.zip" in workflow
+    assert "dist/AccessiWeather_Linux_*.tar.gz" in workflow
     assert "python installer/build_nuitka.py" in workflow
     assert "scripts/generate_build_meta.py" in workflow
     assert "Smoke test packaged app" in workflow
@@ -162,7 +162,7 @@ def test_stage_nuitka_distribution_copies_macos_app_to_dist_shape(tmp_path, monk
     assert (staged / "Contents" / "MacOS" / "AccessiWeather").read_bytes() == b"fake-app"
 
 
-def test_stage_nuitka_distribution_copies_linux_output_to_zip_source_shape(
+def test_stage_nuitka_distribution_copies_linux_output_to_archive_source_shape(
     tmp_path, monkeypatch
 ) -> None:
     build_dir = tmp_path / "build" / "nuitka"

--- a/tests/test_simple_update.py
+++ b/tests/test_simple_update.py
@@ -108,18 +108,18 @@ def test_select_asset_windows_portable():
     assert asset["name"].endswith(".zip")
 
 
-def test_select_asset_linux_prefers_linux_zip():
+def test_select_asset_linux_prefers_linux_tarball():
     release = _release(
         assets=[
             {"name": "AccessiWeather-nightly-20260505-windows-portable.zip"},
-            {"name": "AccessiWeather-nightly-20260505-linux.zip"},
+            {"name": "AccessiWeather-nightly-20260505-linux.tar.gz"},
             {"name": "checksums.txt"},
         ]
     )
 
     asset = select_asset(release, portable=False, platform_system="Linux")
 
-    assert asset["name"] == "AccessiWeather-nightly-20260505-linux.zip"
+    assert asset["name"] == "AccessiWeather-nightly-20260505-linux.tar.gz"
 
 
 def test_build_portable_update_script_contains_extract_and_restart():


### PR DESCRIPTION
## Summary
- package Linux builds as .tar.gz tarballs instead of ZIP archives
- upload and publish Linux tarballs in nightly and stable release assets
- update tests, changelog, and build docs for the Linux artifact name

## Verification
- python -m pytest tests/test_installer_build.py tests/test_installer_version_metadata.py tests/test_nuitka_build.py tests/test_simple_update.py -q
- python -m ruff check installer/build.py installer/build_nuitka.py tests/test_installer_build.py tests/test_installer_version_metadata.py tests/test_nuitka_build.py tests/test_simple_update.py