### PR TITLE
test(integration): add IEM cassettes

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -79,6 +79,7 @@ jobs:
             --record-mode=none
         env:
           LIVE_WEATHER_TESTS: "1"
+          VCR_RECORD_MODE: "none"
         timeout-minutes: 15
 
       - name: Run integration tests (update cassettes)
@@ -90,6 +91,7 @@ jobs:
             --record-mode=all
         env:
           LIVE_WEATHER_TESTS: "1"
+          VCR_RECORD_MODE: "all"
         timeout-minutes: 15
 
       - name: Commit and push new cassettes (if any)
@@ -106,7 +108,7 @@ jobs:
           else
             echo "Committing new/updated cassettes..."
             git add tests/integration/cassettes/
-            git commit -m $'chore: update VCR cassettes from integration tests run\n\nThis commit updates HTTP cassettes recorded from live weather API calls.\nRun: '"$RUN_URL"
+            git commit -m $'test(integration): update VCR cassettes\n\nThis commit updates HTTP cassettes recorded from live weather API calls.\nRun: '"$RUN_URL"$'\n\nTested: pytest tests/integration/ -v --tb=short --record-mode=all\nConfidence: medium\nCo-authored-by: OmX <omx@oh-my-codex.dev>'
             git push
           fi
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -23,14 +23,14 @@ Integration tests verify actual API behavior by recording HTTP interactions as "
 # Default: Run integration tests with recorded cassettes (fast)
 pytest tests/integration/ -v
 
-# Run all tests including live_only (requires network + API keys)
-pytest tests/integration/ -v -m "integration"
+# Run all integration tests except live_only tests
+pytest tests/integration/ -v -m "integration and not live_only"
 
-# Run only live_only tests (for recording/validation)
+# Run only live_only tests (requires network + any required API keys)
 pytest tests/integration/ -v -m "live_only"
 
-# Run with fresh API calls (re-records cassettes)
-set VCR_RECORD_MODE=all && pytest tests/integration/ -v
+# Run with fresh API calls (PowerShell; re-records cassettes)
+$env:VCR_RECORD_MODE = "all"; pytest tests/integration/ -v
 ```
 
 ## VCR Recording Modes
@@ -60,6 +60,8 @@ set PIRATE_WEATHER_API_KEY=your-api-key-here
 ```
 tests/integration/cassettes/
 ├── geocoding/         # Geocoding API tests
+├── iem/               # IEM NWS text product tests
+├── nws/               # National Weather Service API tests
 ├── openmeteo/         # OpenMeteo weather API tests
 ├── pirate_weather/    # Pirate Weather API tests
 └── weather_client/    # WeatherClient orchestration tests

