### PR TITLE
feat(onboarding): let users exit setup from any wizard step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- First-run setup can now import existing settings and encrypted API keys from the wizard, or exit with Escape at any wizard step when you want to configure everything yourself.
 - You can now search for a US street address when adding or editing a location, so AccessiWeather can save coordinates for that specific address instead of the nearest city or ZIP result.
 - Saved locations now stay sorted alphabetically in the location list (#667).
 - You can now choose to sort saved locations alphabetically or nearest to the current location.

--- a/src/accessiweather/app_startup_guidance.py
+++ b/src/accessiweather/app_startup_guidance.py
@@ -10,6 +10,10 @@ import wx
 logger = logging.getLogger("accessiweather.app")
 
 
+class _OnboardingCancelled(Exception):
+    """Raised when the user exits first-start onboarding."""
+
+
 class AppStartupGuidanceMixin:
     def _schedule_startup_guidance_prompts(self) -> None:
         """Schedule lightweight first-run and portable hints after startup."""
@@ -212,13 +216,13 @@ class AppStartupGuidanceMixin:
         if result == wx.ID_YES and self.main_window:
             self.main_window.open_settings()
 
-    def _prompt_optional_secret(self, title: str, message: str) -> str | None:
+    def _prompt_optional_secret(self, title: str, message: str) -> str:
         """Prompt for optional secret text value. Empty input means skip."""
         with wx.TextEntryDialog(
             self.main_window, message, title, style=wx.OK | wx.CANCEL | wx.TE_PASSWORD
         ) as dlg:
             if dlg.ShowModal() != wx.ID_OK:
-                return None
+                raise _OnboardingCancelled
             return dlg.GetValue().strip() or ""
 
     def _prompt_optional_secret_with_link(
@@ -227,16 +231,35 @@ class AppStartupGuidanceMixin:
         message: str,
         key_page_url: str,
         key_page_action_label: str,
-    ) -> str | None:
+    ) -> str:
         """Prompt for an optional secret with an action to open its key page."""
+        setup_dialog = wx.MessageDialog(
+            self.main_window,
+            f"{message}\n\nChoose Set up now to enter or get a key, Skip this key to keep going, "
+            "or Configure myself to close the wizard.",
+            title,
+            wx.YES_NO | wx.CANCEL | wx.ICON_INFORMATION,
+        )
+        setup_dialog.SetYesNoCancelLabels("Set up now", "Skip this key", "Configure myself")
+        setup_result = setup_dialog.ShowModal()
+        setup_dialog.Destroy()
+
+        if setup_result == wx.ID_NO:
+            return ""
+        if setup_result != wx.ID_YES:
+            raise _OnboardingCancelled
+
         while True:
             choice_dialog = wx.MessageDialog(
                 self.main_window,
-                f"{message}\n\nChoose Enter key to type it now, {key_page_action_label}, or Skip.",
+                f"{message}\n\nChoose Enter key to type it now, {key_page_action_label}, "
+                "or Configure myself to close the wizard.",
                 title,
                 wx.YES_NO | wx.CANCEL | wx.ICON_INFORMATION,
             )
-            choice_dialog.SetYesNoCancelLabels("Enter key", key_page_action_label, "Skip")
+            choice_dialog.SetYesNoCancelLabels(
+                "Enter key", key_page_action_label, "Configure myself"
+            )
             result = choice_dialog.ShowModal()
             choice_dialog.Destroy()
 
@@ -250,7 +273,7 @@ class AppStartupGuidanceMixin:
                 except Exception as exc:
                     logger.warning("Failed opening API key page %s: %s", key_page_url, exc)
                 continue
-            return ""
+            raise _OnboardingCancelled
 
     def _maybe_offer_test_key_now(self, key_name: str) -> None:
         """Offer to open settings so users can validate the entered key immediately."""
@@ -313,6 +336,140 @@ class AppStartupGuidanceMixin:
         summary_dialog.ShowModal()
         summary_dialog.Destroy()
 
