### PR TITLE
fix(weather): harden providers, alerts, and text products

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 *.py[cod]
 *.pyo
 .venv/
+.venv-wsl/
 venv/
 *.egg-info/
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Open-Meteo forecasts now keep unit-aware wind, visibility, snow depth, pressure, and freezing-level details instead of misreading feet, meters, or kilometers in some payloads.
+- Open-Meteo daily forecasts now include low temperatures and wind details when the API provides them.
+- Weather history comparisons now skip incomplete Open-Meteo archive responses instead of comparing against placeholder zero values.
+- Pressure outlooks no longer show unrealistic swings when current conditions and hourly forecasts use mixed pressure reference levels.
 - NWS and Pirate Weather data handling is more accurate: NWS alert lookups now avoid rejected radius parameters and stale cross-location alert caches, while Pirate Weather no longer treats precipitation rate as accumulated amount or reuses US units for international minutely precipitation checks.
+- NWS forecasts now pair daytime highs with following nighttime lows when NWS provides day/night forecast periods.
 - Smart Auto mode now keeps the NWS forecaster discussion from its main NWS fetch, avoids a duplicate follow-up request when it already has that discussion, and chooses Open-Meteo for extended US forecasts even if Pirate Weather is listed first.
 - Smart Auto mode now fills in current condition text from Open-Meteo or Pirate Weather when NWS reports an empty or unknown condition.
 - Canadian locations near the border no longer try NWS in Automatic mode when an older/manual location is missing a saved country code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Open-Meteo forecasts now keep unit-aware wind, visibility, snow depth, pressure, and freezing-level details instead of misreading feet, meters, or kilometers in some payloads.
+- NWS and Pirate Weather data handling is more accurate: NWS alert lookups now avoid rejected radius parameters and stale cross-location alert caches, while Pirate Weather no longer treats precipitation rate as accumulated amount or reuses US units for international minutely precipitation checks.
 - Alerts now honor your selected alert area during regular refreshes, including state and zone alert modes.
 - Zone alert mode now checks both county and forecast zones so county-based watches and warnings are less likely to be missed.
 - The "Launch automatically at startup" setting now updates the system startup entry instead of only saving the checkbox.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Smart Auto mode now keeps the NWS forecaster discussion from its main NWS fetch, avoids a duplicate follow-up request when it already has that discussion, and chooses Open-Meteo for extended US forecasts even if Pirate Weather is listed first.
 - Smart Auto mode now fills in current condition text from Open-Meteo or Pirate Weather when NWS reports an empty or unknown condition.
 - Canadian locations near the border no longer try NWS in Automatic mode when an older/manual location is missing a saved country code.
+- IEM text-product lookup errors no longer appear as if they were valid forecaster text.
 - Alerts now honor your selected alert area during regular refreshes, including state and zone alert modes.
 - Zone alert mode now checks both county and forecast zones so county-based watches and warnings are less likely to be missed.
 - The "Launch automatically at startup" setting now updates the system startup entry instead of only saving the checkbox.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Linux nightly and release downloads now ship as `.tar.gz` tarballs instead of ZIP files.
 
 ### Fixed
+- Open-Meteo forecasts now keep unit-aware wind, visibility, snow depth, pressure, and freezing-level details instead of misreading feet, meters, or kilometers in some payloads.
 - Alerts now honor your selected alert area during regular refreshes, including state and zone alert modes.
 - Zone alert mode now checks both county and forecast zones so county-based watches and warnings are less likely to be missed.
 - The "Launch automatically at startup" setting now updates the system startup entry instead of only saving the checkbox.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - NWS and Pirate Weather data handling is more accurate: NWS alert lookups now avoid rejected radius parameters and stale cross-location alert caches, while Pirate Weather no longer treats precipitation rate as accumulated amount or reuses US units for international minutely precipitation checks.
 - Smart Auto mode now keeps the NWS forecaster discussion from its main NWS fetch, avoids a duplicate follow-up request when it already has that discussion, and chooses Open-Meteo for extended US forecasts even if Pirate Weather is listed first.
 - Smart Auto mode now fills in current condition text from Open-Meteo or Pirate Weather when NWS reports an empty or unknown condition.
+- Canadian locations near the border no longer try NWS in Automatic mode when an older/manual location is missing a saved country code.
 - Alerts now honor your selected alert area during regular refreshes, including state and zone alert modes.
 - Zone alert mode now checks both county and forecast zones so county-based watches and warnings are less likely to be missed.
 - The "Launch automatically at startup" setting now updates the system startup entry instead of only saving the checkbox.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Open-Meteo forecasts now keep unit-aware wind, visibility, snow depth, pressure, and freezing-level details instead of misreading feet, meters, or kilometers in some payloads.
 - NWS and Pirate Weather data handling is more accurate: NWS alert lookups now avoid rejected radius parameters and stale cross-location alert caches, while Pirate Weather no longer treats precipitation rate as accumulated amount or reuses US units for international minutely precipitation checks.
 - Smart Auto mode now keeps the NWS forecaster discussion from its main NWS fetch, avoids a duplicate follow-up request when it already has that discussion, and chooses Open-Meteo for extended US forecasts even if Pirate Weather is listed first.
+- Smart Auto mode now fills in current condition text from Open-Meteo or Pirate Weather when NWS reports an empty or unknown condition.
 - Alerts now honor your selected alert area during regular refreshes, including state and zone alert modes.
 - Zone alert mode now checks both county and forecast zones so county-based watches and warnings are less likely to be missed.
 - The "Launch automatically at startup" setting now updates the system startup entry instead of only saving the checkbox.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Open-Meteo forecasts now keep unit-aware wind, visibility, snow depth, pressure, and freezing-level details instead of misreading feet, meters, or kilometers in some payloads.
 - NWS and Pirate Weather data handling is more accurate: NWS alert lookups now avoid rejected radius parameters and stale cross-location alert caches, while Pirate Weather no longer treats precipitation rate as accumulated amount or reuses US units for international minutely precipitation checks.
+- Smart Auto mode now keeps the NWS forecaster discussion from its main NWS fetch, avoids a duplicate follow-up request when it already has that discussion, and chooses Open-Meteo for extended US forecasts even if Pirate Weather is listed first.
 - Alerts now honor your selected alert area during regular refreshes, including state and zone alert modes.
 - Zone alert mode now checks both county and forecast zones so county-based watches and warnings are less likely to be missed.
 - The "Launch automatically at startup" setting now updates the system startup entry instead of only saving the checkbox.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,9 @@
 [pytest]
 # Test configuration optimized for local stability
-# - Parallel execution enabled with a conservative worker cap (-n 8)
+# - Parallel execution enabled with a conservative worker cap (-n 8), matching CI
 # - Verbose output with short tracebacks
 # - pytest-asyncio in auto mode
-addopts = -v --strict-markers -p no:asyncio -p pytest_asyncio.plugin -n 8 --dist loadscope --tb=short -m "not live_only"
+addopts = -v --strict-markers -p no:asyncio -p pytest_asyncio.plugin -n 8 --dist loadgroup --tb=short -m "not live_only"
 
 # =============================================================================
 # QUICK REFERENCE

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -2,6 +2,20 @@
 
 set -euo pipefail
 
