### PR TITLE
fix(build): stop bundling OpenSSL in Linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,6 +297,18 @@ jobs:
             exit "$status"
           fi
 
+      - name: Verify Linux tarball avoids bundled OpenSSL
+        run: |
+          tarball=$(find dist -maxdepth 1 -name 'AccessiWeather_Linux_*.tar.gz' -print -quit)
+          if [ -z "$tarball" ]; then
+            echo "Linux tarball was not created."
+            exit 1
+          fi
+          if tar -tzf "$tarball" | grep -E '(^|/)lib(ssl|crypto)\.so'; then
+            echo "Linux tarball must not bundle OpenSSL libraries; use the target system OpenSSL instead."
+            exit 1
+          fi
+
       - uses: actions/upload-artifact@v7
         with:
           name: linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Linux nightly and release downloads now ship as `.tar.gz` tarballs instead of ZIP files.
 
 ### Fixed
+- Linux builds no longer bundle OpenSSL libraries that can conflict with the target system's `libcurl`.
 - Forecaster Notes now starts with NWS discussion tabs only and adds IEM-backed tabs only when active SPC/WPC products apply to your selected location.
 - Pirate Weather now requests API v2 data and carries v2 precipitation types like freezing rain and wintry mix into current, daily, and hourly forecasts.
 - Forecaster Notes now hides Hazardous Weather Outlook and Special Weather Statement tabs when NWS confirms there is no matching product for the selected office.

--- a/installer/build_nuitka.py
+++ b/installer/build_nuitka.py
@@ -20,11 +20,13 @@ RESOURCES_DIR = SRC_DIR / "accessiweather" / "resources"
 SOUNDPACKS_DIR = ROOT / "soundpacks"
 APP_NAME = "AccessiWeather"
 LINUX_SYSTEM_DLL_EXCLUDES = (
+    "libcrypto.so*",
     "libgio-2.0.so*",
     "libglib-2.0.so*",
     "libgmodule-2.0.so*",
     "libgobject-2.0.so*",
     "libgthread-2.0.so*",
+    "libssl.so*",
 )
 SOUND_LIB_NATIVE_EXTS = {".dll", ".dylib", ".so"}
 

--- a/tests/test_nuitka_build.py
+++ b/tests/test_nuitka_build.py
@@ -79,6 +79,17 @@ def test_linux_nuitka_command_excludes_host_glib_stack() -> None:
         assert f"--noinclude-dlls={pattern}" in command
 
 
+def test_linux_nuitka_command_excludes_openssl_libraries() -> None:
+    command = build_nuitka.build_nuitka_command(
+        output_dir=Path("dist"),
+        build_tag=None,
+        assume_platform="Linux",
+    )
+
+    assert "--noinclude-dlls=libssl.so*" in command
+    assert "--noinclude-dlls=libcrypto.so*" in command
+
+
 def test_nuitka_is_available_as_build_extra() -> None:
     pyproject = (build_nuitka.ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
@@ -102,6 +113,8 @@ def test_production_build_workflow_uses_nuitka() -> None:
     assert "python installer/build_nuitka.py" in workflow
     assert "scripts/generate_build_meta.py" in workflow
     assert "Smoke test packaged app" in workflow
+    assert "Verify Linux tarball avoids bundled OpenSSL" in workflow
+    assert "lib(ssl|crypto)" in workflow
     assert "GLib-GObject-CRITICAL" in workflow
 
 


### PR DESCRIPTION
## Summary
- exclude libssl and libcrypto from Linux Nuitka bundles so system libcurl uses the target system OpenSSL
- add a Linux tarball validation step that fails if OpenSSL libraries are bundled
- add regression coverage for the Linux Nuitka exclude flags

## Verification
- python -m pytest tests/test_nuitka_build.py tests/test_installer_version_metadata.py -q
- python -m ruff check installer/build_nuitka.py tests/test_nuitka_build.py