+    def _finish_first_start_onboarding(self) -> None:
+        """Mark onboarding complete and run any deferred startup work."""
+        self._show_onboarding_readiness_summary()
+        self.config_manager.update_settings(onboarding_wizard_shown=True)
+        self._run_deferred_startup_update_check()
+
+    def _skip_first_start_onboarding(self) -> None:
+        """Close first-start onboarding so users can configure manually."""
+        self.config_manager.update_settings(onboarding_wizard_shown=True)
+        self._run_deferred_startup_update_check()
+
+    def _refresh_after_onboarding_import(self) -> None:
+        """Refresh app state after importing settings or keys during onboarding."""
+        self.refresh_runtime_settings()
+        if not self.main_window:
+            return
+        if hasattr(self.main_window, "_populate_locations"):
+            self.main_window._populate_locations()
+        if (
+            hasattr(self.main_window, "refresh_weather_async")
+            and self.config_manager.has_locations()
+        ):
+            self.main_window.refresh_weather_async(force_refresh=True)
+
+    def _prompt_onboarding_settings_import(self) -> bool:
+        """Prompt for and import an AccessiWeather settings export."""
+        with wx.FileDialog(
+            self.main_window,
+            "Import AccessiWeather settings",
+            wildcard="JSON files (*.json)|*.json",
+            style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST,
+        ) as dlg:
+            if dlg.ShowModal() != wx.ID_OK:
+                raise _OnboardingCancelled
+            import_path = Path(dlg.GetPath())
+
+        if self.config_manager.import_settings(import_path):
+            self._refresh_after_onboarding_import()
+            wx.MessageBox(
+                "Settings imported successfully. Any saved locations from the backup are ready to use.",
+                "Settings imported",
+                wx.OK | wx.ICON_INFORMATION,
+            )
+            return True
+
+        wx.MessageBox(
+            "Failed to import settings. The file may be invalid or corrupted.",
+            "Settings import failed",
+            wx.OK | wx.ICON_ERROR,
+        )
+        return False
+
+    def _prompt_onboarding_api_key_import(self) -> bool:
+        """Prompt for and import an encrypted API key bundle."""
+        with wx.FileDialog(
+            self.main_window,
+            "Import API keys (encrypted)",
+            wildcard="Encrypted bundle (*.keys)|*.keys|Legacy bundle (*.awkeys)|*.awkeys",
+            style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST,
+        ) as dlg:
+            if dlg.ShowModal() != wx.ID_OK:
+                raise _OnboardingCancelled
+            import_path = Path(dlg.GetPath())
+
+        passphrase = self._prompt_optional_secret(
+            "Import API keys (encrypted)",
+            "Enter the passphrase used when exporting this encrypted API key bundle.",
+        )
+        if not passphrase:
+            return False
+
+        if self.config_manager.import_encrypted_api_keys(import_path, passphrase):
+            if self._portable_mode:
+                self._portable_keys_imported_this_session = True
+                from .config.secure_storage import SecureStorage
+
+                SecureStorage.set_password(self._PORTABLE_PASSPHRASE_KEYRING_KEY, passphrase)
+                self._write_keys_file_after_import(self.config_manager.config_dir, passphrase)
+            self._refresh_after_onboarding_import()
+            wx.MessageBox(
+                "API keys imported successfully. They are now active.",
+                "API keys imported",
+                wx.OK | wx.ICON_INFORMATION,
+            )
+            return True
+
+        wx.MessageBox(
+            "Failed to import encrypted API keys. Check the passphrase and bundle file.",
+            "API key import failed",
+            wx.OK | wx.ICON_ERROR,
+        )
+        return False
+
+    def _maybe_run_onboarding_import_flow(self) -> bool:
+        """Offer first-run import of settings and encrypted API keys."""
+        if not self.config_manager or not all(
+            hasattr(self.config_manager, name)
+            for name in ("import_settings", "import_encrypted_api_keys")
+        ):
+            return False
+
+        imported_any = False
+        settings_dialog = wx.MessageDialog(
+            self.main_window,
+            "Import a settings backup now? This can restore preferences and saved locations.\n\n"
+            "Choose Configure myself, or press Escape, to close this wizard.",
+            "Import settings",
+            wx.YES_NO | wx.CANCEL | wx.ICON_INFORMATION,
+        )
+        settings_dialog.SetYesNoCancelLabels("Import settings", "Skip settings", "Configure myself")
+        settings_choice = settings_dialog.ShowModal()
+        settings_dialog.Destroy()
+        if settings_choice == wx.ID_YES:
+            imported_any = self._prompt_onboarding_settings_import() or imported_any
+        elif settings_choice != wx.ID_NO:
+            raise _OnboardingCancelled
+
+        keys_dialog = wx.MessageDialog(
+            self.main_window,
+            "Import an encrypted API key bundle now?\n\n"
+            "Choose Configure myself, or press Escape, to close this wizard.",
+            "Import API keys",
+            wx.YES_NO | wx.CANCEL | wx.ICON_INFORMATION,
+        )
+        keys_dialog.SetYesNoCancelLabels("Import API keys", "Skip API keys", "Configure myself")
+        keys_choice = keys_dialog.ShowModal()
+        keys_dialog.Destroy()
+        if keys_choice == wx.ID_YES:
+            imported_any = self._prompt_onboarding_api_key_import() or imported_any
+        elif keys_choice != wx.ID_NO:
+            raise _OnboardingCancelled
+
+        return imported_any
+
     def _maybe_show_first_start_onboarding(self) -> None:
         """Show a minimal onboarding wizard once on fresh setup."""
         if not self._should_show_first_start_onboarding():
