### PR TITLE
fix(alerts): honor alert area and startup settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 - Linux nightly and release downloads now ship as `.tar.gz` tarballs instead of ZIP files.
 
 ### Fixed
+- Alerts now honor your selected alert area during regular refreshes, including state and zone alert modes.
+- Zone alert mode now checks both county and forecast zones so county-based watches and warnings are less likely to be missed.
+- The "Launch automatically at startup" setting now updates the system startup entry instead of only saving the checkbox.
+- Repeated checks of unchanged alerts no longer use up notification rate-limit capacity before newer alerts are handled.
 - The update dialog now shows release notes as screen-reader-friendly plain text instead of raw Markdown.
 - Linux builds now stage `sound_lib`'s native audio libraries in the path expected by the packaged app.
 - Linux builds no longer bundle OpenSSL libraries that can conflict with the target system's `libcurl`.

--- a/src/accessiweather/alert_manager.py
+++ b/src/accessiweather/alert_manager.py
@@ -253,8 +253,8 @@ class AlertManager:
             )
         return is_fresh
 
-    def _should_notify_alert(self, alert: WeatherAlert) -> tuple[bool, str]:
-        """Determine if we should notify for this alert and why."""
+    def _passes_static_notification_filters(self, alert: WeatherAlert) -> tuple[bool, str]:
+        """Check filters that do not mutate rate-limit or cooldown state."""
         # Check if notifications are enabled
         if not self.settings.notifications_enabled:
             return False, "notifications_disabled"
@@ -271,6 +271,10 @@ class AlertManager:
         if alert.is_expired():
             return False, "alert_expired"
 
+        return True, "allowed"
+
+    def _can_notify_now(self) -> tuple[bool, str]:
+        """Check mutable notification gates only for alerts that will be sent."""
         # Check token bucket rate limit
         if not self._check_rate_limit():
             return False, "rate_limit_exceeded"
@@ -280,6 +284,13 @@ class AlertManager:
             return False, "global_cooldown_active"
 
         return True, "allowed"
