### PR TITLE
feat(locations): geocode US street addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- You can now search for a US street address when adding or editing a location, so AccessiWeather can save coordinates for that specific address instead of the nearest city or ZIP result.
 - **National Products in Forecaster Notes** — Forecaster Notes now opens a dedicated National Products dialog for SPC, WPC, NHC, CPC, and other national NWS text products. The new view replaces the old Nationwide Discussions scraper with IEM AFOS plain-text products while keeping the existing Advanced Lookup path available for direct product searches (#641).
 - **Guided Advanced Lookup in Forecaster Notes** — Advanced Lookup now organizes NWS and IEM text products into product groups with clearer product choices, office selection, date presets, result limits, sort order, source selection, aviation AFD, center, WMO, and text-match filters.
 

--- a/src/accessiweather/config/config_manager.py
+++ b/src/accessiweather/config/config_manager.py
@@ -295,6 +295,24 @@ class ConfigManager:
         """Update marine_mode on an existing location."""
         return self._locations.update_location_marine_mode(name, marine_mode)
 
+    def update_location_details(
+        self,
+        name: str,
+        *,
+        latitude: float,
+        longitude: float,
+        country_code: str | None,
+        marine_mode: bool,
+    ) -> bool:
+        """Update editable details on an existing location."""
+        return self._locations.update_location_details(
+            name,
+            latitude=latitude,
+            longitude=longitude,
+            country_code=country_code,
+            marine_mode=marine_mode,
+        )
+
     def remove_location(self, name: str) -> bool:
         """Remove a location."""
         return self._locations.remove_location(name)

--- a/src/accessiweather/config/locations.py
+++ b/src/accessiweather/config/locations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from math import isclose
 from typing import TYPE_CHECKING
 
 from ..models import Location
@@ -187,6 +188,60 @@ class LocationOperations:
                 location.marine_mode = marine_mode
                 self.logger.info(f"Set marine_mode={marine_mode} on location: {name}")
                 return self._manager.save_config()
+
+        self.logger.warning(f"Location {name} not found")
+        return False
+
+    def update_location_details(
+        self,
+        name: str,
+        *,
+        latitude: float,
+        longitude: float,
+        country_code: str | None,
+        marine_mode: bool,
+    ) -> bool:
+        """
+        Update editable details on an existing location and persist them.
+
+        The location name is intentionally stable. When coordinates change,
+        cached NWS metadata is cleared so the next refresh resolves zones for
+        the new point instead of reusing the old city/ZIP point.
+        """
+        config = self._manager.get_config()
+
+        for location in config.locations:
+            if location.name != name:
+                continue
+
+            coordinates_changed = not (
+                isclose(location.latitude, latitude, abs_tol=1e-6)
+                and isclose(location.longitude, longitude, abs_tol=1e-6)
+            )
+
+            location.latitude = latitude
+            location.longitude = longitude
+            location.country_code = country_code
+            location.marine_mode = marine_mode
+
+            if coordinates_changed:
+                location.timezone = None
+                location.forecast_zone_id = None
+                location.cwa_office = None
+                location.county_zone_id = None
+                location.fire_zone_id = None
+                location.radar_station = None
+
+            current = config.current_location
+            if current is not None and current.name == name:
+                config.current_location = location
+
+            self.logger.info(
+                "Updated location details for %s%s",
+                name,
+                " and cleared zone metadata" if coordinates_changed else "",
+            )
+            return self._manager.save_config()
 
         self.logger.warning(f"Location {name} not found")
         return False

--- a/src/accessiweather/location_manager.py
+++ b/src/accessiweather/location_manager.py
@@ -6,6 +6,7 @@ replacing the complex location service with direct operations.
 """
 
 import logging
+import re
 
 import httpx
 
@@ -23,22 +24,45 @@ logger = logging.getLogger(__name__)
 class LocationManager:
     """Simple location manager with geocoding support via Open-Meteo."""
 
+    STREET_ADDRESS_PATTERN = re.compile(
+        r"\b\d+\b.*\b("
+        r"aly|alley|ave|avenue|blvd|boulevard|cir|circle|ct|court|dr|drive|hwy|highway|"
+        r"ln|lane|pkwy|parkway|pl|place|rd|road|sq|square|st|street|ter|terrace|"
+        r"trail|trl|way"
+        r")\b",
+        re.IGNORECASE,
+    )
+    STARTS_WITH_NUMBER_PATTERN = re.compile(r"^\s*\d+\b")
+
     def __init__(self):
         """Initialize the instance."""
         self.timeout = 10.0
         self.geocoding_base_url = "https://geocoding-api.open-meteo.com/v1"
+        self.census_geocoding_base_url = "https://geocoding.geo.census.gov/geocoder"
 
     @async_retry_with_backoff(max_attempts=3, base_delay=1.0, timeout=15.0)
     async def search_locations(self, query: str, limit: int = 5) -> list[Location]:
         """Search for locations using Open-Meteo geocoding API."""
         logger.info(f"Searching for locations: {sanitize_log(query)}")
 
+        query = query.strip()
+
         # Open-Meteo requires at least 2 characters
-        if len(query.strip()) < 2:
+        if len(query) < 2:
             logger.info("Query too short for geocoding")
             return []
 
         try:
+            if self._looks_like_street_address(query):
+                address_locations = await self._search_us_street_address(query, limit=limit)
+                if address_locations:
+                    logger.info(
+                        "Found %s address locations for query: %s",
+                        len(address_locations),
+                        sanitize_log(query),
+                    )
+                    return address_locations
+
             url = f"{self.geocoding_base_url}/search"
             params = {
                 "name": query,
@@ -102,6 +126,68 @@ class LocationManager:
             if isinstance(e, RETRYABLE_EXCEPTIONS) or is_retryable_http_error(e):
                 raise
             return []
+
+    def _looks_like_street_address(self, query: str) -> bool:
+        """Return True when a query has enough street-address shape for Census geocoding."""
+        return bool(
+            self.STREET_ADDRESS_PATTERN.search(query)
+            or (self.STARTS_WITH_NUMBER_PATTERN.search(query) and "," in query)
+        )
+
+    async def _search_us_street_address(self, query: str, limit: int = 5) -> list[Location]:
+        """Search a US street address with the Census Geocoder."""
+        url = f"{self.census_geocoding_base_url}/locations/onelineaddress"
+        params = {
+            "address": query,
+            "benchmark": "Public_AR_Current",
+            "format": "json",
+        }
+
+        async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
+            response = await client.get(url, params=params)
+            response.raise_for_status()
+            data = response.json()
+
+        matches = data.get("result", {}).get("addressMatches", [])
+        locations: list[Location] = []
+        seen: set[str] = set()
+
+        for match in matches:
+            location = self._parse_census_address_match(match)
+            if location is None:
+                continue
+
+            key = f"{location.name.casefold()}:{location.latitude:.6f}:{location.longitude:.6f}"
+            if key in seen:
+                continue
+
+            seen.add(key)
+            locations.append(location)
+            if len(locations) >= limit:
+                break
+
+        return locations
+
+    def _parse_census_address_match(self, data: dict) -> Location | None:
+        """Parse a Census Geocoder address match into a Location."""
+        try:
+            coordinates = data.get("coordinates", {})
+            latitude = float(coordinates["y"])
+            longitude = float(coordinates["x"])
+            matched_address = str(data.get("matchedAddress") or "").strip()
+            if not matched_address:
+                return None
+
+            return Location(
+                name=matched_address,
+                latitude=latitude,
+                longitude=longitude,
+                country_code="US",
+            )
+
+        except (KeyError, TypeError, ValueError) as e:
+            logger.warning("Skipping Census address match with invalid coordinates: %s", e)
+            return None
 
     def _parse_geocoding_result(self, data: dict) -> Location | None:
         """Parse Open-Meteo geocoding API result into Location object."""

--- a/src/accessiweather/ui/dialogs/location_dialog.py
+++ b/src/accessiweather/ui/dialogs/location_dialog.py
@@ -3,14 +3,26 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import wx
 
 if TYPE_CHECKING:
     from ...app import AccessiWeatherApp
+    from ...models import Location
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class EditLocationResult:
+    """Editable values returned by the edit location dialog."""
+
+    latitude: float
+    longitude: float
+    country_code: str | None
+    marine_mode: bool
 
 
 def show_add_location_dialog(parent, app: AccessiWeatherApp) -> str | None:
@@ -49,19 +61,22 @@ def show_add_location_dialog(parent, app: AccessiWeatherApp) -> str | None:
         return None
 
 
-def show_edit_location_dialog(parent, app: AccessiWeatherApp, location) -> bool | None:
+def show_edit_location_dialog(
+    parent,
+    app: AccessiWeatherApp,
+    location,
+) -> EditLocationResult | None:
     """
     Show a small edit dialog for an existing location.
 
-    Currently edits the per-location ``marine_mode`` flag only. Returns the new
-    value on OK, or ``None`` if the user cancelled.
+    Returns the chosen editable values on OK, or ``None`` if the user cancelled.
     """
     try:
-        dlg = EditLocationDialog(parent, location)
+        dlg = EditLocationDialog(parent, app, location)
         result = dlg.ShowModal()
 
         if result == wx.ID_OK:
-            new_value = dlg.get_marine_mode()
+            new_value = dlg.get_result()
             dlg.Destroy()
             return new_value
 
@@ -103,22 +118,39 @@ def _edit_location_is_us(location) -> bool:
 
 
 class EditLocationDialog(wx.Dialog):
-    """Small dialog for editing an existing location's marine-mode flag."""
+    """Dialog for editing an existing location."""
 
-    def __init__(self, parent, location):
+    def __init__(self, parent, app: AccessiWeatherApp, location: Location):
         """Initialize with the location being edited."""
         super().__init__(
             parent,
             title=f"Edit Location: {location.name}",
-            style=wx.DEFAULT_DIALOG_STYLE,
+            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
         )
+        self.app = app
         self._location = location
+        self._selected_location: Location | None = None
+        self._search_results: list[Location] = []
+        self._is_searching = False
+
+        from ...location_manager import LocationManager
+
+        self.location_manager = LocationManager()
 
         panel = wx.Panel(self)
         sizer = wx.BoxSizer(wx.VERTICAL)
 
         name_label = wx.StaticText(panel, label=f"Location: {location.name}")
         sizer.Add(name_label, 0, wx.ALL, 10)
+
+        self.current_coordinates_label = wx.StaticText(
+            panel,
+            label=(
+                "Current coordinates: "
+                f"{self.location_manager.format_coordinates(location.latitude, location.longitude)}"
+            ),
+        )
+        sizer.Add(self.current_coordinates_label, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
 
         self.marine_checkbox = wx.CheckBox(
             panel,
@@ -130,6 +162,47 @@ class EditLocationDialog(wx.Dialog):
         )
         self.marine_checkbox.SetName("Enable Marine Mode for this location")
         sizer.Add(self.marine_checkbox, 0, wx.ALL | wx.EXPAND, 10)
+
+        address_box = wx.StaticBox(panel, label="Update Coordinates from Address")
+        address_sizer = wx.StaticBoxSizer(address_box, wx.VERTICAL)
+        address_parent = address_box
+
+        address_label = wx.StaticText(
+            address_parent,
+            label="Search for a US street address to update this saved location:",
+        )
+        address_sizer.Add(address_label, 0, wx.ALL, 5)
+
+        search_row = wx.BoxSizer(wx.HORIZONTAL)
+        self.address_input = wx.TextCtrl(address_parent, style=wx.TE_PROCESS_ENTER)
+        self.address_input.SetHint("Street address, city, state, and ZIP")
+        self.address_input.SetName("Address lookup for saved location coordinates")
+        self.address_input.Bind(wx.EVT_TEXT_ENTER, self._on_address_search)
+        search_row.Add(self.address_input, 1, wx.RIGHT, 8)
+
+        self.address_search_button = wx.Button(address_parent, label="Search")
+        self.address_search_button.Bind(wx.EVT_BUTTON, self._on_address_search)
+        search_row.Add(self.address_search_button, 0)
+        address_sizer.Add(search_row, 0, wx.EXPAND | wx.ALL, 5)
+
+        self.address_results_list = wx.ListCtrl(
+            address_parent,
+            style=wx.LC_REPORT | wx.LC_SINGLE_SEL | wx.BORDER_SUNKEN,
+            size=(-1, 110),
+        )
+        self.address_results_list.SetName("Address lookup results")
+        self.address_results_list.InsertColumn(0, "Matched Address", width=320)
+        self.address_results_list.InsertColumn(1, "Coordinates", width=180)
+        self.address_results_list.Bind(wx.EVT_LIST_ITEM_SELECTED, self._on_address_selected)
+        address_sizer.Add(self.address_results_list, 0, wx.EXPAND | wx.ALL, 5)
+
+        self.coordinate_comparison_label = wx.StaticText(
+            address_parent,
+            label="No address selected. Existing coordinates will be kept.",
+        )
+        self.coordinate_comparison_label.SetName("Coordinate comparison")
+        address_sizer.Add(self.coordinate_comparison_label, 0, wx.ALL, 5)
+        sizer.Add(address_sizer, 0, wx.EXPAND | wx.ALL, 10)
 
         # NWS Zone Information section (US locations only, snapshot at open).
         self._zone_info_box = wx.StaticBox(panel, label="NWS Zone Information")
@@ -166,12 +239,112 @@ class EditLocationDialog(wx.Dialog):
         ok_button.SetDefault()
 
         # Fit to content, but keep a baseline minimum width.
-        self.SetMinSize(wx.Size(420, -1))
+        self.SetMinSize(wx.Size(640, -1))
         self.Fit()
 
-    def get_marine_mode(self) -> bool:
-        """Return the marine_mode value chosen in the dialog."""
-        return self.marine_checkbox.GetValue()
+    def _on_address_search(self, event) -> None:
+        """Handle address search button press."""
+        query = self.address_input.GetValue().strip()
+        if not query:
+            self._set_coordinate_comparison("Enter an address to search.", is_error=True)
+            return
+
+        if self._is_searching:
+            self._set_coordinate_comparison("Search already in progress.", is_error=True)
+            return
+
+        self._is_searching = True
+        self.address_search_button.Disable()
+        self._set_coordinate_comparison(f"Searching for '{query}'...")
+        self.address_results_list.DeleteAllItems()
+        self._search_results = []
+        self._selected_location = None
+
+        self.app.run_async(self._do_address_search(query))
+
+    async def _do_address_search(self, query: str) -> None:
+        """Perform the address lookup."""
+        try:
+            locations = await self.location_manager.search_locations(query, limit=5)
+            wx.CallAfter(self._on_address_search_complete, locations)
+        except Exception as e:
+            logger.error(f"Address lookup failed: {e}")
+            wx.CallAfter(self._on_address_search_error, str(e))
+
+    def _on_address_search_complete(self, locations: list[Location]) -> None:
+        """Handle address lookup completion."""
+        self._is_searching = False
+        self.address_search_button.Enable()
+
+        if not locations:
+            self._set_coordinate_comparison("No address matches found.", is_error=True)
+            return
+
+        self._search_results = locations
+        for location in locations:
+            coords = self.location_manager.format_coordinates(
+                location.latitude,
+                location.longitude,
+            )
+            index = self.address_results_list.InsertItem(
+                self.address_results_list.GetItemCount(),
+                location.name,
+            )
+            self.address_results_list.SetItem(index, 1, coords)
+
+        self._set_coordinate_comparison(
+            f"Found {len(locations)} matches. Select one to compare coordinates."
+        )
+
+    def _on_address_search_error(self, error: str) -> None:
+        """Handle address lookup failure."""
+        self._is_searching = False
+        self.address_search_button.Enable()
+        self._set_coordinate_comparison(f"Address search failed: {error}", is_error=True)
+
+    def _on_address_selected(self, event) -> None:
+        """Handle address result selection."""
+        index = event.GetIndex()
+        if not 0 <= index < len(self._search_results):
+            return
+
+        self._selected_location = self._search_results[index]
+        distance = self.location_manager.calculate_distance(
+            self._location,
+            self._selected_location,
+        )
+        current_coords = self.location_manager.format_coordinates(
+            self._location.latitude,
+            self._location.longitude,
+        )
+        new_coords = self.location_manager.format_coordinates(
+            self._selected_location.latitude,
+            self._selected_location.longitude,
+        )
+        self._set_coordinate_comparison(
+            f"Current: {current_coords}. New: {new_coords}. Difference: {distance:.2f} miles."
+        )
+
+    def _set_coordinate_comparison(self, message: str, is_error: bool = False) -> None:
+        """Update the coordinate comparison label."""
+        self.coordinate_comparison_label.SetLabel(message)
+        colour = wx.SystemSettings.GetColour(
+            wx.SYS_COLOUR_GRAYTEXT if is_error else wx.SYS_COLOUR_WINDOWTEXT
+        )
+        self.coordinate_comparison_label.SetForegroundColour(colour)
+        self.coordinate_comparison_label.Wrap(580)
+        self.Layout()
+        self.Fit()
+
+    def get_result(self) -> EditLocationResult:
+        """Return the editable values chosen in the dialog."""
+        selected = self._selected_location
+        return EditLocationResult(
+            latitude=selected.latitude if selected else self._location.latitude,
+            longitude=selected.longitude if selected else self._location.longitude,
+            country_code=(selected.country_code if selected else self._location.country_code),
+            marine_mode=self.marine_checkbox.GetValue(),
+        )
 
 
 class AddLocationDialog(wx.Dialog):
@@ -245,12 +418,15 @@ class AddLocationDialog(wx.Dialog):
 
         # Search section
         search_sizer = wx.BoxSizer(wx.VERTICAL)
-        search_label = wx.StaticText(panel, label="Search for Location (city/zipcode):")
+        search_label = wx.StaticText(
+            panel,
+            label="Search for Location (city, ZIP/postal code, or US address):",
+        )
         search_sizer.Add(search_label, 0, wx.BOTTOM, 5)
 
         search_row = wx.BoxSizer(wx.HORIZONTAL)
         self.search_input = wx.TextCtrl(panel, style=wx.TE_PROCESS_ENTER)
-        self.search_input.SetHint("City name or ZIP/postal code")
+        self.search_input.SetHint("City, ZIP/postal code, or US street address")
         self.search_input.Bind(wx.EVT_TEXT_ENTER, self._on_search)
         search_row.Add(self.search_input, 1, wx.RIGHT, 10)
 
@@ -260,7 +436,10 @@ class AddLocationDialog(wx.Dialog):
 
         search_sizer.Add(search_row, 0, wx.EXPAND)
 
-        search_help = wx.StaticText(panel, label="Examples: 'New York', '10001', 'London'")
+        search_help = wx.StaticText(
+            panel,
+            label="Examples: 'London', 'New York', '10001', or '123 Main St, Carrollton, TX'",
+        )
         search_help.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
         search_sizer.Add(search_help, 0, wx.TOP, 5)
 

--- a/src/accessiweather/ui/main_window_locations.py
+++ b/src/accessiweather/ui/main_window_locations.py
@@ -91,7 +91,7 @@ class MainWindowLocationMixin:
             self.refresh_weather_async()
 
     def on_edit_location(self) -> None:
-        """Handle edit location button click — currently edits marine_mode."""
+        """Handle edit location button click."""
         selected = self.location_dropdown.GetStringSelection()
         if not selected or selected == ALL_LOCATIONS_SENTINEL:
             from . import main_window as base_module
@@ -112,11 +112,20 @@ class MainWindowLocationMixin:
 
         from . import main_window as base_module
 
-        new_marine_mode = base_module.show_edit_location_dialog(self, self.app, location)
-        if new_marine_mode is None:
+        edit_result = base_module.show_edit_location_dialog(self, self.app, location)
+        if edit_result is None:
             return
 
-        self.app.config_manager.update_location_marine_mode(selected, new_marine_mode)
+        if isinstance(edit_result, bool):
+            self.app.config_manager.update_location_marine_mode(selected, edit_result)
+        else:
+            self.app.config_manager.update_location_details(
+                selected,
+                latitude=edit_result.latitude,
+                longitude=edit_result.longitude,
+                country_code=edit_result.country_code,
+                marine_mode=edit_result.marine_mode,
+            )
         self.refresh_weather_async(force_refresh=True)
 
     def on_remove_location(self) -> None:

--- a/tests/test_all_locations_view.py
+++ b/tests/test_all_locations_view.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 # ---------------------------------------------------------------------------
@@ -451,6 +452,34 @@ class TestEditLocation:
         win.app.config_manager.update_location_marine_mode.assert_called_once_with(
             "Annapolis", True
         )
+
+    def test_edit_location_applies_coordinate_result_from_dialog(self):
+        import accessiweather.ui.main_window as mw_module
+        from accessiweather.ui.main_window import MainWindow
+
+        win = _make_window()
+        win.location_dropdown.GetStringSelection.return_value = "Annapolis"
+        annapolis = _make_location("Annapolis")
+        annapolis.marine_mode = False
+        win.app.config_manager.get_all_locations.return_value = [annapolis]
+        edit_result = SimpleNamespace(
+            latitude=38.9784,
+            longitude=-76.4922,
+            country_code="US",
+            marine_mode=True,
+        )
+
+        with patch.object(mw_module, "show_edit_location_dialog", return_value=edit_result):
+            MainWindow.on_edit_location(win)
+
+        win.app.config_manager.update_location_details.assert_called_once_with(
+            "Annapolis",
+            latitude=38.9784,
+            longitude=-76.4922,
+            country_code="US",
+            marine_mode=True,
+        )
+        win.app.config_manager.update_location_marine_mode.assert_not_called()
 
     def test_edit_location_does_nothing_on_cancel(self):
         import accessiweather.ui.main_window as mw_module

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -211,6 +211,76 @@ class TestConfigManager:
         """Updating marine_mode on an unknown location returns False."""
         assert manager.update_location_marine_mode("Nowhere", True) is False
 
+    def test_update_location_details_changes_coordinates_and_clears_zone_metadata(self, manager):
+        """Updating saved coordinates keeps the name and clears stale zone fields."""
+        manager.add_location("Lumberton", 39.965, -74.805, country_code="US")
+        location = manager.get_all_locations()[0]
+        location.timezone = "America/New_York"
+        location.forecast_zone_id = "NJZ020"
+        location.cwa_office = "PHI"
+        location.county_zone_id = "NJC005"
+        location.fire_zone_id = "NJZ020"
+        location.radar_station = "KDIX"
+        manager.save_config()
+
+        result = manager.update_location_details(
+            "Lumberton",
+            latitude=39.9571,
+            longitude=-74.8069,
+            country_code="US",
+            marine_mode=True,
+        )
+
+        assert result is True
+        updated = manager.get_all_locations()[0]
+        assert updated.name == "Lumberton"
+        assert updated.latitude == pytest.approx(39.9571)
+        assert updated.longitude == pytest.approx(-74.8069)
+        assert updated.country_code == "US"
+        assert updated.marine_mode is True
+        assert updated.timezone is None
+        assert updated.forecast_zone_id is None
+        assert updated.cwa_office is None
+        assert updated.county_zone_id is None
+        assert updated.fire_zone_id is None
+        assert updated.radar_station is None
+        assert manager.get_current_location() is not None
+        assert manager.get_current_location().latitude == pytest.approx(39.9571)
+
+    def test_update_location_details_keeps_zone_metadata_when_coordinates_match(self, manager):
+        """Updating only marine mode/country preserves resolved zone metadata."""
+        manager.add_location("Lumberton", 39.965, -74.805, country_code="US")
+        location = manager.get_all_locations()[0]
+        location.forecast_zone_id = "NJZ020"
+        location.county_zone_id = "NJC005"
+        manager.save_config()
+
+        result = manager.update_location_details(
+            "Lumberton",
+            latitude=39.965,
+            longitude=-74.805,
+            country_code="US",
+            marine_mode=True,
+        )
+
+        assert result is True
+        updated = manager.get_all_locations()[0]
+        assert updated.forecast_zone_id == "NJZ020"
+        assert updated.county_zone_id == "NJC005"
+
+    def test_update_location_details_nonexistent_returns_false(self, manager):
+        """Updating an unknown location returns False."""
+        assert (
+            manager.update_location_details(
+                "Nowhere",
+                latitude=1.0,
+                longitude=2.0,
+                country_code="US",
+                marine_mode=False,
+            )
+            is False
+        )
+
     def test_update_settings(self, manager):
         """Test updating settings."""
         manager.load_config()

--- a/tests/test_location_manager_address_geocoding.py
+++ b/tests/test_location_manager_address_geocoding.py
@@ -1,0 +1,123 @@
+"""Tests for street-address geocoding in LocationManager."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from accessiweather.location_manager import LocationManager
+
+
+def _make_response(payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = payload
+    response.raise_for_status = MagicMock()
+    return response
+
+
+@pytest.fixture
+def census_payload() -> dict:
+    return {
+        "result": {
+            "addressMatches": [
+                {
+                    "coordinates": {
+                        "x": -76.928365658124,
+                        "y": 38.845053106269,
+                    },
+                    "matchedAddress": "4600 SILVER HILL RD, WASHINGTON, DC, 20233",
+                }
+            ]
+        }
+    }
+
+
+def test_street_address_detection_keeps_city_and_zip_queries_on_existing_path() -> None:
+    manager = LocationManager()
+
+    assert manager._looks_like_street_address("4600 Silver Hill Rd, Washington, DC")
+    assert manager._looks_like_street_address("123 Main Street, Carrollton, TX")
+    assert manager._looks_like_street_address("1234 Elm, Carrollton, TX")
+    assert not manager._looks_like_street_address("Carrollton, TX")
+    assert not manager._looks_like_street_address("75007")
+
+
+def test_parse_census_address_match_returns_us_location(census_payload: dict) -> None:
+    manager = LocationManager()
+
+    location = manager._parse_census_address_match(census_payload["result"]["addressMatches"][0])
+
+    assert location is not None
+    assert location.name == "4600 SILVER HILL RD, WASHINGTON, DC, 20233"
+    assert location.latitude == pytest.approx(38.845053106269)
+    assert location.longitude == pytest.approx(-76.928365658124)
+    assert location.country_code == "US"
+
+
+@pytest.mark.asyncio
+async def test_search_locations_uses_census_for_street_address(census_payload: dict) -> None:
+    manager = LocationManager()
+
+    with patch("accessiweather.location_manager.httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client.get.return_value = _make_response(census_payload)
+
+        locations = await manager.search_locations(
+            "4600 Silver Hill Rd, Washington, DC 20233",
+            limit=5,
+        )
+
+    assert len(locations) == 1
+    assert locations[0].name == "4600 SILVER HILL RD, WASHINGTON, DC, 20233"
+    assert locations[0].country_code == "US"
+
+    mock_client.get.assert_called_once()
+    call = mock_client.get.call_args
+    assert call.args == ("https://geocoding.geo.census.gov/geocoder/locations/onelineaddress",)
+    assert call.kwargs["params"] == {
+        "address": "4600 Silver Hill Rd, Washington, DC 20233",
+        "benchmark": "Public_AR_Current",
+        "format": "json",
+    }
+
+
+@pytest.mark.asyncio
+async def test_search_locations_falls_back_to_openmeteo_when_address_has_no_match(
+    census_payload: dict,
+) -> None:
+    manager = LocationManager()
+    census_payload["result"]["addressMatches"] = []
+
+    with patch("accessiweather.location_manager.httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client.get.side_effect = [
+            _make_response(census_payload),
+            _make_response(
+                {
+                    "results": [
+                        {
+                            "name": "Carrollton",
+                            "latitude": 32.95373,
+                            "longitude": -96.89028,
+                            "admin1": "Texas",
+                            "country": "United States",
+                            "country_code": "US",
+                        }
+                    ]
+                }
+            ),
+        ]
+
+        locations = await manager.search_locations(
+            "123 Unknown Street, Carrollton, TX",
+            limit=5,
+        )
+
+    assert len(locations) == 1
+    assert locations[0].name == "Carrollton, Texas"
+    assert locations[0].latitude == pytest.approx(32.95373)
+    assert locations[0].longitude == pytest.approx(-96.89028)
+    assert mock_client.get.call_count == 2


### PR DESCRIPTION
## Summary
- add a Census Geocoder path for US street-address searches before the existing Open-Meteo city/ZIP lookup
- return matched address coordinates as selectable locations with country_code=US
- update the Add Location dialog copy and changelog for address-specific location saves

## Notes
- The Census Geocoder address path is US-focused; city, ZIP, and international searches continue through the existing Open-Meteo flow.

## Tests
- pytest tests/test_location_manager_address_geocoding.py -q
- ruff check src/accessiweather/location_manager.py src/accessiweather/ui/dialogs/location_dialog.py tests/test_location_manager_address_geocoding.py
- python scripts/changelog_tools.py check --base origin/dev --head HEAD
- uv run python live Census address smoke for 4600 Silver Hill Rd, Washington, DC 20233