@@ -323,16 +480,31 @@ class AppStartupGuidanceMixin:
 
         step1 = wx.MessageDialog(
             self.main_window,
-            f"Welcome to AccessiWeather.\n\nStep 1 of {total_steps}: Add your first location now?",
+            f"Welcome to AccessiWeather.\n\n"
+            f"Step 1 of {total_steps}: Add your first location now?\n\n"
+            "If you already have settings or API keys to bring over, choose Import existing.\n\n"
+            "Choose Configure myself, or press Escape, to close this wizard and set things up later.",
             "Getting started",
-            wx.YES_NO | wx.ICON_INFORMATION,
+            wx.YES_NO | wx.CANCEL | wx.ICON_INFORMATION,
         )
-        step1.SetYesNoLabels("Add location", "Skip")
+        step1.SetYesNoCancelLabels("Add location", "Import existing", "Configure myself")
         step1_result = step1.ShowModal()
         step1.Destroy()
 
         if step1_result == wx.ID_YES and self.main_window:
             self.main_window.on_add_location()
+        elif step1_result == wx.ID_NO:
+            try:
+                imported = self._maybe_run_onboarding_import_flow()
+            except _OnboardingCancelled:
+                self._skip_first_start_onboarding()
+                return
+            if imported and self.config_manager.has_locations():
+                self._finish_first_start_onboarding()
+                return
+        else:
+            self._skip_first_start_onboarding()
+            return
 
         from .config.secure_storage import is_keyring_available
 
@@ -355,40 +527,54 @@ class AppStartupGuidanceMixin:
         # the bundle rather than going through keyring (which isn't used in portable).
         _wizard_keys: dict[str, str] = {}
 
-        openrouter_key = self._prompt_optional_secret_with_link(
-            "OpenRouter API key (optional)",
-            f"Step 2 of {total_steps}: Enter your OpenRouter API key now, or leave blank to skip.",
-            "https://openrouter.ai/keys",
-            "Get OpenRouter API key",
-        )
-        if openrouter_key is not None and openrouter_key:
-            if not self._portable_mode:
-                self.config_manager.update_settings(openrouter_api_key=openrouter_key)
-                self._maybe_offer_test_key_now("OpenRouter API key")
-            else:
-                _wizard_keys["openrouter_api_key"] = openrouter_key
+        if not self._has_saved_api_key("openrouter_api_key"):
+            try:
+                openrouter_key = self._prompt_optional_secret_with_link(
+                    "OpenRouter API key (optional)",
+                    f"Step 2 of {total_steps}: Enter your OpenRouter API key now, or leave blank to skip.",
+                    "https://openrouter.ai/keys",
+                    "Get OpenRouter API key",
+                )
+            except _OnboardingCancelled:
+                self._skip_first_start_onboarding()
+                return
+            if openrouter_key is not None and openrouter_key:
+                if not self._portable_mode:
+                    self.config_manager.update_settings(openrouter_api_key=openrouter_key)
+                    self._maybe_offer_test_key_now("OpenRouter API key")
+                else:
+                    _wizard_keys["openrouter_api_key"] = openrouter_key
 
-        pirate_weather_key = self._prompt_optional_secret_with_link(
-            "Pirate Weather provider key (optional)",
-            f"Step 3 of {total_steps}: Enter your Pirate Weather provider key now, or leave blank to skip.",
-            "https://pirateweather.net/",
-            "Get Pirate Weather provider key",
-        )
-        if pirate_weather_key is not None and pirate_weather_key:
-            if not self._portable_mode:
-                self.config_manager.update_settings(pirate_weather_api_key=pirate_weather_key)
-                self._maybe_offer_test_key_now("Pirate Weather provider key")
-            else:
-                _wizard_keys["pirate_weather_api_key"] = pirate_weather_key
+        if not self._has_saved_api_key("pirate_weather_api_key"):
+            try:
+                pirate_weather_key = self._prompt_optional_secret_with_link(
+                    "Pirate Weather provider key (optional)",
+                    f"Step 3 of {total_steps}: Enter your Pirate Weather provider key now, or leave blank to skip.",
+                    "https://pirateweather.net/",
+                    "Get Pirate Weather provider key",
+                )
+            except _OnboardingCancelled:
+                self._skip_first_start_onboarding()
+                return
+            if pirate_weather_key is not None and pirate_weather_key:
+                if not self._portable_mode:
+                    self.config_manager.update_settings(pirate_weather_api_key=pirate_weather_key)
+                    self._maybe_offer_test_key_now("Pirate Weather provider key")
+                else:
+                    _wizard_keys["pirate_weather_api_key"] = pirate_weather_key
 
         if self._portable_mode and _wizard_keys:
             # Keys were entered — prompt for passphrase and write bundle directly.