--- a/tests/integration/cassettes/iem/afos_swody1.yaml
+++ b/tests/integration/cassettes/iem/afos_swody1.yaml
@@ -1,0 +1,126 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - mesonet.agron.iastate.edu
+    method: GET
+    uri: https://mesonet.agron.iastate.edu/cgi-bin/afos/retrieve.py?fmt=text&limit=1&order=desc&pil=SWODY1
+  response:
+    body:
+      string: "\x01\n175 \nACUS01 KWNS 080036\nSWODY1\nSPC AC 080035\n\nDay 1 Convective
+        Outlook  \nNWS Storm Prediction Center Norman OK\n0735 PM CDT Thu May 07 2026\n\nValid
+        080100Z - 081200Z\n\n...NO SEVERE THUNDERSTORM AREAS FORECAST...\n\n...SUMMARY...\nSevere
+        storms are not expected through tonight.\n\n...MT/WY...\n\nForcing for ascent
+        attendant to a short-wave trough moving southeast\nthrough the region has
+        fostered widely scattered thunderstorms from\nportions of northwest MT into
+        central WY as of 00z. Moisture is\nlimited, but the presence of steep lapse
+        rates (ref. 00z RIW\nsounding) may be sufficient to support briefly strong
+        storms capable\nof gusty winds and/or small hail for the next couple of hours.\n\n...Carolinas...\n\nA
+        small cluster of showers and thunderstorms is ongoing across parts\nof southern
+        and central NC along a cold front settling south through\nthe area. Weakening,
+        low-level lapse rates and resultant instability\nshould limit any severe-weather
+        threat as the convection continues\neast tonight.\n\n...LA...\n\nA few thunderstorms
+        have recently developed in the vicinity of the\nsurface front in far southeast
+        LA amidst a moist low-level air mass.\nThe 00z LIX sounding located to the
+        immediate north of the front\nsampled MUCAPE of around 1500 J/kg for parcels
+        lifted from around 1\nKM. Moreover, deep-layer shear remains strong (effective
+        bulk shear\nof 60 kt), which would conditionally support some storm\norganization.
+        Current thinking is that nebulous forcing for ascent\nand poor low/mid-level
+        lapse rates will tend to limit updraft vigor\nin an otherwise seemingly favorable,
+        severe-storm environment. As\nsuch, no severe-weather probabilities will be
+        included for this\nforecast.\n\n...Southern AZ/NM into TX...\n\nIsolated thunderstorms
+        remain possible overnight from southern parts\nof AZ and NM into western and
+        southern TX, near and ahead of a\nmid-level low drifting east across Sonora
+        and Chihuahua, Mexico.\n\n..Mead.. 05/08/2026\n\n$$\n\n\x03\n"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 08 May 2026 02:30:54 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Server:
+      - Apache/2.4.62 (AlmaLinux) OpenSSL/3.5.1 mod_fcgid/2.3.9 mod_wsgi/5.0.2 Python/3.14
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-IEM-ServerID:
+      - iemvs37-dc.agron.iastate.edu
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - mesonet.agron.iastate.edu
+    method: GET
+    uri: https://mesonet.agron.iastate.edu/cgi-bin/afos/retrieve.py?fmt=text&limit=1&order=desc&pil=SWODY1
+  response:
+    body:
+      string: "\x01\n175 \nACUS01 KWNS 080036\nSWODY1\nSPC AC 080035\n\nDay 1 Convective
+        Outlook  \nNWS Storm Prediction Center Norman OK\n0735 PM CDT Thu May 07 2026\n\nValid
+        080100Z - 081200Z\n\n...NO SEVERE THUNDERSTORM AREAS FORECAST...\n\n...SUMMARY...\nSevere
+        storms are not expected through tonight.\n\n...MT/WY...\n\nForcing for ascent
+        attendant to a short-wave trough moving southeast\nthrough the region has
+        fostered widely scattered thunderstorms from\nportions of northwest MT into
+        central WY as of 00z. Moisture is\nlimited, but the presence of steep lapse
+        rates (ref. 00z RIW\nsounding) may be sufficient to support briefly strong
+        storms capable\nof gusty winds and/or small hail for the next couple of hours.\n\n...Carolinas...\n\nA
+        small cluster of showers and thunderstorms is ongoing across parts\nof southern
+        and central NC along a cold front settling south through\nthe area. Weakening,
+        low-level lapse rates and resultant instability\nshould limit any severe-weather
+        threat as the convection continues\neast tonight.\n\n...LA...\n\nA few thunderstorms
+        have recently developed in the vicinity of the\nsurface front in far southeast
+        LA amidst a moist low-level air mass.\nThe 00z LIX sounding located to the
+        immediate north of the front\nsampled MUCAPE of around 1500 J/kg for parcels
+        lifted from around 1\nKM. Moreover, deep-layer shear remains strong (effective
+        bulk shear\nof 60 kt), which would conditionally support some storm\norganization.
+        Current thinking is that nebulous forcing for ascent\nand poor low/mid-level
+        lapse rates will tend to limit updraft vigor\nin an otherwise seemingly favorable,
+        severe-storm environment. As\nsuch, no severe-weather probabilities will be
+        included for this\nforecast.\n\n...Southern AZ/NM into TX...\n\nIsolated thunderstorms
+        remain possible overnight from southern parts\nof AZ and NM into western and
+        southern TX, near and ahead of a\nmid-level low drifting east across Sonora
+        and Chihuahua, Mexico.\n\n..Mead.. 05/08/2026\n\n$$\n\n\x03\n"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 08 May 2026 02:31:32 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Server:
+      - Apache/2.4.62 (AlmaLinux) OpenSSL/3.5.1 mod_fcgid/2.3.9 mod_wsgi/5.0.2 Python/3.14
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-IEM-ServerID:
+      - iemvs44-dc.agron.iastate.edu
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/cassettes/iem/spc_outlook_day1.yaml
+++ b/tests/integration/cassettes/iem/spc_outlook_day1.yaml
@@ -1,0 +1,42 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - mesonet.agron.iastate.edu
+    method: GET
+    uri: https://mesonet.agron.iastate.edu/json/spcoutlook.py?current=0&day=1&fmt=json&lat=35.7796&lon=-78.6382&time=2026-05-07T12%3A00%3A00Z
+  response:
+    body:
+      string: '{"query_params": {"time": "2026-05-07T12:00:00Z", "lon": -78.6382,
+        "lat": 35.7796, "cat": "CATEGORICAL", "day": 1}, "outlook": {"threshold":
+        "TSTM", "conditional": null, "utc_product_issue": "2026-05-07T05:32:00Z",
+        "utc_issue": "2026-05-07T12:00:00Z", "utc_expire": "2026-05-08T12:00:00Z"},
+        "generated_at": "2026-05-08T02:31:43Z"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2026 02:31:32 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Server:
+      - Apache/2.4.62 (AlmaLinux) OpenSSL/3.5.1 mod_fcgid/2.3.9 mod_wsgi/5.0.2 Python/3.14
+      Transfer-Encoding:
+      - chunked
+      X-IEM-ServerID:
+      - iemvs42-dc.agron.iastate.edu
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/cassettes/iem/wpc_outlook_day1.yaml
+++ b/tests/integration/cassettes/iem/wpc_outlook_day1.yaml
@@ -1,0 +1,39 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - mesonet.agron.iastate.edu
+    method: GET
+    uri: https://mesonet.agron.iastate.edu/json/wpcoutlook.py?day=1&fmt=json&last=1&lat=35.7796&lon=-78.6382&time=2026-05-07T12%3A00%3A00Z
+  response:
+    body:
+      string: '{"query_params": {"time": "2026-05-07T12:00:00Z", "lon": -78.6382,
+        "lat": 35.7796, "day": 1}, "outlook": {}, "generated_at": "2026-05-08T02:31:53Z"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2026 02:31:43 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Server:
+      - Apache/2.4.62 (AlmaLinux) OpenSSL/3.5.1 mod_fcgid/2.3.9 mod_wsgi/5.0.2 Python/3.14
+      Transfer-Encoding:
+      - chunked
+      X-IEM-ServerID:
+      - iemvs36-dc.agron.iastate.edu
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/test_iem_integration.py
+++ b/tests/integration/test_iem_integration.py
@@ -1,0 +1,68 @@
+"""Integration tests for IEM-backed NWS text products."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from accessiweather.iem_client import (
+    fetch_iem_afos_text,
+    fetch_iem_spc_outlook,
+    fetch_iem_wpc_outlook,
+)
+from tests.integration.conftest import integration_vcr
+
+
+@pytest.mark.integration
+class TestIemTextProducts:
+    """Test IEM product endpoints used by Forecaster Notes."""
+
+    @integration_vcr.use_cassette("iem/afos_swody1.yaml")
+    @pytest.mark.asyncio
+    async def test_fetch_afos_text_product(self):
+        """Test fetching a national AFOS text product from IEM."""
+        product = await fetch_iem_afos_text("SWODY1", limit=1)
+
+        assert product.product_id == "SWODY1"
+        assert product.product_type == "SWODY1"
+        assert product.cwa_office == "IEM"
+        assert "SWODY1" in product.headline
+        assert len(product.product_text) > 100
+
+    @integration_vcr.use_cassette("iem/spc_outlook_day1.yaml")
+    @pytest.mark.asyncio
+    async def test_fetch_spc_outlook_summary(self):
+        """Test fetching a point-based SPC outlook summary from IEM."""
+        product = await fetch_iem_spc_outlook(
+            35.7796,
+            -78.6382,
+            day=1,
+            current=False,
+            valid_at=datetime(2026, 5, 7, 12, tzinfo=UTC),
+            max_items=2,
+            timeout=30.0,
+        )
+
+        assert product.product_id == "SPC_OUTLOOK_DAY1"
+        assert product.product_type == "SPC_OUTLOOK"
+        assert product.cwa_office == "SPC"
+        assert "SPC Day 1 Convective Outlook" in product.product_text
+
+    @integration_vcr.use_cassette("iem/wpc_outlook_day1.yaml")
+    @pytest.mark.asyncio
+    async def test_fetch_wpc_excessive_rainfall_summary(self):
+        """Test fetching a point-based WPC excessive rainfall summary from IEM."""
+        product = await fetch_iem_wpc_outlook(
+            35.7796,
+            -78.6382,
+            day=1,
+            valid_at=datetime(2026, 5, 7, 12, tzinfo=UTC),
+            max_items=2,
+            timeout=30.0,
+        )
+
+        assert product.product_id == "WPC_ERO_DAY1"
+        assert product.product_type == "WPC_ERO"
+        assert product.cwa_office == "WPC"
+        assert "WPC Day 1 Excessive Rainfall Outlook" in product.product_text


### PR DESCRIPTION
## Summary
- add recorded IEM integration coverage for AFOS text products, SPC outlook summaries, and WPC excessive rainfall outlook summaries
- remove the stale Visual Crossing cassette placeholder
- make the integration workflow pass VCR_RECORD_MODE explicitly so the custom VCR fixture honors replay vs update mode
- update the integration test README with current cassette commands and directories

## Verification
- actionlint .github/workflows/integration-tests.yml
- python -m ruff check tests/integration/test_iem_integration.py
- VCR_RECORD_MODE=none python -m pytest tests/integration/ -n 0 -q --tb=short