### PR TITLE
feat(locations): sort saved locations alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - You can now search for a US street address when adding or editing a location, so AccessiWeather can save coordinates for that specific address instead of the nearest city or ZIP result.
+- Saved locations now stay sorted alphabetically in the location list (#667).
 - **National Products in Forecaster Notes** — Forecaster Notes now opens a dedicated National Products dialog for SPC, WPC, NHC, CPC, and other national NWS text products. The new view replaces the old Nationwide Discussions scraper with IEM AFOS plain-text products while keeping the existing Advanced Lookup path available for direct product searches (#641).
 - **Guided Advanced Lookup in Forecaster Notes** — Advanced Lookup now organizes NWS and IEM text products into product groups with clearer product choices, office selection, date presets, result limits, sort order, source selection, aviation AFD, center, WMO, and text-match filters.
 

--- a/src/accessiweather/config/locations.py
+++ b/src/accessiweather/config/locations.py
@@ -15,6 +15,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger("accessiweather.config")
 
 
+def _location_sort_key(location: Location) -> tuple[str, str]:
+    """Return a stable, case-insensitive sort key for saved locations."""
+    return (location.name.casefold(), location.name)
+
+
 class LocationOperations:
     """Encapsulate location CRUD operations for the configuration manager."""
 
@@ -66,6 +71,7 @@ class LocationOperations:
             marine_mode=marine_mode,
         )
         config.locations.append(new_location)
+        self._sort_locations(config)
 
         if config.current_location is None:
             config.current_location = new_location
@@ -115,6 +121,7 @@ class LocationOperations:
             self.logger.debug("Zone enrichment raised unexpectedly for %s: %s", name, exc)
 
         config.locations.append(new_location)
+        self._sort_locations(config)
 
         if config.current_location is None:
             config.current_location = new_location
@@ -130,6 +137,10 @@ class LocationOperations:
 
             self._zone_enrichment_service = ZoneEnrichmentService()
         return self._zone_enrichment_service
+
+    def _sort_locations(self, config) -> None:
+        """Keep saved locations in alphabetical order."""
+        config.locations.sort(key=_location_sort_key)
 
     def update_zone_metadata(self, location_name: str, fields: dict[str, str]) -> bool:
         """
@@ -253,6 +264,7 @@ class LocationOperations:
         for index, location in enumerate(config.locations):
             if location.name == name:
                 config.locations.pop(index)
+                self._sort_locations(config)
 
                 if config.current_location and config.current_location.name == name:
                     config.current_location = None
@@ -290,11 +302,14 @@ class LocationOperations:
 
     def get_all_locations(self) -> list[Location]:
         """Return configured locations without synthetic nationwide entries."""
-        return [
-            location
-            for location in self._manager.get_config().locations.copy()
-            if location.name != "Nationwide"
-        ]
+        return sorted(
+            [
+                location
+                for location in self._manager.get_config().locations.copy()
+                if location.name != "Nationwide"
+            ],
+            key=_location_sort_key,
+        )
 
     def get_location_names(self) -> list[str]:
         """Return the list of configured location names."""

--- a/src/accessiweather/models/config_app.py
+++ b/src/accessiweather/models/config_app.py
@@ -10,6 +10,11 @@ from .weather import Location
 _LEGACY_NATIONWIDE_LOCATION_NAME = "Nationwide"
 
 
+def _location_sort_key(location: Location) -> tuple[str, str]:
+    """Return a stable, case-insensitive sort key for saved locations."""
+    return (location.name.casefold(), location.name)
+
+
 @dataclass
 class AppConfig:
     """Application configuration."""
@@ -36,7 +41,7 @@ class AppConfig:
                     **({"fire_zone_id": loc.fire_zone_id} if loc.fire_zone_id else {}),
                     **({"radar_station": loc.radar_station} if loc.radar_station else {}),
                 }
-                for loc in self.locations
+                for loc in sorted(self.locations, key=_location_sort_key)
                 if loc.name != _LEGACY_NATIONWIDE_LOCATION_NAME
             ],
             "current_location": {

--- a/src/accessiweather/ui/main_window_ui.py
+++ b/src/accessiweather/ui/main_window_ui.py
@@ -183,7 +183,10 @@ class MainWindowUIMixin:
         """
         try:
             locations = self.app.config_manager.get_all_locations()
-            location_names = [loc.name for loc in locations]
+            location_names = sorted(
+                (loc.name for loc in locations),
+                key=lambda name: (name.casefold(), name),
+            )
             all_names = [ALL_LOCATIONS_SENTINEL] + location_names
             self.location_dropdown.Clear()
             self.location_dropdown.Append(all_names)

--- a/tests/test_all_locations_view.py
+++ b/tests/test_all_locations_view.py
@@ -154,10 +154,7 @@ class TestPopulateLocations:
         MainWindow._populate_locations(win)
 
         call_args = win.location_dropdown.Append.call_args[0][0]
-        assert "Boston" in call_args
-        assert "Austin" in call_args
-        assert call_args.index("Boston") > 0
-        assert call_args.index("Austin") > 0
+        assert call_args == ["All Locations", "Austin", "Boston"]
 
     def test_selects_current_location_when_set(self):
         from accessiweather.ui.main_window import MainWindow
@@ -169,8 +166,8 @@ class TestPopulateLocations:
 
         MainWindow._populate_locations(win)
 
-        # Austin is at index 2 (0=All Locations, 1=Boston, 2=Austin)
-        win.location_dropdown.SetSelection.assert_called_with(2)
+        # Austin is at index 1 (0=All Locations, then sorted saved locations)
+        win.location_dropdown.SetSelection.assert_called_with(1)
 
     def test_falls_back_to_index_zero_when_no_current(self):
         from accessiweather.ui.main_window import MainWindow

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -6,6 +6,7 @@ Tests configuration loading, saving, and location management.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -148,6 +149,31 @@ class TestConfigManager:
         manager.add_location("Test", 40.0, -74.0)
         result = manager.add_location("Test", 40.0, -74.0)
         assert result is False
+
+    def test_locations_are_returned_alphabetically(self, manager):
+        """Saved locations are listed alphabetically regardless of add order."""
+        manager.add_location("zurich", 47.3769, 8.5417)
+        manager.add_location("Austin", 30.2672, -97.7431)
+        manager.add_location("boston", 42.3601, -71.0589)
+
+        assert [location.name for location in manager.get_all_locations()] == [
+            "Austin",
+            "boston",
+            "zurich",
+        ]
+        assert manager.get_location_names() == ["Austin", "boston", "zurich"]
+
+    def test_locations_are_saved_alphabetically(self, manager):
+        """Location order is persisted alphabetically for future app launches."""
+        manager.add_location("Zurich", 47.3769, 8.5417)
+        manager.add_location("Austin", 30.2672, -97.7431)
+
+        data = json.loads(manager.config_file.read_text(encoding="utf-8"))
+        assert [location["name"] for location in data["locations"]] == ["Austin", "Zurich"]
+
+        manager2 = ConfigManager(manager.app, config_dir=manager.config_dir)
+        manager2.load_config()
+        assert manager2.get_location_names() == ["Austin", "Zurich"]
 
     def test_remove_location(self, manager):
         """Test removing a location."""


### PR DESCRIPTION
## Summary
- Keep saved locations sorted alphabetically when they are added, loaded, saved, and displayed in the location dropdown.
- Add focused coverage for sorted config order and dropdown selection.

Fixes #667.

Thanks @MichalSuchy for the request.

## Verification
- uv run pytest tests/test_config_manager.py tests/test_all_locations_view.py tests/test_zone_enrichment_service.py tests/test_ai_tools_extended.py -q
- uv run ruff check src\accessiweather\config\locations.py src\accessiweather\models\config_app.py src\accessiweather\ui\main_window_ui.py tests\test_config_manager.py tests\test_all_locations_view.py
- uv run ruff format --check src\accessiweather\config\locations.py src\accessiweather\models\config_app.py src\accessiweather\ui\main_window_ui.py tests\test_config_manager.py tests\test_all_locations_view.py
- uv run pyright src\accessiweather\config\locations.py src\accessiweather\models\config_app.py
- Manual smoke: launched with uv run accessiweather and confirmed by local testing