-            passphrase = self._prompt_optional_secret(
-                f"Step {total_steps} of {total_steps}: Secure your API keys",
-                "Enter a passphrase to encrypt your API keys into a portable bundle.\n"
-                "This bundle travels with the app so your keys work on any machine.\n\n"
-                "Leave blank to skip (keys will not be saved).",
-            )
+            try:
+                passphrase = self._prompt_optional_secret(
+                    f"Step {total_steps} of {total_steps}: Secure your API keys",
+                    "Enter a passphrase to encrypt your API keys into a portable bundle.\n"
+                    "This bundle travels with the app so your keys work on any machine.\n\n"
+                    "Leave blank to skip (keys will not be saved).",
+                )
+            except _OnboardingCancelled:
+                self._skip_first_start_onboarding()
+                return
             if passphrase:
                 try:
                     # Set keys in-memory first so export_encrypted_api_keys can read them.
@@ -430,9 +616,7 @@ class AppStartupGuidanceMixin:
                 )
         # No keys entered — skip step 4 entirely, nothing to bundle.
 
-        self._show_onboarding_readiness_summary()
-        self.config_manager.update_settings(onboarding_wizard_shown=True)
-        self._run_deferred_startup_update_check()
+        self._finish_first_start_onboarding()
 
     def _show_force_start_dialog(self) -> bool:
         """

--- a/tests/test_keyring_warning.py
+++ b/tests/test_keyring_warning.py
@@ -148,7 +148,8 @@ class TestWizardKeyringWarning:
 
         def fake_msg_dialog(parent, msg, title, style=0):
             shown_titles.append(title)
-            return _make_wx_dialog()
+            result = wx.ID_YES if title == "Getting started" else wx.ID_OK
+            return _make_wx_dialog(result)
 
         with (
             patch("accessiweather.app.wx.MessageDialog", side_effect=fake_msg_dialog),
@@ -174,7 +175,8 @@ class TestWizardKeyringWarning:
 
         def fake_msg_dialog(parent, msg, title, style=0):
             shown_titles.append(title)
-            return _make_wx_dialog()
+            result = wx.ID_YES if title == "Getting started" else wx.ID_OK
+            return _make_wx_dialog(result)
 
         with (
             patch("accessiweather.app.wx.MessageDialog", side_effect=fake_msg_dialog),
@@ -199,7 +201,8 @@ class TestWizardKeyringWarning:
 
         def fake_msg_dialog(parent, msg, title, style=0):
             shown_titles.append(title)
-            return _make_wx_dialog()
+            result = wx.ID_YES if title == "Getting started" else wx.ID_OK
+            return _make_wx_dialog(result)
 
         with (
             patch("accessiweather.app.wx.MessageDialog", side_effect=fake_msg_dialog),
@@ -231,7 +234,10 @@ class TestWizardKeyringWarning:
 
         with (
             patch(
-                "accessiweather.app.wx.MessageDialog", side_effect=lambda *a, **k: _make_wx_dialog()
+                "accessiweather.app.wx.MessageDialog",
+                side_effect=lambda *a, **k: _make_wx_dialog(
+                    wx.ID_YES if len(a) >= 3 and a[2] == "Getting started" else wx.ID_OK
+                ),
             ),
             patch.object(app, "_prompt_optional_secret_with_link", side_effect=fake_prompt),
             patch.object(app, "_should_show_first_start_onboarding", return_value=True),

--- a/tests/test_startup_guidance_prompts.py
+++ b/tests/test_startup_guidance_prompts.py
@@ -22,6 +22,8 @@ def _ensure_wx_dialog_constants() -> None:
         "ID_YES": 1,
         "ID_NO": 0,
         "ID_CANCEL": 2,
+        "FD_OPEN": 0,
+        "FD_FILE_MUST_EXIST": 0,
     }.items():
         if not hasattr(wx, name):
             setattr(wx, name, value)
@@ -61,6 +63,23 @@ class _FakeTextEntryDialog:
         if self._responses:
             return self._responses.pop(0)
         return ""
+
+
+class _FakeFileDialog:
+    def __init__(self, paths: list[str]):
+        self._paths = paths
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def ShowModal(self):
+        return getattr(wx, "ID_OK", 1)
+
+    def GetPath(self):
+        return self._paths.pop(0)
 
 
 def test_portable_missing_api_keys_hint_shown_once_and_persists(monkeypatch, tmp_path):
@@ -140,10 +159,11 @@ def test_portable_missing_api_keys_hint_noops_when_not_portable():
     app.config_manager.update_settings.assert_not_called()
 
 
-def test_onboarding_wizard_shown_once_with_skip_path(monkeypatch):
+def test_onboarding_wizard_escape_closes_and_marks_shown(monkeypatch):
     app = AccessiWeatherApp.__new__(AccessiWeatherApp)
     app._portable_mode = False
     app._force_wizard = False
+    app._run_deferred_startup_update_check = MagicMock()
     app.main_window = SimpleNamespace(on_add_location=MagicMock(), open_settings=MagicMock())
     settings = SimpleNamespace(onboarding_wizard_shown=False)
     app.config_manager = SimpleNamespace(
@@ -152,9 +172,8 @@ def test_onboarding_wizard_shown_once_with_skip_path(monkeypatch):
     )
 
     _ensure_wx_dialog_constants()
-    skip_id = getattr(wx, "ID_NO", 0)
     cancel_id = getattr(wx, "ID_CANCEL", 2)
-    responses = [skip_id, cancel_id, cancel_id, cancel_id, getattr(wx, "ID_OK", 1)]
+    responses = [cancel_id]
     monkeypatch.setattr(
         "accessiweather.app.wx.MessageDialog",
         lambda *args, **kwargs: _FakeDialog(responses),
@@ -174,11 +193,279 @@ def test_onboarding_wizard_shown_once_with_skip_path(monkeypatch):
     assert app.config_manager.update_settings.call_args_list[-1].kwargs == {
         "onboarding_wizard_shown": True
     }
+    app._run_deferred_startup_update_check.assert_called_once()
 
     settings.onboarding_wizard_shown = True
     app.config_manager.update_settings.reset_mock()
     app._maybe_show_first_start_onboarding()
     app.config_manager.update_settings.assert_not_called()
+
+
+def test_onboarding_wizard_escape_from_key_setup_closes_without_summary(monkeypatch):
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    app._portable_mode = False
+    app._force_wizard = False
+    app._portable_keys_imported_this_session = False
+    app._run_deferred_startup_update_check = MagicMock()
+    app._show_onboarding_readiness_summary = MagicMock()
+    app.main_window = SimpleNamespace(on_add_location=MagicMock(), open_settings=MagicMock())
+    settings = SimpleNamespace(onboarding_wizard_shown=False)
+    app.config_manager = SimpleNamespace(
+        get_config=lambda: SimpleNamespace(locations=[], settings=settings),
+        update_settings=MagicMock(),
+    )
+
+    _ensure_wx_dialog_constants()
+    responses = [
+        getattr(wx, "ID_YES", 1),  # step 1: add location
+        getattr(wx, "ID_CANCEL", 2),  # OpenRouter key setup: configure myself / Escape
+    ]
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageDialog",
+        lambda *args, **kwargs: _FakeDialog(responses),
+        raising=False,
+    )
+    monkeypatch.setattr(app, "_has_saved_api_key", lambda key_name: False)
+
+    app._maybe_show_first_start_onboarding()
+
+    app.main_window.on_add_location.assert_called_once()
+    app._show_onboarding_readiness_summary.assert_not_called()
+    assert app.config_manager.update_settings.call_args_list[-1].kwargs == {
+        "onboarding_wizard_shown": True
+    }
+    app._run_deferred_startup_update_check.assert_called_once()
+
+
+def test_onboarding_wizard_escape_from_key_entry_closes_without_summary(monkeypatch):
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    app._portable_mode = False
+    app._force_wizard = False
+    app._portable_keys_imported_this_session = False
+    app._run_deferred_startup_update_check = MagicMock()
+    app._show_onboarding_readiness_summary = MagicMock()
+    app.main_window = SimpleNamespace(on_add_location=MagicMock(), open_settings=MagicMock())
+    settings = SimpleNamespace(onboarding_wizard_shown=False)
+    app.config_manager = SimpleNamespace(
+        get_config=lambda: SimpleNamespace(locations=[], settings=settings),
+        update_settings=MagicMock(),
+    )
+
+    class _CancelTextEntryDialog:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def ShowModal(self):
+            return getattr(wx, "ID_CANCEL", 2)
+
+        def GetValue(self):
+            return ""
+
+    _ensure_wx_dialog_constants()
+    responses = [
+        getattr(wx, "ID_YES", 1),  # step 1: add location
+        getattr(wx, "ID_YES", 1),  # OpenRouter key: set up now
+        getattr(wx, "ID_YES", 1),  # OpenRouter key: enter key
+    ]
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageDialog",
+        lambda *args, **kwargs: _FakeDialog(responses),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "accessiweather.app.wx.TextEntryDialog",
+        _CancelTextEntryDialog,
+        raising=False,
+    )
+    monkeypatch.setattr(app, "_has_saved_api_key", lambda key_name: False)
+
+    app._maybe_show_first_start_onboarding()
+
+    app._show_onboarding_readiness_summary.assert_not_called()
+    assert app.config_manager.update_settings.call_args_list[-1].kwargs == {
+        "onboarding_wizard_shown": True
+    }
+    app._run_deferred_startup_update_check.assert_called_once()
+
+
+def test_onboarding_wizard_escape_from_import_file_picker_closes_without_summary(
+    monkeypatch, tmp_path
+):
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    app._portable_mode = False
+    app._force_wizard = False
+    app._portable_keys_imported_this_session = False
+    app._run_deferred_startup_update_check = MagicMock()
+    app._show_onboarding_readiness_summary = MagicMock()
+    app.main_window = SimpleNamespace(on_add_location=MagicMock(), open_settings=MagicMock())
+    settings = SimpleNamespace(onboarding_wizard_shown=False)
+    config = SimpleNamespace(locations=[], settings=settings)
+    app.config_manager = SimpleNamespace(
+        get_config=lambda: config,
+        update_settings=MagicMock(),
+        import_settings=MagicMock(return_value=True),
+        import_encrypted_api_keys=MagicMock(return_value=True),
+        has_locations=lambda: False,
+        config_dir=tmp_path,
+    )
+
+    class _CancelFileDialog:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def ShowModal(self):
+            return getattr(wx, "ID_CANCEL", 2)
+
+        def GetPath(self):
+            return ""
+
+    _ensure_wx_dialog_constants()
+    responses = [
+        getattr(wx, "ID_NO", 0),  # step 1: import existing
+        getattr(wx, "ID_YES", 1),  # import settings
+    ]
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageDialog",
+        lambda *args, **kwargs: _FakeDialog(responses),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "accessiweather.app.wx.FileDialog",
+        _CancelFileDialog,
+        raising=False,
+    )
+
+    app._maybe_show_first_start_onboarding()
+
+    app.config_manager.import_settings.assert_not_called()
+    app._show_onboarding_readiness_summary.assert_not_called()
+    assert app.config_manager.update_settings.call_args_list[-1].kwargs == {
+        "onboarding_wizard_shown": True
+    }
+    app._run_deferred_startup_update_check.assert_called_once()
+
+
+def test_onboarding_wizard_imports_existing_setup_and_finishes(monkeypatch, tmp_path):
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    app._portable_mode = False
+    app._force_wizard = False
+    app._portable_keys_imported_this_session = False
+    app.refresh_runtime_settings = MagicMock()
+    app._run_deferred_startup_update_check = MagicMock()
+    app.main_window = SimpleNamespace(
+        on_add_location=MagicMock(),
+        open_settings=MagicMock(),
+        _populate_locations=MagicMock(),
+        refresh_weather_async=MagicMock(),
+    )
+    settings = SimpleNamespace(onboarding_wizard_shown=False)
+    config = SimpleNamespace(locations=[], settings=settings)
+
+    def import_settings(_path):
+        config.locations.append(SimpleNamespace(name="Home"))
+        return True
+
+    app.config_manager = SimpleNamespace(
+        get_config=lambda: config,
+        update_settings=MagicMock(),
+        import_settings=MagicMock(side_effect=import_settings),
+        import_encrypted_api_keys=MagicMock(return_value=True),
+        has_locations=lambda: bool(config.locations),
+    )
+
+    _ensure_wx_dialog_constants()
+    responses = [
+        getattr(wx, "ID_NO", 0),  # step 1: import existing
+        getattr(wx, "ID_YES", 1),  # import settings
+        getattr(wx, "ID_YES", 1),  # import API keys
+        getattr(wx, "ID_OK", 1),  # onboarding summary
+    ]
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageDialog",
+        lambda *args, **kwargs: _FakeDialog(responses),
+        raising=False,
+    )
+    file_paths = [str(tmp_path / "settings.json"), str(tmp_path / "api-keys.keys")]
+    monkeypatch.setattr(
+        "accessiweather.app.wx.FileDialog",
+        lambda *args, **kwargs: _FakeFileDialog(file_paths),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "accessiweather.app.wx.TextEntryDialog",
+        lambda *args, **kwargs: _FakeTextEntryDialog(["FAKE_IMPORT_PASSPHRASE"]),
+        raising=False,
+    )
+    monkeypatch.setattr("accessiweather.app.wx.MessageBox", lambda *a, **kw: None, raising=False)
+    monkeypatch.setattr(app, "_has_saved_api_key", lambda key_name: True)
+
+    app._maybe_show_first_start_onboarding()
+
+    app.main_window.on_add_location.assert_not_called()
+    app.config_manager.import_settings.assert_called_once()
+    app.config_manager.import_encrypted_api_keys.assert_called_once()
+    app.main_window._populate_locations.assert_called()
+    app.main_window.refresh_weather_async.assert_called_with(force_refresh=True)
+    assert app.config_manager.update_settings.call_args_list[-1].kwargs == {
+        "onboarding_wizard_shown": True
+    }
+    app._run_deferred_startup_update_check.assert_called_once()
+
+
+def test_onboarding_import_prompt_can_continue_normal_wizard(monkeypatch):
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    app._portable_mode = False
+    app._force_wizard = False
+    app._portable_keys_imported_this_session = False
+    app.main_window = SimpleNamespace(on_add_location=MagicMock(), open_settings=MagicMock())
+    settings = SimpleNamespace(onboarding_wizard_shown=False)
+    app.config_manager = SimpleNamespace(
+        get_config=lambda: SimpleNamespace(locations=[], settings=settings),
+        update_settings=MagicMock(),
+        import_settings=MagicMock(return_value=False),
+        import_encrypted_api_keys=MagicMock(return_value=False),
+    )
+
+    _ensure_wx_dialog_constants()
+    responses = [
+        getattr(wx, "ID_NO", 0),  # step 1: import existing
+        getattr(wx, "ID_NO", 0),  # skip settings import
+        getattr(wx, "ID_NO", 0),  # skip API key import
+        getattr(wx, "ID_NO", 0),  # skip OpenRouter key
+        getattr(wx, "ID_NO", 0),  # skip Pirate Weather key
+        getattr(wx, "ID_OK", 1),  # onboarding summary
+    ]
+    monkeypatch.setattr(
+        "accessiweather.app.wx.MessageDialog",
+        lambda *args, **kwargs: _FakeDialog(responses),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "accessiweather.app.wx.TextEntryDialog",
+        lambda *args, **kwargs: _FakeTextEntryDialog([]),
+        raising=False,
+    )
+    monkeypatch.setattr(app, "_has_saved_api_key", lambda key_name: False)
+
+    app._maybe_show_first_start_onboarding()
+
+    app.config_manager.import_settings.assert_not_called()
+    app.config_manager.import_encrypted_api_keys.assert_not_called()
+    assert app.config_manager.update_settings.call_args_list[-1].kwargs == {
+        "onboarding_wizard_shown": True
+    }
 
 
 def test_onboarding_wizard_portable_happy_path_sets_keys_and_bundle(monkeypatch, tmp_path):
@@ -199,10 +486,12 @@ def test_onboarding_wizard_portable_happy_path_sets_keys_and_bundle(monkeypatch,
     )
 
     _ensure_wx_dialog_constants()
-    # Step 1: skip location; step 2: OR key; step 3: Pirate key; summary OK
+    # Step 1: add location; step 2: OR key; step 3: Pirate key; summary OK
     responses = [
-        getattr(wx, "ID_NO", 0),  # step 1: skip location
+        getattr(wx, "ID_YES", 1),  # step 1: add location
+        getattr(wx, "ID_YES", 1),  # step 2: OR key — set up now
         getattr(wx, "ID_YES", 1),  # step 2: OR key — choose "Enter key"
+        getattr(wx, "ID_YES", 1),  # step 3: Pirate key — set up now
         getattr(wx, "ID_YES", 1),  # step 3: Pirate key — choose "Enter key"
         getattr(wx, "ID_OK", 1),  # onboarding summary
     ]
@@ -264,14 +553,14 @@ def test_onboarding_wizard_api_key_link_actions_open_browser(monkeypatch):
 
     _ensure_wx_dialog_constants()
     responses = [
-        getattr(wx, "ID_NO", 0),
-        getattr(wx, "ID_NO", 0),
-        getattr(wx, "ID_YES", 1),
-        getattr(wx, "ID_NO", 0),
-        getattr(wx, "ID_NO", 0),
-        getattr(wx, "ID_CANCEL", 2),
-        getattr(wx, "ID_NO", 0),
-        getattr(wx, "ID_CANCEL", 2),
+        getattr(wx, "ID_YES", 1),  # step 1: add location
+        getattr(wx, "ID_YES", 1),  # OpenRouter: set up now
+        getattr(wx, "ID_NO", 0),  # OpenRouter: open key page
+        getattr(wx, "ID_YES", 1),  # OpenRouter: enter key
+        getattr(wx, "ID_NO", 0),  # OpenRouter saved: test later
+        getattr(wx, "ID_YES", 1),  # Pirate Weather: set up now
+        getattr(wx, "ID_NO", 0),  # Pirate Weather: open key page
+        getattr(wx, "ID_YES", 1),  # Pirate Weather: enter blank to skip
         getattr(wx, "ID_OK", 1),
     ]
     monkeypatch.setattr(
@@ -323,10 +612,9 @@ def test_onboarding_summary_includes_readiness_status(monkeypatch):
 
     _ensure_wx_dialog_constants()
     responses = [
+        getattr(wx, "ID_YES", 1),
         getattr(wx, "ID_NO", 0),
-        getattr(wx, "ID_CANCEL", 2),
-        getattr(wx, "ID_CANCEL", 2),
-        getattr(wx, "ID_CANCEL", 2),
+        getattr(wx, "ID_NO", 0),
         getattr(wx, "ID_OK", 1),
     ]
     captured_messages: list[str] = []
@@ -374,10 +662,9 @@ def test_onboarding_completion_triggers_deferred_startup_update_check(monkeypatc
 
     _ensure_wx_dialog_constants()
     responses = [
+        getattr(wx, "ID_YES", 1),
         getattr(wx, "ID_NO", 0),
-        getattr(wx, "ID_CANCEL", 2),
-        getattr(wx, "ID_CANCEL", 2),
-        getattr(wx, "ID_CANCEL", 2),
+        getattr(wx, "ID_NO", 0),
         getattr(wx, "ID_OK", 1),
     ]
     monkeypatch.setattr(
@@ -422,11 +709,11 @@ def _capture_wizard_step_messages(monkeypatch, *, portable: bool):
             super().__init__(responses)
             captured_messages.append(message)
 
-    # Skip location, skip OR key, skip Pirate key, OK summary
+    # Add location, skip OR key, skip Pirate key, OK summary
     responses = [
+        getattr(wx, "ID_YES", 1),
         getattr(wx, "ID_NO", 0),
-        getattr(wx, "ID_CANCEL", 2),
-        getattr(wx, "ID_CANCEL", 2),
+        getattr(wx, "ID_NO", 0),
         getattr(wx, "ID_OK", 1),
     ]
     monkeypatch.setattr(
@@ -934,10 +1221,10 @@ def test_wizard_portable_export_failure_shows_warning(monkeypatch, tmp_path):
 
     _ensure_wx_dialog_constants()
     responses = [
-        getattr(wx, "ID_NO", 0),  # step 1: skip location
+        getattr(wx, "ID_YES", 1),  # step 1: add location
+        getattr(wx, "ID_YES", 1),  # step 2: OR key — set up now
         getattr(wx, "ID_YES", 1),  # step 2: OR key — choose "Enter key"
-        getattr(wx, "ID_CANCEL", 2),  # step 3: VC key — skip
-        getattr(wx, "ID_CANCEL", 2),  # step 4: Pirate key — skip
+        getattr(wx, "ID_NO", 0),  # step 3: Pirate key — skip
         getattr(wx, "ID_OK", 1),  # onboarding summary
     ]
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- add a first-run import/configure-yourself path for existing settings and encrypted API keys
- make Escape/Cancel leave onboarding consistently from wizard prompts, import pickers, and key entry dialogs
- keep explicit Skip actions for moving past individual optional setup steps

## Tests
- python -m pytest tests/test_startup_guidance_prompts.py tests/test_keyring_warning.py tests/test_wizard_cli_flag.py tests/test_settings_dialog_portable_copy.py -q
- python -m ruff check src/accessiweather/app_startup_guidance.py tests/test_startup_guidance_prompts.py tests/test_keyring_warning.py
- python -m ruff format --check src/accessiweather/app_startup_guidance.py tests/test_startup_guidance_prompts.py tests/test_keyring_warning.py
- git --no-pager diff --check