### PR TITLE
ci(build): reschedule nightly trigger

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -22,7 +22,7 @@ This directory contains the GitHub Actions workflows for AccessiWeather. Below i
 ### 2. Build and Package (`build.yml`)
 **Purpose**: Build nightly or tagged release artifacts separately from pull request validation
 **Triggers**:
-- Nightly schedule
+- Nightly schedule at 02:17 UTC (10:17 PM EDT / 9:17 PM EST)
 - Version tags
 - Manual dispatch (with optional version override)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,9 @@ name: Build
 
 on:
   schedule:
-    - cron: "30 3 * * *"  # Nightly at 3:30 UTC
+    # Nightly at 02:17 UTC (10:17 PM EDT / 9:17 PM EST).
+    # GitHub Actions schedules are UTC-only and can queue late, so avoid :00/:30.
+    - cron: "17 2 * * *"
   push:
     tags: ['v*.*.*']
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- move the nightly build cron from 03:30 UTC to 02:17 UTC
- document the Eastern-time conversion and why the trigger avoids :00/:30 scheduler slots

## Verification
- actionlint .github/workflows/build.yml
- git --no-pager diff --check origin/main...HEAD