### PR TITLE
feat(locations): add nearest saved-location sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - You can now search for a US street address when adding or editing a location, so AccessiWeather can save coordinates for that specific address instead of the nearest city or ZIP result.
 - Saved locations now stay sorted alphabetically in the location list (#667).
+- You can now choose to sort saved locations alphabetically or nearest to the current location.
 - **National Products in Forecaster Notes** — Forecaster Notes now opens a dedicated National Products dialog for SPC, WPC, NHC, CPC, and other national NWS text products. The new view replaces the old Nationwide Discussions scraper with IEM AFOS plain-text products while keeping the existing Advanced Lookup path available for direct product searches (#641).
 - **Guided Advanced Lookup in Forecaster Notes** — Advanced Lookup now organizes NWS and IEM text products into product groups with clearer product choices, office selection, date presets, result limits, sort order, source selection, aviation AFD, center, WMO, and text-match filters.
 

--- a/src/accessiweather/config/locations.py
+++ b/src/accessiweather/config/locations.py
@@ -6,6 +6,7 @@ import logging
 from math import isclose
 from typing import TYPE_CHECKING
 
+from ..location_sorting import location_name_sort_key
 from ..models import Location
 
 if TYPE_CHECKING:
@@ -13,11 +14,6 @@ if TYPE_CHECKING:
     from .config_manager import ConfigManager
 
 logger = logging.getLogger("accessiweather.config")
-
-
-def _location_sort_key(location: Location) -> tuple[str, str]:
-    """Return a stable, case-insensitive sort key for saved locations."""
-    return (location.name.casefold(), location.name)
 
 
 class LocationOperations:
@@ -140,7 +136,7 @@ class LocationOperations:
 
     def _sort_locations(self, config) -> None:
         """Keep saved locations in alphabetical order."""
-        config.locations.sort(key=_location_sort_key)
+        config.locations.sort(key=location_name_sort_key)
 
     def update_zone_metadata(self, location_name: str, fields: dict[str, str]) -> bool:
         """
@@ -308,7 +304,7 @@ class LocationOperations:
                 for location in self._manager.get_config().locations.copy()
                 if location.name != "Nationwide"
             ],
-            key=_location_sort_key,
+            key=location_name_sort_key,
         )
 
     def get_location_names(self) -> list[str]:

--- a/src/accessiweather/location_sorting.py
+++ b/src/accessiweather/location_sorting.py
@@ -1,0 +1,63 @@
+"""Helpers for ordering saved locations."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from math import atan2, cos, radians, sin, sqrt
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .models import Location
+
+LOCATION_SORT_ALPHABETICAL = "alphabetical"
+LOCATION_SORT_NEAREST_CURRENT = "nearest_current"
+
+
+def normalize_location_sort_order(value: object) -> str:
+    """Return a supported location sort order."""
+    if value == LOCATION_SORT_NEAREST_CURRENT:
+        return LOCATION_SORT_NEAREST_CURRENT
+    return LOCATION_SORT_ALPHABETICAL
+
+
+def location_name_sort_key(location: Location) -> tuple[str, str]:
+    """Return a stable, case-insensitive sort key for saved locations."""
+    return (location.name.casefold(), location.name)
+
+
+def sort_locations_for_display(
+    locations: Iterable[Location],
+    sort_order: object,
+    *,
+    anchor: Location | None = None,
+) -> list[Location]:
+    """Sort saved locations for user-facing lists."""
+    sorted_locations = sorted(locations, key=location_name_sort_key)
+    if normalize_location_sort_order(sort_order) != LOCATION_SORT_NEAREST_CURRENT or anchor is None:
+        return sorted_locations
+
+    return sorted(
+        sorted_locations,
+        key=lambda location: (_distance_miles(anchor, location), location_name_sort_key(location)),
+    )
+
+
+def _distance_miles(first: Location, second: Location) -> float:
+    """Return the great-circle distance between two locations in miles."""
+    try:
+        first_lat = float(first.latitude)
+        first_lon = float(first.longitude)
+        second_lat = float(second.latitude)
+        second_lon = float(second.longitude)
+    except (TypeError, ValueError):
+        return float("inf")
+
+    earth_radius_miles = 3958.7613
+    lat1 = radians(first_lat)
+    lat2 = radians(second_lat)
+    delta_lat = radians(second_lat - first_lat)
+    delta_lon = radians(second_lon - first_lon)
+
+    a = sin(delta_lat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(delta_lon / 2) ** 2
+    c = 2 * atan2(sqrt(a), sqrt(max(0, 1 - a)))
+    return earth_radius_miles * c

--- a/src/accessiweather/models/config_app.py
+++ b/src/accessiweather/models/config_app.py
@@ -4,15 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ..location_sorting import location_name_sort_key
 from .config_settings import AppSettings
 from .weather import Location
 
 _LEGACY_NATIONWIDE_LOCATION_NAME = "Nationwide"
-
-
-def _location_sort_key(location: Location) -> tuple[str, str]:
-    """Return a stable, case-insensitive sort key for saved locations."""
-    return (location.name.casefold(), location.name)
 
 
 @dataclass
@@ -41,7 +37,7 @@ class AppConfig:
                     **({"fire_zone_id": loc.fire_zone_id} if loc.fire_zone_id else {}),
                     **({"radar_station": loc.radar_station} if loc.radar_station else {}),
                 }
-                for loc in sorted(self.locations, key=_location_sort_key)
+                for loc in sorted(self.locations, key=location_name_sort_key)
                 if loc.name != _LEGACY_NATIONWIDE_LOCATION_NAME
             ],
             "current_location": {

--- a/src/accessiweather/models/config_constants.py
+++ b/src/accessiweather/models/config_constants.py
@@ -86,6 +86,7 @@ NON_CRITICAL_SETTINGS: set[str] = {
     "time_format_12hour",
     "show_timezone_suffix",
     "alert_display_style",
+    "location_sort_order",
     "date_format",
     "taskbar_icon_text_enabled",
     "taskbar_icon_dynamic_enabled",

--- a/src/accessiweather/models/config_serialization.py
+++ b/src/accessiweather/models/config_serialization.py
@@ -76,6 +76,7 @@ class AppSettingsSerializationMixin:
             "show_timezone_suffix": settings.show_timezone_suffix,
             "alert_display_style": settings.alert_display_style,
             "location_buttons_on_top": settings.location_buttons_on_top,
+            "location_sort_order": settings.location_sort_order,
             "date_format": settings.date_format,
             "taskbar_icon_text_enabled": settings.taskbar_icon_text_enabled,
             "taskbar_icon_dynamic_enabled": settings.taskbar_icon_dynamic_enabled,
@@ -191,6 +192,7 @@ class AppSettingsSerializationMixin:
             location_buttons_on_top=settings_cls._as_bool(
                 data.get("location_buttons_on_top"), False
             ),
+            location_sort_order=data.get("location_sort_order", "alphabetical"),
             date_format=data.get("date_format", "iso"),
             taskbar_icon_text_enabled=settings_cls._as_bool(
                 data.get("taskbar_icon_text_enabled"), False
@@ -252,6 +254,7 @@ class AppSettingsSerializationMixin:
         )
         settings.validate_on_access("auto_mode_api_budget")
         settings.validate_on_access("alert_display_style")
+        settings.validate_on_access("location_sort_order")
         settings.validate_on_access("date_format")
         settings.validate_on_access("source_priority_us")
         settings.validate_on_access("source_priority_international")

--- a/src/accessiweather/models/config_settings.py
+++ b/src/accessiweather/models/config_settings.py
@@ -80,6 +80,8 @@ class AppSettings(AppSettingsValidationMixin, AppSettingsSerializationMixin):
     # Place Add/Edit/Remove Location buttons on the location row instead of the
     # bottom button panel.  Takes effect on app restart.
     location_buttons_on_top: bool = False
+    # Saved location ordering in user-facing lists.
+    location_sort_order: str = "alphabetical"  # "alphabetical" | "nearest_current"
     # Date format preset for rendered dates
     date_format: str = "iso"  # "iso" | "us_short" | "us_long" | "eu"
     # Taskbar icon text options

--- a/src/accessiweather/models/config_validation.py
+++ b/src/accessiweather/models/config_validation.py
@@ -199,6 +199,11 @@ class AppSettingsValidationMixin:
             if value not in valid_styles:
                 setattr(settings, setting_name, "separate")
 
+        elif setting_name == "location_sort_order":
+            valid_orders = {"alphabetical", "nearest_current"}
+            if value not in valid_orders:
+                setattr(settings, setting_name, "alphabetical")
+
         elif setting_name == "date_format":
             valid_formats = {"iso", "us_short", "us_long", "eu"}
             if value not in valid_formats:

--- a/src/accessiweather/ui/dialogs/settings_tabs/display.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/display.py
@@ -21,6 +21,12 @@ _VERBOSITY_MAP = {"minimal": 0, "standard": 1, "detailed": 2}
 _ALERT_DISPLAY_MAP = {"separate": 0, "combined": 1}
 _ALERT_DISPLAY_VALUES = ["separate", "combined"]
 _ALERT_DISPLAY_CHOICES = ["Separate fields (default)", "Single combined view"]
+_LOCATION_SORT_MAP = {"alphabetical": 0, "nearest_current": 1}
+_LOCATION_SORT_VALUES = ["alphabetical", "nearest_current"]
+_LOCATION_SORT_CHOICES = [
+    "Alphabetical (default)",
+    "Nearest to current location",
+]
 
 _DATE_FORMAT_MAP = {"iso": 0, "us_short": 1, "us_long": 2, "eu": 3}
 _DATE_FORMAT_VALUES = ["iso", "us_short", "us_long", "eu"]
@@ -269,8 +275,15 @@ class DisplayTab:
             panel,
             sizer,
             "Main window layout",
-            "Adjust where the main window places location-management buttons. "
-            "Changes take effect after you restart AccessiWeather.",
+            "Adjust how the main window orders saved locations and where it places "
+            "location-management buttons. Button placement changes take effect after "
+            "you restart AccessiWeather.",
+        )
+        controls["location_sort_order"] = self.dialog.add_labeled_control_row(
+            panel,
+            layout_section,
+            "Saved location order:",
+            lambda parent: wx.Choice(parent, choices=_LOCATION_SORT_CHOICES),
         )
         controls["location_buttons_on_top"] = wx.CheckBox(
             panel,
@@ -337,6 +350,9 @@ class DisplayTab:
         alert_display = getattr(settings, "alert_display_style", "separate")
         controls["alert_display_style"].SetSelection(_ALERT_DISPLAY_MAP.get(alert_display, 0))
 
+        location_sort_order = getattr(settings, "location_sort_order", "alphabetical")
+        controls["location_sort_order"].SetSelection(_LOCATION_SORT_MAP.get(location_sort_order, 0))
+
         controls["location_buttons_on_top"].SetValue(
             getattr(settings, "location_buttons_on_top", False)
         )
@@ -368,6 +384,9 @@ class DisplayTab:
             "severe_weather_override": controls["severe_weather_override"].GetValue(),
             "alert_display_style": _ALERT_DISPLAY_VALUES[
                 controls["alert_display_style"].GetSelection()
+            ],
+            "location_sort_order": _LOCATION_SORT_VALUES[
+                controls["location_sort_order"].GetSelection()
             ],
             "location_buttons_on_top": controls["location_buttons_on_top"].GetValue(),
         }
@@ -401,6 +420,7 @@ class DisplayTab:
             "verbosity_level": "Verbosity level",
             "severe_weather_override": "Automatically prioritize severe weather details",
             "alert_display_style": "Alert display style",
+            "location_sort_order": "Saved location order",
             "location_buttons_on_top": (
                 "Show Add, Edit, and Remove Location buttons next to the "
                 "location dropdown (restart required)"

--- a/src/accessiweather/ui/main_window_display.py
+++ b/src/accessiweather/ui/main_window_display.py
@@ -192,7 +192,7 @@ class MainWindowDisplayMixin:
 
         """
         try:
-            all_locs = self.app.config_manager.get_all_locations()
+            all_locs = self._get_ordered_saved_locations()
         except Exception as e:
             logger.error(f"Failed to get locations for All Locations summary: {e}")
             all_locs = []

--- a/src/accessiweather/ui/main_window_locations.py
+++ b/src/accessiweather/ui/main_window_locations.py
@@ -186,6 +186,7 @@ class MainWindowLocationMixin:
 
         if show_settings_dialog(self, self.app, tab=tab):
             self.app.refresh_runtime_settings()
+            self._populate_locations()
             # Update menu label in case update channel changed
             self.update_check_updates_menu_label()
             # Immediately refresh weather so source/key changes take effect

--- a/src/accessiweather/ui/main_window_shared.py
+++ b/src/accessiweather/ui/main_window_shared.py
@@ -11,6 +11,7 @@ import wx
 from wx.lib.sized_controls import SizedPanel
 
 from ..display.presentation.formatters import get_temperature_precision
+from ..location_sorting import sort_locations_for_display
 from ..runtime_env import is_compiled_runtime
 from ..units import resolve_temperature_unit_preference
 from ..user_manual import open_user_manual
@@ -61,5 +62,6 @@ __all__ = [
     "open_user_manual",
     "resolve_temperature_unit_preference",
     "show_edit_location_dialog",
+    "sort_locations_for_display",
     "wx",
 ]

--- a/src/accessiweather/ui/main_window_ui.py
+++ b/src/accessiweather/ui/main_window_ui.py
@@ -182,18 +182,18 @@ class MainWindowUIMixin:
         "All Locations" is always the first entry.
         """
         try:
-            locations = self.app.config_manager.get_all_locations()
-            location_names = sorted(
-                (loc.name for loc in locations),
-                key=lambda name: (name.casefold(), name),
-            )
+            locations = self._get_ordered_saved_locations()
+            location_names = [loc.name for loc in locations]
             all_names = [ALL_LOCATIONS_SENTINEL] + location_names
             self.location_dropdown.Clear()
             self.location_dropdown.Append(all_names)
 
             # Select current location if set; otherwise land on "All Locations".
             current = self.app.config_manager.get_current_location()
-            if current and current.name in all_names:
+            if getattr(self, "_all_locations_active", False):
+                self.location_dropdown.SetSelection(0)
+                self._update_title_for_location(ALL_LOCATIONS_SENTINEL)
+            elif current and current.name in all_names:
                 idx = all_names.index(current.name)
                 self.location_dropdown.SetSelection(idx)
                 self._update_title_for_location(current.name)
@@ -203,6 +203,14 @@ class MainWindowUIMixin:
             self._update_forecast_products_button_state()
         except Exception as e:
             logger.error(f"Failed to populate locations: {e}")
+
+    def _get_ordered_saved_locations(self):
+        """Return saved locations in the user's preferred display order."""
+        locations = self.app.config_manager.get_all_locations()
+        settings = self.app.config_manager.get_settings()
+        sort_order = getattr(settings, "location_sort_order", "alphabetical")
+        current = self.app.config_manager.get_current_location()
+        return sort_locations_for_display(locations, sort_order, anchor=current)
 
     def _update_title_for_location(self, location_name: str | None) -> None:
         """

--- a/tests/test_all_locations_view.py
+++ b/tests/test_all_locations_view.py
@@ -74,6 +74,9 @@ def _make_window():
     win._get_all_locations_tray_data = MainWindow._get_all_locations_tray_data.__get__(
         win, MainWindow
     )
+    win._get_ordered_saved_locations = MainWindow._get_ordered_saved_locations.__get__(
+        win, MainWindow
+    )
     win._show_alert_details = MainWindow._show_alert_details.__get__(win, MainWindow)
     win.refresh_weather_async = MainWindow.refresh_weather_async.__get__(win, MainWindow)
 
@@ -156,6 +159,24 @@ class TestPopulateLocations:
         call_args = win.location_dropdown.Append.call_args[0][0]
         assert call_args == ["All Locations", "Austin", "Boston"]
 
+    def test_real_locations_can_sort_nearest_to_current_location(self):
+        from accessiweather.ui.main_window import MainWindow
+
+        win = _make_window()
+        denver = _make_location("Denver", 39.7392, -104.9903)
+        boulder = _make_location("Boulder", 40.0150, -105.2705)
+        miami = _make_location("Miami", 25.7617, -80.1918)
+        anchorage = _make_location("Anchorage", 61.2181, -149.9003)
+        locs = [anchorage, miami, denver, boulder]
+        win.app.config_manager.get_all_locations.return_value = locs
+        win.app.config_manager.get_current_location.return_value = denver
+        win.app.config_manager.get_settings.return_value.location_sort_order = "nearest_current"
+
+        MainWindow._populate_locations(win)
+
+        call_args = win.location_dropdown.Append.call_args[0][0]
+        assert call_args == ["All Locations", "Denver", "Boulder", "Miami", "Anchorage"]
+
     def test_selects_current_location_when_set(self):
         from accessiweather.ui.main_window import MainWindow
 
@@ -168,6 +189,20 @@ class TestPopulateLocations:
 
         # Austin is at index 1 (0=All Locations, then sorted saved locations)
         win.location_dropdown.SetSelection.assert_called_with(1)
+
+    def test_keeps_all_locations_selected_when_active(self):
+        from accessiweather.ui.main_window import MainWindow
+
+        win = _make_window()
+        win._all_locations_active = True
+        locs = [_make_location("Boston"), _make_location("Austin")]
+        win.app.config_manager.get_all_locations.return_value = locs
+        win.app.config_manager.get_current_location.return_value = locs[1]
+
+        MainWindow._populate_locations(win)
+
+        win.location_dropdown.SetSelection.assert_called_with(0)
+        win._update_title_for_location.assert_called_with("All Locations")
 
     def test_falls_back_to_index_zero_when_no_current(self):
         from accessiweather.ui.main_window import MainWindow

--- a/tests/test_config_alert_display.py
+++ b/tests/test_config_alert_display.py
@@ -12,19 +12,28 @@ class TestDefaults:
     def test_date_format_defaults_to_iso(self) -> None:
         assert AppSettings().date_format == "iso"
 
+    def test_location_sort_order_defaults_to_alphabetical(self) -> None:
+        assert AppSettings().location_sort_order == "alphabetical"
+
 
 class TestRoundTrip:
     def test_to_dict_includes_new_fields(self) -> None:
         data = AppSettings().to_dict()
         assert data["alert_display_style"] == "separate"
         assert data["date_format"] == "iso"
+        assert data["location_sort_order"] == "alphabetical"
 
     def test_from_dict_preserves_valid_values(self) -> None:
         settings = AppSettings.from_dict(
-            {"alert_display_style": "combined", "date_format": "us_long"}
+            {
+                "alert_display_style": "combined",
+                "date_format": "us_long",
+                "location_sort_order": "nearest_current",
+            }
         )
         assert settings.alert_display_style == "combined"
         assert settings.date_format == "us_long"
+        assert settings.location_sort_order == "nearest_current"
 
     def test_from_dict_falls_back_on_bogus_alert_display_style(self) -> None:
         settings = AppSettings.from_dict({"alert_display_style": "bogus"})
@@ -34,18 +43,31 @@ class TestRoundTrip:
         settings = AppSettings.from_dict({"date_format": "not-a-format"})
         assert settings.date_format == "iso"
 
+    def test_from_dict_falls_back_on_bogus_location_sort_order(self) -> None:
+        settings = AppSettings.from_dict({"location_sort_order": "distance-ish"})
+        assert settings.location_sort_order == "alphabetical"
+
     def test_from_dict_empty_dict_uses_defaults(self) -> None:
         settings = AppSettings.from_dict({})
         assert settings.alert_display_style == "separate"
         assert settings.date_format == "iso"
+        assert settings.location_sort_order == "alphabetical"
 
     def test_from_dict_non_string_values_fall_back(self) -> None:
-        settings = AppSettings.from_dict({"alert_display_style": None, "date_format": 42})
+        settings = AppSettings.from_dict(
+            {"alert_display_style": None, "date_format": 42, "location_sort_order": 12}
+        )
         assert settings.alert_display_style == "separate"
         assert settings.date_format == "iso"
+        assert settings.location_sort_order == "alphabetical"
 
     def test_full_round_trip_preserves_combined_and_us_long(self) -> None:
-        original = AppSettings(alert_display_style="combined", date_format="us_long")
+        original = AppSettings(
+            alert_display_style="combined",
+            date_format="us_long",
+            location_sort_order="nearest_current",
+        )
         restored = AppSettings.from_dict(original.to_dict())
         assert restored.alert_display_style == "combined"
         assert restored.date_format == "us_long"
+        assert restored.location_sort_order == "nearest_current"


### PR DESCRIPTION
## Summary
- add a Display setting for saved location order: alphabetical or nearest to current location
- apply the selected order to the main location dropdown and All Locations summary
- keep persisted location storage alphabetized while using distance sorting only for display

## Verification
- pytest tests/test_config_manager.py tests/test_settings_dialog_tray_text.py tests/test_all_locations_view.py tests/test_config_alert_display.py -q
- ruff check targeted touched files
- git diff --check