+UV_BIN=""
+if command -v uv >/dev/null 2>&1; then
+    UV_BIN=$(command -v uv)
+elif [ -x "${HOME:-}/.local/bin/uv" ]; then
+    UV_BIN="${HOME:-}/.local/bin/uv"
+fi
+
+if [ -n "$UV_BIN" ]; then
+    if [ -d ".venv/Scripts" ] && [ ! -x ".venv/bin/python" ]; then
+        export UV_PROJECT_ENVIRONMENT="${UV_PROJECT_ENVIRONMENT:-.venv-wsl}"
+    fi
+    exec "$UV_BIN" run --extra dev pytest tests/ -m "not integration and not live_only" --maxfail=5 -x
+fi
+
 choose_python() {
     for candidate in \
         "${VIRTUAL_ENV:-}"/bin/python \
@@ -21,4 +35,4 @@ choose_python() {
 
 PYTHON_BIN=$(choose_python)
 
-exec "$PYTHON_BIN" -m pytest tests/ -m "unit" --maxfail=5 -x
+exec "$PYTHON_BIN" -m pytest tests/ -m "not integration and not live_only" --maxfail=5 -x

--- a/src/accessiweather/api/nws/alerts_discussions.py
+++ b/src/accessiweather/api/nws/alerts_discussions.py
@@ -13,6 +13,10 @@ from typing import Any, cast
 import httpx
 
 from accessiweather.api_client import ApiClientError, NoaaApiError
+from accessiweather.nws_national_products import (
+    fetch_iem_national_product,
+    national_product_afos_id,
+)
 from accessiweather.weather_gov_api_client.api.default import alerts_active, alerts_active_zone
 
 logger = logging.getLogger(__name__)
@@ -35,12 +39,14 @@ class NwsAlertsDiscussions:
         self._alert_etag: str | None = None
         self._alert_last_modified: str | None = None
         self._cached_alert_response: dict[str, Any] | None = None
+        self._alert_conditional_cache: dict[str, dict[str, Any]] = {}
 
     def reset_conditional_cache(self) -> None:
         """Reset conditional GET cache state (e.g. when location changes)."""
         self._alert_etag = None
         self._alert_last_modified = None
         self._cached_alert_response = None
+        self._alert_conditional_cache.clear()
 
     def _fetch_alerts_conditional(self, url: str) -> dict[str, Any]:
         """
@@ -52,18 +58,22 @@ class NwsAlertsDiscussions:
         """
         self.wrapper._rate_limit()
 
+        cache_entry = self._alert_conditional_cache.get(url, {})
         headers = {"User-Agent": f"{self.wrapper.user_agent} ({self.wrapper.contact_info})"}
-        if self._alert_etag:
-            headers["If-None-Match"] = self._alert_etag
-        if self._alert_last_modified:
-            headers["If-Modified-Since"] = self._alert_last_modified
+        if cache_entry.get("etag"):
+            headers["If-None-Match"] = cache_entry["etag"]
+        if cache_entry.get("last_modified"):
+            headers["If-Modified-Since"] = cache_entry["last_modified"]
 
         with httpx.Client(timeout=httpx.Timeout(10.0), follow_redirects=True) as client:
             response = client.get(url, headers=headers)
 
-            if response.status_code == 304 and self._cached_alert_response is not None:
+            if response.status_code == 304 and cache_entry.get("response") is not None:
                 logger.debug("Alerts not modified (304), returning cached data")
-                return self._cached_alert_response
+                return cache_entry["response"]
+            if response.status_code == 304:
+                logger.debug("Alerts not modified (304), but no URL-specific cached data exists")
+                return {"features": []}
 
             response.raise_for_status()
 
@@ -77,6 +87,11 @@ class NwsAlertsDiscussions:
 
             data = response.json()
             self._cached_alert_response = data
+            self._alert_conditional_cache[url] = {
+                "etag": etag,
+                "last_modified": last_modified,
+                "response": data,
+            }
             return data
 
     def get_alerts(
@@ -197,18 +212,18 @@ class NwsAlertsDiscussions:
                     self.wrapper._get_cached_or_fetch(cache_key, fetch_data, force_refresh),
                 )
 
-            # If we couldn't determine location or state, fall back to point-radius search
+            # If we couldn't determine location or state, fall back to point alerts.
             if location_type is None or location_id is None:
                 logger.info(
-                    f"Using point-radius search for alerts since location could not be determined: ({lat}, {lon}) with radius {radius} miles"
+                    f"Using point search for alerts since location could not be determined: ({lat}, {lon})"
                 )
                 cache_key = self.wrapper._generate_cache_key(
-                    "alerts_point", {"lat": lat, "lon": lon, "radius": radius}
+                    "alerts_point", {"lat": lat, "lon": lon}
                 )
 
                 def fetch_data() -> dict[str, Any]:
                     try:
-                        url = f"{self.wrapper.core_client.BASE_URL}/alerts/active?point={lat},{lon}&radius={radius}"
+                        url = f"{self.wrapper.core_client.BASE_URL}/alerts/active?point={lat},{lon}"
                         response = self._fetch_alerts_conditional(url)
                         return self._transform_alerts_data(response)
                     except Exception as e:
@@ -343,6 +358,13 @@ class NwsAlertsDiscussions:
 
             def fetch_data() -> str | None:
                 self.wrapper._rate_limit()
+                if national_product_afos_id(product_type, location) is not None:
+                    user_agent = f"{self.wrapper.user_agent} ({self.wrapper.contact_info})"
+                    return fetch_iem_national_product(
+                        product_type,
+                        location,
+                        user_agent=user_agent,
+                    )
                 try:
                     products_url = f"{self.wrapper.core_client.BASE_URL}/products/types/{product_type}/locations/{location}"
                     products_response = self.wrapper._fetch_url(products_url)

--- a/src/accessiweather/api/nws/point_location.py
+++ b/src/accessiweather/api/nws/point_location.py
@@ -5,6 +5,7 @@ This module handles geographic point data retrieval, transformation,
 and location type identification operations.
 """
 
+import json
 import logging
 from typing import Any, cast
 
@@ -55,8 +56,25 @@ class NwsPointLocation:
             self.wrapper._rate_limit()
             try:
                 point_str = f"{lat},{lon}"
-                response = self.wrapper.core_client.make_api_request(point.sync, point=point_str)
-                return self._transform_point_data(response)
+                response = point.sync_detailed(
+                    point=point_str,
+                    client=self.wrapper.core_client.client,
+                )
+                if response.parsed is not None:
+                    return self._transform_point_data(response.parsed)
+
+                status_code = int(response.status_code)
+                error_data = self._decode_problem_detail(response.content)
+                if 400 <= status_code < 500 and error_data is not None:
+                    return error_data
+
+                url = f"{self.wrapper.core_client.BASE_URL}/{endpoint}"
+                raise NoaaApiError(
+                    message=f"HTTP {status_code} error getting point data",
+                    error_type=NoaaApiError.HTTP_ERROR,
+                    url=url,
+                    status_code=status_code,
+                )
             except NoaaApiError:
                 raise
             except Exception as e:
@@ -70,6 +88,17 @@ class NwsPointLocation:
         return cast(
             dict[str, Any], self.wrapper._get_cached_or_fetch(cache_key, fetch_data, force_refresh)
         )
+
+    @staticmethod
+    def _decode_problem_detail(content: bytes | str) -> dict[str, Any] | None:
+        """Decode a weather.gov problem-detail response body."""
+        try:
+            if isinstance(content, bytes):
+                content = content.decode("utf-8")
+            decoded = json.loads(content)
+        except (UnicodeDecodeError, json.JSONDecodeError, TypeError):
+            return None
+        return decoded if isinstance(decoded, dict) else None
 
     def _transform_point_data(self, point_data: Any) -> dict[str, Any]:
         """
@@ -86,6 +115,8 @@ class NwsPointLocation:
         """
         # Extract and transform the data to match the format expected by the application
         if isinstance(point_data, dict):
+            if "properties" not in point_data and ("status" in point_data or "title" in point_data):
+                return point_data
             properties = point_data.get("properties", {})
             transformed = {
                 "properties": {
@@ -103,6 +134,11 @@ class NwsPointLocation:
                 }
             }
         else:
+            if hasattr(point_data, "to_dict") and not getattr(point_data, "properties", None):
+                point_dict = point_data.to_dict()
+                if "status" in point_dict or "title" in point_dict:
+                    return cast(dict[str, Any], point_dict)
+
             # Handle object with properties attribute
             properties_obj = getattr(point_data, "properties", None)
             if properties_obj:

--- a/src/accessiweather/api_client/alerts_and_products.py
+++ b/src/accessiweather/api_client/alerts_and_products.py
@@ -9,6 +9,11 @@ import logging
 import traceback
 from typing import Any
 
+from accessiweather.nws_national_products import (
+    fetch_iem_national_product,
+    national_product_afos_id,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -66,10 +71,8 @@ class AlertsAndProductsMixin:
         ----
             lat: Latitude of the location
             lon: Longitude of the location
-            radius: Radius in miles to search for alerts
-                    (used if location type cannot be determined)
-            precise_location: Whether to get alerts for the precise location (county/zone)
-                             or for the entire state
+            radius: Deprecated compatibility argument; NWS point alert queries do not support it
+            precise_location: Whether to get alerts for the precise point or broader state mode
             force_refresh: If True, bypass cache and fetch fresh data
 
         Returns:
@@ -82,17 +85,18 @@ class AlertsAndProductsMixin:
             f"precise_location={precise_location}"
         )
 
-        # Identify the location type
+        if precise_location:
+            logger.info(f"Fetching point-based alerts for precise location: ({lat}, {lon})")
+            return self._make_request(
+                "alerts/active",
+                params={"point": f"{lat},{lon}"},
+                force_refresh=force_refresh,
+            )
+
+        # Identify the location type for broader state/zone fallback modes.
         location_type, location_id = self.identify_location_type(
             lat, lon, force_refresh=force_refresh
         )
-
-        if precise_location and location_type in ("county", "forecast", "fire") and location_id:
-            # Get alerts for the specific zone
-            logger.info(f"Fetching alerts for {location_type} zone: {location_id}")
-            return self._make_request(
-                "alerts/active", params={"zone": location_id}, force_refresh=force_refresh
-            )
         if location_type == "state" or not precise_location:
             # If we're not using precise location or we only have state info,
             # get alerts for the entire state
@@ -119,14 +123,13 @@ class AlertsAndProductsMixin:
                     "alerts/active", params={"area": state}, force_refresh=force_refresh
                 )
 
-        # If we couldn't determine location or state, fall back to point-radius search
+        # If we couldn't determine location or state, fall back to point alerts.
         logger.info(
-            "Using point-radius search for alerts since location could not "
-            f"be determined: ({lat}, {lon}) with radius {radius} miles"
+            f"Using point search for alerts since location could not be determined: ({lat}, {lon})"
         )
         return self._make_request(
             "alerts/active",
-            params={"point": f"{lat},{lon}", "radius": str(radius)},
+            params={"point": f"{lat},{lon}"},
             force_refresh=force_refresh,
         )
 
@@ -249,6 +252,13 @@ class AlertsAndProductsMixin:
 
         """
         try:
+            if national_product_afos_id(product_type, location) is not None:
+                return fetch_iem_national_product(
+                    product_type,
+                    location,
+                    user_agent=self.headers.get("User-Agent", "AccessiWeather/1.0"),
+                )
+
             endpoint = f"products/types/{product_type}/locations/{location}"
             logger.debug(
                 f"Requesting national product: type={product_type}, "

--- a/src/accessiweather/api_wrapper.py
+++ b/src/accessiweather/api_wrapper.py
@@ -15,6 +15,22 @@ from accessiweather.api.openmeteo_wrapper import OpenMeteoApiWrapper
 logger = logging.getLogger(__name__)
 
 
+def _is_nws_supported_coordinate(lat: float, lon: float) -> bool:
+    """Return whether a coordinate is inside the approximate NWS coverage area."""
+    bounds = [
+        (24.0, 50.0, -125.0, -66.0),  # Continental US
+        (51.0, 72.0, -180.0, -130.0),  # Alaska
+        (51.0, 55.0, 172.0, 180.0),  # Aleutians crossing the dateline
+        (18.0, 23.0, -161.0, -154.0),  # Hawaii
+        (17.0, 19.0, -68.0, -64.0),  # Puerto Rico / US Virgin Islands
+        (13.0, 14.0, 144.0, 146.0),  # Guam
+    ]
+    return any(
+        min_lat <= lat <= max_lat and min_lon <= lon <= max_lon
+        for min_lat, max_lat, min_lon, max_lon in bounds
+    )
+
+
 class NoaaApiWrapper:
     """
     Provider coordinator for weather API operations.
@@ -96,9 +112,8 @@ class NoaaApiWrapper:
             return "openmeteo"
         if self.preferred_provider == "auto":
             # Auto-selection logic: Use NWS for US locations, Open-Meteo for international
-            # US boundaries (approximate): lat 24-49, lon -125 to -66
-            if 24.0 <= lat <= 49.0 and -125.0 <= lon <= -66.0:
-                logger.debug(f"Auto-selected NWS for US location: ({lat}, {lon})")
+            if _is_nws_supported_coordinate(lat, lon):
+                logger.debug(f"Auto-selected NWS for NWS-supported location: ({lat}, {lon})")
                 return "nws"
             logger.debug(f"Auto-selected Open-Meteo for international location: ({lat}, {lon})")
             return "openmeteo"

--- a/src/accessiweather/display/presentation/current_condition_trends.py
+++ b/src/accessiweather/display/presentation/current_condition_trends.py
@@ -7,6 +7,9 @@ from collections.abc import Iterable
 from ...models import CurrentConditions, HourlyForecast, HourlyForecastPeriod, TrendInsight
 from ...utils import TemperatureUnit
 
+MAX_LEGACY_PRESSURE_TREND_IN = 0.30
+MAX_LEGACY_PRESSURE_TREND_MB = 10.0
+
 
 def _adapt_temperature_trend_summary(trend: TrendInsight, unit_pref: TemperatureUnit) -> str:
     """Return a temperature-trend summary adapted to the user's unit preference."""
@@ -132,10 +135,14 @@ def compute_pressure_trend_from_hourly(
 
     if base_in is not None and future_in is not None:
         change = future_in - base_in
+        if abs(change) > MAX_LEGACY_PRESSURE_TREND_IN:
+            return None
         descriptor = direction_descriptor(change, minor=0.02, strong=0.05)
         magnitude = f"{change:+.2f} inHg"
     elif base_mb is not None and future_mb is not None:
         change = future_mb - base_mb
+        if abs(change) > MAX_LEGACY_PRESSURE_TREND_MB:
+            return None
         descriptor = direction_descriptor(change, minor=0.5, strong=1.5)
         magnitude = f"{change:+.1f} mb"
 

--- a/src/accessiweather/display/presentation/forecast.py
+++ b/src/accessiweather/display/presentation/forecast.py
@@ -7,6 +7,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from ...forecast_confidence import ForecastConfidence
 from ...impact_summary import ImpactSummary, build_forecast_impact_summary
+from ...location_classification import is_us_location
 from ...models import (
     AppSettings,
     Forecast,
@@ -41,16 +42,7 @@ __all__ = [
 
 def _is_us_location(location: Location) -> bool:
     """Determine whether a location should use US/NWS forecast limits."""
-    country_code = getattr(location, "country_code", None)
-    if country_code:
-        return country_code.upper() == "US"
-
-    lat = location.latitude
-    lon = location.longitude
-    in_continental_bounds = 24.0 <= lat <= 49.0 and -125.0 <= lon <= -66.0
-    in_alaska_bounds = 51.0 <= lat <= 71.5 and -172.0 <= lon <= -130.0
-    in_hawaii_bounds = 18.0 <= lat <= 23.0 and -161.0 <= lon <= -154.0
-    return in_continental_bounds or in_alaska_bounds or in_hawaii_bounds
+    return is_us_location(location)
 
 
 def _looks_like_half_day_periods(forecast: Forecast) -> bool:

--- a/src/accessiweather/display/weather_presenter.py
+++ b/src/accessiweather/display/weather_presenter.py
@@ -133,6 +133,7 @@ class WeatherPresenter:
             current=weather_data.current,
             hourly_forecast=weather_data.hourly_forecast,
             include_pressure=getattr(self.settings, "show_pressure_trend", True),
+            unit_pref=unit_pref,
         )
         status_messages = self._build_status_messages(weather_data)
         source_attribution = self._build_source_attribution(weather_data)
@@ -312,6 +313,7 @@ class WeatherPresenter:
             weather_data.trend_insights,
             current=weather_data.current,
             hourly_forecast=weather_data.hourly_forecast,
+            unit_pref=unit_pref,
         )
         if trend_lines:
             parts.append(trend_lines[0])

--- a/src/accessiweather/iem_client.py
+++ b/src/accessiweather/iem_client.py
@@ -59,6 +59,12 @@ def _clean_iem_text(value: str) -> str:
     return "".join(char for char in value if char in "\n\r\t" or ord(char) >= 32).strip()
 
 
+def _is_iem_error_text(value: str) -> bool:
+    """Return True when IEM reports a lookup error inside a 200 text response."""
+    first_line = next((line.strip() for line in value.splitlines() if line.strip()), "")
+    return first_line.upper().startswith("ERROR:")
+
+
 def _describe_request_error(exc: Exception) -> str:
     return str(exc) or exc.__class__.__name__
 
@@ -213,6 +219,8 @@ async def fetch_iem_afos_text(
         text = _clean_iem_text(response.text)
         if not text:
             raise IemProductFetchError(f"IEM AFOS returned no text for {product_id}")
+        if _is_iem_error_text(text):
+            raise IemProductFetchError(text.splitlines()[0])
         return TextProduct(
             product_type=product_id,
             product_id=product_id,
@@ -277,6 +285,8 @@ def fetch_iem_afos_text_sync(
         text = _clean_iem_text(response.text)
         if not text:
             raise IemProductFetchError(f"IEM AFOS returned no text for {product_id}")
+        if _is_iem_error_text(text):
+            raise IemProductFetchError(text.splitlines()[0])
         return TextProduct(
             product_type=product_id,
             product_id=product_id,

--- a/src/accessiweather/location_classification.py
+++ b/src/accessiweather/location_classification.py
@@ -1,0 +1,43 @@
+"""Location classification helpers shared by weather-source decisions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def is_us_location(location: Any) -> bool:
+    """
+    Return whether a location should use US/NWS weather surfaces.
+
+    Country codes are authoritative. Coordinate fallback is intentionally
+    conservative near the Canadian border, where legacy/manual locations may
+    lack ``country_code`` and otherwise look like US coordinates.
+    """
+    country_code = getattr(location, "country_code", None)
+    if country_code:
+        return str(country_code).upper() == "US"
+
+    lat = float(getattr(location, "latitude", 0.0))
+    lon = float(getattr(location, "longitude", 0.0))
+
+    in_alaska_bounds = 51.0 <= lat <= 71.5 and -172.0 <= lon <= -130.0
+    in_hawaii_bounds = 18.0 <= lat <= 23.0 and -161.0 <= lon <= -154.0
+    if in_alaska_bounds or in_hawaii_bounds:
+        return True
+
+    in_continental_bounds = 24.0 <= lat <= 49.0 and -125.0 <= lon <= -66.0
+    if not in_continental_bounds:
+        return False
+
+    # Victoria/Vancouver Island and the lower mainland sit inside the broad
+    # continental US box. Without a country code, avoid firing NWS /points at
+    # Canadian coordinates in this ambiguous western border strip.
+    in_western_canada_border_strip = lat >= 48.0 and -125.0 <= lon <= -122.0
+    if in_western_canada_border_strip:
+        return False
+
+    # Great Lakes and St. Lawrence corridor coordinates overlap many Canadian
+    # cities. Require a country code there too; geocoder-created locations have
+    # one, while old/manual entries can still fall back to Open-Meteo safely.
+    in_eastern_canada_border_strip = lat >= 43.0 and -95.0 < lon < -70.0
+    return not in_eastern_canada_border_strip

--- a/src/accessiweather/models/config_constants.py
+++ b/src/accessiweather/models/config_constants.py
@@ -69,6 +69,7 @@ NON_CRITICAL_SETTINGS: set[str] = {
     "update_check_interval_hours",
     "trend_insights_enabled",
     "trend_hours",
+    "parallel_fetch_timeout",
     "show_dewpoint",
     "show_pressure_trend",
     "show_visibility",

--- a/src/accessiweather/models/config_serialization.py
+++ b/src/accessiweather/models/config_serialization.py
@@ -85,6 +85,7 @@ class AppSettingsSerializationMixin:
             "auto_mode_api_budget": settings.auto_mode_api_budget,
             "auto_sources_us": settings.auto_sources_us,
             "auto_sources_international": settings.auto_sources_international,
+            "parallel_fetch_timeout": settings.parallel_fetch_timeout,
             "openmeteo_weather_model": settings.openmeteo_weather_model,
             "station_selection_strategy": settings.station_selection_strategy,
             # AI settings and AVWX key stored in secure storage, not here
@@ -209,6 +210,10 @@ class AppSettingsSerializationMixin:
             auto_sources_international=data.get(
                 "auto_sources_international", ["openmeteo", "pirateweather"]
             ),
+            parallel_fetch_timeout=settings_cls._as_float(
+                data.get("parallel_fetch_timeout"),
+                10.0,
+            ),
             openmeteo_weather_model=data.get("openmeteo_weather_model", "best_match"),
             station_selection_strategy=data.get("station_selection_strategy", "hybrid_default"),
             # AVWX and AI settings (stored in secure storage)
@@ -252,6 +257,7 @@ class AppSettingsSerializationMixin:
         settings.validate_on_access("source_priority_international")
         settings.validate_on_access("auto_sources_us")
         settings.validate_on_access("auto_sources_international")
+        settings.validate_on_access("parallel_fetch_timeout")
         if settings.data_source not in {"auto", "nws", "openmeteo", "pirateweather"}:
             settings.data_source = "auto"
         return settings

--- a/src/accessiweather/models/config_settings.py
+++ b/src/accessiweather/models/config_settings.py
@@ -128,7 +128,7 @@ class AppSettings(AppSettingsValidationMixin, AppSettingsSerializationMixin):
     # Impact summaries (Outdoor, Driving, Allergy) — opt-in, off by default
     show_impact_summaries: bool = False
     # Parallel fetch timeout for smart auto mode (seconds)
-    parallel_fetch_timeout: float = 5.0
+    parallel_fetch_timeout: float = 10.0
     # Auto mode source selection — which sources participate in auto mode
     auto_mode_api_budget: str = "max_coverage"
     auto_sources_us: list[str] = field(

--- a/src/accessiweather/models/config_validation.py
+++ b/src/accessiweather/models/config_validation.py
@@ -31,6 +31,16 @@ class AppSettingsValidationMixin:
             return bool(value)
         return default
 
+    @staticmethod
+    def _as_float(value, default: float) -> float:
+        """Normalize numeric configuration values to float."""
+        if value is None:
+            return default
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
     def validate_on_access(self, setting_name: str) -> bool:
         """
         Validate a non-critical setting on first access.
@@ -120,6 +130,12 @@ class AppSettingsValidationMixin:
             # Ensure reasonable range for trend hours (1-168 hours = 1 week)
             if not isinstance(value, int) or value < 1 or value > 168:
                 setattr(settings, setting_name, 24)
+
+        elif setting_name == "parallel_fetch_timeout":
+            timeout = settings._as_float(value, 10.0)
+            if timeout < 1.0 or timeout > 60.0:
+                timeout = 10.0
+            setattr(settings, setting_name, timeout)
 
         elif setting_name == "ai_cache_ttl":
             # Ensure non-negative integer for cache TTL

--- a/src/accessiweather/models/weather_data.py
+++ b/src/accessiweather/models/weather_data.py
@@ -34,6 +34,8 @@ class SourceData:
     forecast: Forecast | None = None
     hourly_forecast: HourlyForecast | None = None
     alerts: WeatherAlerts | None = None
+    discussion: str | None = None
+    discussion_issuance_time: datetime | None = None
     fetch_time: datetime = field(default_factory=lambda: datetime.now(UTC))
     success: bool = True
     error: str | None = None

--- a/src/accessiweather/nws_national_products.py
+++ b/src/accessiweather/nws_national_products.py
@@ -1,0 +1,48 @@
+"""Helpers for legacy national NWS product aliases."""
+
+from __future__ import annotations
+
+import logging
+
+from accessiweather.iem_client import IemProductFetchError, fetch_iem_afos_text_sync
+
+logger = logging.getLogger(__name__)
+
+NATIONAL_PRODUCT_AFOS_IDS: dict[tuple[str, str], str] = {
+    ("FXUS01", "KWNH"): "PMDSPD",
+    ("FXUS06", "KWNH"): "PMDEPD",
+    ("FXUS07", "KWNH"): "PMDET4",
+    ("FXUS02", "KWNH"): "QPFPFD",
+    ("ACUS01", "KWNS"): "SWODY1",
+    ("ACUS02", "KWNS"): "SWODY2",
+    ("ACUS03", "KWNS"): "SWODY3",
+    ("MIATWOAT", "KNHC"): "TWOAT",
+    ("MIATWOEP", "KNHC"): "TWOEP",
+    ("FXUS05", "KWNC"): "PMDMRD",
+    ("FXUS07", "KWNC"): "PMDMRD",
+}
+
+
+def national_product_afos_id(product_type: str, location: str) -> str | None:
+    """Return the IEM AFOS product ID for a legacy national product alias."""
+    return NATIONAL_PRODUCT_AFOS_IDS.get((product_type.upper(), location.upper()))
+
+
+def fetch_iem_national_product(
+    product_type: str,
+    location: str,
+    *,
+    timeout: int = 10,
+    user_agent: str = "AccessiWeather/1.0 (AccessiWeather)",
+) -> str | None:
+    """Fetch a national product through IEM when weather.gov lacks that product type."""
+    afos_id = national_product_afos_id(product_type, location)
+    if afos_id is None:
+        return None
+
+    try:
+        product = fetch_iem_afos_text_sync(afos_id, timeout=timeout, user_agent=user_agent)
+    except IemProductFetchError as exc:
+        logger.warning("IEM AFOS lookup failed for %s/%s: %s", product_type, location, exc)
+        return None
+    return product.product_text

--- a/src/accessiweather/openmeteo_mapper.py
+++ b/src/accessiweather/openmeteo_mapper.py
@@ -20,6 +20,22 @@ from .utils import TemperatureUnit, calculate_dewpoint
 logger = logging.getLogger(__name__)
 
 
+def _pressure_to_pascals(value: float | int | None, unit: str | None) -> float | None:
+    """Normalize Open-Meteo pressure values to the NWS-compatible Pascal unit."""
+    if value is None:
+        return None
+
+    numeric = float(value)
+    unit_text = (unit or "").strip().lower()
+    if "hpa" in unit_text or "mb" in unit_text:
+        return numeric * 100
+    if "pa" in unit_text:
+        return numeric
+    if "inch" in unit_text or unit_text in {"in", "inhg"}:
+        return numeric * 3386.39
+    return numeric * 100
+
+
 def _parse_openmeteo_datetime(
     datetime_str: str | None, utc_offset_seconds: int | None
 ) -> str | None:
@@ -150,10 +166,9 @@ class OpenMeteoMapper:
                         "qualityControl": "qc:V",
                     },
                     "barometricPressure": {
-                        "value": (
-                            current.get("pressure_msl") * 100
-                            if current.get("pressure_msl") is not None
-                            else None
+                        "value": _pressure_to_pascals(
+                            current.get("pressure_msl"),
+                            current_units.get("pressure_msl", "hPa"),
                         ),
                         "unitCode": "wmoUnit:Pa",
                         "qualityControl": "qc:V",

--- a/src/accessiweather/pirate_weather_current.py
+++ b/src/accessiweather/pirate_weather_current.py
@@ -96,14 +96,10 @@ def parse_current_conditions(client: Any, data: dict) -> CurrentConditions:
         wind_gust_mph = wind_gust_mps * 2.23694 if wind_gust_mps is not None else None
         wind_gust_kph = wind_gust_mps * 3.6 if wind_gust_mps is not None else None
 
-    # Precipitation intensity – PW "us" = in/hr, others = mm/hr
-    precip_intensity = current.get("precipIntensity")
-    if using_us:
-        precip_in = float(precip_intensity) if precip_intensity is not None else None
-        precip_mm = precip_in * 25.4 if precip_in is not None else None
-    else:
-        precip_mm = float(precip_intensity) if precip_intensity is not None else None
-        precip_in = precip_mm / 25.4 if precip_mm is not None else None
+    # Current-condition model fields represent accumulated amount. Pirate Weather's
+    # current precipIntensity is a rate, so leave amount fields blank.
+    precip_in = None
+    precip_mm = None
 
     cloud_cover_raw = current.get("cloudCover")
     cloud_cover = round(cloud_cover_raw * 100) if cloud_cover_raw is not None else None

--- a/src/accessiweather/pirate_weather_parsing.py
+++ b/src/accessiweather/pirate_weather_parsing.py
@@ -162,6 +162,41 @@ def _normalize_daily_start_time(
     return local_date, normalized
 
 
+def _epoch_to_datetime(value: object, response_tz: timezone | ZoneInfo) -> datetime | None:
+    """Parse a Pirate Weather epoch timestamp, treating sentinel values as missing."""
+    if value in (None, "", -999):
+        return None
+    try:
+        timestamp = float(value)
+    except (TypeError, ValueError):
+        return None
+    if timestamp == -999:
+        return None
+    return datetime.fromtimestamp(timestamp, tz=response_tz)
+
+
+def _accumulation_inches(client: Any, value: object) -> float | None:
+    """Normalize Pirate Weather accumulation depth to inches."""
+    if value is None:
+        return None
+    try:
+        amount = float(value)
+    except (TypeError, ValueError):
+        return None
+    if client.units == "us":
+        return amount
+    return amount / 2.54
+
+
+def _precipitation_amount_inches(client: Any, data_point: dict[str, object]) -> float | None:
+    """Return accumulated precipitation amount, not precipitation rate."""
+    for key in ("liquidAccumulation", "precipAccumulation"):
+        amount = _accumulation_inches(client, data_point.get(key))
+        if amount is not None:
+            return amount
+    return None
+
+
 def parse_forecast(client: Any, data: dict, days: int | None = None) -> Forecast | None:
     """
     Parse Pirate Weather ``daily`` block into a Forecast.
@@ -193,8 +228,12 @@ def parse_forecast(client: Any, data: dict, days: int | None = None) -> Forecast
             name = f"Day {i + 1}"
             start_time = None
 
-        temp_high = day.get("temperatureHigh") if using_us else day.get("temperatureMax")
-        temp_low = day.get("temperatureLow") if using_us else day.get("temperatureMin")
+        temp_high = day.get("temperatureHigh")
+        if temp_high is None:
+            temp_high = day.get("temperatureMax")
+        temp_low = day.get("temperatureLow")
+        if temp_low is None:
+            temp_low = day.get("temperatureMin")
 
         # Wind speed formatting
         wind_raw = day.get("windSpeed")
@@ -222,11 +261,8 @@ def parse_forecast(client: Any, data: dict, days: int | None = None) -> Forecast
         precip_prob_raw = day.get("precipProbability")
         precip_prob = round(precip_prob_raw * 100) if precip_prob_raw is not None else None
 
-        precip_intensity = day.get("precipIntensity")
-        if precip_intensity is not None:
-            precip_amount = precip_intensity if using_us else precip_intensity / 25.4
-        else:
-            precip_amount = None
+        precip_amount = _precipitation_amount_inches(client, day)
+        snowfall = _accumulation_inches(client, day.get("snowAccumulation"))
 
         cloud_cover_raw = day.get("cloudCover")
         cloud_cover = round(cloud_cover_raw * 100) if cloud_cover_raw is not None else None
@@ -246,6 +282,7 @@ def parse_forecast(client: Any, data: dict, days: int | None = None) -> Forecast
             wind_speed=wind_str,
             wind_direction=degrees_to_cardinal(day.get("windBearing")),
             precipitation_probability=precip_prob,
+            snowfall=snowfall,
             uv_index=uv_index,
             cloud_cover=cloud_cover,
             wind_gust=wind_gust_str,
@@ -339,11 +376,8 @@ def parse_hourly_forecast(client: Any, data: dict) -> HourlyForecast:
         precip_prob_raw = hour.get("precipProbability")
         precip_prob = round(precip_prob_raw * 100) if precip_prob_raw is not None else None
 
-        precip_intensity = hour.get("precipIntensity")
-        if precip_intensity is not None:
-            precip_amount = precip_intensity if using_us else precip_intensity / 25.4
-        else:
-            precip_amount = None
+        precip_amount = _precipitation_amount_inches(client, hour)
+        snowfall = _accumulation_inches(client, hour.get("snowAccumulation"))
 
         cloud_cover_raw = hour.get("cloudCover")
         cloud_cover = round(cloud_cover_raw * 100) if cloud_cover_raw is not None else None
@@ -386,6 +420,7 @@ def parse_hourly_forecast(client: Any, data: dict) -> HourlyForecast:
             pressure_mb=pressure_mb,
             pressure_in=pressure_in,
             precipitation_probability=precip_prob,
+            snowfall=snowfall,
             uv_index=uv_index,
             cloud_cover=cloud_cover,
             wind_gust_mph=wind_gust_mph,
@@ -425,13 +460,8 @@ def parse_alerts(client: Any, data: dict) -> WeatherAlerts:
             continue
         alert_id = _build_alert_id(alert_data)
 
-        onset_raw = alert_data.get("time")
-        expires_raw_val = alert_data.get("expires")
-
-        onset = datetime.fromtimestamp(onset_raw, tz=location_tz) if onset_raw else None
-        expires = (
-            datetime.fromtimestamp(expires_raw_val, tz=location_tz) if expires_raw_val else None
-        )
+        onset = _epoch_to_datetime(alert_data.get("time"), location_tz)
+        expires = _epoch_to_datetime(alert_data.get("expires"), location_tz)
 
         areas = _normalize_regions(alert_data.get("regions"))
 

--- a/src/accessiweather/services/zone_enrichment_service.py
+++ b/src/accessiweather/services/zone_enrichment_service.py
@@ -19,6 +19,8 @@ from typing import TYPE_CHECKING
 
 import httpx
 
+from ..location_classification import is_us_location
+
 if TYPE_CHECKING:
     from ..models import Location
 
@@ -33,19 +35,10 @@ def _is_us_location(location: Location) -> bool:
     """
     Return True when the location should use NWS (US) data sources.
 
-    Mirrors the heuristic in ``display/presentation/forecast.py`` so enrichment
-    and forecast-rendering agree on what counts as a US location.
+    Kept as a local wrapper for existing callers; the shared helper keeps
+    enrichment, fetching, fusion, and forecast rendering aligned.
     """
-    country_code = getattr(location, "country_code", None)
-    if country_code:
-        return country_code.upper() == "US"
-
-    lat = location.latitude
-    lon = location.longitude
-    in_continental_bounds = 24.0 <= lat <= 49.0 and -125.0 <= lon <= -66.0
-    in_alaska_bounds = 51.0 <= lat <= 71.5 and -172.0 <= lon <= -130.0
-    in_hawaii_bounds = 18.0 <= lat <= 23.0 and -161.0 <= lon <= -154.0
-    return in_continental_bounds or in_alaska_bounds or in_hawaii_bounds
+    return is_us_location(location)
 
 
 def _last_path_segment(url: str | None) -> str | None:

--- a/src/accessiweather/weather_client_auto.py
+++ b/src/accessiweather/weather_client_auto.py
@@ -29,6 +29,12 @@ from .weather_client_parallel import ParallelFetchCoordinator
 
 logger = logging.getLogger(__name__)
 
+AUTO_NWS_DISCUSSION_PLACEHOLDER = "Forecast discussion available from NWS for US locations."
+AUTO_NO_NWS_DISCUSSION_TEXT = (
+    "Forecast discussion is unavailable because Automatic mode did not use NWS."
+)
+AUTO_NON_NWS_DISCUSSION_TEXT = "Forecast discussion not available from Open-Meteo."
+
 
 class WeatherClientAutoMixin:
     def _get_auto_mode_api_budget(self) -> str:
@@ -87,6 +93,25 @@ class WeatherClientAutoMixin:
             ),
         )
 
+    @staticmethod
+    def _has_real_discussion(weather_data: WeatherData) -> bool:
+        """Return whether weather data already carries fetched forecast discussion text."""
+        discussion = weather_data.discussion
+        if not discussion:
+            return False
+        return discussion not in {
+            AUTO_NWS_DISCUSSION_PLACEHOLDER,
+            AUTO_NO_NWS_DISCUSSION_TEXT,
+            AUTO_NON_NWS_DISCUSSION_TEXT,
+        } and not discussion.startswith("Forecast discussion not available")
+
+    @staticmethod
+    def _should_enrich_nws_discussion(weather_data: WeatherData) -> bool:
+        """Return whether auto mode should make a follow-up NWS discussion request."""
+        if WeatherClientAutoMixin._has_real_discussion(weather_data):
+            return False
+        return weather_data.discussion != AUTO_NO_NWS_DISCUSSION_TEXT
+
     async def _fetch_smart_auto_source(
         self, location: Location, skip_notifications: bool = False
     ) -> WeatherData:
@@ -130,7 +155,7 @@ class WeatherClientAutoMixin:
                 alerts,
                 hourly,
             ) = await self._fetch_nws_data(location)
-            return (current, forecast, hourly, alerts)
+            return (current, forecast, hourly, alerts, _discussion, _discussion_time)
 
         async def fetch_pw():
             pirate_weather_client = self._pirate_weather_client_for_location(location)
@@ -170,13 +195,17 @@ class WeatherClientAutoMixin:
             fetched_sources = {source.source for source in source_results}
             primary_result = source_results[0] if source_results else None
             core_complete = self._source_has_complete_core_data(primary_result)
-            needs_us_openmeteo = (
+            needs_us_extended_openmeteo = (
                 is_us
                 and "openmeteo" in fetchers
                 and "openmeteo" not in fetched_sources
-                and (
-                    self._should_use_openmeteo_for_extended_forecast(location, source="auto")
-                    or not core_complete
+                and self._should_use_openmeteo_for_extended_forecast(location, source="auto")
+            )
+            needs_us_core_fallback = (
+                is_us
+                and not core_complete
+                and any(
+                    source in fetchers for source in active_sources if source not in fetched_sources
                 )
             )
             needs_intl_alert_source = (
@@ -197,7 +226,9 @@ class WeatherClientAutoMixin:
                 return []
 
             secondary_sources: list[str] = []
-            if needs_us_openmeteo or (auto_budget == "balanced" and is_us and not core_complete):
+            if needs_us_extended_openmeteo:
+                secondary_sources = _pick_secondary_candidate(lambda source: source == "openmeteo")
+            elif needs_us_core_fallback:
                 secondary_sources = _pick_secondary_candidate(lambda _source: True)
             elif needs_intl_alert_source:
                 secondary_sources = _pick_secondary_candidate(
@@ -295,16 +326,25 @@ class WeatherClientAutoMixin:
         if merged_hourly is None:
             incomplete_sections.add("hourly_forecast")
 
-        if is_us and any(source.source == "nws" for source in source_results):
-            discussion = "Forecast discussion available from NWS for US locations."
+        nws_discussion_source = next(
+            (
+                source
+                for source in source_results
+                if source.source == "nws" and source.success and source.discussion
+            ),
+            None,
+        )
+        if is_us and nws_discussion_source:
+            discussion = nws_discussion_source.discussion
+            discussion_issuance_time = nws_discussion_source.discussion_issuance_time
+        elif is_us and any(source.source == "nws" for source in source_results):
+            discussion = AUTO_NWS_DISCUSSION_PLACEHOLDER
             discussion_issuance_time = None
         elif is_us:
-            discussion = (
-                "Forecast discussion is unavailable because Automatic mode did not use NWS."
-            )
+            discussion = AUTO_NO_NWS_DISCUSSION_TEXT
             discussion_issuance_time = None
         else:
-            discussion = "Forecast discussion not available from Open-Meteo."
+            discussion = AUTO_NON_NWS_DISCUSSION_TEXT
             discussion_issuance_time = None
 
         confidence = calculate_forecast_confidence(source_results)
@@ -410,9 +450,10 @@ class WeatherClientAutoMixin:
             tasks["sunrise_sunset"] = asyncio.create_task(
                 enrichment.enrich_with_sunrise_sunset(self, weather_data, location)
             )
-            tasks["nws_discussion"] = asyncio.create_task(
-                enrichment.enrich_with_nws_discussion(self, weather_data, location)
-            )
+            if self._is_us_location(location) and self._should_enrich_nws_discussion(weather_data):
+                tasks["nws_discussion"] = asyncio.create_task(
+                    enrichment.enrich_with_nws_discussion(self, weather_data, location)
+                )
 
         # Post-processing enrichments (always run)
         tasks["environmental"] = asyncio.create_task(

--- a/src/accessiweather/weather_client_auto.py
+++ b/src/accessiweather/weather_client_auto.py
@@ -134,7 +134,7 @@ class WeatherClientAutoMixin:
             international_default=auto_sources_international,
         )
         auto_budget = self._get_auto_mode_api_budget()
-        parallel_timeout = getattr(self.settings, "parallel_fetch_timeout", 5.0)
+        parallel_timeout = getattr(self.settings, "parallel_fetch_timeout", self.timeout)
         coordinator = ParallelFetchCoordinator(timeout=parallel_timeout)
         fusion_engine = DataFusionEngine(config)
         alert_aggregator = AlertAggregator()

--- a/src/accessiweather/weather_client_fusion.py
+++ b/src/accessiweather/weather_client_fusion.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from typing import Any
 
 from accessiweather.config.source_priority import SourcePriorityConfig
+from accessiweather.location_classification import is_us_location
 from accessiweather.models.weather import (
     CurrentConditions,
     Forecast,
@@ -75,11 +76,7 @@ class DataFusionEngine:
 
     def _is_us_location(self, location: Location) -> bool:
         """Check if location is in the US."""
-        if location.country_code:
-            return location.country_code.upper() == "US"
-        # Rough bounding box for continental US
-        lat, lon = location.latitude, location.longitude
-        return 24.0 <= lat <= 50.0 and -125.0 <= lon <= -66.0
+        return is_us_location(location)
 
     def _get_field_value(self, obj: Any, field_name: str) -> Any:
         """Get a field value from an object, returning None if not present."""

--- a/src/accessiweather/weather_client_fusion.py
+++ b/src/accessiweather/weather_client_fusion.py
@@ -47,6 +47,17 @@ from accessiweather.weather_client_fusion_values import (
 logger = logging.getLogger(__name__)
 
 KM_PER_MILE = 1.609344
+MISSING_CONDITION_TEXT = {
+    "",
+    "n/a",
+    "na",
+    "none",
+    "not available",
+    "null",
+    "unavailable",
+    "unknown",
+    "--",
+}
 
 
 class DataFusionEngine:
@@ -74,6 +85,18 @@ class DataFusionEngine:
         """Get a field value from an object, returning None if not present."""
         return getattr(obj, field_name, None)
 
+    def _field_value_is_present(self, field_name: str, value: Any) -> bool:
+        """Return whether a source value is useful enough to win fusion."""
+        if value is None:
+            return False
+        if isinstance(value, str):
+            normalized = value.strip()
+            if not normalized:
+                return False
+            if field_name == "condition" and normalized.casefold() in MISSING_CONDITION_TEXT:
+                return False
+        return True
+
     def _source_priority_index(
         self,
         source_name: str,
@@ -94,7 +117,10 @@ class DataFusionEngine:
         if source.current is None:
             return False
         return any(
-            self._get_field_value(source.current, field_name) is not None
+            self._field_value_is_present(
+                field_name,
+                self._get_field_value(source.current, field_name),
+            )
             for field_name in field_names
         )
 
@@ -194,7 +220,7 @@ class DataFusionEngine:
             # Find first non-None value
             for source in field_sources:
                 value = self._get_field_value(source.current, field_name)
-                if value is not None:
+                if self._field_value_is_present(field_name, value):
                     merged_values[field_name] = value
                     attribution.field_sources[field_name] = source.source
                     break

--- a/src/accessiweather/weather_client_notification.py
+++ b/src/accessiweather/weather_client_notification.py
@@ -74,7 +74,7 @@ class WeatherClientNotificationMixin:
             # This avoids an extra API call every 60s for users who don't use it.
             if (
                 self.data_source in ("auto", "pirateweather")
-                and self.pirate_weather_client
+                and self._pirate_weather_client_for_location(location)
                 and self.settings
             ):
                 _want_start = getattr(self.settings, "notify_minutely_precipitation_start", False)
@@ -118,7 +118,7 @@ class WeatherClientNotificationMixin:
         self, location: Location
     ) -> MinutelyPrecipitationForecast | None:
         """Fetch Pirate Weather minutely precipitation when a client is configured."""
-        client = getattr(self, "pirate_weather_client", None)
+        client = self._pirate_weather_client_for_location(location)
         if client is None:
             return None
 

--- a/src/accessiweather/weather_client_nws_parsers.py
+++ b/src/accessiweather/weather_client_nws_parsers.py
@@ -203,10 +203,24 @@ def parse_nws_alerts(data: dict) -> WeatherAlerts:
                 logger.warning(f"Failed to parse effective time: {props['effective']}")
 
         references = []
-        for ref in props.get("references", []):
+        raw_references = props.get("references") or []
+        if not isinstance(raw_references, list):
+            raw_references = []
+        for ref in raw_references:
+            if not isinstance(ref, dict):
+                continue
             ref_id = ref.get("identifier") or ref.get("@id") or ref.get("id")
             if ref_id:
                 references.append(ref_id)
+
+        area_desc = props.get("areaDesc")
+        areas = []
+        if isinstance(area_desc, str):
+            areas = [area.strip() for area in area_desc.split(";") if area.strip()]
+
+        affected_zones_raw = props.get("affectedZones") or []
+        if not isinstance(affected_zones_raw, list):
+            affected_zones_raw = []
 
         alert = WeatherAlert(
             title=props.get("headline", "Weather Alert"),
@@ -221,14 +235,14 @@ def parse_nws_alerts(data: dict) -> WeatherAlerts:
             expires=expires,
             sent=sent,
             effective=effective,
-            areas=props.get("areaDesc", "").split("; ") if props.get("areaDesc") else [],
+            areas=areas,
             references=references,
             id=alert_id,
             source="NWS",
             message_type=props.get("messageType"),
             affected_zones=[
                 zone.rsplit("/", 1)[-1]
-                for zone in props.get("affectedZones", [])
+                for zone in affected_zones_raw
                 if isinstance(zone, str) and zone
             ],
         )
@@ -306,6 +320,7 @@ def parse_nws_hourly_forecast(data: dict, location: Location | None = None) -> H
             temperature_unit=str(temperature_unit),
             short_forecast=period_data.get("shortForecast"),
             wind_speed=_format_wind_speed(period_data.get("windSpeed")),
+            wind_speed_mph=_extract_wind_speed_mph(period_data.get("windSpeed")),
             wind_direction=wind_direction,
             icon=period_data.get("icon"),
             precipitation_probability=_extract_float(period_data.get("probabilityOfPrecipitation")),

--- a/src/accessiweather/weather_client_nws_parsers.py
+++ b/src/accessiweather/weather_client_nws_parsers.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from .weather_client_nws_common import *  # noqa: F403
+from .weather_client_parsers import normalize_pressure
 
 
 def parse_nws_current_conditions(
@@ -334,21 +335,46 @@ def parse_nws_gridpoint_pressure(data: dict) -> dict[datetime, tuple[float | Non
     """Parse NWS gridpoint pressure values keyed by valid-time start."""
     pressure = data.get("properties", {}).get("pressure", {})
     values = pressure.get("values", []) if isinstance(pressure, dict) else []
+    pressure_unit = None
+    if isinstance(pressure, dict):
+        pressure_unit = pressure.get("uom") or pressure.get("unitCode")
     pressure_by_time: dict[datetime, tuple[float | None, float | None]] = {}
 
     for item in values:
         if not isinstance(item, dict):
             continue
         start_time = _parse_valid_time_start(item.get("validTime"))
-        pressure_pa = item.get("value")
-        if start_time is None or pressure_pa is None:
+        pressure_value = _extract_float(item.get("value"))
+        if start_time is None or pressure_value is None:
             continue
-        pressure_by_time[start_time] = (
-            convert_pa_to_inches(pressure_pa),
-            convert_pa_to_mb(pressure_pa),
+        pressure_by_time[start_time] = _normalize_nws_gridpoint_pressure(
+            pressure_value,
+            item.get("uom") or item.get("unitCode") or pressure_unit,
         )
 
     return pressure_by_time
+
+
+def _normalize_nws_gridpoint_pressure(
+    value: float, unit_code: str | None
+) -> tuple[float | None, float | None]:
+    """
+    Normalize NWS gridpoint pressure values to inches and millibars.
+
+    Most NWS pressure values are pascals, but some gridpoint layers currently
+    return station-pressure-like values around 29-31 with no unit metadata. Treat
+    those as inches of mercury instead of displaying impossible sub-1 mb values.
+    """
+    if unit_code:
+        pressure_in, pressure_mb = normalize_pressure(value, str(unit_code))
+        if pressure_in is not None or pressure_mb is not None:
+            return pressure_in, pressure_mb
+
+    if 20 <= value <= 35:
+        return value, value * 33.8639
+    if 850 <= value <= 1100:
+        return value * 0.0295299830714, value
+    return convert_pa_to_inches(value), convert_pa_to_mb(value)
 
 
 def apply_nws_gridpoint_pressure(

--- a/src/accessiweather/weather_client_openmeteo.py
+++ b/src/accessiweather/weather_client_openmeteo.py
@@ -30,9 +30,16 @@ from .weather_client_openmeteo_current import (
     pick_precipitation_type,
     resolve_current_condition_description,
 )
+from .weather_client_openmeteo_units import (
+    normalize_height_to_feet,
+    normalize_snow_depth_to_inches_and_cm,
+    normalize_visibility_to_miles_and_km,
+)
 from .weather_client_parsers import (
+    convert_wind_speed_to_mph_and_kph,
     degrees_to_cardinal,
     format_date_name,
+    normalize_pressure,
     weather_code_to_description,
 )
 
@@ -47,6 +54,13 @@ def _pick_precipitation_type(rain_in: float, snow_in: float) -> list[str] | None
 def _resolve_current_condition_description(current: dict[str, Any]) -> str | None:
     """Compatibility wrapper for Open-Meteo current condition text."""
     return resolve_current_condition_description(current)
+
+
+def _format_wind_speed_mph(value: float | None) -> str | None:
+    """Format a normalized wind speed for legacy text-only display paths."""
+    if value is None:
+        return None
+    return f"{value:.1f}".rstrip("0").rstrip(".") + " mph"
 
 
 async def _client_get(
@@ -279,12 +293,16 @@ async def get_openmeteo_hourly_forecast(
 def parse_openmeteo_forecast(data: dict) -> Forecast:
     """Parse Open-Meteo daily forecast payload into a Forecast model."""
     daily = data.get("daily", {})
+    daily_units = data.get("daily_units", {})
     utc_offset_seconds = data.get("utc_offset_seconds")
     periods = []
 
     dates = daily.get("time", [])
     max_temps = daily.get("temperature_2m_max", [])
+    min_temps = daily.get("temperature_2m_min", [])
     weather_codes = daily.get("weather_code", [])
+    wind_speeds = daily.get("wind_speed_10m_max", [])
+    wind_directions = daily.get("wind_direction_10m_dominant", [])
     precip_probs = daily.get("precipitation_probability_max", [])
     snowfall_sums = daily.get("snowfall_sum", [])
     uv_indices = daily.get("uv_index_max", [])
@@ -294,6 +312,13 @@ def parse_openmeteo_forecast(data: dict) -> Forecast:
             precip_prob = precip_probs[i] if i < len(precip_probs) else None
             snowfall = snowfall_sums[i] if i < len(snowfall_sums) else None
             uv_index = uv_indices[i] if i < len(uv_indices) else None
+            temp_low = min_temps[i] if i < len(min_temps) else None
+            wind_speed = wind_speeds[i] if i < len(wind_speeds) else None
+            wind_speed_mph, _wind_speed_kph = convert_wind_speed_to_mph_and_kph(
+                wind_speed,
+                daily_units.get("wind_speed_10m_max", "mph"),
+            )
+            wind_direction = wind_directions[i] if i < len(wind_directions) else None
             # Pass utc_offset_seconds so the noon timestamp is tagged with the
             # location's local timezone, not UTC.  Without this, for offsets ≥ 12 h
             # the UTC .date() can land on the wrong calendar day.
@@ -303,8 +328,12 @@ def parse_openmeteo_forecast(data: dict) -> Forecast:
             period = ForecastPeriod(
                 name=format_date_name(date, i),
                 temperature=max_temps[i],
+                temperature_low=temp_low,
                 temperature_unit="F",
                 short_forecast=weather_code_to_description(weather_codes[i]),
+                wind_speed=_format_wind_speed_mph(wind_speed_mph),
+                wind_speed_mph=wind_speed_mph,
+                wind_direction=degrees_to_cardinal(wind_direction),
                 start_time=start_time,
                 precipitation_probability=precip_prob,
                 snowfall=snowfall,
@@ -319,6 +348,7 @@ def parse_openmeteo_hourly_forecast(data: dict) -> HourlyForecast:
     """Parse Open-Meteo hourly forecast payload into an HourlyForecast model."""
     periods: list[HourlyForecastPeriod] = []
     hourly = data.get("hourly", {})
+    hourly_units = data.get("hourly_units", {})
     utc_offset_seconds = data.get("utc_offset_seconds")
 
     times = hourly.get("time", [])
@@ -346,26 +376,38 @@ def parse_openmeteo_hourly_forecast(data: dict) -> HourlyForecast:
         dewpoint = dew_points[i] if i < len(dew_points) else None
         weather_code = weather_codes[i] if i < len(weather_codes) else None
         wind_speed = wind_speeds[i] if i < len(wind_speeds) else None
+        wind_speed_mph, _wind_speed_kph = convert_wind_speed_to_mph_and_kph(
+            wind_speed,
+            hourly_units.get("wind_speed_10m", "mph"),
+        )
         wind_direction = wind_directions[i] if i < len(wind_directions) else None
-        pressure_mb = pressures[i] if i < len(pressures) else None
-        pressure_in = pressure_mb * 0.0295299830714 if pressure_mb is not None else None
+        pressure_raw = pressures[i] if i < len(pressures) else None
+        pressure_in, pressure_mb = normalize_pressure(
+            pressure_raw,
+            hourly_units.get("pressure_msl", "hPa"),
+        )
         precip_prob = precip_probs[i] if i < len(precip_probs) else None
         snowfall = snowfalls[i] if i < len(snowfalls) else None
         uv_index = uv_indices[i] if i < len(uv_indices) else None
 
         # Seasonal fields
-        # With precipitation_unit=inch, snow_depth is returned in feet
-        snow_depth_ft = snow_depths[i] if i < len(snow_depths) else None
-        snow_depth_in = snow_depth_ft * 12 if snow_depth_ft is not None else None
+        snow_depth_raw = snow_depths[i] if i < len(snow_depths) else None
+        snow_depth_in, _snow_depth_cm = normalize_snow_depth_to_inches_and_cm(
+            snow_depth_raw,
+            hourly_units.get("snow_depth"),
+        )
 
-        freezing_level_m = freezing_levels[i] if i < len(freezing_levels) else None
-        freezing_level_ft = freezing_level_m * 3.28084 if freezing_level_m is not None else None
+        freezing_level_raw = freezing_levels[i] if i < len(freezing_levels) else None
+        freezing_level_ft = normalize_height_to_feet(
+            freezing_level_raw,
+            hourly_units.get("freezing_level_height"),
+        )
 
-        visibility_m = visibilities[i] if i < len(visibilities) else None
-        # Cap at 10 statute miles — Open-Meteo model visibility is unreliable above this
-        if visibility_m is not None:
-            visibility_m = min(visibility_m, 16093.4)
-        visibility_miles = visibility_m / 1609.344 if visibility_m is not None else None
+        visibility_raw = visibilities[i] if i < len(visibilities) else None
+        visibility_miles, visibility_km = normalize_visibility_to_miles_and_km(
+            visibility_raw,
+            hourly_units.get("visibility"),
+        )
 
         apparent_temp = apparent_temps[i] if i < len(apparent_temps) else None
         dewpoint_f = dewpoint
@@ -392,7 +434,7 @@ def parse_openmeteo_hourly_forecast(data: dict) -> HourlyForecast:
             temperature=temperature,
             temperature_unit="F",
             short_forecast=weather_code_to_description(weather_code),
-            wind_speed=f"{wind_speed} mph" if wind_speed is not None else None,
+            wind_speed=_format_wind_speed_mph(wind_speed_mph),
             wind_direction=degrees_to_cardinal(wind_direction),
             humidity=humidity,
             dewpoint_f=dewpoint_f,
@@ -402,10 +444,12 @@ def parse_openmeteo_hourly_forecast(data: dict) -> HourlyForecast:
             precipitation_probability=precip_prob,
             snowfall=snowfall,
             uv_index=uv_index,
+            wind_speed_mph=wind_speed_mph,
             # Seasonal fields
             snow_depth=snow_depth_in,
             freezing_level_ft=freezing_level_ft,
             visibility_miles=visibility_miles,
+            visibility_km=visibility_km,
             feels_like=apparent_temp,
             wind_chill_f=wind_chill_f,
             heat_index_f=heat_index_f,

--- a/src/accessiweather/weather_client_openmeteo_current.py
+++ b/src/accessiweather/weather_client_openmeteo_current.py
@@ -8,6 +8,10 @@ from typing import Any
 
 from .models import CurrentConditions
 from .utils.temperature_utils import TemperatureUnit, calculate_dewpoint
+from .weather_client_openmeteo_units import (
+    normalize_snow_depth_to_inches_and_cm,
+    normalize_visibility_to_miles_and_km,
+)
 from .weather_client_parsers import (
     convert_f_to_c,
     convert_wind_speed_to_mph_and_kph,
@@ -22,7 +26,6 @@ SNOW_WEATHER_CODES = {71, 73, 75, 77, 85, 86}
 RAIN_WEATHER_CODES = {51, 53, 55, 56, 57, 61, 63, 65, 66, 67, 80, 81, 82}
 ACTIVE_PRECIP_EPSILON_IN = 0.001
 NEAR_ZERO_SNOW_EPSILON_IN = 0.0005
-VISIBILITY_CAP_M = 16093.4
 
 
 def pick_precipitation_type(rain_in: float, snow_in: float) -> list[str] | None:
@@ -120,19 +123,6 @@ def _parse_uv_index(current: dict[str, Any], daily: dict[str, Any]) -> float | N
     return None
 
 
-def _normalize_snow_depth(
-    value: float | None,
-    unit: str,
-) -> tuple[float | None, float | None]:
-    if value is None:
-        return None, None
-    if "ft" in unit or "feet" in unit:
-        return value * 12, value * 30.48
-    if "m" in unit and "mm" not in unit:
-        return value * 39.3701, value * 100
-    return value * 39.3701, value * 100
-
-
 def parse_openmeteo_current_conditions(data: dict) -> CurrentConditions:
     """Parse Open-Meteo current condition payload into a CurrentConditions model."""
     current = data.get("current", {})
@@ -183,16 +173,15 @@ def parse_openmeteo_current_conditions(data: dict) -> CurrentConditions:
     snow_rate_in = float(snowfall_rate or 0.0)
     precipitation_type = pick_precipitation_type(rain_rate_in, snow_rate_in)
 
-    snow_depth_in, snow_depth_cm = _normalize_snow_depth(
+    snow_depth_in, snow_depth_cm = normalize_snow_depth_to_inches_and_cm(
         current.get("snow_depth"),
-        units.get("snow_depth", "").lower(),
+        units.get("snow_depth"),
     )
 
-    visibility_m = current.get("visibility")
-    if visibility_m is not None:
-        visibility_m = min(visibility_m, VISIBILITY_CAP_M)
-    visibility_miles = visibility_m / 1609.344 if visibility_m is not None else None
-    visibility_km = visibility_m / 1000 if visibility_m is not None else None
+    visibility_miles, visibility_km = normalize_visibility_to_miles_and_km(
+        current.get("visibility"),
+        units.get("visibility"),
+    )
 
     wind_chill_f = None
     wind_chill_c = None

--- a/src/accessiweather/weather_client_openmeteo_units.py
+++ b/src/accessiweather/weather_client_openmeteo_units.py
@@ -1,0 +1,80 @@
+"""Unit normalization helpers for Open-Meteo payloads."""
+
+from __future__ import annotations
+
+CM_PER_INCH = 2.54
+FEET_PER_METER = 3.28084
+INCHES_PER_FOOT = 12
+KM_PER_MILE = 1.609344
+METERS_PER_MILE = 1609.344
+VISIBILITY_CAP_MILES = 10.0
+
+
+def _unit_text(unit: str | None) -> str:
+    return (unit or "").strip().lower().replace(" ", "_")
+
+
+def normalize_snow_depth_to_inches_and_cm(
+    value: float | int | None,
+    unit: str | None,
+) -> tuple[float | None, float | None]:
+    """Return Open-Meteo snow depth normalized to inches and centimeters."""
+    if value is None:
+        return None, None
+
+    numeric = float(value)
+    unit_text = _unit_text(unit)
+
+    if "ft" in unit_text or "feet" in unit_text:
+        inches = numeric * INCHES_PER_FOOT
+    elif "mm" in unit_text or "millimeter" in unit_text or "millimetre" in unit_text:
+        inches = numeric / 25.4
+    elif "cm" in unit_text or "centimeter" in unit_text or "centimetre" in unit_text:
+        inches = numeric / CM_PER_INCH
+    elif unit_text in {"in", "inch", "inches"}:
+        inches = numeric
+    else:
+        # Open-Meteo uses meters when no precipitation_unit override is applied.
+        inches = numeric * FEET_PER_METER * INCHES_PER_FOOT
+
+    return inches, inches * CM_PER_INCH
+
+
+def normalize_height_to_feet(value: float | int | None, unit: str | None) -> float | None:
+    """Return a height value normalized to feet."""
+    if value is None:
+        return None
+
+    numeric = float(value)
+    unit_text = _unit_text(unit)
+
+    if "ft" in unit_text or "feet" in unit_text:
+        return numeric
+    if "km" in unit_text or "kilometer" in unit_text or "kilometre" in unit_text:
+        return numeric * 1000 * FEET_PER_METER
+
+    return numeric * FEET_PER_METER
+
+
+def normalize_visibility_to_miles_and_km(
+    value: float | int | None,
+    unit: str | None,
+) -> tuple[float | None, float | None]:
+    """Return Open-Meteo visibility normalized to capped miles and kilometers."""
+    if value is None:
+        return None, None
+
+    numeric = float(value)
+    unit_text = _unit_text(unit)
+
+    if "ft" in unit_text or "feet" in unit_text:
+        miles = numeric / 5280
+    elif "km" in unit_text or "kilometer" in unit_text or "kilometre" in unit_text:
+        miles = numeric / KM_PER_MILE
+    elif unit_text in {"mi", "mile", "miles"}:
+        miles = numeric
+    else:
+        miles = numeric / METERS_PER_MILE
+
+    miles = min(miles, VISIBILITY_CAP_MILES)
+    return miles, miles * KM_PER_MILE

--- a/src/accessiweather/weather_client_parallel.py
+++ b/src/accessiweather/weather_client_parallel.py
@@ -46,17 +46,7 @@ class ParallelFetchCoordinator:
     async def fetch_all(
         self,
         location: Location,
-        fetch_nws: Coroutine[
-            Any,
-            Any,
-            tuple[
-                CurrentConditions | None,
-                Forecast | None,
-                HourlyForecast | None,
-                WeatherAlerts | None,
-            ],
-        ]
-        | None = None,
+        fetch_nws: Coroutine[Any, Any, tuple[Any, ...]] | None = None,
         fetch_openmeteo: Coroutine[
             Any, Any, tuple[CurrentConditions | None, Forecast | None, HourlyForecast | None]
         ]
@@ -199,7 +189,8 @@ class ParallelFetchCoordinator:
 
         Args:
             source_name: Name of the source
-            result: Tuple of (current, forecast, hourly_forecast, [alerts])
+            result: Tuple of (current, forecast, hourly_forecast, [alerts], [discussion],
+                [discussion_issuance_time])
 
         Returns:
             SourceData with the fetched data
@@ -210,6 +201,8 @@ class ParallelFetchCoordinator:
         forecast = result[1] if len(result) > 1 else None
         hourly_forecast = result[2] if len(result) > 2 else None
         alerts = result[3] if len(result) > 3 else None
+        discussion = result[4] if len(result) > 4 else None
+        discussion_issuance_time = result[5] if len(result) > 5 else None
 
         return SourceData(
             source=source_name,
@@ -217,6 +210,8 @@ class ParallelFetchCoordinator:
             forecast=forecast,
             hourly_forecast=hourly_forecast,
             alerts=alerts,
+            discussion=discussion,
+            discussion_issuance_time=discussion_issuance_time,
             fetch_time=datetime.now(UTC),
             success=True,
             error=None,

--- a/src/accessiweather/weather_client_sources.py
+++ b/src/accessiweather/weather_client_sources.py
@@ -12,6 +12,7 @@ from . import (
     weather_client_openmeteo as openmeteo_client,
     weather_client_parsers as parsers,
 )
+from .location_classification import is_us_location
 from .models import (
     AviationData,
     CurrentConditions,
@@ -101,50 +102,16 @@ class WeatherClientSourcesMixin:
         Uses country_code when available for accurate detection. Falls back to
         coordinate bounds only for clear-cut cases. For ambiguous regions (near US-Canada
         border), requires country_code to be set - otherwise returns False to avoid
-        misclassifying Canadian cities like Toronto, Montreal, Ottawa as US locations.
+        misclassifying Canadian cities as US locations.
         """
-        country_code = getattr(location, "country_code", None)
-        if country_code:
-            return country_code.upper() == "US"
-
-        lat = location.latitude
-        lon = location.longitude
-
-        # Continental US bounds (approximate)
-        in_continental_bounds = 24.0 <= lat <= 49.0 and -125.0 <= lon <= -66.0
-
-        # Alaska bounds (51-71°N, 130-172°W)
-        in_alaska_bounds = 51.0 <= lat <= 71.5 and -172.0 <= lon <= -130.0
-
-        # Hawaii bounds (18-23°N, 154-161°W)
-        in_hawaii_bounds = 18.0 <= lat <= 23.0 and -161.0 <= lon <= -154.0
-
-        # For clear-cut cases (far from borders), coordinate bounds are reliable
-        # - Hawaii (obvious island)
-        # - Alaska (far northwest, separated from Canada)
-        # - Deep in continental US (away from Canadian/Mexican borders)
-        if in_hawaii_bounds or in_alaska_bounds:
-            return True
-
-        # For continental US, use both lat/lon to identify clearly US vs ambiguous zones
-        if in_continental_bounds:
-            # Canadian border cities (Toronto ~43°N/-79°, Montreal ~45.5°N/-73°, Ottawa ~45.4°N/-75°)
-            # are in the eastern half of the continent (east of ~-95° longitude)
-            # US Pacific Northwest (Seattle ~47.6°N/-122°, Portland ~45.5°N/-122°) is further west
-            # Use lon < -95 as a proxy for "eastern region where Canadian cities cluster"
-            if lat >= 43.0 and lon > -95.0 and lon < -70.0:
-                # Eastern region near Canadian border - require country_code for accurate detection
-                # This catches Canadian cities while allowing US Pacific Northwest
-                logger.debug(
-                    f"Location '{location.name}' ({lat:.2f}, {lon:.2f}) is in eastern "
-                    f"North America near Canadian border but has no country_code. "
-                    f"To ensure correct detection, re-add the location to set country_code via geocoding."
-                )
-                return False
-            return True
-
-        # Outside all US bounds - definitely not US
-        return False
+        result = is_us_location(location)
+        if not result and getattr(location, "country_code", None) is None:
+            logger.debug(
+                "Location '%s' lacks country_code and is not safely classifiable as US; "
+                "re-add it through geocoding to set country_code.",
+                location.name,
+            )
+        return result
 
     def _set_empty_weather_data(self, weather_data: WeatherData) -> None:
         """Set empty weather data when all APIs fail."""

--- a/src/accessiweather/weather_client_trends.py
+++ b/src/accessiweather/weather_client_trends.py
@@ -10,6 +10,14 @@ from .models import HourlyForecastPeriod, TrendInsight, WeatherData
 
 logger = logging.getLogger(__name__)
 
+MAX_PRESSURE_TREND_MB = 24.0
+MAX_PRESSURE_TREND_IN = MAX_PRESSURE_TREND_MB / 33.8639
+MIN_PRESSURE_TREND_MB = 10.0
+MIN_PRESSURE_TREND_IN = 0.30
+MIXED_PRESSURE_REFERENCE_SUMMARY = (
+    "Pressure outlook unavailable: pressure data uses mixed reference levels."
+)
+
 
 def apply_trend_insights(
     weather_data: WeatherData,
@@ -125,6 +133,14 @@ def compute_pressure_trend(
 
     base, future, unit = value_pairs[0]
     change = future - base
+    if pressure_change_is_implausible(change, unit, trend_hours):
+        logger.debug(
+            "Suppressing implausible pressure trend: change=%s %s over %sh",
+            change,
+            unit,
+            trend_hours,
+        )
+        return _pressure_unavailable_insight(MIXED_PRESSURE_REFERENCE_SUMMARY, trend_hours)
     direction, sparkline = trend_descriptor(
         change,
         minor=0.5 if unit == "mb" else 0.02,
@@ -140,6 +156,15 @@ def compute_pressure_trend(
         summary=summary,
         sparkline=sparkline,
     )
+
+
+def pressure_change_is_implausible(change: float, unit: str, trend_hours: int) -> bool:
+    """Return True when pressure change is too large to present as a reliable trend."""
+    if unit == "mb":
+        max_change = max(MIN_PRESSURE_TREND_MB, min(MAX_PRESSURE_TREND_MB, trend_hours * 1.0))
+    else:
+        max_change = max(MIN_PRESSURE_TREND_IN, min(MAX_PRESSURE_TREND_IN, trend_hours / 33.8639))
+    return abs(change) > max_change
 
 
 def compute_pressure_outlook_unavailable(
@@ -218,7 +243,7 @@ def pressure_trend_summary(direction: str, change: float, unit: str, trend_hours
     elif direction == "rising":
         action = "rise predicted"
     else:
-        action = "steady"
+        return f"Pressure steady over next {trend_hours}h"
     return f"Pressure {action}: {change:+.2f} {unit} over next {trend_hours}h"
 
 

--- a/src/accessiweather/weather_history.py
+++ b/src/accessiweather/weather_history.py
@@ -19,6 +19,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _daily_value(daily: dict, field_name: str, target_date: date) -> float | int | str | None:
+    """Return the first daily archive value, rejecting absent or empty fields."""
+    values = daily.get(field_name)
+    if not isinstance(values, list) or not values:
+        logger.warning("Archive response for %s did not include %s", target_date, field_name)
+        return None
+    return values[0]
+
+
 @dataclass
 class HistoricalWeatherData:
     """Historical weather data for a specific date."""
@@ -197,19 +206,39 @@ class WeatherHistoryService:
             if not daily.get("time") or len(daily["time"]) == 0:
                 return None
 
-            # Get weather description from code
-            weather_code = daily.get("weather_code", [0])[0]
+            weather_code = _daily_value(daily, "weather_code", target_date)
             condition = self.openmeteo_client.get_weather_description(weather_code)
+            temperature_max = _daily_value(daily, "temperature_2m_max", target_date)
+            temperature_min = _daily_value(daily, "temperature_2m_min", target_date)
+            temperature_mean = _daily_value(daily, "temperature_2m_mean", target_date)
+            wind_speed = _daily_value(daily, "wind_speed_10m_max", target_date)
+            wind_direction = _daily_value(daily, "wind_direction_10m_dominant", target_date)
+
+            required_values = {
+                "weather_code": weather_code,
+                "temperature_2m_max": temperature_max,
+                "temperature_2m_min": temperature_min,
+                "temperature_2m_mean": temperature_mean,
+                "wind_speed_10m_max": wind_speed,
+            }
+            missing = [field for field, value in required_values.items() if value is None]
+            if missing:
+                logger.warning(
+                    "Archive response for %s is missing required daily values: %s",
+                    target_date,
+                    ", ".join(missing),
+                )
+                return None
 
             return HistoricalWeatherData(
                 date=target_date,
-                temperature_max=daily.get("temperature_2m_max", [0])[0],
-                temperature_min=daily.get("temperature_2m_min", [0])[0],
-                temperature_mean=daily.get("temperature_2m_mean", [0])[0],
+                temperature_max=float(temperature_max),
+                temperature_min=float(temperature_min),
+                temperature_mean=float(temperature_mean),
                 condition=condition,
                 humidity=None,  # Not available in archive endpoint
-                wind_speed=daily.get("wind_speed_10m_max", [0])[0],
-                wind_direction=daily.get("wind_direction_10m_dominant", [None])[0],
+                wind_speed=float(wind_speed),
+                wind_direction=int(wind_direction) if wind_direction is not None else None,
                 pressure=None,  # Not available in archive endpoint
             )
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -72,7 +72,7 @@ tests/integration/cassettes/
 1. **Record cassettes in isolation**: Run one test at a time when recording
 2. **Review cassettes before committing**: Ensure no sensitive data leaked
 3. **Use meaningful cassette names**: Match the test name for clarity
-4. **Don't match on query params**: API keys vary between environments
+4. **Match non-secret query params**: Query values often choose provider response shape; API keys are filtered before matching
 5. **Filter headers**: User-Agent and auth headers should be filtered
 6. **Keep cassettes small**: Request only data needed for assertions
 

--- a/tests/integration/cassettes/openmeteo/current_weather_alaska.yaml
+++ b/tests/integration/cassettes/openmeteo/current_weather_alaska.yaml
@@ -30,4 +30,35 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - api.open-meteo.com
+    method: GET
+    uri: https://api.open-meteo.com/v1/forecast?current=apparent_temperature&current=cloud_cover&current=dew_point_2m&current=is_day&current=precipitation&current=pressure_msl&current=relative_humidity_2m&current=snow_depth&current=snowfall&current=surface_pressure&current=temperature_2m&current=uv_index&current=visibility&current=weather_code&current=wind_direction_10m&current=wind_gusts_10m&current=wind_speed_10m&daily=sunrise&daily=sunset&daily=uv_index_max&forecast_days=1&latitude=61.2181&longitude=-149.9003&precipitation_unit=inch&temperature_unit=fahrenheit&timezone=auto&wind_speed_unit=mph
+  response:
+    body:
+      string: "{\"latitude\":61.265377,\"longitude\":-149.92735,\"generationtime_ms\":0.25653839111328125,\"utc_offset_seconds\":-28800,\"timezone\":\"America/Anchorage\",\"timezone_abbreviation\":\"GMT-8\",\"elevation\":34.0,\"current_units\":{\"time\":\"iso8601\",\"interval\":\"seconds\",\"temperature_2m\":\"\xB0F\",\"relative_humidity_2m\":\"%\",\"dew_point_2m\":\"\xB0F\",\"apparent_temperature\":\"\xB0F\",\"is_day\":\"\",\"precipitation\":\"inch\",\"weather_code\":\"wmo
+        code\",\"cloud_cover\":\"%\",\"pressure_msl\":\"hPa\",\"surface_pressure\":\"hPa\",\"wind_speed_10m\":\"mp/h\",\"wind_direction_10m\":\"\xB0\",\"wind_gusts_10m\":\"mp/h\",\"uv_index\":\"\",\"snowfall\":\"inch\",\"snow_depth\":\"ft\",\"visibility\":\"ft\"},\"current\":{\"time\":\"2026-05-11T14:30\",\"interval\":900,\"temperature_2m\":52.2,\"relative_humidity_2m\":37,\"dew_point_2m\":27.0,\"apparent_temperature\":44.5,\"is_day\":1,\"precipitation\":0.000,\"weather_code\":3,\"cloud_cover\":86,\"pressure_msl\":1015.6,\"surface_pressure\":1011.5,\"wind_speed_10m\":8.0,\"wind_direction_10m\":143,\"wind_gusts_10m\":21.3,\"uv_index\":4.55,\"snowfall\":0.000,\"snow_depth\":0.000,\"visibility\":203149.609},\"daily_units\":{\"time\":\"iso8601\",\"sunrise\":\"iso8601\",\"sunset\":\"iso8601\",\"uv_index_max\":\"\"},\"daily\":{\"time\":[\"2026-05-11\"],\"sunrise\":[\"2026-05-11T05:20\"],\"sunset\":[\"2026-05-11T22:31\"],\"uv_index_max\":[4.65]}}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 May 2026 22:44:57 GMT
+      Transfer-Encoding:
+      - chunked
+      content-length:
+      - '1229'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/integration/cassettes/openmeteo/current_weather_celsius.yaml
+++ b/tests/integration/cassettes/openmeteo/current_weather_celsius.yaml
@@ -11,13 +11,45 @@ interactions:
       Host:
       - api.open-meteo.com
     method: GET
-    uri: https://api.open-meteo.com/v1/forecast?latitude=40.7128&longitude=-74.006&current=temperature_2m%2Crelative_humidity_2m%2Capparent_temperature%2Cis_day%2Cprecipitation%2Cweather_code%2Ccloud_cover%2Cpressure_msl%2Csurface_pressure%2Cwind_speed_10m%2Cwind_direction_10m%2Cwind_gusts_10m%2Cuv_index%2Csnowfall%2Csnow_depth%2Cvisibility&daily=sunrise%2Csunset%2Cuv_index_max&temperature_unit=celsius&wind_speed_unit=mph&precipitation_unit=inch&timezone=auto&forecast_days=1
+    uri: https://api.open-meteo.com/v1/forecast?current=temperature_2m%2Crelative_humidity_2m%2Capparent_temperature%2Cis_day%2Cprecipitation%2Cweather_code%2Ccloud_cover%2Cpressure_msl%2Csurface_pressure%2Cwind_speed_10m%2Cwind_direction_10m%2Cwind_gusts_10m%2Cuv_index%2Csnowfall%2Csnow_depth%2Cvisibility&daily=sunrise%2Csunset%2Cuv_index_max&forecast_days=1&latitude=40.7128&longitude=-74.006&precipitation_unit=inch&temperature_unit=celsius&timezone=auto&wind_speed_unit=mph
   response:
     body:
-      string: '{"latitude":40.710335,"longitude":-73.99307,"generationtime_ms":0.098,"utc_offset_seconds":-18000,"timezone":"America/New_York","timezone_abbreviation":"EST","elevation":10.0,"current_units":{"time":"iso8601","interval":"seconds","temperature_2m":"\u00b0C","relative_humidity_2m":"%","apparent_temperature":"\u00b0C","is_day":"","precipitation":"inch","weather_code":"wmo code","cloud_cover":"%","pressure_msl":"hPa","surface_pressure":"hPa","wind_speed_10m":"mp/h","wind_direction_10m":"\u00b0","wind_gusts_10m":"mp/h","uv_index":"","snowfall":"inch","snow_depth":"inch","visibility":"ft"},"current":{"time":"2025-01-15T12:00","interval":900,"temperature_2m":7.5,"relative_humidity_2m":65,"apparent_temperature":5.7,"is_day":1,"precipitation":0.0,"weather_code":2,"cloud_cover":50,"pressure_msl":1020.5,"surface_pressure":1019.2,"wind_speed_10m":8.5,"wind_direction_10m":270,"wind_gusts_10m":15.2,"uv_index":2.5,"snowfall":0.0,"snow_depth":0.0,"visibility":32808},"daily_units":{"time":"iso8601","sunrise":"iso8601","sunset":"iso8601","uv_index_max":""},"daily":{"time":["2025-01-15"],"sunrise":["2025-01-15T07:15"],"sunset":["2025-01-15T16:55"],"uv_index_max":[3.2]}}'
+      string: '{"latitude":40.710335,"longitude":-73.99307,"generationtime_ms":0.098,"utc_offset_seconds":-18000,"timezone":"America/New_York","timezone_abbreviation":"EST","elevation":10.0,"current_units":{"time":"iso8601","interval":"seconds","temperature_2m":"\u00b0C","relative_humidity_2m":"%","apparent_temperature":"\u00b0C","is_day":"","precipitation":"inch","weather_code":"wmo
+        code","cloud_cover":"%","pressure_msl":"hPa","surface_pressure":"hPa","wind_speed_10m":"mp/h","wind_direction_10m":"\u00b0","wind_gusts_10m":"mp/h","uv_index":"","snowfall":"inch","snow_depth":"inch","visibility":"ft"},"current":{"time":"2025-01-15T12:00","interval":900,"temperature_2m":7.5,"relative_humidity_2m":65,"apparent_temperature":5.7,"is_day":1,"precipitation":0.0,"weather_code":2,"cloud_cover":50,"pressure_msl":1020.5,"surface_pressure":1019.2,"wind_speed_10m":8.5,"wind_direction_10m":270,"wind_gusts_10m":15.2,"uv_index":2.5,"snowfall":0.0,"snow_depth":0.0,"visibility":32808},"daily_units":{"time":"iso8601","sunrise":"iso8601","sunset":"iso8601","uv_index_max":""},"daily":{"time":["2025-01-15"],"sunrise":["2025-01-15T07:15"],"sunset":["2025-01-15T16:55"],"uv_index_max":[3.2]}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - api.open-meteo.com
+    method: GET
+    uri: https://api.open-meteo.com/v1/forecast?current=apparent_temperature&current=cloud_cover&current=dew_point_2m&current=is_day&current=precipitation&current=pressure_msl&current=relative_humidity_2m&current=snow_depth&current=snowfall&current=surface_pressure&current=temperature_2m&current=uv_index&current=visibility&current=weather_code&current=wind_direction_10m&current=wind_gusts_10m&current=wind_speed_10m&daily=sunrise&daily=sunset&daily=uv_index_max&forecast_days=1&latitude=40.7128&longitude=-74.006&precipitation_unit=inch&temperature_unit=celsius&timezone=auto&wind_speed_unit=mph
+  response:
+    body:
+      string: "{\"latitude\":40.710335,\"longitude\":-73.99308,\"generationtime_ms\":0.22733211517333984,\"utc_offset_seconds\":-14400,\"timezone\":\"America/New_York\",\"timezone_abbreviation\":\"GMT-4\",\"elevation\":32.0,\"current_units\":{\"time\":\"iso8601\",\"interval\":\"seconds\",\"temperature_2m\":\"\xB0C\",\"relative_humidity_2m\":\"%\",\"dew_point_2m\":\"\xB0C\",\"apparent_temperature\":\"\xB0C\",\"is_day\":\"\",\"precipitation\":\"inch\",\"weather_code\":\"wmo
+        code\",\"cloud_cover\":\"%\",\"pressure_msl\":\"hPa\",\"surface_pressure\":\"hPa\",\"wind_speed_10m\":\"mp/h\",\"wind_direction_10m\":\"\xB0\",\"wind_gusts_10m\":\"mp/h\",\"uv_index\":\"\",\"snowfall\":\"inch\",\"snow_depth\":\"ft\",\"visibility\":\"ft\"},\"current\":{\"time\":\"2026-05-11T18:30\",\"interval\":900,\"temperature_2m\":16.1,\"relative_humidity_2m\":31,\"dew_point_2m\":-1.1,\"apparent_temperature\":13.3,\"is_day\":1,\"precipitation\":0.000,\"weather_code\":1,\"cloud_cover\":47,\"pressure_msl\":1018.0,\"surface_pressure\":1014.2,\"wind_speed_10m\":2.1,\"wind_direction_10m\":238,\"wind_gusts_10m\":11.9,\"uv_index\":1.20,\"snowfall\":0.000,\"snow_depth\":0.000,\"visibility\":201115.484},\"daily_units\":{\"time\":\"iso8601\",\"sunrise\":\"iso8601\",\"sunset\":\"iso8601\",\"uv_index_max\":\"\"},\"daily\":{\"time\":[\"2026-05-11\"],\"sunrise\":[\"2026-05-11T05:42\"],\"sunset\":[\"2026-05-11T20:02\"],\"uv_index_max\":[5.15]}}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 May 2026 22:44:57 GMT
+      Transfer-Encoding:
+      - chunked
+      content-length:
+      - '1227'
     status:
       code: 200
       message: OK

--- a/tests/integration/cassettes/openmeteo/current_weather_london.yaml
+++ b/tests/integration/cassettes/openmeteo/current_weather_london.yaml
@@ -11,13 +11,45 @@ interactions:
       Host:
       - api.open-meteo.com
     method: GET
-    uri: https://api.open-meteo.com/v1/forecast?latitude=51.5074&longitude=-0.1278&current=temperature_2m%2Crelative_humidity_2m%2Capparent_temperature%2Cis_day%2Cprecipitation%2Cweather_code%2Ccloud_cover%2Cpressure_msl%2Csurface_pressure%2Cwind_speed_10m%2Cwind_direction_10m%2Cwind_gusts_10m%2Cuv_index%2Csnowfall%2Csnow_depth%2Cvisibility&daily=sunrise%2Csunset%2Cuv_index_max&temperature_unit=fahrenheit&wind_speed_unit=mph&precipitation_unit=inch&timezone=auto&forecast_days=1
+    uri: https://api.open-meteo.com/v1/forecast?current=temperature_2m%2Crelative_humidity_2m%2Capparent_temperature%2Cis_day%2Cprecipitation%2Cweather_code%2Ccloud_cover%2Cpressure_msl%2Csurface_pressure%2Cwind_speed_10m%2Cwind_direction_10m%2Cwind_gusts_10m%2Cuv_index%2Csnowfall%2Csnow_depth%2Cvisibility&daily=sunrise%2Csunset%2Cuv_index_max&forecast_days=1&latitude=51.5074&longitude=-0.1278&precipitation_unit=inch&temperature_unit=fahrenheit&timezone=auto&wind_speed_unit=mph
   response:
     body:
-      string: '{"latitude":51.5,"longitude":-0.125,"generationtime_ms":0.089,"utc_offset_seconds":0,"timezone":"Europe/London","timezone_abbreviation":"GMT","elevation":25.0,"current_units":{"time":"iso8601","interval":"seconds","temperature_2m":"\u00b0F","relative_humidity_2m":"%","apparent_temperature":"\u00b0F","is_day":"","precipitation":"inch","weather_code":"wmo code","cloud_cover":"%","pressure_msl":"hPa","surface_pressure":"hPa","wind_speed_10m":"mp/h","wind_direction_10m":"\u00b0","wind_gusts_10m":"mp/h","uv_index":"","snowfall":"inch","snow_depth":"inch","visibility":"ft"},"current":{"time":"2025-01-15T17:00","interval":900,"temperature_2m":48.2,"relative_humidity_2m":78,"apparent_temperature":44.1,"is_day":0,"precipitation":0.0,"weather_code":3,"cloud_cover":85,"pressure_msl":1015.3,"surface_pressure":1014.1,"wind_speed_10m":12.3,"wind_direction_10m":225,"wind_gusts_10m":22.5,"uv_index":0.0,"snowfall":0.0,"snow_depth":0.0,"visibility":26247},"daily_units":{"time":"iso8601","sunrise":"iso8601","sunset":"iso8601","uv_index_max":""},"daily":{"time":["2025-01-15"],"sunrise":["2025-01-15T08:02"],"sunset":["2025-01-15T16:15"],"uv_index_max":[1.5]}}'
+      string: '{"latitude":51.5,"longitude":-0.125,"generationtime_ms":0.089,"utc_offset_seconds":0,"timezone":"Europe/London","timezone_abbreviation":"GMT","elevation":25.0,"current_units":{"time":"iso8601","interval":"seconds","temperature_2m":"\u00b0F","relative_humidity_2m":"%","apparent_temperature":"\u00b0F","is_day":"","precipitation":"inch","weather_code":"wmo
+        code","cloud_cover":"%","pressure_msl":"hPa","surface_pressure":"hPa","wind_speed_10m":"mp/h","wind_direction_10m":"\u00b0","wind_gusts_10m":"mp/h","uv_index":"","snowfall":"inch","snow_depth":"inch","visibility":"ft"},"current":{"time":"2025-01-15T17:00","interval":900,"temperature_2m":48.2,"relative_humidity_2m":78,"apparent_temperature":44.1,"is_day":0,"precipitation":0.0,"weather_code":3,"cloud_cover":85,"pressure_msl":1015.3,"surface_pressure":1014.1,"wind_speed_10m":12.3,"wind_direction_10m":225,"wind_gusts_10m":22.5,"uv_index":0.0,"snowfall":0.0,"snow_depth":0.0,"visibility":26247},"daily_units":{"time":"iso8601","sunrise":"iso8601","sunset":"iso8601","uv_index_max":""},"daily":{"time":["2025-01-15"],"sunrise":["2025-01-15T08:02"],"sunset":["2025-01-15T16:15"],"uv_index_max":[1.5]}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - api.open-meteo.com
+    method: GET
+    uri: https://api.open-meteo.com/v1/forecast?current=apparent_temperature&current=cloud_cover&current=dew_point_2m&current=is_day&current=precipitation&current=pressure_msl&current=relative_humidity_2m&current=snow_depth&current=snowfall&current=surface_pressure&current=temperature_2m&current=uv_index&current=visibility&current=weather_code&current=wind_direction_10m&current=wind_gusts_10m&current=wind_speed_10m&daily=sunrise&daily=sunset&daily=uv_index_max&forecast_days=1&latitude=51.5074&longitude=-0.1278&precipitation_unit=inch&temperature_unit=fahrenheit&timezone=auto&wind_speed_unit=mph
+  response:
+    body:
+      string: "{\"latitude\":51.51147,\"longitude\":-0.13078308,\"generationtime_ms\":0.31769275665283203,\"utc_offset_seconds\":3600,\"timezone\":\"Europe/London\",\"timezone_abbreviation\":\"GMT+1\",\"elevation\":16.0,\"current_units\":{\"time\":\"iso8601\",\"interval\":\"seconds\",\"temperature_2m\":\"\xB0F\",\"relative_humidity_2m\":\"%\",\"dew_point_2m\":\"\xB0F\",\"apparent_temperature\":\"\xB0F\",\"is_day\":\"\",\"precipitation\":\"inch\",\"weather_code\":\"wmo
+        code\",\"cloud_cover\":\"%\",\"pressure_msl\":\"hPa\",\"surface_pressure\":\"hPa\",\"wind_speed_10m\":\"mp/h\",\"wind_direction_10m\":\"\xB0\",\"wind_gusts_10m\":\"mp/h\",\"uv_index\":\"\",\"snowfall\":\"inch\",\"snow_depth\":\"ft\",\"visibility\":\"ft\"},\"current\":{\"time\":\"2026-05-11T23:30\",\"interval\":900,\"temperature_2m\":47.3,\"relative_humidity_2m\":55,\"dew_point_2m\":31.9,\"apparent_temperature\":41.3,\"is_day\":0,\"precipitation\":0.000,\"weather_code\":0,\"cloud_cover\":0,\"pressure_msl\":1016.2,\"surface_pressure\":1014.2,\"wind_speed_10m\":5.1,\"wind_direction_10m\":61,\"wind_gusts_10m\":11.6,\"uv_index\":0.00,\"snowfall\":0.000,\"snow_depth\":0.000,\"visibility\":92454.070},\"daily_units\":{\"time\":\"iso8601\",\"sunrise\":\"iso8601\",\"sunset\":\"iso8601\",\"uv_index_max\":\"\"},\"daily\":{\"time\":[\"2026-05-11\"],\"sunrise\":[\"2026-05-11T05:14\"],\"sunset\":[\"2026-05-11T20:39\"],\"uv_index_max\":[2.15]}}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 May 2026 22:44:56 GMT
+      Transfer-Encoding:
+      - chunked
+      content-length:
+      - '1220'
     status:
       code: 200
       message: OK

--- a/tests/integration/cassettes/openmeteo/current_weather_nyc.yaml
+++ b/tests/integration/cassettes/openmeteo/current_weather_nyc.yaml
@@ -11,13 +11,45 @@ interactions:
       Host:
       - api.open-meteo.com
     method: GET
-    uri: https://api.open-meteo.com/v1/forecast?latitude=40.7128&longitude=-74.006&current=temperature_2m%2Crelative_humidity_2m%2Capparent_temperature%2Cis_day%2Cprecipitation%2Cweather_code%2Ccloud_cover%2Cpressure_msl%2Csurface_pressure%2Cwind_speed_10m%2Cwind_direction_10m%2Cwind_gusts_10m%2Cuv_index%2Csnowfall%2Csnow_depth%2Cvisibility&daily=sunrise%2Csunset%2Cuv_index_max&temperature_unit=fahrenheit&wind_speed_unit=mph&precipitation_unit=inch&timezone=auto&forecast_days=1
+    uri: https://api.open-meteo.com/v1/forecast?current=temperature_2m%2Crelative_humidity_2m%2Capparent_temperature%2Cis_day%2Cprecipitation%2Cweather_code%2Ccloud_cover%2Cpressure_msl%2Csurface_pressure%2Cwind_speed_10m%2Cwind_direction_10m%2Cwind_gusts_10m%2Cuv_index%2Csnowfall%2Csnow_depth%2Cvisibility&daily=sunrise%2Csunset%2Cuv_index_max&forecast_days=1&latitude=40.7128&longitude=-74.006&precipitation_unit=inch&temperature_unit=fahrenheit&timezone=auto&wind_speed_unit=mph
   response:
     body:
-      string: '{"latitude":40.710335,"longitude":-73.99307,"generationtime_ms":0.123,"utc_offset_seconds":-18000,"timezone":"America/New_York","timezone_abbreviation":"EST","elevation":10.0,"current_units":{"time":"iso8601","interval":"seconds","temperature_2m":"\u00b0F","relative_humidity_2m":"%","apparent_temperature":"\u00b0F","is_day":"","precipitation":"inch","weather_code":"wmo code","cloud_cover":"%","pressure_msl":"hPa","surface_pressure":"hPa","wind_speed_10m":"mp/h","wind_direction_10m":"\u00b0","wind_gusts_10m":"mp/h","uv_index":"","snowfall":"inch","snow_depth":"inch","visibility":"ft"},"current":{"time":"2025-01-15T12:00","interval":900,"temperature_2m":45.5,"relative_humidity_2m":65,"apparent_temperature":42.3,"is_day":1,"precipitation":0.0,"weather_code":2,"cloud_cover":50,"pressure_msl":1020.5,"surface_pressure":1019.2,"wind_speed_10m":8.5,"wind_direction_10m":270,"wind_gusts_10m":15.2,"uv_index":2.5,"snowfall":0.0,"snow_depth":0.0,"visibility":32808},"daily_units":{"time":"iso8601","sunrise":"iso8601","sunset":"iso8601","uv_index_max":""},"daily":{"time":["2025-01-15"],"sunrise":["2025-01-15T07:15"],"sunset":["2025-01-15T16:55"],"uv_index_max":[3.2]}}'
+      string: '{"latitude":40.710335,"longitude":-73.99307,"generationtime_ms":0.123,"utc_offset_seconds":-18000,"timezone":"America/New_York","timezone_abbreviation":"EST","elevation":10.0,"current_units":{"time":"iso8601","interval":"seconds","temperature_2m":"\u00b0F","relative_humidity_2m":"%","apparent_temperature":"\u00b0F","is_day":"","precipitation":"inch","weather_code":"wmo
+        code","cloud_cover":"%","pressure_msl":"hPa","surface_pressure":"hPa","wind_speed_10m":"mp/h","wind_direction_10m":"\u00b0","wind_gusts_10m":"mp/h","uv_index":"","snowfall":"inch","snow_depth":"inch","visibility":"ft"},"current":{"time":"2025-01-15T12:00","interval":900,"temperature_2m":45.5,"relative_humidity_2m":65,"apparent_temperature":42.3,"is_day":1,"precipitation":0.0,"weather_code":2,"cloud_cover":50,"pressure_msl":1020.5,"surface_pressure":1019.2,"wind_speed_10m":8.5,"wind_direction_10m":270,"wind_gusts_10m":15.2,"uv_index":2.5,"snowfall":0.0,"snow_depth":0.0,"visibility":32808},"daily_units":{"time":"iso8601","sunrise":"iso8601","sunset":"iso8601","uv_index_max":""},"daily":{"time":["2025-01-15"],"sunrise":["2025-01-15T07:15"],"sunset":["2025-01-15T16:55"],"uv_index_max":[3.2]}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - api.open-meteo.com
+    method: GET
+    uri: https://api.open-meteo.com/v1/forecast?current=apparent_temperature&current=cloud_cover&current=dew_point_2m&current=is_day&current=precipitation&current=pressure_msl&current=relative_humidity_2m&current=snow_depth&current=snowfall&current=surface_pressure&current=temperature_2m&current=uv_index&current=visibility&current=weather_code&current=wind_direction_10m&current=wind_gusts_10m&current=wind_speed_10m&daily=sunrise&daily=sunset&daily=uv_index_max&forecast_days=1&latitude=40.7128&longitude=-74.006&precipitation_unit=inch&temperature_unit=fahrenheit&timezone=auto&wind_speed_unit=mph
+  response:
+    body:
+      string: "{\"latitude\":40.710335,\"longitude\":-73.99308,\"generationtime_ms\":0.2601146697998047,\"utc_offset_seconds\":-14400,\"timezone\":\"America/New_York\",\"timezone_abbreviation\":\"GMT-4\",\"elevation\":32.0,\"current_units\":{\"time\":\"iso8601\",\"interval\":\"seconds\",\"temperature_2m\":\"\xB0F\",\"relative_humidity_2m\":\"%\",\"dew_point_2m\":\"\xB0F\",\"apparent_temperature\":\"\xB0F\",\"is_day\":\"\",\"precipitation\":\"inch\",\"weather_code\":\"wmo
+        code\",\"cloud_cover\":\"%\",\"pressure_msl\":\"hPa\",\"surface_pressure\":\"hPa\",\"wind_speed_10m\":\"mp/h\",\"wind_direction_10m\":\"\xB0\",\"wind_gusts_10m\":\"mp/h\",\"uv_index\":\"\",\"snowfall\":\"inch\",\"snow_depth\":\"ft\",\"visibility\":\"ft\"},\"current\":{\"time\":\"2026-05-11T18:30\",\"interval\":900,\"temperature_2m\":60.9,\"relative_humidity_2m\":31,\"dew_point_2m\":30.1,\"apparent_temperature\":55.9,\"is_day\":1,\"precipitation\":0.000,\"weather_code\":1,\"cloud_cover\":47,\"pressure_msl\":1018.0,\"surface_pressure\":1014.2,\"wind_speed_10m\":2.1,\"wind_direction_10m\":238,\"wind_gusts_10m\":11.9,\"uv_index\":1.20,\"snowfall\":0.000,\"snow_depth\":0.000,\"visibility\":201115.484},\"daily_units\":{\"time\":\"iso8601\",\"sunrise\":\"iso8601\",\"sunset\":\"iso8601\",\"uv_index_max\":\"\"},\"daily\":{\"time\":[\"2026-05-11\"],\"sunrise\":[\"2026-05-11T05:42\"],\"sunset\":[\"2026-05-11T20:02\"],\"uv_index_max\":[5.15]}}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 May 2026 22:44:56 GMT
+      Transfer-Encoding:
+      - chunked
+      content-length:
+      - '1226'
     status:
       code: 200
       message: OK

--- a/tests/integration/cassettes/openmeteo/current_weather_with_uv.yaml
+++ b/tests/integration/cassettes/openmeteo/current_weather_with_uv.yaml
@@ -30,4 +30,35 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - api.open-meteo.com
+    method: GET
+    uri: https://api.open-meteo.com/v1/forecast?current=apparent_temperature&current=cloud_cover&current=dew_point_2m&current=is_day&current=precipitation&current=pressure_msl&current=relative_humidity_2m&current=snow_depth&current=snowfall&current=surface_pressure&current=temperature_2m&current=uv_index&current=visibility&current=weather_code&current=wind_direction_10m&current=wind_gusts_10m&current=wind_speed_10m&daily=sunrise&daily=sunset&daily=uv_index_max&forecast_days=1&latitude=40.7128&longitude=-74.006&precipitation_unit=inch&temperature_unit=fahrenheit&timezone=auto&wind_speed_unit=mph
+  response:
+    body:
+      string: "{\"latitude\":40.710335,\"longitude\":-73.99308,\"generationtime_ms\":0.15676021575927734,\"utc_offset_seconds\":-14400,\"timezone\":\"America/New_York\",\"timezone_abbreviation\":\"GMT-4\",\"elevation\":32.0,\"current_units\":{\"time\":\"iso8601\",\"interval\":\"seconds\",\"temperature_2m\":\"\xB0F\",\"relative_humidity_2m\":\"%\",\"dew_point_2m\":\"\xB0F\",\"apparent_temperature\":\"\xB0F\",\"is_day\":\"\",\"precipitation\":\"inch\",\"weather_code\":\"wmo
+        code\",\"cloud_cover\":\"%\",\"pressure_msl\":\"hPa\",\"surface_pressure\":\"hPa\",\"wind_speed_10m\":\"mp/h\",\"wind_direction_10m\":\"\xB0\",\"wind_gusts_10m\":\"mp/h\",\"uv_index\":\"\",\"snowfall\":\"inch\",\"snow_depth\":\"ft\",\"visibility\":\"ft\"},\"current\":{\"time\":\"2026-05-11T18:30\",\"interval\":900,\"temperature_2m\":60.9,\"relative_humidity_2m\":31,\"dew_point_2m\":30.1,\"apparent_temperature\":55.9,\"is_day\":1,\"precipitation\":0.000,\"weather_code\":1,\"cloud_cover\":47,\"pressure_msl\":1018.0,\"surface_pressure\":1014.2,\"wind_speed_10m\":2.1,\"wind_direction_10m\":238,\"wind_gusts_10m\":11.9,\"uv_index\":1.20,\"snowfall\":0.000,\"snow_depth\":0.000,\"visibility\":201115.484},\"daily_units\":{\"time\":\"iso8601\",\"sunrise\":\"iso8601\",\"sunset\":\"iso8601\",\"uv_index_max\":\"\"},\"daily\":{\"time\":[\"2026-05-11\"],\"sunrise\":[\"2026-05-11T05:42\"],\"sunset\":[\"2026-05-11T20:02\"],\"uv_index_max\":[5.15]}}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 May 2026 22:44:58 GMT
+      Transfer-Encoding:
+      - chunked
+      content-length:
+      - '1227'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/integration/cassettes/pirate_weather/alerts_nyc.yaml
+++ b/tests/integration/cassettes/pirate_weather/alerts_nyc.yaml
@@ -11,7 +11,7 @@ interactions:
       Host:
       - api.pirateweather.net
     method: GET
-    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/40.7128,-74.006?extend=hourly&units=us
+    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/40.7128,-74.006?extend=hourly&units=us&version=2
   response:
     body:
       string: "{\"latitude\":40.7128,\"longitude\":-74.006,\"timezone\":\"America/New_York\",\"offset\":-4.0,\"elevation\":62,\"currently\":{\"time\":1773877680,\"summary\":\"Clear\",\"icon\":\"clear-night\",\"nearestStormDistance\":356.19,\"nearestStormBearing\":35,\"precipIntensity\":0.0,\"precipProbability\":0.0,\"precipIntensityError\":0.0,\"precipType\":\"none\",\"temperature\":32.88,\"apparentTemperature\":21.34,\"dewPoint\":16.48,\"humidity\":0.5,\"pressure\":1028.29,\"windSpeed\":10.46,\"windGust\":13.69,\"windBearing\":141,\"cloudCover\":0.0,\"uvIndex\":0.06,\"visibility\":10.0,\"ozone\":401.24},\"minutely\":{\"summary\":\"Clear

--- a/tests/integration/cassettes/pirate_weather/alerts_tromso.yaml
+++ b/tests/integration/cassettes/pirate_weather/alerts_tromso.yaml
@@ -11,7 +11,7 @@ interactions:
       Host:
       - api.pirateweather.net
     method: GET
-    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/69.6489,18.9551?extend=hourly&units=us
+    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/69.6489,18.9551?extend=hourly&units=us&version=2
   response:
     body:
       string: "{\"latitude\":69.6489,\"longitude\":18.9551,\"timezone\":\"Europe/Oslo\",\"offset\":1.0,\"elevation\":43,\"currently\":{\"time\":1773877680,\"summary\":\"Drizzle

--- a/tests/integration/cassettes/pirate_weather/current_london.yaml
+++ b/tests/integration/cassettes/pirate_weather/current_london.yaml
@@ -11,7 +11,7 @@ interactions:
       Host:
       - api.pirateweather.net
     method: GET
-    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/51.5074,-0.1278?extend=hourly&units=us
+    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/51.5074,-0.1278?extend=hourly&units=us&version=2
   response:
     body:
       string: "{\"latitude\":51.5074,\"longitude\":-0.1278,\"timezone\":\"Europe/London\",\"offset\":0.0,\"elevation\":52,\"currently\":{\"time\":1773877680,\"summary\":\"Clear\",\"icon\":\"clear-night\",\"nearestStormDistance\":691.82,\"nearestStormBearing\":180,\"precipIntensity\":0.0,\"precipProbability\":0.0,\"precipIntensityError\":0.0,\"precipType\":\"none\",\"temperature\":45.54,\"apparentTemperature\":39.16,\"dewPoint\":36.86,\"humidity\":0.72,\"pressure\":1025.8,\"windSpeed\":5.97,\"windGust\":10.57,\"windBearing\":81,\"cloudCover\":0.01,\"uvIndex\":0.0,\"visibility\":9.56,\"ozone\":345.66},\"minutely\":{\"summary\":\"Clear

--- a/tests/integration/cassettes/pirate_weather/current_nyc.yaml
+++ b/tests/integration/cassettes/pirate_weather/current_nyc.yaml
@@ -11,7 +11,7 @@ interactions:
       Host:
       - api.pirateweather.net
     method: GET
-    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/40.7128,-74.006?extend=hourly&units=us
+    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/40.7128,-74.006?extend=hourly&units=us&version=2
   response:
     body:
       string: "{\"latitude\":40.7128,\"longitude\":-74.006,\"timezone\":\"America/New_York\",\"offset\":-4.0,\"elevation\":62,\"currently\":{\"time\":1773877680,\"summary\":\"Clear\",\"icon\":\"clear-night\",\"nearestStormDistance\":356.19,\"nearestStormBearing\":35,\"precipIntensity\":0.0,\"precipProbability\":0.0,\"precipIntensityError\":0.0,\"precipType\":\"none\",\"temperature\":32.88,\"apparentTemperature\":21.34,\"dewPoint\":16.48,\"humidity\":0.5,\"pressure\":1028.29,\"windSpeed\":10.46,\"windGust\":13.69,\"windBearing\":141,\"cloudCover\":0.0,\"uvIndex\":0.06,\"visibility\":10.0,\"ozone\":401.24},\"minutely\":{\"summary\":\"Clear

--- a/tests/integration/cassettes/pirate_weather/current_wind_gust.yaml
+++ b/tests/integration/cassettes/pirate_weather/current_wind_gust.yaml
@@ -11,7 +11,7 @@ interactions:
       Host:
       - api.pirateweather.net
     method: GET
-    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/40.7128,-74.006?extend=hourly&units=us
+    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/40.7128,-74.006?extend=hourly&units=us&version=2
   response:
     body:
       string: "{\"latitude\":40.7128,\"longitude\":-74.006,\"timezone\":\"America/New_York\",\"offset\":-4.0,\"elevation\":62,\"currently\":{\"time\":1773877680,\"summary\":\"Clear\",\"icon\":\"clear-night\",\"nearestStormDistance\":356.19,\"nearestStormBearing\":35,\"precipIntensity\":0.0,\"precipProbability\":0.0,\"precipIntensityError\":0.0,\"precipType\":\"none\",\"temperature\":32.88,\"apparentTemperature\":21.34,\"dewPoint\":16.48,\"humidity\":0.5,\"pressure\":1028.29,\"windSpeed\":10.46,\"windGust\":13.69,\"windBearing\":141,\"cloudCover\":0.0,\"uvIndex\":0.06,\"visibility\":10.0,\"ozone\":401.24},\"minutely\":{\"summary\":\"Clear

--- a/tests/integration/cassettes/pirate_weather/forecast_daily_summary.yaml
+++ b/tests/integration/cassettes/pirate_weather/forecast_daily_summary.yaml
@@ -11,7 +11,7 @@ interactions:
       Host:
       - api.pirateweather.net
     method: GET
-    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/40.7128,-74.006?extend=hourly&units=us
+    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/40.7128,-74.006?extend=hourly&units=us&version=2
   response:
     body:
       string: "{\"latitude\":40.7128,\"longitude\":-74.006,\"timezone\":\"America/New_York\",\"offset\":-4.0,\"elevation\":62,\"currently\":{\"time\":1773877680,\"summary\":\"Clear\",\"icon\":\"clear-night\",\"nearestStormDistance\":356.19,\"nearestStormBearing\":35,\"precipIntensity\":0.0,\"precipProbability\":0.0,\"precipIntensityError\":0.0,\"precipType\":\"none\",\"temperature\":32.88,\"apparentTemperature\":21.34,\"dewPoint\":16.48,\"humidity\":0.5,\"pressure\":1028.29,\"windSpeed\":10.46,\"windGust\":13.69,\"windBearing\":141,\"cloudCover\":0.0,\"uvIndex\":0.06,\"visibility\":10.0,\"ozone\":401.24},\"minutely\":{\"summary\":\"Clear

--- a/tests/integration/cassettes/pirate_weather/forecast_nyc.yaml
+++ b/tests/integration/cassettes/pirate_weather/forecast_nyc.yaml
@@ -11,7 +11,7 @@ interactions:
       Host:
       - api.pirateweather.net
     method: GET
-    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/40.7128,-74.006?extend=hourly&units=us
+    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/40.7128,-74.006?extend=hourly&units=us&version=2
   response:
     body:
       string: "{\"latitude\":40.7128,\"longitude\":-74.006,\"timezone\":\"America/New_York\",\"offset\":-4.0,\"elevation\":62,\"currently\":{\"time\":1773877680,\"summary\":\"Clear\",\"icon\":\"clear-night\",\"nearestStormDistance\":356.19,\"nearestStormBearing\":35,\"precipIntensity\":0.0,\"precipProbability\":0.0,\"precipIntensityError\":0.0,\"precipType\":\"none\",\"temperature\":32.88,\"apparentTemperature\":21.34,\"dewPoint\":16.48,\"humidity\":0.5,\"pressure\":1028.29,\"windSpeed\":10.46,\"windGust\":13.69,\"windBearing\":141,\"cloudCover\":0.0,\"uvIndex\":0.06,\"visibility\":10.0,\"ozone\":401.24},\"minutely\":{\"summary\":\"Clear

--- a/tests/integration/cassettes/pirate_weather/hourly_nyc.yaml
+++ b/tests/integration/cassettes/pirate_weather/hourly_nyc.yaml
@@ -11,7 +11,7 @@ interactions:
       Host:
       - api.pirateweather.net
     method: GET
-    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/40.7128,-74.006?extend=hourly&units=us
+    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/40.7128,-74.006?extend=hourly&units=us&version=2
   response:
     body:
       string: "{\"latitude\":40.7128,\"longitude\":-74.006,\"timezone\":\"America/New_York\",\"offset\":-4.0,\"elevation\":62,\"currently\":{\"time\":1773877680,\"summary\":\"Clear\",\"icon\":\"clear-night\",\"nearestStormDistance\":356.19,\"nearestStormBearing\":35,\"precipIntensity\":0.0,\"precipProbability\":0.0,\"precipIntensityError\":0.0,\"precipType\":\"none\",\"temperature\":32.88,\"apparentTemperature\":21.34,\"dewPoint\":16.48,\"humidity\":0.5,\"pressure\":1028.29,\"windSpeed\":10.46,\"windGust\":13.69,\"windBearing\":141,\"cloudCover\":0.0,\"uvIndex\":0.06,\"visibility\":10.0,\"ozone\":401.24},\"minutely\":{\"summary\":\"Clear

--- a/tests/integration/cassettes/pirate_weather/minutely_nyc.yaml
+++ b/tests/integration/cassettes/pirate_weather/minutely_nyc.yaml
@@ -11,7 +11,7 @@ interactions:
       Host:
       - api.pirateweather.net
     method: GET
-    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/40.7128,-74.006?extend=hourly&units=us
+    uri: https://api.pirateweather.net/forecast/FILTERED_API_KEY/40.7128,-74.006?extend=hourly&units=us&version=2
   response:
     body:
       string: "{\"latitude\":40.7128,\"longitude\":-74.006,\"timezone\":\"America/New_York\",\"offset\":-4.0,\"elevation\":62,\"currently\":{\"time\":1773877680,\"summary\":\"Clear\",\"icon\":\"clear-night\",\"nearestStormDistance\":356.19,\"nearestStormBearing\":35,\"precipIntensity\":0.0,\"precipProbability\":0.0,\"precipIntensityError\":0.0,\"precipType\":\"none\",\"temperature\":32.88,\"apparentTemperature\":21.34,\"dewPoint\":16.48,\"humidity\":0.5,\"pressure\":1028.29,\"windSpeed\":10.46,\"windGust\":13.69,\"windBearing\":141,\"cloudCover\":0.0,\"uvIndex\":0.06,\"visibility\":10.0,\"ozone\":401.24},\"minutely\":{\"summary\":\"Clear

--- a/tests/integration/cassettes/weather_client/openmeteo_current.yaml
+++ b/tests/integration/cassettes/weather_client/openmeteo_current.yaml
@@ -92,4 +92,97 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - api.open-meteo.com
+    method: GET
+    uri: https://api.open-meteo.com/v1/forecast?daily=temperature_2m_max%2Ctemperature_2m_min%2Cweather_code%2Cwind_speed_10m_max%2Cwind_direction_10m_dominant%2Cprecipitation_probability_max%2Csnowfall_sum%2Cuv_index_max&forecast_days=7&latitude=51.5074&longitude=-0.1278&precipitation_unit=inch&temperature_unit=fahrenheit&timezone=auto&wind_speed_unit=mph
+  response:
+    body:
+      string: "{\"latitude\":51.51147,\"longitude\":-0.13078308,\"generationtime_ms\":0.4183053970336914,\"utc_offset_seconds\":3600,\"timezone\":\"Europe/London\",\"timezone_abbreviation\":\"GMT+1\",\"elevation\":16.0,\"daily_units\":{\"time\":\"iso8601\",\"temperature_2m_max\":\"\xB0F\",\"temperature_2m_min\":\"\xB0F\",\"weather_code\":\"wmo
+        code\",\"wind_speed_10m_max\":\"mp/h\",\"wind_direction_10m_dominant\":\"\xB0\",\"precipitation_probability_max\":\"%\",\"snowfall_sum\":\"inch\",\"uv_index_max\":\"\"},\"daily\":{\"time\":[\"2026-05-11\",\"2026-05-12\",\"2026-05-13\",\"2026-05-14\",\"2026-05-15\",\"2026-05-16\",\"2026-05-17\"],\"temperature_2m_max\":[53.4,61.9,55.2,56.5,52.0,56.6,59.5],\"temperature_2m_min\":[41.3,44.5,48.6,44.0,44.2,45.9,47.2],\"weather_code\":[51,3,63,51,51,51,51],\"wind_speed_10m_max\":[8.3,12.5,13.2,10.7,9.6,6.9,10.3],\"wind_direction_10m_dominant\":[357,288,279,313,335,294,245],\"precipitation_probability_max\":[57,12,90,78,25,10,29],\"snowfall_sum\":[0.000,0.000,0.000,0.000,0.000,0.000,0.000],\"uv_index_max\":[2.15,4.65,4.90,5.60,5.35,6.30,5.00]}}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 May 2026 22:36:25 GMT
+      Transfer-Encoding:
+      - chunked
+      content-length:
+      - '982'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - api.open-meteo.com
+    method: GET
+    uri: https://api.open-meteo.com/v1/forecast?forecast_hours=24&hourly=temperature_2m%2Crelative_humidity_2m%2Cdew_point_2m%2Cweather_code%2Cwind_speed_10m%2Cwind_direction_10m%2Cpressure_msl%2Cprecipitation_probability%2Csnowfall%2Cuv_index%2Csnow_depth%2Cfreezing_level_height%2Cvisibility%2Capparent_temperature&latitude=51.5074&longitude=-0.1278&precipitation_unit=inch&temperature_unit=fahrenheit&timezone=auto&wind_speed_unit=mph
+  response:
+    body:
+      string: "{\"latitude\":51.51147,\"longitude\":-0.13078308,\"generationtime_ms\":1.1463165283203125,\"utc_offset_seconds\":3600,\"timezone\":\"Europe/London\",\"timezone_abbreviation\":\"GMT+1\",\"elevation\":16.0,\"hourly_units\":{\"time\":\"iso8601\",\"temperature_2m\":\"\xB0F\",\"relative_humidity_2m\":\"%\",\"dew_point_2m\":\"\xB0F\",\"weather_code\":\"wmo
+        code\",\"wind_speed_10m\":\"mp/h\",\"wind_direction_10m\":\"\xB0\",\"pressure_msl\":\"hPa\",\"precipitation_probability\":\"%\",\"snowfall\":\"inch\",\"uv_index\":\"\",\"snow_depth\":\"ft\",\"freezing_level_height\":\"ft\",\"visibility\":\"ft\",\"apparent_temperature\":\"\xB0F\"},\"hourly\":{\"time\":[\"2026-05-11T23:00\",\"2026-05-12T00:00\",\"2026-05-12T01:00\",\"2026-05-12T02:00\",\"2026-05-12T03:00\",\"2026-05-12T04:00\",\"2026-05-12T05:00\",\"2026-05-12T06:00\",\"2026-05-12T07:00\",\"2026-05-12T08:00\",\"2026-05-12T09:00\",\"2026-05-12T10:00\",\"2026-05-12T11:00\",\"2026-05-12T12:00\",\"2026-05-12T13:00\",\"2026-05-12T14:00\",\"2026-05-12T15:00\",\"2026-05-12T16:00\",\"2026-05-12T17:00\",\"2026-05-12T18:00\",\"2026-05-12T19:00\",\"2026-05-12T20:00\",\"2026-05-12T21:00\",\"2026-05-12T22:00\"],\"temperature_2m\":[47.5,46.6,46.7,46.6,46.7,45.7,45.1,44.5,45.1,47.1,49.8,53.6,56.0,58.4,60.1,61.3,61.9,61.1,60.4,58.6,58.8,58.1,56.5,54.0],\"relative_humidity_2m\":[53,57,57,57,56,60,61,62,58,56,54,50,36,37,39,38,39,46,48,49,42,37,40,45],\"dew_point_2m\":[31.2,32.1,32.2,32.1,31.9,32.6,32.5,32.3,31.2,32.2,33.8,35.4,29.4,32.3,35.0,35.5,36.6,40.1,40.6,39.5,35.8,31.9,32.4,33.2],\"weather_code\":[0,0,2,3,3,1,0,2,0,1,1,2,3,1,3,1,3,2,3,2,2,1,0,0],\"wind_speed_10m\":[5.8,3.4,3.4,1.8,3.4,2.5,4.0,4.9,4.0,4.9,6.3,7.8,8.3,7.6,8.5,8.9,9.8,11.9,11.0,12.5,10.3,9.4,8.5,8.5],\"wind_direction_10m\":[56,82,64,56,218,228,226,224,216,250,252,262,274,276,272,276,280,302,304,322,310,310,316,322],\"pressure_msl\":[1016.1,1016.3,1016.2,1016.3,1016.4,1016.5,1016.4,1016.5,1016.0,1016.0,1015.9,1015.4,1014.9,1014.2,1013.5,1012.9,1012.2,1012.1,1011.9,1012.0,1011.8,1011.8,1011.8,1011.8],\"precipitation_probability\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,2,4,7,11,12,9,4,0],\"snowfall\":[0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000],\"uv_index\":[0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.15,0.70,1.70,3.00,3.30,4.65,3.60,4.00,2.20,1.80,1.00,0.50,0.15,0.00,0.00,0.00],\"snow_depth\":[0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000,0.000],\"freezing_level_height\":[3576.115,3772.966,3904.199,3904.199,3871.391,3871.391,3937.008,3969.816,4002.625,4002.625,4068.241,4101.050,4396.326,4560.368,4888.452,5183.727,5380.578,5479.002,5249.344,5216.536,4921.260,4822.834,4724.410,4691.601],\"visibility\":[93700.789,91797.898,95931.758,88976.375,63648.293,51181.102,46784.777,43700.789,36876.641,40813.648,43307.086,55249.344,77690.289,83136.484,85826.773,91666.664,89501.312,91469.820,95538.055,105774.281,108661.422,107808.398,103805.773,113254.594],\"apparent_temperature\":[41.1,41.3,41.4,42.0,41.5,40.9,39.7,38.6,39.5,41.2,43.6,47.4,48.4,53.0,53.2,55.7,54.7,53.7,53.5,50.8,51.3,50.3,49.1,46.8]}}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 May 2026 22:36:25 GMT
+      Transfer-Encoding:
+      - chunked
+      content-length:
+      - '3055'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - api.open-meteo.com
+    method: GET
+    uri: https://api.open-meteo.com/v1/forecast?current=temperature_2m%2Crelative_humidity_2m%2Capparent_temperature%2Cweather_code%2Cwind_speed_10m%2Cwind_direction_10m%2Cpressure_msl%2Cprecipitation%2Crain%2Cshowers%2Csnowfall%2Csnow_depth%2Cvisibility%2Cuv_index&daily=sunrise%2Csunset%2Cuv_index_max&forecast_days=1&latitude=51.5074&longitude=-0.1278&precipitation_unit=inch&temperature_unit=fahrenheit&timezone=auto&wind_speed_unit=mph
+  response:
+    body:
+      string: "{\"latitude\":51.51147,\"longitude\":-0.13078308,\"generationtime_ms\":0.23043155670166016,\"utc_offset_seconds\":3600,\"timezone\":\"Europe/London\",\"timezone_abbreviation\":\"GMT+1\",\"elevation\":16.0,\"current_units\":{\"time\":\"iso8601\",\"interval\":\"seconds\",\"temperature_2m\":\"\xB0F\",\"relative_humidity_2m\":\"%\",\"apparent_temperature\":\"\xB0F\",\"weather_code\":\"wmo
+        code\",\"wind_speed_10m\":\"mp/h\",\"wind_direction_10m\":\"\xB0\",\"pressure_msl\":\"hPa\",\"precipitation\":\"inch\",\"rain\":\"inch\",\"showers\":\"inch\",\"snowfall\":\"inch\",\"snow_depth\":\"ft\",\"visibility\":\"ft\",\"uv_index\":\"\"},\"current\":{\"time\":\"2026-05-11T23:30\",\"interval\":900,\"temperature_2m\":46.9,\"relative_humidity_2m\":55,\"apparent_temperature\":41.1,\"weather_code\":0,\"wind_speed_10m\":4.5,\"wind_direction_10m\":69,\"pressure_msl\":1016.2,\"precipitation\":0.000,\"rain\":0.000,\"showers\":0.000,\"snowfall\":0.000,\"snow_depth\":0.000,\"visibility\":92782.156,\"uv_index\":0.00},\"daily_units\":{\"time\":\"iso8601\",\"sunrise\":\"iso8601\",\"sunset\":\"iso8601\",\"uv_index_max\":\"\"},\"daily\":{\"time\":[\"2026-05-11\"],\"sunrise\":[\"2026-05-11T05:14\"],\"sunset\":[\"2026-05-11T20:39\"],\"uv_index_max\":[2.15]}}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 May 2026 22:36:25 GMT
+      Transfer-Encoding:
+      - chunked
+      content-length:
+      - '1085'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,8 +10,7 @@ This module provides:
 Best Practices for API Integration Testing:
 1. Use VCR cassettes to record and replay HTTP interactions
 2. Filter sensitive data (API keys) from recorded cassettes
-3. Match Open-Meteo /forecast requests by query, because that endpoint switches
-   current/hourly/daily payload shape through query parameters
+3. Match provider request query strings when non-secret parameters affect payload shape.
 4. Set record_mode="none" in CI to ensure tests only use recorded cassettes
 5. Use record_mode="new_episodes" when adding new tests
 6. Run live tests periodically to catch API changes
@@ -95,8 +94,16 @@ def _is_openmeteo_forecast(uri: str) -> bool:
     return parts.netloc.endswith("open-meteo.com") and parts.path.endswith("/v1/forecast")
 
 
+def _is_query_sensitive_provider(uri: str) -> bool:
+    parts = urlsplit(uri)
+    host = parts.netloc.lower()
+    if _is_openmeteo_forecast(uri):
+        return True
+    return host.endswith(("api.weather.gov", "api.pirateweather.net"))
+
+
 def _scrubbed_query_items(uri: str) -> list[tuple[str, str]]:
-    sensitive = {"key", "api_key", "apikey", "token"}
+    sensitive = {"key", "api_key", "apikey", "token", "appid", "app_id", "password"}
     list_parameters = {"current", "daily", "hourly"}
     items = []
     for key, value in parse_qsl(urlsplit(uri).query, keep_blank_values=True):
@@ -110,9 +117,11 @@ def _scrubbed_query_items(uri: str) -> list[tuple[str, str]]:
     return sorted(items)
 
 
-def _match_openmeteo_forecast_query(request_1, request_2):
-    """Require query equality for Open-Meteo forecast cassettes only."""
-    if not (_is_openmeteo_forecast(request_1.uri) or _is_openmeteo_forecast(request_2.uri)):
+def _match_provider_query(request_1, request_2):
+    """Require query equality for provider endpoints whose query changes the response."""
+    if not (
+        _is_query_sensitive_provider(request_1.uri) or _is_query_sensitive_provider(request_2.uri)
+    ):
         return
 
     query_1 = _scrubbed_query_items(request_1.uri)
@@ -124,8 +133,8 @@ def _match_openmeteo_forecast_query(request_1, request_2):
 integration_vcr = vcr.VCR(
     cassette_library_dir=str(CASSETTE_DIR),
     record_mode=RECORD_MODE,
-    # Query-sensitive Open-Meteo matching prevents hourly/daily/current payload mixups.
-    match_on=["method", "scheme", "host", "port", "path", "openmeteo_forecast_query"],
+    # Query-sensitive matching prevents payload mixups when params drive provider response shape.
+    match_on=["method", "scheme", "host", "port", "path", "provider_query"],
     # Filter sensitive data from recorded cassettes
     filter_query_parameters=["key", "api_key", "apikey", "token"],
     filter_headers=["authorization", "x-api-key", "api-key", "user-agent"],
@@ -135,8 +144,8 @@ integration_vcr = vcr.VCR(
     decode_compressed_response=True,
 )
 integration_vcr.register_matcher(
-    "openmeteo_forecast_query",
-    _match_openmeteo_forecast_query,
+    "provider_query",
+    _match_provider_query,
 )
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,7 +10,8 @@ This module provides:
 Best Practices for API Integration Testing:
 1. Use VCR cassettes to record and replay HTTP interactions
 2. Filter sensitive data (API keys) from recorded cassettes
-3. Match requests by method, host, path (not query params which may contain API keys)
+3. Match Open-Meteo /forecast requests by query, because that endpoint switches
+   current/hourly/daily payload shape through query parameters
 4. Set record_mode="none" in CI to ensure tests only use recorded cassettes
 5. Use record_mode="new_episodes" when adding new tests
 6. Run live tests periodically to catch API changes
@@ -21,6 +22,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING
+from urllib.parse import parse_qsl, urlsplit
 
 import pytest
 
@@ -37,6 +39,9 @@ except ImportError:  # pragma: no cover - optional test dependency fallback
                 return func
 
             return decorator
+
+        def register_matcher(self, *_args, **_kwargs):
+            pass
 
     class _FallbackVcrModule:
         VCR = _FallbackVcrInstance
@@ -85,11 +90,42 @@ def _scrub_pw_key_from_uri(request):
     return request
 
 
+def _is_openmeteo_forecast(uri: str) -> bool:
+    parts = urlsplit(uri)
+    return parts.netloc.endswith("open-meteo.com") and parts.path.endswith("/v1/forecast")
+
+
+def _scrubbed_query_items(uri: str) -> list[tuple[str, str]]:
+    sensitive = {"key", "api_key", "apikey", "token"}
+    list_parameters = {"current", "daily", "hourly"}
+    items = []
+    for key, value in parse_qsl(urlsplit(uri).query, keep_blank_values=True):
+        normalized_key = key.lower()
+        if normalized_key in sensitive:
+            continue
+        if normalized_key in list_parameters:
+            items.extend((normalized_key, item) for item in value.split(",") if item)
+        else:
+            items.append((normalized_key, value))
+    return sorted(items)
+
+
+def _match_openmeteo_forecast_query(request_1, request_2):
+    """Require query equality for Open-Meteo forecast cassettes only."""
+    if not (_is_openmeteo_forecast(request_1.uri) or _is_openmeteo_forecast(request_2.uri)):
+        return
+
+    query_1 = _scrubbed_query_items(request_1.uri)
+    query_2 = _scrubbed_query_items(request_2.uri)
+    if query_1 != query_2:
+        raise AssertionError(f"{query_1} != {query_2}")
+
+
 integration_vcr = vcr.VCR(
     cassette_library_dir=str(CASSETTE_DIR),
     record_mode=RECORD_MODE,
-    # Match on method, scheme, host, port, path - NOT query params (API keys vary)
-    match_on=["method", "scheme", "host", "port", "path"],
+    # Query-sensitive Open-Meteo matching prevents hourly/daily/current payload mixups.
+    match_on=["method", "scheme", "host", "port", "path", "openmeteo_forecast_query"],
     # Filter sensitive data from recorded cassettes
     filter_query_parameters=["key", "api_key", "apikey", "token"],
     filter_headers=["authorization", "x-api-key", "api-key", "user-agent"],
@@ -97,6 +133,10 @@ integration_vcr = vcr.VCR(
     before_record_request=_scrub_pw_key_from_uri,
     # Decode compressed responses for readable cassettes
     decode_compressed_response=True,
+)
+integration_vcr.register_matcher(
+    "openmeteo_forecast_query",
+    _match_openmeteo_forecast_query,
 )
 
 

--- a/tests/integration/test_nws_integration.py
+++ b/tests/integration/test_nws_integration.py
@@ -30,7 +30,7 @@ class TestNwsPointData:
         """Test fetching point data for a US location."""
         from accessiweather.api.nws import NwsApiWrapper
 
-        wrapper = NwsApiWrapper()
+        wrapper = NwsApiWrapper(min_request_interval=0)
         data = wrapper.get_point_data(
             lat=us_location.latitude,
             lon=us_location.longitude,
@@ -51,7 +51,7 @@ class TestNwsPointData:
         """Test fetching point data for Alaska (edge case for NWS coverage)."""
         from accessiweather.api.nws import NwsApiWrapper
 
-        wrapper = NwsApiWrapper()
+        wrapper = NwsApiWrapper(min_request_interval=0)
         data = wrapper.get_point_data(
             lat=alaska_location.latitude,
             lon=alaska_location.longitude,
@@ -74,7 +74,7 @@ class TestNwsPointData:
         from accessiweather.api.nws import NwsApiWrapper
         from accessiweather.api_client import NoaaApiError
 
-        wrapper = NwsApiWrapper()
+        wrapper = NwsApiWrapper(min_request_interval=0)
 
         # NWS should return 404 for international locations
         # With VCR replay, may return error response instead of raising
@@ -90,7 +90,7 @@ class TestNwsPointData:
                 data.get("status") == 404
                 or data.get("title") == "Data Unavailable For Requested Point"
             )
-        except (NoaaApiError, Exception):
+        except NoaaApiError:
             # Exception is also acceptable (live API behavior)
             pass
 
@@ -104,7 +104,7 @@ class TestNwsCurrentConditions:
         """Test fetching current conditions for a US location."""
         from accessiweather.api.nws import NwsApiWrapper
 
-        wrapper = NwsApiWrapper()
+        wrapper = NwsApiWrapper(min_request_interval=0)
         data = wrapper.get_current_conditions(
             lat=us_location.latitude,
             lon=us_location.longitude,
@@ -120,7 +120,7 @@ class TestNwsCurrentConditions:
         """Test fetching current conditions for Alaska."""
         from accessiweather.api.nws import NwsApiWrapper
 
-        wrapper = NwsApiWrapper()
+        wrapper = NwsApiWrapper(min_request_interval=0)
         data = wrapper.get_current_conditions(
             lat=alaska_location.latitude,
             lon=alaska_location.longitude,
@@ -138,7 +138,7 @@ class TestNwsForecast:
         """Test fetching forecast for a US location."""
         from accessiweather.api.nws import NwsApiWrapper
 
-        wrapper = NwsApiWrapper()
+        wrapper = NwsApiWrapper(min_request_interval=0)
         data = wrapper.get_forecast(
             lat=us_location.latitude,
             lon=us_location.longitude,
@@ -164,7 +164,7 @@ class TestNwsForecast:
         """Test fetching forecast for Alaska."""
         from accessiweather.api.nws import NwsApiWrapper
 
-        wrapper = NwsApiWrapper()
+        wrapper = NwsApiWrapper(min_request_interval=0)
         data = wrapper.get_forecast(
             lat=alaska_location.latitude,
             lon=alaska_location.longitude,
@@ -184,7 +184,7 @@ class TestNwsHourlyForecast:
         """Test fetching hourly forecast for a US location."""
         from accessiweather.api.nws import NwsApiWrapper
 
-        wrapper = NwsApiWrapper()
+        wrapper = NwsApiWrapper(min_request_interval=0)
         data = wrapper.get_hourly_forecast(
             lat=us_location.latitude,
             lon=us_location.longitude,
@@ -214,7 +214,7 @@ class TestNwsStations:
         """Test fetching observation stations for a US location."""
         from accessiweather.api.nws import NwsApiWrapper
 
-        wrapper = NwsApiWrapper()
+        wrapper = NwsApiWrapper(min_request_interval=0)
         data = wrapper.get_stations(
             lat=us_location.latitude,
             lon=us_location.longitude,
@@ -240,7 +240,7 @@ class TestNwsAlerts:
         """Test fetching alerts for a US location."""
         from accessiweather.api.nws import NwsApiWrapper
 
-        wrapper = NwsApiWrapper()
+        wrapper = NwsApiWrapper(min_request_interval=0)
         data = wrapper.get_alerts(
             lat=us_location.latitude,
             lon=us_location.longitude,
@@ -257,7 +257,7 @@ class TestNwsAlerts:
         """Test fetching alerts for Alaska."""
         from accessiweather.api.nws import NwsApiWrapper
 
-        wrapper = NwsApiWrapper()
+        wrapper = NwsApiWrapper(min_request_interval=0)
         data = wrapper.get_alerts(
             lat=alaska_location.latitude,
             lon=alaska_location.longitude,
@@ -276,7 +276,7 @@ class TestNwsDiscussion:
         """Test fetching forecast discussion for a US location."""
         from accessiweather.api.nws import NwsApiWrapper
 
-        wrapper = NwsApiWrapper()
+        wrapper = NwsApiWrapper(min_request_interval=0)
         discussion = wrapper.get_discussion(
             lat=us_location.latitude,
             lon=us_location.longitude,
@@ -300,7 +300,7 @@ class TestNwsLocationIdentification:
         """Test identifying location type for a US location."""
         from accessiweather.api.nws import NwsApiWrapper
 
-        wrapper = NwsApiWrapper()
+        wrapper = NwsApiWrapper(min_request_interval=0)
         location_type, location_id = wrapper.identify_location_type(
             lat=us_location.latitude,
             lon=us_location.longitude,
@@ -329,7 +329,7 @@ class TestNwsErrorHandling:
         from accessiweather.api.nws import NwsApiWrapper
         from accessiweather.api_client import ApiClientError, NoaaApiError
 
-        wrapper = NwsApiWrapper()
+        wrapper = NwsApiWrapper(min_request_interval=0)
 
         # Ocean coordinates (no NWS coverage)
         # With VCR replay, may return error response instead of raising
@@ -345,6 +345,6 @@ class TestNwsErrorHandling:
                 data.get("status") == 404
                 or data.get("title") == "Data Unavailable For Requested Point"
             )
-        except (NoaaApiError, ApiClientError, Exception):
+        except (NoaaApiError, ApiClientError):
             # Exception is also acceptable (live API behavior)
             pass

--- a/tests/integration/test_pirate_weather_integration.py
+++ b/tests/integration/test_pirate_weather_integration.py
@@ -193,6 +193,7 @@ class TestPirateWeatherMinutely:
 class TestPirateWeatherErrorHandling:
     """Test Pirate Weather error handling."""
 
+    @pytest.mark.live_only
     @pytest.mark.asyncio
     async def test_invalid_api_key(self, us_location):
         """Test that invalid API key raises appropriate error."""

--- a/tests/integration/test_weather_client_integration.py
+++ b/tests/integration/test_weather_client_integration.py
@@ -54,7 +54,6 @@ class TestWeatherClientDataSourceSelection:
 class TestWeatherClientOpenMeteoIntegration:
     """Test WeatherClient with OpenMeteo backend."""
 
-    @pytest.mark.live_only  # Current conditions parsing needs investigation
     @integration_vcr.use_cassette("weather_client/openmeteo_current.yaml")
     @pytest.mark.asyncio
     async def test_get_weather_openmeteo(self, international_location):

--- a/tests/test_alerts_conditional_get.py
+++ b/tests/test_alerts_conditional_get.py
@@ -59,6 +59,13 @@ class TestConditionalGet:
         discussions._alert_etag = '"abc123"'
         discussions._alert_last_modified = "Wed, 11 Mar 2026 12:00:00 GMT"
         discussions._cached_alert_response = {"features": [{"id": "cached"}]}
+        discussions._alert_conditional_cache[
+            "https://api.weather.gov/alerts/active?point=40,-90"
+        ] = {
+            "etag": '"abc123"',
+            "last_modified": "Wed, 11 Mar 2026 12:00:00 GMT",
+            "response": {"features": [{"id": "cached"}]},
+        }
 
         resp = _mock_response(304)
         with patch("accessiweather.api.nws.alerts_discussions.httpx.Client") as mock_client_cls:
@@ -79,11 +86,46 @@ class TestConditionalGet:
             assert headers.get("If-None-Match") == '"abc123"'
             assert headers.get("If-Modified-Since") == "Wed, 11 Mar 2026 12:00:00 GMT"
 
+    def test_conditional_cache_is_keyed_by_alert_url(self, discussions):
+        """A 304 for one alert URL must not reuse another location's cached response."""
+        first_url = "https://api.weather.gov/alerts/active?point=40,-90"
+        second_url = "https://api.weather.gov/alerts/active?point=41,-91"
+        first_response = _mock_response(
+            200,
+            json_data={"features": [{"id": "first-location"}]},
+            headers={"ETag": '"first-etag"'},
+        )
+        second_response = _mock_response(304)
+
+        with patch("accessiweather.api.nws.alerts_discussions.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.get.side_effect = [first_response, second_response]
+            mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            assert discussions._fetch_alerts_conditional(first_url) == {
+                "features": [{"id": "first-location"}]
+            }
+            assert discussions._fetch_alerts_conditional(second_url) == {"features": []}
+
+        second_headers = mock_client.get.call_args_list[1].kwargs["headers"]
+        assert "If-None-Match" not in second_headers
+        assert discussions._alert_conditional_cache[first_url]["response"] == {
+            "features": [{"id": "first-location"}]
+        }
+
     def test_subsequent_request_sends_conditional_headers(self, discussions):
         # Pre-populate cached state
         discussions._alert_etag = '"etag-value"'
         discussions._alert_last_modified = "Mon, 09 Mar 2026 08:00:00 GMT"
         discussions._cached_alert_response = {"features": []}
+        discussions._alert_conditional_cache[
+            "https://api.weather.gov/alerts/active?point=40,-90"
+        ] = {
+            "etag": '"etag-value"',
+            "last_modified": "Mon, 09 Mar 2026 08:00:00 GMT",
+            "response": {"features": []},
+        }
 
         resp = _mock_response(
             200,
@@ -160,6 +202,7 @@ class TestConditionalGet:
         assert discussions._alert_etag is None
         assert discussions._alert_last_modified is None
         assert discussions._cached_alert_response is None
+        assert discussions._alert_conditional_cache == {}
 
 
 class TestHardcodedAlertPollInterval:

--- a/tests/test_auto_mode_api_budget.py
+++ b/tests/test_auto_mode_api_budget.py
@@ -257,6 +257,69 @@ async def test_economy_us_fetches_nws_then_openmeteo_for_extended_forecast(
 
 
 @pytest.mark.asyncio
+async def test_economy_us_extended_forecast_prefers_openmeteo_over_ordered_pirateweather(
+    us_location: Location,
+) -> None:
+    settings = AppSettings(
+        auto_mode_api_budget="economy",
+        auto_sources_us=["nws", "pirateweather", "openmeteo"],
+        forecast_duration_days=10,
+    )
+    client = WeatherClient(data_source="auto", settings=settings, pirate_weather_api_key="test-key")
+    _stub_enrichments(client)
+    client._fetch_nws_data = AsyncMock(
+        return_value=(_current(), _forecast("NWS"), None, None, WeatherAlerts(alerts=[]), _hourly())
+    )
+    client._fetch_openmeteo_data = AsyncMock(return_value=(_current(), _forecast("OM"), _hourly()))
+
+    pw_client = MagicMock()
+    pw_client.get_current_conditions = AsyncMock(return_value=_current())
+    pw_client.get_forecast = AsyncMock(return_value=_forecast("PW"))
+    pw_client.get_hourly_forecast = AsyncMock(return_value=_hourly())
+    pw_client.get_alerts = AsyncMock(return_value=WeatherAlerts(alerts=[]))
+    client._pirate_weather_client_for_location = MagicMock(return_value=pw_client)
+
+    calls: list[list[str]] = []
+
+    async def _recording_fetch_all(self, location, **kwargs):
+        calls.append(
+            [name.removeprefix("fetch_") for name, coro in kwargs.items() if coro is not None]
+        )
+        return await _execute_fetch_all(self, location, **kwargs)
+
+    with patch.object(ParallelFetchCoordinator, "fetch_all", new=_recording_fetch_all):
+        await client._fetch_smart_auto_source(us_location)
+
+    assert calls == [["nws"], ["openmeteo"]]
+    client._fetch_openmeteo_data.assert_awaited_once()
+    pw_client.get_current_conditions.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auto_mode_uses_nws_discussion_from_primary_fetch(us_location: Location) -> None:
+    issuance = datetime(2026, 5, 11, 12, 30, tzinfo=UTC)
+    client = WeatherClient(data_source="auto", settings=AppSettings(auto_mode_api_budget="economy"))
+    _stub_enrichments(client)
+    client._fetch_nws_data = AsyncMock(
+        return_value=(
+            _current(),
+            _forecast("NWS"),
+            "AFD text from primary fetch",
+            issuance,
+            WeatherAlerts(alerts=[]),
+            _hourly(),
+        )
+    )
+    client._fetch_openmeteo_data = AsyncMock()
+
+    with patch.object(ParallelFetchCoordinator, "fetch_all", new=_execute_fetch_all):
+        result = await client._fetch_smart_auto_source(us_location)
+
+    assert result.discussion == "AFD text from primary fetch"
+    assert result.discussion_issuance_time == issuance
+
+
+@pytest.mark.asyncio
 async def test_economy_us_skips_pw_when_nws_is_sufficient(us_location: Location) -> None:
     settings = AppSettings(auto_mode_api_budget="economy", forecast_duration_days=7)
     client = WeatherClient(data_source="auto", settings=settings)

--- a/tests/test_auto_mode_api_budget.py
+++ b/tests/test_auto_mode_api_budget.py
@@ -116,12 +116,15 @@ def _stub_enrichments(client: WeatherClient) -> None:
 def test_auto_mode_api_budget_defaults_and_round_trips() -> None:
     settings = AppSettings()
     assert settings.auto_mode_api_budget == "max_coverage"
+    assert settings.parallel_fetch_timeout == 10.0
 
     restored = AppSettings.from_dict(settings.to_dict())
     assert restored.auto_mode_api_budget == "max_coverage"
+    assert restored.parallel_fetch_timeout == 10.0
 
     restored = AppSettings.from_dict({})
     assert restored.auto_mode_api_budget == "max_coverage"
+    assert restored.parallel_fetch_timeout == 10.0
 
     restored.auto_mode_api_budget = "nope"
     assert restored.validate_on_access("auto_mode_api_budget") is True
@@ -129,6 +132,13 @@ def test_auto_mode_api_budget_defaults_and_round_trips() -> None:
 
     restored = AppSettings.from_dict({"auto_mode_api_budget": "nope"})
     assert restored.auto_mode_api_budget == "max_coverage"
+
+    restored = AppSettings.from_dict({"parallel_fetch_timeout": "12.5"})
+    assert restored.parallel_fetch_timeout == 12.5
+    assert restored.to_dict()["parallel_fetch_timeout"] == 12.5
+
+    restored = AppSettings.from_dict({"parallel_fetch_timeout": 0})
+    assert restored.parallel_fetch_timeout == 10.0
 
 
 def test_data_sources_tab_budget_load_save_round_trip() -> None:
@@ -221,6 +231,32 @@ async def test_default_auto_mode_max_coverage_fetches_all_enabled_sources(
     assert {"nws", "openmeteo", "pirateweather"}.issubset(
         result.source_attribution.contributing_sources
     )
+
+
+@pytest.mark.asyncio
+async def test_auto_mode_uses_configured_parallel_fetch_timeout(
+    us_location: Location,
+) -> None:
+    settings = AppSettings(
+        parallel_fetch_timeout=12.5,
+        auto_sources_us=["nws"],
+    )
+    client = WeatherClient(data_source="auto", settings=settings)
+    _stub_enrichments(client)
+    client._fetch_nws_data = AsyncMock(
+        return_value=(_current(), _forecast("NWS"), None, None, WeatherAlerts(alerts=[]), _hourly())
+    )
+
+    timeouts: list[float] = []
+
+    async def _recording_fetch_all(self, location, **kwargs):
+        timeouts.append(self.timeout)
+        return await _execute_fetch_all(self, location, **kwargs)
+
+    with patch.object(ParallelFetchCoordinator, "fetch_all", new=_recording_fetch_all):
+        await client._fetch_smart_auto_source(us_location)
+
+    assert timeouts == [12.5]
 
 
 @pytest.mark.asyncio

--- a/tests/test_coverage_fix_pr449.py
+++ b/tests/test_coverage_fix_pr449.py
@@ -114,7 +114,7 @@ def test_parse_nws_alerts_extracts_references():
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_launch_enrichment_tasks_auto_mode_creates_smart_tasks():
-    """_launch_enrichment_tasks with data_source='auto' creates all smart enrichment tasks."""
+    """_launch_enrichment_tasks with auto mode creates missing smart enrichment tasks."""
     import asyncio
 
     import accessiweather.weather_client_enrichment as enrichment
@@ -146,6 +146,71 @@ async def test_launch_enrichment_tasks_auto_mode_creates_smart_tasks():
     assert "environmental" in tasks
     assert "aviation" in tasks
     assert "marine" in tasks
+
+
+@pytest.mark.asyncio
+async def test_launch_enrichment_tasks_auto_mode_reuses_existing_nws_discussion():
+    """Auto mode should not refetch NWS discussion when the main source fetch already has it."""
+    import asyncio
+
+    import accessiweather.weather_client_enrichment as enrichment
+    from accessiweather.models import Location, WeatherData
+    from accessiweather.weather_client import WeatherClient
+
+    client = WeatherClient(data_source="auto")
+    location = Location(name="NYC", latitude=40.7128, longitude=-74.0060)
+    weather_data = WeatherData(location=location, discussion="AFD text")
+
+    async def _noop(*args, **kwargs):
+        pass
+
+    with (
+        patch.object(enrichment, "enrich_with_sunrise_sunset", side_effect=_noop),
+        patch.object(enrichment, "enrich_with_nws_discussion", side_effect=_noop),
+        patch.object(enrichment, "populate_environmental_metrics", side_effect=_noop),
+        patch.object(enrichment, "enrich_with_aviation_data", side_effect=_noop),
+        patch.object(enrichment, "enrich_with_marine_data", side_effect=_noop),
+    ):
+        tasks = client._launch_enrichment_tasks(weather_data, location)
+        for t in tasks.values():
+            t.cancel()
+        await asyncio.gather(*tasks.values(), return_exceptions=True)
+
+    assert "sunrise_sunset" in tasks
+    assert "nws_discussion" not in tasks
+    assert "environmental" in tasks
+
+
+@pytest.mark.asyncio
+async def test_launch_enrichment_tasks_auto_mode_respects_disabled_nws_source():
+    """Auto mode should not make an NWS discussion call after NWS was intentionally skipped."""
+    import asyncio
+
+    import accessiweather.weather_client_enrichment as enrichment
+    from accessiweather.models import Location, WeatherData
+    from accessiweather.weather_client import WeatherClient
+    from accessiweather.weather_client_auto import AUTO_NO_NWS_DISCUSSION_TEXT
+
+    client = WeatherClient(data_source="auto")
+    location = Location(name="NYC", latitude=40.7128, longitude=-74.0060)
+    weather_data = WeatherData(location=location, discussion=AUTO_NO_NWS_DISCUSSION_TEXT)
+
+    async def _noop(*args, **kwargs):
+        pass
+
+    with (
+        patch.object(enrichment, "enrich_with_sunrise_sunset", side_effect=_noop),
+        patch.object(enrichment, "enrich_with_nws_discussion", side_effect=_noop),
+        patch.object(enrichment, "populate_environmental_metrics", side_effect=_noop),
+        patch.object(enrichment, "enrich_with_aviation_data", side_effect=_noop),
+        patch.object(enrichment, "enrich_with_marine_data", side_effect=_noop),
+    ):
+        tasks = client._launch_enrichment_tasks(weather_data, location)
+        for t in tasks.values():
+            t.cancel()
+        await asyncio.gather(*tasks.values(), return_exceptions=True)
+
+    assert "nws_discussion" not in tasks
 
 
 @pytest.mark.asyncio

--- a/tests/test_current_conditions.py
+++ b/tests/test_current_conditions.py
@@ -618,6 +618,19 @@ class TestComputePressureTrend:
         result = compute_pressure_trend_from_hourly(current, hourly)
         assert result is None
 
+    def test_implausible_pressure_mismatch_is_suppressed(self):
+        """Do not announce huge trends caused by mixed pressure reference surfaces."""
+        current = CurrentConditions(pressure_in=30.0, pressure_mb=1015.9)
+        dt = datetime(2026, 2, 7, 12, 0, tzinfo=UTC)
+        periods = [
+            HourlyForecastPeriod(start_time=dt, pressure_in=29.03, pressure_mb=983.1),
+        ]
+        hourly = HourlyForecast(periods=periods)
+
+        result = compute_pressure_trend_from_hourly(current, hourly)
+
+        assert result is None
+
 
 # ── format_trend_lines ──
 

--- a/tests/test_iem_text_products.py
+++ b/tests/test_iem_text_products.py
@@ -134,6 +134,22 @@ async def test_afos_retrieve_raises_on_http_error():
 
 
 @pytest.mark.asyncio
+async def test_afos_retrieve_raises_on_iem_error_text():
+    client = _client(_resp(text="ERROR: Could not Find: PMDSPD\n"))
+
+    with pytest.raises(IemProductFetchError, match="Could not Find"):
+        await fetch_iem_afos_text("PMDSPD", client=client, iem_base_url=IEM_BASE)
+
+
+def test_afos_retrieve_sync_raises_on_iem_error_text():
+    client = MagicMock(spec=httpx.Client)
+    client.get.return_value = _resp(text="ERROR: Could not Find: QPFPFD\n")
+
+    with pytest.raises(IemProductFetchError, match="Could not Find"):
+        fetch_iem_afos_text_sync("QPFPFD", client=client, iem_base_url=IEM_BASE)
+
+
+@pytest.mark.asyncio
 async def test_spc_outlook_returns_accessible_summary():
     client = _client(
         _resp(

--- a/tests/test_nws_alerts.py
+++ b/tests/test_nws_alerts.py
@@ -212,6 +212,25 @@ class TestParseNwsAlerts:
         alerts = parse_nws_alerts(data)
         assert alerts.alerts[0].id == "at-id-based-id"
 
+    def test_area_desc_splits_semicolon_without_spaces(self):
+        """NWS areaDesc is semicolon-delimited; spaces are not guaranteed."""
+        data = {
+            "features": [
+                {
+                    "id": "area-test",
+                    "properties": {
+                        "headline": "Test Alert",
+                        "severity": "Moderate",
+                        "areaDesc": "County A;County B; County C ",
+                    },
+                }
+            ]
+        }
+
+        alerts = parse_nws_alerts(data)
+
+        assert alerts.alerts[0].areas == ["County A", "County B", "County C"]
+
 
 class TestGetNwsAlertsParameters:
     """

--- a/tests/test_nws_high_low.py
+++ b/tests/test_nws_high_low.py
@@ -152,6 +152,18 @@ def _hourly_payload(start_time: str = "2026-04-26T10:00:00-04:00"):
 
 
 class TestNwsHourlyPressure:
+    def test_hourly_wind_speed_mph_populated_from_string(self):
+        hourly = parse_nws_hourly_forecast(_hourly_payload())
+
+        assert hourly.periods[0].wind_speed_mph == 5.0
+
+    def test_hourly_wind_speed_mph_populated_from_range(self):
+        payload = _hourly_payload()
+        payload["properties"]["periods"][0]["windSpeed"] = "5 to 15 mph"
+        hourly = parse_nws_hourly_forecast(payload)
+
+        assert hourly.periods[0].wind_speed_mph == 15.0
+
     def test_probability_of_precipitation_preserved(self):
         """NWS hourly probabilityOfPrecipitation.value is mapped to the hourly period."""
         hourly = parse_nws_hourly_forecast(_hourly_payload())

--- a/tests/test_nws_high_low.py
+++ b/tests/test_nws_high_low.py
@@ -256,6 +256,47 @@ class TestNwsHourlyPressure:
         assert result.periods[0].pressure_mb == 1013.25
         assert result.periods[0].pressure_in is not None
 
+    def test_gridpoint_pressure_normalizes_unlabelled_inches(self):
+        """Some NWS gridpoint pressure layers return inHg-like values without a unit."""
+        pressure = parse_nws_gridpoint_pressure(
+            {
+                "properties": {
+                    "pressure": {
+                        "values": [
+                            {
+                                "validTime": "2026-04-26T10:00:00-04:00/PT1H",
+                                "value": 29.03,
+                            }
+                        ],
+                    }
+                }
+            }
+        )
+
+        pressure_in, pressure_mb = next(iter(pressure.values()))
+        assert pressure_in == 29.03
+        assert pressure_mb == pytest.approx(983.0, abs=0.1)
+
+    def test_gridpoint_pressure_normalizes_unlabelled_hpa(self):
+        pressure = parse_nws_gridpoint_pressure(
+            {
+                "properties": {
+                    "pressure": {
+                        "values": [
+                            {
+                                "validTime": "2026-04-26T10:00:00-04:00/PT1H",
+                                "value": 1013.25,
+                            }
+                        ],
+                    }
+                }
+            }
+        )
+
+        pressure_in, pressure_mb = next(iter(pressure.values()))
+        assert pressure_in == pytest.approx(29.92, abs=0.01)
+        assert pressure_mb == 1013.25
+
     def test_gridpoint_pressure_ignores_far_valid_times(self):
         hourly = parse_nws_hourly_forecast(_hourly_payload())
         pressure = parse_nws_gridpoint_pressure(

--- a/tests/test_nws_legacy_paths.py
+++ b/tests/test_nws_legacy_paths.py
@@ -1,0 +1,141 @@
+"""Regression tests for legacy NWS wrapper paths."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from accessiweather.api.nws import NwsApiWrapper
+from accessiweather.api_client import NoaaApiClient
+from accessiweather.api_wrapper import NoaaApiWrapper
+
+
+def test_legacy_precise_alerts_use_point_query_not_zone():
+    client = NoaaApiClient()
+    client.identify_location_type = MagicMock(return_value=("county", "NYC061"))  # type: ignore[method-assign]
+    client._make_request = MagicMock(return_value={"features": []})  # type: ignore[method-assign]
+
+    assert client.get_alerts(40.7128, -74.006, precise_location=True) == {"features": []}
+
+    client.identify_location_type.assert_not_called()
+    client._make_request.assert_called_once_with(
+        "alerts/active",
+        params={"point": "40.7128,-74.006"},
+        force_refresh=False,
+    )
+
+
+def test_legacy_alert_fallback_omits_unsupported_radius_parameter():
+    client = NoaaApiClient()
+    client.identify_location_type = MagicMock(return_value=(None, None))  # type: ignore[method-assign]
+    client._make_request = MagicMock(return_value={"features": []})  # type: ignore[method-assign]
+
+    assert client.get_alerts(40.7128, -74.006, precise_location=False, radius=50) == {
+        "features": []
+    }
+
+    client._make_request.assert_called_once_with(
+        "alerts/active",
+        params={"point": "40.7128,-74.006"},
+        force_refresh=False,
+    )
+
+
+def test_nws_wrapper_alert_fallback_omits_unsupported_radius_parameter():
+    wrapper = NwsApiWrapper(min_request_interval=0)
+    wrapper.point_location.identify_location_type = MagicMock(return_value=(None, None))
+
+    with (
+        patch.object(wrapper, "_get_cached_or_fetch", side_effect=lambda _key, fn, _force: fn()),
+        patch("accessiweather.api.nws.alerts_discussions.httpx") as mock_httpx,
+    ):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.json.return_value = {"features": []}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response
+        mock_httpx.Client.return_value = mock_client
+        mock_httpx.Timeout = MagicMock()
+
+        wrapper.get_alerts(40.7128, -74.006, precise_location=False, radius=50)
+
+    requested_url = mock_client.get.call_args.args[0]
+    assert requested_url == "https://api.weather.gov/alerts/active?point=40.7128,-74.006"
+
+
+def test_nws_point_transform_preserves_problem_detail_errors():
+    wrapper = NwsApiWrapper(min_request_interval=0)
+    problem = SimpleNamespace(
+        to_dict=lambda: {
+            "status": 404,
+            "title": "Data Unavailable For Requested Point",
+            "detail": "Unable to provide data for requested point",
+        }
+    )
+
+    result = wrapper.point_location._transform_point_data(problem)
+
+    assert result["status"] == 404
+    assert result["title"] == "Data Unavailable For Requested Point"
+
+
+def test_nws_wrapper_national_aliases_use_iem_afos_instead_of_weather_gov_product_types():
+    wrapper = NwsApiWrapper(min_request_interval=0)
+
+    with (
+        patch(
+            "accessiweather.api.nws.alerts_discussions.fetch_iem_national_product",
+            return_value="WPC short range text",
+        ) as mock_iem,
+        patch.object(wrapper, "_fetch_url") as mock_weather_gov,
+    ):
+        result = wrapper.get_national_product("FXUS01", "KWNH", force_refresh=True)
+
+    assert result == "WPC short range text"
+    mock_iem.assert_called_once()
+    mock_weather_gov.assert_not_called()
+
+
+def test_legacy_national_aliases_use_iem_afos_instead_of_weather_gov_product_types():
+    client = NoaaApiClient()
+
+    with (
+        patch(
+            "accessiweather.api_client.alerts_and_products.fetch_iem_national_product",
+            return_value="SPC day one text",
+        ) as mock_iem,
+        patch.object(client, "_make_request") as mock_weather_gov,
+    ):
+        result = client.get_national_product("ACUS01", "KWNS", force_refresh=True)
+
+    assert result == "SPC day one text"
+    mock_iem.assert_called_once()
+    mock_weather_gov.assert_not_called()
+
+
+def test_nws_national_product_helper_maps_to_iem_afos():
+    with patch(
+        "accessiweather.nws_national_products.fetch_iem_afos_text_sync",
+        return_value=SimpleNamespace(product_text="NHC outlook"),
+    ) as mock_iem:
+        from accessiweather.nws_national_products import fetch_iem_national_product
+
+        result = fetch_iem_national_product("MIATWOAT", "KNHC")
+
+    assert result == "NHC outlook"
+    mock_iem.assert_called_once()
+    assert mock_iem.call_args.args[0] == "TWOAT"
+
+
+def test_auto_provider_selects_nws_for_alaska_hawaii_and_puerto_rico():
+    wrapper = NoaaApiWrapper(min_request_interval=0, preferred_provider="auto")
+
+    assert wrapper.get_active_provider(61.2181, -149.9003) == "nws"
+    assert wrapper.get_active_provider(21.3069, -157.8583) == "nws"
+    assert wrapper.get_active_provider(18.4655, -66.1057) == "nws"
+    assert wrapper.get_active_provider(51.5074, -0.1278) == "openmeteo"

--- a/tests/test_openmeteo_mapper.py
+++ b/tests/test_openmeteo_mapper.py
@@ -3,6 +3,47 @@
 from accessiweather.openmeteo_mapper import OpenMeteoMapper
 
 
+class TestOpenMeteoMapperCurrentFields:
+    def test_current_pressure_hpa_is_mapped_to_pascals(self):
+        mapped = OpenMeteoMapper().map_current_conditions(
+            {
+                "current": {
+                    "temperature_2m": 72.0,
+                    "relative_humidity_2m": 55,
+                    "apparent_temperature": 72.0,
+                    "wind_direction_10m": 180,
+                    "wind_speed_10m": 8.0,
+                    "pressure_msl": 1015.0,
+                    "weather_code": 1,
+                },
+                "current_units": {"temperature_2m": "°F", "pressure_msl": "hPa"},
+            }
+        )
+
+        pressure = mapped["properties"]["barometricPressure"]
+
+        assert pressure["value"] == 101500.0
+        assert pressure["unitCode"] == "wmoUnit:Pa"
+
+    def test_current_pressure_pascal_unit_is_not_scaled_twice(self):
+        mapped = OpenMeteoMapper().map_current_conditions(
+            {
+                "current": {
+                    "temperature_2m": 72.0,
+                    "relative_humidity_2m": 55,
+                    "apparent_temperature": 72.0,
+                    "wind_direction_10m": 180,
+                    "wind_speed_10m": 8.0,
+                    "pressure_msl": 101500.0,
+                    "weather_code": 1,
+                },
+                "current_units": {"temperature_2m": "°F", "pressure_msl": "Pa"},
+            }
+        )
+
+        assert mapped["properties"]["barometricPressure"]["value"] == 101500.0
+
+
 def _make_daily_payload(
     dates: list[str],
     highs: list[float | None],

--- a/tests/test_pirate_weather_client.py
+++ b/tests/test_pirate_weather_client.py
@@ -246,6 +246,20 @@ class TestParseCurrentConditions:
         assert result.condition == "Freezing Rain"
         assert result.precipitation_type == ["ice"]
 
+    def test_current_precip_intensity_does_not_fill_amount_fields(
+        self, client, sample_forecast_payload
+    ):
+        payload = dict(sample_forecast_payload)
+        payload["currently"] = {
+            **sample_forecast_payload["currently"],
+            "precipIntensity": 0.25,
+        }
+
+        result = client._parse_current_conditions(payload)
+
+        assert result.precipitation_in is None
+        assert result.precipitation_mm is None
+
     def test_current_sunrise_uses_response_timezone_name(self, client, sample_forecast_payload):
         """IANA timezone from PW should override the fixed offset fallback."""
         payload = dict(sample_forecast_payload)
@@ -343,6 +357,73 @@ class TestParseForecast:
         result = si_client._parse_forecast(sample_forecast_payload)
         assert result.periods[0].wind_speed is not None
         assert "m/s" in result.periods[0].wind_speed
+
+    def test_non_us_daily_prefers_daytime_high_low(self, sample_forecast_payload):
+        """SI payloads still expose day/night high/low separately from max/min."""
+        si_client = PirateWeatherClient(api_key="key", units="si")
+        day = {
+            **sample_forecast_payload["daily"]["data"][0],
+            "temperatureHigh": 20.0,
+            "temperatureLow": 10.0,
+            "temperatureMax": 25.0,
+            "temperatureMin": 5.0,
+        }
+        payload = dict(sample_forecast_payload)
+        payload["daily"] = {"data": [day]}
+
+        result = si_client._parse_forecast(payload)
+
+        assert result.periods[0].temperature == 20.0
+        assert result.periods[0].temperature_low == 10.0
+
+    def test_daily_precipitation_uses_accumulation_before_intensity(
+        self, client, sample_forecast_payload
+    ):
+        day = {
+            **sample_forecast_payload["daily"]["data"][0],
+            "precipAccumulation": 0.5,
+            "precipIntensity": 0.01,
+            "snowAccumulation": 2.0,
+        }
+        payload = dict(sample_forecast_payload)
+        payload["daily"] = {"data": [day]}
+
+        result = client._parse_forecast(payload)
+
+        assert result.periods[0].precipitation_amount == 0.5
+        assert result.periods[0].snowfall == 2.0
+
+    def test_daily_accumulation_cm_converts_to_inches_for_si_units(self, sample_forecast_payload):
+        si_client = PirateWeatherClient(api_key="key", units="si")
+        day = {
+            **sample_forecast_payload["daily"]["data"][0],
+            "liquidAccumulation": 1.27,
+            "precipIntensity": 2.54,
+            "snowAccumulation": 2.54,
+        }
+        payload = dict(sample_forecast_payload)
+        payload["daily"] = {"data": [day]}
+
+        result = si_client._parse_forecast(payload)
+
+        assert result.periods[0].precipitation_amount == pytest.approx(0.5)
+        assert result.periods[0].snowfall == pytest.approx(1.0)
+
+    def test_daily_precipitation_ignores_intensity_without_accumulation(
+        self, client, sample_forecast_payload
+    ):
+        day = {
+            **sample_forecast_payload["daily"]["data"][0],
+            "precipIntensity": 0.25,
+        }
+        day.pop("precipAccumulation", None)
+        day.pop("liquidAccumulation", None)
+        payload = dict(sample_forecast_payload)
+        payload["daily"] = {"data": [day]}
+
+        result = client._parse_forecast(payload)
+
+        assert result.periods[0].precipitation_amount is None
 
     def test_daily_summary_parsed(self, client):
         """Summary field is populated from data['daily']['summary']."""
@@ -537,6 +618,39 @@ class TestParseHourlyForecast:
         assert period.pressure_in is not None
         assert abs(period.pressure_in - 1013.0 / 33.8639) < 0.01
 
+    def test_hourly_precipitation_uses_accumulation_before_intensity(
+        self, client, sample_forecast_payload
+    ):
+        hour = {
+            **sample_forecast_payload["hourly"]["data"][0],
+            "liquidAccumulation": 0.25,
+            "precipIntensity": 0.01,
+            "snowAccumulation": 1.5,
+        }
+        payload = dict(sample_forecast_payload)
+        payload["hourly"] = {"data": [hour]}
+
+        result = client._parse_hourly_forecast(payload)
+
+        assert result.periods[0].precipitation_amount == 0.25
+        assert result.periods[0].snowfall == 1.5
+
+    def test_hourly_precipitation_ignores_intensity_without_accumulation(
+        self, client, sample_forecast_payload
+    ):
+        hour = {
+            **sample_forecast_payload["hourly"]["data"][0],
+            "precipIntensity": 0.25,
+        }
+        hour.pop("precipAccumulation", None)
+        hour.pop("liquidAccumulation", None)
+        payload = dict(sample_forecast_payload)
+        payload["hourly"] = {"data": [hour]}
+
+        result = client._parse_hourly_forecast(payload)
+
+        assert result.periods[0].precipitation_amount is None
+
     def test_empty_hourly_block(self, client, sample_forecast_payload):
         payload = dict(sample_forecast_payload)
         payload["hourly"] = {"data": []}
@@ -647,6 +761,16 @@ class TestParseAlerts:
         assert alert.onset is not None
         assert alert.expires is not None
         assert alert.expires > alert.onset
+
+    def test_alert_expires_sentinel_returns_none(self, client, sample_payload_with_alerts):
+        payload = dict(sample_payload_with_alerts)
+        alert = dict(sample_payload_with_alerts["alerts"][0])
+        alert["expires"] = -999
+        payload["alerts"] = [alert]
+
+        result = client._parse_alerts(payload)
+
+        assert result.alerts[0].expires is None
 
     def test_alert_times_use_response_timezone_name(self, client, sample_payload_with_alerts):
         """Alert epoch timestamps should use PW's IANA timezone when present."""

--- a/tests/test_pw_coverage.py
+++ b/tests/test_pw_coverage.py
@@ -849,6 +849,50 @@ class TestFetchPirateWeatherInAutoMode:
         assert result is not None
         assert result.minutely_precipitation is mock_minutely
 
+    @pytest.mark.asyncio
+    async def test_minutely_fetch_uses_location_specific_units(self, intl_location):
+        """International minutely polling should not reuse a default US-units client."""
+        wc = WeatherClient(data_source="pirateweather", pirate_weather_api_key="test-key")
+        default_us_client = MagicMock()
+        default_us_client.units = "us"
+        default_us_client.get_minutely_forecast = AsyncMock(
+            return_value={
+                "minutely": {
+                    "data": [
+                        {
+                            "time": 1700000000,
+                            "precipIntensity": 0.1,
+                            "precipProbability": 0.8,
+                        }
+                    ]
+                }
+            }
+        )
+        ca_client = MagicMock()
+        ca_client.units = "ca"
+        ca_client.get_minutely_forecast = AsyncMock(
+            return_value={
+                "minutely": {
+                    "data": [
+                        {
+                            "time": 1700000000,
+                            "precipIntensity": 0.1,
+                            "precipProbability": 0.8,
+                        }
+                    ]
+                }
+            }
+        )
+        wc._pirate_weather_client = default_us_client
+
+        with patch.object(wc, "_pirate_weather_client_for_location", return_value=ca_client):
+            result = await wc._get_pirate_weather_minutely(intl_location)
+
+        assert result is not None
+        assert result.points[0].precipitation_intensity == pytest.approx(0.1)
+        ca_client.get_minutely_forecast.assert_awaited_once_with(intl_location)
+        default_us_client.get_minutely_forecast.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # display/presentation/forecast.py – summary field from Forecast

--- a/tests/test_unit_preference_bugs.py
+++ b/tests/test_unit_preference_bugs.py
@@ -23,6 +23,7 @@ from accessiweather.display.presentation.current_conditions import (
     format_trend_lines,
 )
 from accessiweather.display.presentation.forecast import build_hourly_summary
+from accessiweather.display.weather_presenter import WeatherPresenter
 from accessiweather.models import (
     AppSettings,
     CurrentConditions,
@@ -30,6 +31,7 @@ from accessiweather.models import (
     HourlyForecastPeriod,
     Location,
     TrendInsight,
+    WeatherData,
 )
 from accessiweather.pirate_weather_client import PirateWeatherClient
 from accessiweather.utils import TemperatureUnit
@@ -155,6 +157,27 @@ class TestTemperatureTrendUnitBug:
         assert len(lines) == 1
         assert "°C" in lines[0]
         assert "°F" not in lines[0]
+
+    def test_weather_presentation_summary_uses_resolved_unit_pref(self):
+        settings = _make_settings(temperature_unit="celsius", show_pressure_trend=False)
+        weather = WeatherData(
+            location=Location(
+                name="London",
+                latitude=51.5,
+                longitude=-0.1,
+                timezone="Europe/London",
+                country_code="GB",
+            ),
+            current=CurrentConditions(temperature_f=50.0, temperature_c=10.0, condition="Clear"),
+            trend_insights=[self._trend_f(9.0)],
+        )
+
+        presentation = WeatherPresenter(settings).present(weather)
+
+        assert "10°C" in presentation.summary_text
+        assert "Temperature rising +5.0°C over 24h" in presentation.summary_text
+        assert "°F" not in presentation.summary_text
+        assert presentation.trend_summary == ["Temperature rising +5.0°C over 24h"]
 
 
 @given(

--- a/tests/test_weather_client.py
+++ b/tests/test_weather_client.py
@@ -86,6 +86,11 @@ class TestWeatherClientDataSource:
         intl_loc = Location(name="Test", latitude=51.5, longitude=-0.1)
         assert client._is_us_location(intl_loc) is False
 
+    def test_is_us_location_rejects_western_canada_without_country_code(self, client):
+        """Legacy/manual Victoria coordinates should not be treated as NWS-capable."""
+        victoria = Location(name="Victoria", latitude=48.4284, longitude=-123.3656)
+        assert client._is_us_location(victoria) is False
+
     def test_determine_api_choice_auto_us(self, client, us_location):
         """Test auto mode selects NWS for US."""
         client.data_source = "auto"

--- a/tests/test_weather_client_fusion.py
+++ b/tests/test_weather_client_fusion.py
@@ -149,6 +149,36 @@ class TestMergeCurrentConditions:
         assert result.humidity == 55  # from openmeteo (nws was None)
         assert attr.field_sources["humidity"] == "openmeteo"
 
+    def test_empty_condition_falls_back_to_next_source(self, engine, us_location):
+        """Empty NWS condition text should not block lower-priority usable text."""
+        nws_cc = CurrentConditions(temperature_f=70.0, condition="")
+        om_cc = CurrentConditions(temperature_f=68.0, condition="Partly Cloudy")
+        sources = [
+            _make_source("nws", current=nws_cc),
+            _make_source("openmeteo", current=om_cc),
+        ]
+
+        result, attr = engine.merge_current_conditions(sources, us_location)
+
+        assert result is not None
+        assert result.condition == "Partly Cloudy"
+        assert attr.field_sources["condition"] == "openmeteo"
+
+    def test_unknown_condition_falls_back_to_next_source(self, engine, us_location):
+        """Placeholder condition text should not win automatic source fusion."""
+        nws_cc = CurrentConditions(temperature_f=70.0, condition="Unknown")
+        om_cc = CurrentConditions(temperature_f=68.0, condition="Clear")
+        sources = [
+            _make_source("nws", current=nws_cc),
+            _make_source("openmeteo", current=om_cc),
+        ]
+
+        result, attr = engine.merge_current_conditions(sources, us_location)
+
+        assert result is not None
+        assert result.condition == "Clear"
+        assert attr.field_sources["condition"] == "openmeteo"
+
     def test_failed_sources_tracked(self, engine, us_location):
         cc = CurrentConditions(temperature_f=70.0)
         sources = [

--- a/tests/test_weather_client_fusion.py
+++ b/tests/test_weather_client_fusion.py
@@ -79,6 +79,10 @@ class TestIsUsLocation:
     def test_outside_us_bounding_box(self, engine, intl_location_no_country):
         assert engine._is_us_location(intl_location_no_country) is False
 
+    def test_western_canada_without_country_code_is_not_us(self, engine):
+        loc = Location(name="Victoria", latitude=48.4284, longitude=-123.3656)
+        assert engine._is_us_location(loc) is False
+
 
 # --- merge_current_conditions ---
 

--- a/tests/test_weather_client_openmeteo_parser.py
+++ b/tests/test_weather_client_openmeteo_parser.py
@@ -1,5 +1,7 @@
 """Tests for Open-Meteo parser behavior."""
 
+import pytest
+
 from accessiweather.weather_client_openmeteo import (
     _pick_precipitation_type,
     _resolve_current_condition_description,
@@ -22,6 +24,28 @@ def test_parse_openmeteo_forecast_sets_start_time_for_periods():
 
     assert len(forecast.periods) == 2
     assert all(p.start_time is not None for p in forecast.periods)
+
+
+def test_parse_openmeteo_forecast_carries_low_and_numeric_wind():
+    data = {
+        "daily": {
+            "time": ["2026-02-27"],
+            "temperature_2m_max": [50.0],
+            "temperature_2m_min": [38.0],
+            "weather_code": [3],
+            "wind_speed_10m_max": [16.0934],
+            "wind_direction_10m_dominant": [180],
+        },
+        "daily_units": {"wind_speed_10m_max": "km/h"},
+    }
+
+    forecast = parse_openmeteo_forecast(data)
+    period = forecast.periods[0]
+
+    assert period.temperature_low == 38.0
+    assert period.wind_speed_mph == pytest.approx(10.0, abs=0.01)
+    assert period.wind_speed == "10 mph"
+    assert period.wind_direction == "S"
 
 
 def test_current_drizzle_not_mapped_to_snow_when_snowfall_is_zero():
@@ -87,6 +111,41 @@ def test_current_mixed_precip_fields_return_mixed_condition():
 
     assert current.condition == "Mixed rain and snow"
     assert current.precipitation_type == ["rain", "snow"]
+
+
+def test_current_visibility_respects_openmeteo_unit_metadata():
+    data = {
+        "current": {
+            "temperature_2m": 41.0,
+            "relative_humidity_2m": 95,
+            "apparent_temperature": 39.0,
+            "weather_code": 3,
+            "wind_speed_10m": 8.0,
+            "wind_direction_10m": 180,
+            "pressure_msl": 1010,
+            "rain": 0.0,
+            "showers": 0.0,
+            "snowfall": 0.0,
+            "snow_depth": 0.5,
+            "visibility": 2640.0,
+        },
+        "current_units": {
+            "temperature_2m": "°F",
+            "apparent_temperature": "°F",
+            "wind_speed_10m": "mph",
+            "pressure_msl": "hPa",
+            "snow_depth": "ft",
+            "visibility": "ft",
+        },
+        "daily": {"sunrise": [], "sunset": [], "uv_index_max": []},
+    }
+
+    current = parse_openmeteo_current_conditions(data)
+
+    assert current.visibility_miles == pytest.approx(0.5)
+    assert current.visibility_km == pytest.approx(0.804672)
+    assert current.snow_depth_in == pytest.approx(6.0)
+    assert current.snow_depth_cm == pytest.approx(15.24)
 
 
 def test_pick_precipitation_type_handles_snow_only_and_none():
@@ -207,6 +266,45 @@ def test_parse_openmeteo_hourly_forecast_surfaces_humidity_and_dewpoint():
     assert period.humidity == 55
     assert period.dewpoint_f == 54.0
     assert period.dewpoint_c is not None
+
+
+def test_parse_openmeteo_hourly_forecast_respects_unit_metadata():
+    data = {
+        "utc_offset_seconds": 0,
+        "hourly": {
+            "time": ["2026-03-19T12:00"],
+            "temperature_2m": [72.0],
+            "relative_humidity_2m": [55],
+            "weather_code": [1],
+            "wind_speed_10m": [16.0934],
+            "wind_direction_10m": [180],
+            "pressure_msl": [1015.0],
+            "precipitation_probability": [20],
+            "snowfall": [0.0],
+            "uv_index": [4.0],
+            "snow_depth": [0.5],
+            "freezing_level_height": [6500.0],
+            "visibility": [52800.0],
+            "apparent_temperature": [72.0],
+        },
+        "hourly_units": {
+            "wind_speed_10m": "km/h",
+            "pressure_msl": "hPa",
+            "snow_depth": "ft",
+            "freezing_level_height": "ft",
+            "visibility": "ft",
+        },
+    }
+
+    hourly = parse_openmeteo_hourly_forecast(data)
+    period = hourly.periods[0]
+
+    assert period.wind_speed_mph == pytest.approx(10.0, abs=0.01)
+    assert period.wind_speed == "10 mph"
+    assert period.snow_depth == pytest.approx(6.0)
+    assert period.freezing_level_ft == pytest.approx(6500.0)
+    assert period.visibility_miles == pytest.approx(10.0)
+    assert period.visibility_km == pytest.approx(16.09344)
 
 
 def test_parse_openmeteo_hourly_forecast_calculates_dewpoint_when_missing():

--- a/tests/test_weather_client_parallel.py
+++ b/tests/test_weather_client_parallel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -68,6 +69,21 @@ class TestParallelFetchCoordinator:
         assert results[0].hourly_forecast is mock_hourly
         assert results[0].alerts is None
         assert results[0].error is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_preserves_nws_discussion(
+        self, coordinator, location, mock_current, mock_forecast, mock_hourly
+    ):
+        """NWS source metadata survives the shared parallel fetch wrapper."""
+        issuance = datetime(2026, 5, 11, 12, 30, tzinfo=UTC)
+
+        async def fake_nws():
+            return (mock_current, mock_forecast, mock_hourly, None, "AFD text", issuance)
+
+        results = await coordinator.fetch_all(location, fetch_nws=fake_nws())
+
+        assert results[0].discussion == "AFD text"
+        assert results[0].discussion_issuance_time == issuance
 
     @pytest.mark.asyncio
     async def test_fetch_all_multiple_sources(

--- a/tests/test_weather_client_trends.py
+++ b/tests/test_weather_client_trends.py
@@ -311,6 +311,46 @@ class TestComputePressureTrend:
         assert result.summary is not None
         assert "drop predicted" in result.summary
 
+    def test_implausible_pressure_mismatch_returns_unavailable(self):
+        now = datetime.now()
+        periods = [
+            HourlyForecastPeriod(
+                start_time=now + timedelta(hours=24),
+                pressure_mb=983.1,
+                pressure_in=29.03,
+            )
+        ]
+        wd = _make_weather_data(
+            temp_f=75.0,
+            pressure_mb=1016.9,
+            pressure_in=30.03,
+            hourly_periods=periods,
+        )
+
+        result = compute_pressure_trend(wd, 24)
+
+        assert result is not None
+        assert result.direction == "unavailable"
+        assert result.summary == (
+            "Pressure outlook unavailable: pressure data uses mixed reference levels."
+        )
+
+    def test_large_but_plausible_24_hour_pressure_change_is_kept(self):
+        now = datetime.now()
+        periods = [HourlyForecastPeriod(start_time=now + timedelta(hours=24), pressure_mb=1002.4)]
+        wd = _make_weather_data(
+            temp_f=65.0,
+            pressure_mb=1013.0,
+            hourly_periods=periods,
+        )
+
+        result = compute_pressure_trend(wd, 24)
+
+        assert result is not None
+        assert result.direction == "falling"
+        assert result.summary is not None
+        assert "-10.60 mb" in result.summary
+
     def test_does_not_report_pressure_outlook_when_requested_window_exceeds_data(self):
         periods = _make_hourly_periods(
             hours=24,
@@ -400,7 +440,7 @@ class TestComputePressureTrend:
 class TestPressureTrendSummary:
     def test_steady_pressure_uses_steady_language(self):
         result = pressure_trend_summary("steady", 0.0, "mb", 24)
-        assert result == "Pressure steady: +0.00 mb over next 24h"
+        assert result == "Pressure steady over next 24h"
 
     def test_falling_pressure_uses_drop_language(self):
         result = pressure_trend_summary("falling", -0.08, "inHg", 24)

--- a/tests/test_weather_history.py
+++ b/tests/test_weather_history.py
@@ -192,6 +192,47 @@ class TestWeatherHistoryService:
         result = service.get_historical_weather(40.0, -74.0, date(2025, 1, 1))
         assert result is None
 
+    def test_get_historical_weather_missing_required_daily_value(self):
+        mock_client = MagicMock()
+        mock_client._make_request.return_value = {
+            "daily": {
+                "time": ["2025-01-01"],
+                "weather_code": [3],
+                "temperature_2m_max": [80.0],
+                "temperature_2m_min": [60.0],
+                "temperature_2m_mean": [70.0],
+                "wind_speed_10m_max": [],
+                "wind_direction_10m_dominant": [180],
+            }
+        }
+        service = WeatherHistoryService(openmeteo_client=mock_client)
+        result = service.get_historical_weather(40.0, -74.0, date(2025, 1, 1))
+        assert result is None
+
+    def test_get_historical_weather_preserves_zero_values(self):
+        mock_client = MagicMock()
+        mock_client._make_request.return_value = {
+            "daily": {
+                "time": ["2025-01-01"],
+                "weather_code": [0],
+                "temperature_2m_max": [0.0],
+                "temperature_2m_min": [0.0],
+                "temperature_2m_mean": [0.0],
+                "wind_speed_10m_max": [0.0],
+                "wind_direction_10m_dominant": [0],
+            }
+        }
+        mock_client.get_weather_description.return_value = "Clear"
+        service = WeatherHistoryService(openmeteo_client=mock_client)
+        result = service.get_historical_weather(40.0, -74.0, date(2025, 1, 1))
+
+        assert result is not None
+        assert result.temperature_max == 0.0
+        assert result.temperature_min == 0.0
+        assert result.temperature_mean == 0.0
+        assert result.wind_speed == 0.0
+        assert result.wind_direction == 0
+
     def test_get_historical_weather_exception(self):
         mock_client = MagicMock()
         mock_client._make_request.side_effect = Exception("Network error")

--- a/tests/test_zone_enrichment_service.py
+++ b/tests/test_zone_enrichment_service.py
@@ -113,6 +113,10 @@ class TestIsUsLocation:
         loc = Location(name="London", latitude=51.5, longitude=-0.12)
         assert _is_us_location(loc) is False
 
+    def test_western_canada_without_country_code_is_not_us(self):
+        loc = Location(name="Victoria", latitude=48.4284, longitude=-123.3656)
+        assert _is_us_location(loc) is False
+
 
 # ---------------------------------------------------------------------------
 # ZoneEnrichmentService scenarios (plan A-R1 / A-R2 / A-R3)

--- a/verify_tests.py
+++ b/verify_tests.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 import ast
 import sys
 from pathlib import Path
+from typing import Any
 
 
-def analyze_test_file(test_file: Path) -> dict[str, any]:
+def analyze_test_file(test_file: Path) -> dict[str, Any]:
     """Analyze a test file for completeness and correctness."""
     try:
         with open(test_file) as f:
@@ -67,22 +68,6 @@ def main():
     print(f"✅ Found {unit_results['total_tests']} test functions")
     print()
 
-    # Check integration tests
-    integration_test_file = Path("tests/test_config_properties.py")
-    if not integration_test_file.exists():
-        print(f"❌ ERROR: {integration_test_file} not found!")
-        return 1
-
-    print(f"📁 Analyzing {integration_test_file}...")
-    integration_results = analyze_test_file(integration_test_file)
-
-    if not integration_results["valid"]:
-        print(f"❌ ERROR: {integration_results['error']}")
-        return 1
-
-    print(f"✅ Valid Python syntax")
-    print()
-
     # Check source module
     source_file = Path("src/accessiweather/config/file_permissions.py")
     if not source_file.exists():
@@ -108,13 +93,10 @@ def main():
     print("1. Unit Tests (cross-platform):")
     print("   pytest tests/test_file_permissions.py -v")
     print()
-    print("2. Integration Tests (cross-platform):")
-    print("   pytest tests/test_config_properties.py::TestConfigFilePermissionsIntegration -v")
+    print("2. All file permission checks with parallel execution disabled:")
+    print("   pytest tests/test_file_permissions.py -n 0 -v")
     print()
-    print("3. All Tests with Parallel Execution:")
-    print("   pytest tests/test_file_permissions.py tests/test_config_properties.py -n auto -v")
-    print()
-    print("4. Platform-Specific Verification:")
+    print("3. Platform-Specific Verification:")
     print()
     print("   On Windows:")
     print("   - Verify USERNAME environment variable is set")
@@ -137,13 +119,6 @@ def main():
     print("  ✅ File validation and path conversion")
     print("  ✅ Subprocess timeout and error handling")
     print("  ✅ Integration tests on real files")
-    print()
-    print("Integration Tests (test_config_properties.py):")
-    print("  ✅ POSIX permissions after config save")
-    print("  ✅ Windows permissions after config save")
-    print("  ✅ Fail-safe behavior (permission failures don't prevent saves)")
-    print("  ✅ Multiple saves maintain permissions")
-    print("  ✅ New config file creation with correct permissions")
     print()
     print("=" * 70)
     print("✅ ALL STATIC CHECKS PASSED")


### PR DESCRIPTION
## Summary
- Normalize Open-Meteo forecast units for wind, visibility, snow depth, freezing level, pressure, and daily/hourly forecast values
- Restore user-visible Open-Meteo details such as daily lows and wind, and keep weather-history comparisons from using placeholder zero values when archive data is incomplete
- Fix NWS alert query construction, URL-scoped conditional alert caching, invalid-point error preservation, national-product routing, legacy precise alert lookups, forecast high/low pairing, and pressure normalization
- Fix Pirate Weather precipitation amounts, alert sentinel timestamps, daily high/low selection, and location-specific minutely units
- Validate alert handling across NWS and Pirate Weather, including escalation/cancel/disappearance behavior plus NWS point, county, zone, and state alert modes
- Harden IEM text-product handling so lookup errors returned as HTTP 200 text no longer display as valid forecaster text, while AFOS national aliases and SPC/WPC products still render usable summaries
- Tighten Smart Auto mode so NWS discussions are preserved from the primary NWS fetch, redundant discussion calls are avoided, disabled NWS stays disabled, extended US forecasts pick Open-Meteo when needed, placeholder condition text is ignored, and legacy Canadian locations avoid NWS misclassification
- Suppress unrealistic pressure outlook swings when providers mix pressure reference levels
- Clean up the test suite and VCR matching around provider integration coverage, including refreshed weather-provider cassettes and faster unit-test defaults
- Expand the user-facing changelog so the release notes cover the full weather bugfix pass

## Verification
- `uv run pytest tests/test_iem_text_products.py -q`
- `uv run pytest tests/test_alert_lifecycle.py tests/test_alert_aggregator.py tests/test_nws_alerts.py tests/test_nws_cancel_references.py tests/test_pirate_weather_client.py::TestParseAlerts -q`
- Python CLI live smoke across NWS alerts, Pirate Weather alerts with keyring credentials, IEM AFOS text products, IEM national aliases, and SPC/WPC structured products
- `uv run pytest tests/test_auto_mode_api_budget.py tests/test_weather_client_parallel.py tests/test_coverage_fix_pr449.py -q`
- `uv run pytest tests/test_weather_client.py tests/test_alert_lifecycle_pipeline.py tests/test_nws_afd_notification.py tests/test_split_notification_timers.py -q`
- `uv run pytest tests/integration/test_nws_integration.py tests/integration/test_pirate_weather_integration.py -q -m "not live_only"`
- `uv run pytest -n 8 -q`
- `uv run ruff check .`
- `uv run pyright`
- `actionlint`
- `git --no-pager diff --check`