+
+    def _should_notify_alert(self, alert: WeatherAlert) -> tuple[bool, str]:
+        """Determine if we should notify for this alert and why."""
+        passes_filters, reason = self._passes_static_notification_filters(alert)
+        if not passes_filters:
+            return False, reason
+        return self._can_notify_now()
 
     def process_alerts(self, alerts: WeatherAlerts) -> list[tuple[WeatherAlert, str]]:
         """
@@ -313,9 +324,8 @@ class AlertManager:
             # Extract alert sent/effective timestamp for freshness check
             alert_sent_time = alert.sent or alert.effective
 
-            # Check if we should notify for this alert
-            should_notify, reason = self._should_notify_alert(alert)
-            if not should_notify:
+            passes_filters, reason = self._passes_static_notification_filters(alert)
+            if not passes_filters:
                 logger.info(
                     "[alertmgr] Skipping alert %r: %s (severity=%s, threshold=%s, "
                     "notifications_enabled=%s, global_cooldown=%sm, available_tokens=%.2f)",
@@ -333,6 +343,18 @@ class AlertManager:
             existing_state = self.alert_states.get(alert_id)
 
             if existing_state is None:
+                can_notify, reason = self._can_notify_now()
+                if not can_notify:
+                    logger.info(
+                        "[alertmgr] Skipping new alert %r: %s "
+                        "(global_cooldown=%sm, available_tokens=%.2f)",
+                        alert_id,
+                        reason,
+                        self.settings.global_cooldown,
+                        self._rate_limit_tokens,
+                    )
+                    continue
+
                 # New alert - always notify
                 new_state = AlertState(
                     alert_id=alert_id,
@@ -346,6 +368,18 @@ class AlertManager:
                 logger.info(f"New alert detected: {alert_id}")
 
             elif existing_state.has_changed(content_hash):
+                can_notify, reason = self._can_notify_now()
+                if not can_notify:
+                    logger.info(
+                        "[alertmgr] Skipping changed alert %r: %s "
+                        "(global_cooldown=%sm, available_tokens=%.2f)",
+                        alert_id,
+                        reason,
+                        self.settings.global_cooldown,
+                        self._rate_limit_tokens,
+                    )
+                    continue
+
                 # Alert content changed - always notify
                 is_escalation = existing_state.is_escalated(severity_priority)
                 # Add new state to history
@@ -362,6 +396,18 @@ class AlertManager:
                 is_fresh = self._is_alert_fresh(alert_sent_time)
 
                 if is_fresh and existing_state.last_notified is None:
+                    can_notify, reason = self._can_notify_now()
+                    if not can_notify:
+                        logger.info(
+                            "[alertmgr] Skipping fresh alert %r: %s "
+                            "(global_cooldown=%sm, available_tokens=%.2f)",
+                            alert_id,
+                            reason,
+                            self.settings.global_cooldown,
+                            self._rate_limit_tokens,
+                        )
+                        continue
+
                     # Fresh alert that was never notified - notify once
                     notifications_to_send.append((alert, "fresh_alert"))
                     logger.info(f"Fresh alert detected (never notified): {alert_id}")

--- a/src/accessiweather/ui/dialogs/settings_dialog_core.py
+++ b/src/accessiweather/ui/dialogs/settings_dialog_core.py
@@ -181,6 +181,8 @@ class SettingsDialogCoreMixin:
     def _load_settings(self):
         """Load current settings into UI controls."""
         try:
+            if hasattr(self.config_manager, "sync_startup_setting"):
+                self.config_manager.sync_startup_setting()
             settings = self.config_manager.get_settings()
             for tab in getattr(self, "_tab_objects", []):
                 tab.load(settings)
@@ -211,6 +213,10 @@ class SettingsDialogCoreMixin:
                         )
                         settings_dict.pop(key, None)
 
+            startup_result = self._apply_startup_enabled_setting(settings_dict)
+            if startup_result is False:
+                return False
+
             success = self.config_manager.update_settings(**settings_dict)
             if success:
                 logger.info("Settings saved successfully")
@@ -221,6 +227,42 @@ class SettingsDialogCoreMixin:
         except Exception as e:
             logger.error(f"Failed to save settings: {e}")
             return False
+
+    def _apply_startup_enabled_setting(self, settings_dict: dict) -> bool | None:
+        """
+        Apply the OS startup registration for the Advanced tab startup checkbox.
+
+        Returns False only when the requested startup state could not be applied.
+        None means the settings payload did not include startup_enabled.
+        """
+        if "startup_enabled" not in settings_dict:
+            return None
+
+        desired_enabled = bool(settings_dict["startup_enabled"])
+        current_enabled = False
+        if hasattr(self.config_manager, "is_startup_enabled"):
+            current_enabled = bool(self.config_manager.is_startup_enabled())
+
+        if desired_enabled == current_enabled:
+            return True
+
+        if desired_enabled:
+            success, message = self.config_manager.enable_startup()
+        else:
+            success, message = self.config_manager.disable_startup()
+
+        if success:
+            logger.info("Startup setting applied: %s", message)
+            return True
+
+        logger.error("Failed to apply startup setting: %s", message)
+        wx.MessageBox(
+            message,
+            "Startup Setting Failed",
+            wx.OK | wx.ICON_ERROR,
+        )
+        settings_dict["startup_enabled"] = current_enabled
+        return False
 
     def _setup_accessibility(self):
         """Set up accessibility labels for controls."""

--- a/src/accessiweather/weather_client_base.py
+++ b/src/accessiweather/weather_client_base.py
@@ -294,6 +294,7 @@ class WeatherClient(
                     self.user_agent,
                     self.timeout,
                     client,
+                    alert_radius_type=getattr(self.settings, "alert_radius_type", "county"),
                     max_retries=1,
                     initial_delay=1.0,
                 )

--- a/src/accessiweather/weather_client_nws.py
+++ b/src/accessiweather/weather_client_nws.py
@@ -68,6 +68,7 @@ async def get_nws_all_data_parallel(
     user_agent: str,
     timeout: float,
     client: httpx.AsyncClient,
+    alert_radius_type: str = "county",
 ) -> tuple[
     CurrentConditions | None,
     Forecast | None,
@@ -105,7 +106,14 @@ async def get_nws_all_data_parallel(
             )
         )
         alerts_task = asyncio.create_task(
-            get_nws_alerts(location, nws_base_url, user_agent, timeout, client)
+            get_nws_alerts(
+                location,
+                nws_base_url,
+                user_agent,
+                timeout,
+                client,
+                alert_radius_type=alert_radius_type,
+            )
         )
         hourly_task = asyncio.create_task(
             get_nws_hourly_forecast(location, nws_base_url, user_agent, timeout, client, grid_data)

--- a/src/accessiweather/weather_client_nws_alerts.py
+++ b/src/accessiweather/weather_client_nws_alerts.py
@@ -88,14 +88,16 @@ async def get_nws_alerts(
                 params = {"point": f"{location.latitude},{location.longitude}", "status": "actual"}
 
         elif alert_radius_type == "zone":
-            # Prefer the stored forecast_zone_id (populated by zone enrichment
-            # and kept fresh by drift correction). This skips a redundant
-            # /points round-trip on each refresh. Fall back to /points
-            # resolution when the stored field is absent.
-            if location.forecast_zone_id:
-                params = {"zone": location.forecast_zone_id, "status": "actual"}
-            else:
-                # Get zone from point data
+            # Query both county and forecast zones. Many alert products,
+            # including severe thunderstorm watches, are county-zone products
+            # even when the UI label says "zone".
+            zone_ids: list[str] = []
+            if location.county_zone_id:
+                zone_ids.append(location.county_zone_id)
+            if location.forecast_zone_id and location.forecast_zone_id not in zone_ids:
+                zone_ids.append(location.forecast_zone_id)
+
+            if not zone_ids:
                 point_url = f"{nws_base_url}/points/{location.latitude},{location.longitude}"
                 if client is not None:
                     point_response = await _client_get(client, point_url, headers=headers)
@@ -107,25 +109,39 @@ async def get_nws_alerts(
                 point_response.raise_for_status()
                 point_data = point_response.json()
 
-                # Try to get zone ID (prefer county, then forecast zone)
-                zone_id = None
                 county_url = point_data.get("properties", {}).get("county")
                 if county_url and "/county/" in county_url:
-                    zone_id = county_url.split("/county/")[1]
-                if not zone_id:
-                    forecast_zone_url = point_data.get("properties", {}).get("forecastZone")
-                    if forecast_zone_url and "/forecast/" in forecast_zone_url:
-                        zone_id = forecast_zone_url.split("/forecast/")[1]
+                    zone_ids.append(county_url.split("/county/")[1])
+                forecast_zone_url = point_data.get("properties", {}).get("forecastZone")
+                if forecast_zone_url and "/forecast/" in forecast_zone_url:
+                    forecast_zone_id = forecast_zone_url.split("/forecast/")[1]
+                    if forecast_zone_id not in zone_ids:
+                        zone_ids.append(forecast_zone_id)
 
-                if zone_id:
-                    params = {"zone": zone_id, "status": "actual"}
-                else:
-                    # Fall back to point query if zone not found
-                    logger.warning("Could not determine zone, falling back to point query")
-                    params = {
-                        "point": f"{location.latitude},{location.longitude}",
-                        "status": "actual",
-                    }
+            if zone_ids:
+                combined_features: list[dict] = []
+                async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as new_client:
+                    active_client = client or new_client
+                    for zone_id in zone_ids:
+                        try:
+                            response = await _client_get(
+                                active_client,
+                                alerts_url,
+                                headers=headers,
+                                params={"zone": zone_id, "status": "actual"},
+                            )
+                            response.raise_for_status()
+                            alerts_data = response.json()
+                            combined_features.extend(alerts_data.get("features", []))
+                        except Exception as exc:  # noqa: BLE001
+                            logger.warning("Failed getting alerts for zone %s: %s", zone_id, exc)
+                return parse_nws_alerts({"features": combined_features})
+
+            logger.warning("Could not determine zone, falling back to point query")
+            params = {
+                "point": f"{location.latitude},{location.longitude}",
+                "status": "actual",
+            }
 
         else:  # "point" (default) - most precise
             params = {

--- a/src/accessiweather/weather_client_nws_parsers.py
+++ b/src/accessiweather/weather_client_nws_parsers.py
@@ -226,6 +226,11 @@ def parse_nws_alerts(data: dict) -> WeatherAlerts:
             id=alert_id,
             source="NWS",
             message_type=props.get("messageType"),
+            affected_zones=[
+                zone.rsplit("/", 1)[-1]
+                for zone in props.get("affectedZones", [])
+                if isinstance(zone, str) and zone
+            ],
         )
         alerts.append(alert)
 

--- a/tests/test_alert_manager.py
+++ b/tests/test_alert_manager.py
@@ -331,3 +331,37 @@ class TestAlertManager:
 
         # Should be rate limited to 2
         assert len(notifications) <= 2
+
+    def test_unchanged_alert_does_not_consume_rate_limit_token(self, manager, sample_alert):
+        """Polling an already-seen alert must not starve later real notifications."""
+        alerts = WeatherAlerts(alerts=[sample_alert])
+        manager.process_alerts(alerts)
+        manager.last_global_notification = None
+        manager._rate_limit_tokens = 1.0
+
+        notifications = manager.process_alerts(alerts)
+
+        assert notifications == []
+        assert manager._rate_limit_tokens == 1.0
+
+    def test_unchanged_alert_does_not_starve_new_alert_in_same_batch(self, manager, sample_alert):
+        """An unchanged first alert should not spend the only token before a new alert."""
+        manager.process_alerts(WeatherAlerts(alerts=[sample_alert]))
+        manager.last_global_notification = None
+        manager._rate_limit_tokens = 1.0
+        new_alert = WeatherAlert(
+            id="NWS-ALERT-002",
+            title="Tornado Warning",
+            description="Tornado warning text.",
+            severity="Extreme",
+            urgency="Immediate",
+            certainty="Observed",
+            event="Tornado Warning",
+            expires=datetime.now(UTC) + timedelta(hours=1),
+        )
+
+        notifications = manager.process_alerts(WeatherAlerts(alerts=[sample_alert, new_alert]))
+
+        assert [(alert.id, reason) for alert, reason in notifications] == [
+            ("NWS-ALERT-002", "new_alert")
+        ]

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -348,6 +348,30 @@ class TestWeatherClientGetNwsAlerts:
             call_kwargs = mock_nws.get_nws_alerts.call_args
             assert call_kwargs.kwargs.get("alert_radius_type") == "county"
 
+    @pytest.mark.asyncio
+    async def test_fetch_nws_data_parallel_passes_alert_radius_type(self):
+        """The optimized NWS refresh path must honor the configured alert area."""
+        from accessiweather.weather_client_base import WeatherClient
+
+        expected = (None, None, None, None, None, None)
+        settings = AppSettings(alert_radius_type="state")
+        client = WeatherClient(settings=settings)
+        client._test_mode = False
+        client._get_http_client = MagicMock(return_value=MagicMock())
+        location = MagicMock()
+
+        with patch(
+            "accessiweather.weather_client_base.nws_client.get_nws_all_data_parallel",
+            new_callable=AsyncMock,
+        ) as mock_parallel:
+            mock_parallel.return_value = expected
+
+            result = await client._fetch_nws_data(location)
+
+            assert result == expected
+            mock_parallel.assert_awaited_once()
+            assert mock_parallel.await_args.kwargs.get("alert_radius_type") == "state"
+
 
 # =============================================================================
 # 5. NWS county alert path and deduplication

--- a/tests/test_nws_alerts.py
+++ b/tests/test_nws_alerts.py
@@ -375,6 +375,30 @@ class TestGetNwsAlertsParameters:
             assert result.alerts[0].event == "Winter Storm Warning"
             assert "UPDATED" in result.alerts[0].headline
 
+    def test_parse_alerts_populates_affected_zones(self):
+        """NWS affectedZones should be preserved as compact zone IDs."""
+        data = {
+            "features": [
+                {
+                    "id": "urn:test:zones",
+                    "properties": {
+                        "headline": "Severe Thunderstorm Watch",
+                        "description": "Watch text.",
+                        "severity": "Severe",
+                        "event": "Severe Thunderstorm Watch",
+                        "affectedZones": [
+                            "https://api.weather.gov/zones/county/TXC121",
+                            "https://api.weather.gov/zones/forecast/TXZ119",
+                        ],
+                    },
+                }
+            ]
+        }
+
+        result = parse_nws_alerts(data)
+
+        assert result.alerts[0].affected_zones == ["TXC121", "TXZ119"]
+
 
 class TestAlertTimeParsing:
     """Tests for alert time field parsing."""

--- a/tests/test_settings_dialog_startup.py
+++ b/tests/test_settings_dialog_startup.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from accessiweather.ui.dialogs.settings_dialog import SettingsDialogSimple
+
+
+class _StartupTab:
+    def __init__(self, startup_enabled: bool) -> None:
+        self.startup_enabled = startup_enabled
+        self.loaded_settings = None
+
+    def load(self, settings) -> None:
+        self.loaded_settings = settings
+
+    def save(self) -> dict:
+        return {"startup_enabled": self.startup_enabled}
+
+
+def _make_dialog(*, startup_enabled: bool, actual_enabled: bool = False) -> SettingsDialogSimple:
+    dialog = SettingsDialogSimple.__new__(SettingsDialogSimple)
+    dialog._tab_objects = [_StartupTab(startup_enabled)]
+    dialog.config_manager = MagicMock()
+    dialog.config_manager.get_settings.return_value = SimpleNamespace(
+        startup_enabled=actual_enabled
+    )
+    dialog.config_manager.update_settings.return_value = True
+    dialog.config_manager.is_startup_enabled.return_value = actual_enabled
+    dialog.config_manager.enable_startup.return_value = (True, "Startup enabled successfully")
+    dialog.config_manager.disable_startup.return_value = (True, "Startup disabled successfully")
+    return dialog
+
+
+def test_load_settings_syncs_startup_state_before_populating_tabs():
+    dialog = _make_dialog(startup_enabled=False, actual_enabled=True)
+
+    dialog._load_settings()
+
+    dialog.config_manager.sync_startup_setting.assert_called_once()
+    dialog.config_manager.get_settings.assert_called_once()
+    assert dialog._tab_objects[0].loaded_settings.startup_enabled is True
+
+
+def test_save_settings_enables_os_startup_before_persisting_setting():
+    dialog = _make_dialog(startup_enabled=True, actual_enabled=False)
+
+    assert dialog._save_settings() is True
+
+    dialog.config_manager.enable_startup.assert_called_once()
+    dialog.config_manager.disable_startup.assert_not_called()
+    dialog.config_manager.update_settings.assert_called_once_with(startup_enabled=True)
+
+
+def test_save_settings_disables_os_startup_before_persisting_setting():
+    dialog = _make_dialog(startup_enabled=False, actual_enabled=True)
+
+    assert dialog._save_settings() is True
+
+    dialog.config_manager.disable_startup.assert_called_once()
+    dialog.config_manager.enable_startup.assert_not_called()
+    dialog.config_manager.update_settings.assert_called_once_with(startup_enabled=False)
+
+
+def test_save_settings_stops_when_os_startup_enable_fails():
+    dialog = _make_dialog(startup_enabled=True, actual_enabled=False)
+    dialog.config_manager.enable_startup.return_value = (False, "Failed to enable startup")
+
+    with patch("accessiweather.ui.dialogs.settings_dialog_core.wx.MessageBox") as message_box:
+        assert dialog._save_settings() is False
+
+    dialog.config_manager.update_settings.assert_not_called()
+    message_box.assert_called_once()

--- a/tests/test_weather_client_nws_alerts_zone_reuse.py
+++ b/tests/test_weather_client_nws_alerts_zone_reuse.py
@@ -132,8 +132,10 @@ async def test_county_happy_path_uses_stored_zone(stored_location, empty_alerts_
 
 
 @pytest.mark.asyncio
-async def test_zone_happy_path_uses_stored_forecast_zone(stored_location, empty_alerts_payload):
-    """Zone radius + stored forecast_zone_id → zone param used, no /points call."""
+async def test_zone_happy_path_uses_stored_county_and_forecast_zones(
+    stored_location, empty_alerts_payload
+):
+    """Zone radius + stored zones → county and forecast zones are queried, no /points call."""
     alerts_response = _make_response(empty_alerts_payload)
 
     with patch("accessiweather.weather_client_nws.httpx.AsyncClient") as mock_client_class:
@@ -151,13 +153,171 @@ async def test_zone_happy_path_uses_stored_forecast_zone(stored_location, empty_
 
     assert result is not None
     counts = _count_calls(mock_client)
-    assert counts["points"] == 0, "Stored forecast_zone_id must skip /points"
+    assert counts["points"] == 0, "Stored zone IDs must skip /points"
+    assert counts["alerts"] == 2
+
+    alert_params = [
+        call.kwargs.get("params", {})
+        for call in mock_client.get.call_args_list
+        if _classify_call(call) == "alerts"
+    ]
+    assert alert_params == [
+        {"zone": "NYC061", "status": "actual"},
+        {"zone": "NYZ072", "status": "actual"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_zone_happy_path_deduplicates_county_and_forecast_alerts(stored_location):
+    """Zone radius should not show duplicate alerts returned by both zone endpoints."""
+    alert_feature = {
+        "id": "urn:test:duplicate-alert",
+        "properties": {
+            "headline": "Duplicate Alert",
+            "description": "Returned by both county and forecast zone endpoints.",
+            "event": "Test Warning",
+            "severity": "Severe",
+        },
+    }
+
+    with patch("accessiweather.weather_client_nws.httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client.get.side_effect = [
+            _make_response({"features": [alert_feature]}),
+            _make_response({"features": [alert_feature]}),
+        ]
+
+        result = await get_nws_alerts(
+            location=stored_location,
+            nws_base_url=BASE_URL,
+            user_agent=USER_AGENT,
+            timeout=10.0,
+            alert_radius_type="zone",
+        )
+
+    assert result is not None
+    assert len(result.alerts) == 1
+    assert result.alerts[0].id == "urn:test:duplicate-alert"
+
+
+@pytest.mark.asyncio
+async def test_zone_happy_path_keeps_good_zone_when_other_zone_fails(stored_location):
+    """A failed county/forecast zone request should not discard the other zone's alerts."""
+    alert_feature = {
+        "id": "urn:test:forecast-alert",
+        "properties": {
+            "headline": "Forecast Zone Alert",
+            "description": "Only one zone endpoint returned this alert.",
+            "event": "Test Warning",
+            "severity": "Severe",
+        },
+    }
+
+    with patch("accessiweather.weather_client_nws.httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client.get.side_effect = [
+            _make_response({}, status_code=404),
+            _make_response({"features": [alert_feature]}),
+        ]
+
+        result = await get_nws_alerts(
+            location=stored_location,
+            nws_base_url=BASE_URL,
+            user_agent=USER_AGENT,
+            timeout=10.0,
+            alert_radius_type="zone",
+        )
+
+    assert result is not None
+    assert len(result.alerts) == 1
+    assert result.alerts[0].id == "urn:test:forecast-alert"
+
+
+@pytest.mark.asyncio
+async def test_zone_fallback_resolves_county_and_forecast_zones(
+    unstored_location, empty_alerts_payload, points_payload
+):
+    """Zone radius + no stored zones resolves both zone IDs from /points."""
+    points_response = _make_response(points_payload)
+    alerts_response = _make_response(empty_alerts_payload)
+
+    with patch("accessiweather.weather_client_nws.httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        def _dispatch(url: str, *_args: object, **_kwargs: object):  # noqa: ARG001
+            del _args, _kwargs
+            if "/points/" in url:
+                return points_response
+            return alerts_response
+
+        mock_client.get.side_effect = _dispatch
+
+        result = await get_nws_alerts(
+            location=unstored_location,
+            nws_base_url=BASE_URL,
+            user_agent=USER_AGENT,
+            timeout=10.0,
+            alert_radius_type="zone",
+        )
+
+    assert result is not None
+    counts = _count_calls(mock_client)
+    assert counts["points"] == 1
+    assert counts["alerts"] == 2
+
+    alert_params = [
+        call.kwargs.get("params", {})
+        for call in mock_client.get.call_args_list
+        if _classify_call(call) == "alerts"
+    ]
+    assert alert_params == [
+        {"zone": "NYC061", "status": "actual"},
+        {"zone": "NYZ072", "status": "actual"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_zone_fallback_uses_point_query_when_points_has_no_zones(
+    unstored_location, empty_alerts_payload
+):
+    """Zone radius falls back to point alerts when /points has no zone URLs."""
+    points_response = _make_response({"properties": {}})
+    alerts_response = _make_response(empty_alerts_payload)
+
+    with patch("accessiweather.weather_client_nws.httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        def _dispatch(url: str, *_args: object, **_kwargs: object):  # noqa: ARG001
+            del _args, _kwargs
+            if "/points/" in url:
+                return points_response
+            return alerts_response
+
+        mock_client.get.side_effect = _dispatch
+
+        result = await get_nws_alerts(
+            location=unstored_location,
+            nws_base_url=BASE_URL,
+            user_agent=USER_AGENT,
+            timeout=10.0,
+            alert_radius_type="zone",
+        )
+
+    assert result is not None
+    counts = _count_calls(mock_client)
+    assert counts["points"] == 1
     assert counts["alerts"] == 1
 
     alert_call = next(c for c in mock_client.get.call_args_list if _classify_call(c) == "alerts")
     params = alert_call.kwargs.get("params", {})
-    assert params.get("zone") == "NYZ072"
-    assert params.get("status") == "actual"
+    assert params == {
+        "point": f"{unstored_location.latitude},{unstored_location.longitude}",
+        "status": "actual",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_zone_enrichment_drift.py
+++ b/tests/test_zone_enrichment_drift.py
@@ -423,3 +423,48 @@ class TestPointsFetchErrorSkipsDrift:
         finally:
             weather_client_nws.set_zone_drift_sink(None)
         assert manager.save_calls == 0
+
+    async def test_get_nws_all_data_parallel_passes_alert_radius_type(self):
+        """The parallel helper should pass the selected alert area to alert fetching."""
+        from accessiweather import weather_client_nws
+        from accessiweather.models import WeatherAlerts
+
+        stored = _us_location()
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        point_response = MagicMock()
+        point_response.raise_for_status = MagicMock()
+        point_response.json.return_value = {"properties": {}}
+        mock_client.get = AsyncMock(return_value=point_response)
+
+        with (
+            patch.object(
+                weather_client_nws, "get_nws_current_conditions", new_callable=AsyncMock
+            ) as mock_current,
+            patch.object(
+                weather_client_nws,
+                "get_nws_forecast_and_discussion",
+                new_callable=AsyncMock,
+            ) as mock_forecast,
+            patch.object(
+                weather_client_nws, "get_nws_alerts", new_callable=AsyncMock
+            ) as mock_alerts,
+            patch.object(
+                weather_client_nws, "get_nws_hourly_forecast", new_callable=AsyncMock
+            ) as mock_hourly,
+        ):
+            mock_current.return_value = None
+            mock_forecast.return_value = (None, None, None)
+            mock_alerts.return_value = WeatherAlerts(alerts=[])
+            mock_hourly.return_value = None
+
+            await weather_client_nws.get_nws_all_data_parallel.__wrapped__(
+                stored,
+                "https://api.weather.gov",
+                "UA",
+                5.0,
+                mock_client,
+                alert_radius_type="state",
+            )
+
+            mock_alerts.assert_awaited_once()
+            assert mock_alerts.await_args.kwargs.get("alert_radius_type") == "state"


### PR DESCRIPTION
## Summary
- pass the configured alert area through the optimized NWS refresh path
- make zone alert mode query both county and forecast zones, preserving NWS affected zone IDs
- wire the startup checkbox to the platform startup manager and avoid alert rate-limit token loss on unchanged alerts

## Tests
- pytest tests/test_settings_dialog_startup.py tests/test_coverage_gaps.py::TestWeatherClientGetNwsAlerts tests/test_zone_enrichment_drift.py::TestPointsFetchErrorSkipsDrift::test_get_nws_all_data_parallel_passes_alert_radius_type tests/test_weather_client_nws_alerts_zone_reuse.py tests/test_nws_alerts.py::TestGetNwsAlertsParameters::test_parse_alerts_populates_affected_zones tests/test_alert_manager.py::TestAlertManager::test_unchanged_alert_does_not_consume_rate_limit_token tests/test_alert_manager.py::TestAlertManager::test_unchanged_alert_does_not_starve_new_alert_in_same_batch -q
- ruff check on touched files