### PR TITLE
fix(build): stage Linux sound_lib libraries in x64 layout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -309,6 +309,20 @@ jobs:
             exit 1
           fi
 
+      - name: Verify Linux tarball includes sound_lib x64 libraries
+        run: |
+          tarball=$(find dist -maxdepth 1 -name 'AccessiWeather_Linux_*.tar.gz' -print -quit)
+          if [ -z "$tarball" ]; then
+            echo "Linux tarball was not created."
+            exit 1
+          fi
+          for lib in libbass.so libbassmix.so libbassopus.so libtags.so; do
+            if ! tar -tzf "$tarball" | grep -qx "AccessiWeather/sound_lib/lib/x64/$lib"; then
+              echo "Linux tarball is missing sound_lib/lib/x64/$lib."
+              exit 1
+            fi
+          done
+
       - uses: actions/upload-artifact@v7
         with:
           name: linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Linux nightly and release downloads now ship as `.tar.gz` tarballs instead of ZIP files.
 
 ### Fixed
+- Linux builds now stage `sound_lib`'s native audio libraries in the path expected by the packaged app.
 - Linux builds no longer bundle OpenSSL libraries that can conflict with the target system's `libcurl`.
 - Forecaster Notes now starts with NWS discussion tabs only and adds IEM-backed tabs only when active SPC/WPC products apply to your selected location.
 - Pirate Weather now requests API v2 data and carries v2 precipitation types like freezing rain and wintry mix into current, daily, and hourly forecasts.

--- a/installer/build_nuitka.py
+++ b/installer/build_nuitka.py
@@ -29,6 +29,7 @@ LINUX_SYSTEM_DLL_EXCLUDES = (
     "libssl.so*",
 )
 SOUND_LIB_NATIVE_EXTS = {".dll", ".dylib", ".so"}
+SOUND_LIB_ARCH_DIR = "x64"
 
 
 def _sound_lib_lib_dir() -> Path:
@@ -59,6 +60,7 @@ def _stage_sound_lib_runtime_files(staged_dir: Path) -> Path:
         shutil.rmtree(target_dir)
     target_dir.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(source_dir, target_dir)
+    _mirror_sound_lib_flat_files_to_arch_dir(target_dir)
 
     native_files = [
         path
@@ -68,6 +70,18 @@ def _stage_sound_lib_runtime_files(staged_dir: Path) -> Path:
     if not native_files:
         raise RuntimeError(f"No sound_lib native libraries were staged under {target_dir}")
     return target_dir
+
+
+def _mirror_sound_lib_flat_files_to_arch_dir(target_dir: Path) -> None:
+    """Support sound_lib loaders that still search sound_lib/lib/x64 in frozen apps."""
+    flat_files = [path for path in target_dir.iterdir() if path.is_file()]
+    if not flat_files:
+        return
+
+    arch_dir = target_dir / SOUND_LIB_ARCH_DIR
+    arch_dir.mkdir(exist_ok=True)
+    for path in flat_files:
+        shutil.copy2(path, arch_dir / path.name)
 
 
 def _repo_path(path: Path) -> str:

--- a/tests/test_nuitka_build.py
+++ b/tests/test_nuitka_build.py
@@ -114,6 +114,8 @@ def test_production_build_workflow_uses_nuitka() -> None:
     assert "scripts/generate_build_meta.py" in workflow
     assert "Smoke test packaged app" in workflow
     assert "Verify Linux tarball avoids bundled OpenSSL" in workflow
+    assert "Verify Linux tarball includes sound_lib x64 libraries" in workflow
+    assert "AccessiWeather/sound_lib/lib/x64/$lib" in workflow
     assert "lib(ssl|crypto)" in workflow
     assert "GLib-GObject-CRITICAL" in workflow
 
@@ -208,6 +210,25 @@ def test_stage_sound_lib_runtime_files_copies_native_libraries(tmp_path, monkeyp
     assert target == staged / "sound_lib" / "lib"
     assert (target / "bass.dll").read_bytes() == b"dll"
     assert (target / "notes.txt").read_text(encoding="utf-8") == "ignored but copied"
+    assert (target / "x64" / "bass.dll").read_bytes() == b"dll"
+    assert (target / "x64" / "notes.txt").read_text(encoding="utf-8") == "ignored but copied"
+
+
+def test_stage_sound_lib_runtime_files_preserves_existing_arch_layout(
+    tmp_path, monkeypatch
+) -> None:
+    source = tmp_path / "site-packages" / "sound_lib" / "lib"
+    arch_source = source / "x64"
+    arch_source.mkdir(parents=True)
+    (arch_source / "libbass.so").write_bytes(b"so")
+    staged = tmp_path / "dist" / "AccessiWeather"
+    staged.mkdir(parents=True)
+    monkeypatch.setattr(build_nuitka, "_sound_lib_lib_dir", lambda: source)
+
+    target = build_nuitka._stage_sound_lib_runtime_files(staged)
+
+    assert target == staged / "sound_lib" / "lib"
+    assert (target / "x64" / "libbass.so").read_bytes() == b"so"
 
 
 def test_stage_nuitka_distribution_fails_when_output_missing(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- mirror packaged sound_lib native libraries into sound_lib/lib/x64 for frozen Linux runtime compatibility
- keep the existing flat sound_lib/lib layout for newer loader variants
- add CI verification that the Linux tarball includes key sound_lib x64 libraries

## Verification
- python -m pytest tests/test_nuitka_build.py tests/test_installer_version_metadata.py -q
- python -m ruff check installer/build_nuitka.py tests/test_nuitka_build.py