### PR TITLE
fix(notifications): suppress minutely precipitation countdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Default soundpack now includes specific sounds for mapped weather alert types.
+- Pirate Weather minute-by-minute precipitation notifications now wait until start/stop changes are near-term and no longer count down repeatedly for the same rain event.
 - Saving Settings no longer waits on the Windows startup shortcut check unless you actually change the launch-at-startup checkbox.
 - Settings now opens without waiting on the Windows startup shortcut check.
 - The weather-refresh completion sound is now off by default, and switching to a cached location no longer plays it before the real refresh finishes.

--- a/src/accessiweather/notifications/minutely_precipitation.py
+++ b/src/accessiweather/notifications/minutely_precipitation.py
@@ -36,6 +36,7 @@ def _probability_band(prob: float) -> str:
 INTENSITY_THRESHOLD_LIGHT = 0.01
 INTENSITY_THRESHOLD_MODERATE = 0.1
 INTENSITY_THRESHOLD_HEAVY = 1.0
+TRANSITION_NOTICE_LEAD_MINUTES = 10
 
 # Map setting values to thresholds
 SENSITIVITY_THRESHOLDS: dict[str, float] = {
@@ -195,6 +196,9 @@ def build_minutely_transition_signature(
     """
     Return a stable signature for the current minutely transition state.
 
+    The signature intentionally excludes ``minutes_until`` so repeated polls of
+    the same forecasted start/stop do not become countdown notifications.
+
     ``None`` means the forecast was unavailable. ``NO_TRANSITION_SIGNATURE`` means
     the forecast was available but no dry/wet transition was detected.
 
@@ -211,7 +215,7 @@ def build_minutely_transition_signature(
         return NO_TRANSITION_SIGNATURE
 
     precip_type = transition.precipitation_type or "precipitation"
-    return f"{transition.transition_type}:{transition.minutes_until}:{precip_type}"
+    return f"{transition.transition_type}:{precip_type}"
 
 
 def detect_minutely_precipitation_likelihood(

--- a/src/accessiweather/notifications/notification_event_manager.py
+++ b/src/accessiweather/notifications/notification_event_manager.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 from ..runtime_state import RuntimeStateManager
 from .minutely_precipitation import (
     SENSITIVITY_THRESHOLDS,
+    TRANSITION_NOTICE_LEAD_MINUTES,
     build_minutely_likelihood_signature,
     build_minutely_transition_signature,
     detect_minutely_precipitation_likelihood,
@@ -503,6 +504,18 @@ class NotificationEventManager:
         if signature is None:
             return None
 
+        transition = detect_minutely_precipitation_transition(
+            minutely_precipitation, threshold=threshold
+        )
+        if transition is not None and transition.minutes_until > TRANSITION_NOTICE_LEAD_MINUTES:
+            signature = f"pending:{signature}"
+            if self.state.last_minutely_transition_signature not in (
+                signature,
+                signature.removeprefix("pending:"),
+            ):
+                self.state.last_minutely_transition_signature = signature
+            return None
+
         if self.state.last_minutely_transition_signature is None:
             self.state.last_minutely_transition_signature = signature
             logger.debug("First minutely precipitation state stored: %s", signature)
@@ -512,9 +525,6 @@ class NotificationEventManager:
             return None
 
         self.state.last_minutely_transition_signature = signature
-        transition = detect_minutely_precipitation_transition(
-            minutely_precipitation, threshold=threshold
-        )
         if transition is None:
             return None
 

--- a/tests/test_notification_event_manager.py
+++ b/tests/test_notification_event_manager.py
@@ -61,12 +61,12 @@ class TestNotificationState:
 
     def test_minutely_signature_round_trip(self):
         """Test minutely state serialization."""
-        state = NotificationState(last_minutely_transition_signature="starting:12:rain")
+        state = NotificationState(last_minutely_transition_signature="starting:rain")
 
         data = state.to_dict()
         restored = NotificationState.from_dict(data)
 
-        assert restored.last_minutely_transition_signature == "starting:12:rain"
+        assert restored.last_minutely_transition_signature == "starting:rain"
 
 
 class TestNotificationEventManager:
@@ -559,7 +559,7 @@ class TestNotificationEventManager:
         assert transition.transition_type == "starting"
         assert transition.minutes_until == 2
         assert transition.precipitation_type == "rain"
-        assert build_minutely_transition_signature(forecast) == "starting:2:rain"
+        assert build_minutely_transition_signature(forecast) == "starting:rain"
 
     def test_detect_minutely_precipitation_stop_transition(self):
         """Wet-to-dry transitions should announce when precipitation stops."""
@@ -592,7 +592,7 @@ class TestNotificationEventManager:
             {
                 "data": [
                     {"time": 1768917600, "precipIntensity": 0},
-                    {"time": 1768917660, "precipIntensity": 0.02, "precipType": "rain"},
+                    {"time": 1768917660, "precipIntensity": 0},
                 ]
             }
         )
@@ -618,7 +618,187 @@ class TestNotificationEventManager:
         assert events[0].event_type == "minutely_precipitation_start"
         assert events[0].title == "Rain starting in 2 minutes"
         assert events[0].message == "Rain starting in 2 minutes for Test City."
-        assert manager.state.last_minutely_transition_signature == "starting:2:rain"
+        assert manager.state.last_minutely_transition_signature == "starting:rain"
+
+    def test_minutely_start_countdown_does_not_renotify(self, manager, settings_with_minutely):
+        """Same forecasted start should notify once even as minutes count down."""
+        weather_data = MagicMock(spec=WeatherData)
+        weather_data.discussion = None
+        weather_data.discussion_issuance_time = None
+        weather_data.current = None
+        weather_data.minutely_precipitation = parse_pirate_weather_minutely_block(
+            {
+                "data": [
+                    {"time": 1768917600, "precipIntensity": 0},
+                    {"time": 1768917660, "precipIntensity": 0},
+                ]
+            }
+        )
+        manager.check_for_events(weather_data, settings_with_minutely, "Test City")
+
+        weather_data.minutely_precipitation = parse_pirate_weather_minutely_block(
+            {
+                "data": [
+                    {"time": 1768917600, "precipIntensity": 0},
+                    {"time": 1768917660, "precipIntensity": 0},
+                    {"time": 1768917720, "precipIntensity": 0.02, "precipType": "rain"},
+                ]
+            }
+        )
+        events = manager.check_for_events(weather_data, settings_with_minutely, "Test City")
+        assert len(events) == 1
+        assert events[0].title == "Rain starting in 2 minutes"
+
+        weather_data.minutely_precipitation = parse_pirate_weather_minutely_block(
+            {
+                "data": [
+                    {"time": 1768917600, "precipIntensity": 0},
+                    {"time": 1768917660, "precipIntensity": 0.02, "precipType": "rain"},
+                ]
+            }
+        )
+        events = manager.check_for_events(weather_data, settings_with_minutely, "Test City")
+
+        assert events == []
+        assert manager.state.last_minutely_transition_signature == "starting:rain"
+
+    def test_minutely_start_waits_until_near_term_window(self, manager, settings_with_minutely):
+        """Forecasted starts should notify when they become actionable, not an hour out."""
+        weather_data = MagicMock(spec=WeatherData)
+        weather_data.discussion = None
+        weather_data.discussion_issuance_time = None
+        weather_data.current = None
+        weather_data.minutely_precipitation = parse_pirate_weather_minutely_block(
+            {
+                "data": [
+                    {"time": 1768917600, "precipIntensity": 0},
+                    {"time": 1768917660, "precipIntensity": 0},
+                ]
+            }
+        )
+        manager.check_for_events(weather_data, settings_with_minutely, "Test City")
+
+        far_start_points = [
+            {"time": 1768917600 + (minute * 60), "precipIntensity": 0} for minute in range(12)
+        ]
+        far_start_points.append(
+            {"time": 1768917600 + (12 * 60), "precipIntensity": 0.02, "precipType": "rain"}
+        )
+        weather_data.minutely_precipitation = parse_pirate_weather_minutely_block(
+            {"data": far_start_points}
+        )
+        events = manager.check_for_events(weather_data, settings_with_minutely, "Test City")
+
+        assert events == []
+        assert manager.state.last_minutely_transition_signature == "pending:starting:rain"
+
+        near_start_points = [
+            {"time": 1768917600 + (minute * 60), "precipIntensity": 0} for minute in range(9)
+        ]
+        near_start_points.append(
+            {"time": 1768917600 + (9 * 60), "precipIntensity": 0.02, "precipType": "rain"}
+        )
+        weather_data.minutely_precipitation = parse_pirate_weather_minutely_block(
+            {"data": near_start_points}
+        )
+        events = manager.check_for_events(weather_data, settings_with_minutely, "Test City")
+
+        assert len(events) == 1
+        assert events[0].title == "Rain starting in 9 minutes"
+        assert manager.state.last_minutely_transition_signature == "starting:rain"
+
+    def test_minutely_stop_countdown_does_not_renotify(self, manager, settings_with_minutely):
+        """Same forecasted stop should notify once even as minutes count down."""
+        weather_data = MagicMock(spec=WeatherData)
+        weather_data.discussion = None
+        weather_data.discussion_issuance_time = None
+        weather_data.current = None
+        weather_data.minutely_precipitation = parse_pirate_weather_minutely_block(
+            {
+                "data": [
+                    {"time": 1768917600, "precipIntensity": 0.04, "precipType": "rain"},
+                    {"time": 1768917660, "precipIntensity": 0.03, "precipType": "rain"},
+                ]
+            }
+        )
+        manager.check_for_events(weather_data, settings_with_minutely, "Test City")
+
+        weather_data.minutely_precipitation = parse_pirate_weather_minutely_block(
+            {
+                "data": [
+                    {"time": 1768917600, "precipIntensity": 0.04, "precipType": "rain"},
+                    {"time": 1768917660, "precipIntensity": 0.03, "precipType": "rain"},
+                    {"time": 1768917720, "precipIntensity": 0},
+                ]
+            }
+        )
+        events = manager.check_for_events(weather_data, settings_with_minutely, "Test City")
+        assert len(events) == 1
+        assert events[0].title == "Rain stopping in 2 minutes"
+
+        weather_data.minutely_precipitation = parse_pirate_weather_minutely_block(
+            {
+                "data": [
+                    {"time": 1768917600, "precipIntensity": 0.04, "precipType": "rain"},
+                    {"time": 1768917660, "precipIntensity": 0},
+                ]
+            }
+        )
+        events = manager.check_for_events(weather_data, settings_with_minutely, "Test City")
+
+        assert events == []
+        assert manager.state.last_minutely_transition_signature == "stopping:rain"
+
+    def test_minutely_stop_waits_until_near_term_window(self, manager, settings_with_minutely):
+        """Forecasted stops should notify when the stop is near, not an hour out."""
+        weather_data = MagicMock(spec=WeatherData)
+        weather_data.discussion = None
+        weather_data.discussion_issuance_time = None
+        weather_data.current = None
+        weather_data.minutely_precipitation = parse_pirate_weather_minutely_block(
+            {
+                "data": [
+                    {"time": 1768917600, "precipIntensity": 0.04, "precipType": "rain"},
+                    {"time": 1768917660, "precipIntensity": 0.03, "precipType": "rain"},
+                ]
+            }
+        )
+        manager.check_for_events(weather_data, settings_with_minutely, "Test City")
+
+        far_stop_points = [
+            {
+                "time": 1768917600 + (minute * 60),
+                "precipIntensity": 0.04,
+                "precipType": "rain",
+            }
+            for minute in range(12)
+        ]
+        far_stop_points.append({"time": 1768917600 + (12 * 60), "precipIntensity": 0})
+        weather_data.minutely_precipitation = parse_pirate_weather_minutely_block(
+            {"data": far_stop_points}
+        )
+        events = manager.check_for_events(weather_data, settings_with_minutely, "Test City")
+
+        assert events == []
+        assert manager.state.last_minutely_transition_signature == "pending:stopping:rain"
+
+        near_stop_points = [
+            {
+                "time": 1768917600 + (minute * 60),
+                "precipIntensity": 0.04,
+                "precipType": "rain",
+            }
+            for minute in range(9)
+        ]
+        near_stop_points.append({"time": 1768917600 + (9 * 60), "precipIntensity": 0})
+        weather_data.minutely_precipitation = parse_pirate_weather_minutely_block(
+            {"data": near_stop_points}
+        )
+        events = manager.check_for_events(weather_data, settings_with_minutely, "Test City")
+
+        assert len(events) == 1
+        assert events[0].title == "Rain stopping in 9 minutes"
+        assert manager.state.last_minutely_transition_signature == "stopping:rain"
 
     def test_minutely_precipitation_stop_can_be_disabled(self, manager):
         """Disabled stop notifications should still update state without notifying."""
@@ -657,7 +837,7 @@ class TestNotificationEventManager:
         events = manager.check_for_events(weather_data, settings, "Test City")
 
         assert events == []
-        assert manager.state.last_minutely_transition_signature == "stopping:2:rain"
+        assert manager.state.last_minutely_transition_signature == "stopping:rain"
 
     # ------------------------------------------------------------------
     # is_wet threshold tests


### PR DESCRIPTION
## User-facing changes
- Pirate Weather minutely precipitation start notifications now wait until rain/snow/etc. is close enough to be useful, instead of alerting when the transition is still far out.
- Start and stop notifications fire once for the same ongoing minutely transition instead of counting down every poll.
- Stop notifications use the same near-term behavior, so ongoing rain no longer repeatedly announces a moving stop time when Pirate Weather keeps extending the event.
- The user-facing fix is listed in `CHANGELOG.md` under Unreleased > Fixed.

## Developer changes
- Added a 10-minute near-term notice window for Pirate Weather minutely start/stop transitions.
- Changed the internal minutely transition signature to dedupe by transition direction and precipitation type, not by countdown minute.
- Track far-out transitions as pending so they can still notify once when they enter the near-term window.
- Added regression tests for start countdown suppression, stop countdown suppression, and far-out-to-near-term notification behavior.
- Added the required changelog entry after CI flagged the missing user-facing note.

## Verification
- `uv run pytest tests/test_notification_event_manager.py -q --tb=short` -> 51 passed
- `uv run pytest tests/test_minutely_precipitation_likelihood.py tests/test_auto_mode_api_budget.py -q --tb=short` -> 31 passed
- `uv run ruff check src/accessiweather/notifications/minutely_precipitation.py src/accessiweather/notifications/notification_event_manager.py tests/test_notification_event_manager.py` -> passed
- `uv run pyright src/accessiweather/notifications/minutely_precipitation.py src/accessiweather/notifications/notification_event_manager.py` -> 0 errors
- `git --no-pager diff --check` -> passed after adding the changelog entry
- External API docs were not needed: this change uses AccessiWeather's existing Pirate Weather minutely model and only changes local notification timing/deduplication.