### PR TITLE
feat(forecaster-notes): add daily climate reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - You can now search for a US street address when adding or editing a location, so AccessiWeather can save coordinates for that specific address instead of the nearest city or ZIP result.
 - Saved locations now stay sorted alphabetically in the location list (#667).
 - You can now choose to sort saved locations alphabetically or nearest to the current location.
+- **Daily Climate Reports in Forecaster Notes** — You can now read the latest NWS Daily Climate Report for supported US climate stations, with station-aware lookup, cached refreshes, history through Advanced Lookup, and optional update notifications.
 - **National Products in Forecaster Notes** — Forecaster Notes now opens a dedicated National Products dialog for SPC, WPC, NHC, CPC, and other national NWS text products. The new view replaces the old Nationwide Discussions scraper with IEM AFOS plain-text products while keeping the existing Advanced Lookup path available for direct product searches (#641).
 - **Guided Advanced Lookup in Forecaster Notes** — Advanced Lookup now organizes NWS and IEM text products into product groups with clearer product choices, office selection, date presets, result limits, sort order, source selection, aviation AFD, center, WMO, and text-match filters.
 

--- a/src/accessiweather/models/config_constants.py
+++ b/src/accessiweather/models/config_constants.py
@@ -35,6 +35,7 @@ NON_CRITICAL_SETTINGS: set[str] = {
     "specific_alert_sound_packs",
     # Event notifications
     "notify_discussion_update",
+    "notify_daily_climate_report_update",
     "notify_hwo_update",
     "notify_sps_issued",
     "notify_severe_risk_change",

--- a/src/accessiweather/models/config_serialization.py
+++ b/src/accessiweather/models/config_serialization.py
@@ -33,6 +33,7 @@ class AppSettingsSerializationMixin:
             "muted_sound_events": settings.muted_sound_events,
             "specific_alert_sound_packs": settings.specific_alert_sound_packs,
             "notify_discussion_update": settings.notify_discussion_update,
+            "notify_daily_climate_report_update": settings.notify_daily_climate_report_update,
             "notify_hwo_update": settings.notify_hwo_update,
             "notify_sps_issued": settings.notify_sps_issued,
             "notify_severe_risk_change": settings.notify_severe_risk_change,
@@ -136,6 +137,9 @@ class AppSettingsSerializationMixin:
             specific_alert_sound_packs=specific_alert_sound_packs,
             notify_discussion_update=settings_cls._as_bool(
                 data.get("notify_discussion_update"), True
+            ),
+            notify_daily_climate_report_update=settings_cls._as_bool(
+                data.get("notify_daily_climate_report_update"), False
             ),
             notify_hwo_update=settings_cls._as_bool(data.get("notify_hwo_update"), True),
             notify_sps_issued=settings_cls._as_bool(data.get("notify_sps_issued"), True),

--- a/src/accessiweather/models/config_settings.py
+++ b/src/accessiweather/models/config_settings.py
@@ -30,6 +30,7 @@ class AppSettings(AppSettingsValidationMixin, AppSettingsSerializationMixin):
     specific_alert_sound_packs: list[str] = field(default_factory=list)
     # Event-based notifications
     notify_discussion_update: bool = True
+    notify_daily_climate_report_update: bool = False
     notify_hwo_update: bool = True
     notify_sps_issued: bool = True
     notify_severe_risk_change: bool = False

--- a/src/accessiweather/notifications/notification_event_manager.py
+++ b/src/accessiweather/notifications/notification_event_manager.py
@@ -308,6 +308,84 @@ class NotificationEventManager:
         )
         return None
 
+    def check_daily_climate_report(
+        self,
+        product: TextProduct | None,
+        settings: AppSettings,
+        location_name: str,
+    ) -> NotificationEvent | None:
+        """Inspect a daily climate report and notify only on newer report text."""
+        if product is None or not getattr(settings, "notify_daily_climate_report_update", False):
+            return None
+        issuance_time = product.issuance_time
+        product_text = product.product_text
+        station = product.cwa_office
+        if issuance_time is None or not product_text:
+            return None
+
+        same_station = self.state.last_daily_climate_report_station == station
+        last_issuance = self.state.last_daily_climate_report_issuance_time
+        if last_issuance is None or not same_station:
+            self.state.last_daily_climate_report_issuance_time = issuance_time
+            self.state.last_daily_climate_report_text = product_text
+            self.state.last_daily_climate_report_station = station
+            self._save_state()
+            return None
+
+        if issuance_time <= last_issuance:
+            self.state.last_daily_climate_report_text = product_text
+            self._save_state()
+            return None
+
+        summary = self._summarize_daily_climate_change(
+            self.state.last_daily_climate_report_text,
+            product_text,
+        )
+        if summary is None:
+            summary = summarize_discussion_change(
+                self.state.last_daily_climate_report_text,
+                product_text,
+            )
+        self.state.last_daily_climate_report_issuance_time = issuance_time
+        self.state.last_daily_climate_report_text = product_text
+        self.state.last_daily_climate_report_station = station
+        self._save_state()
+
+        message = (
+            f"The Daily Climate Report for {location_name} ({station}) was updated by "
+            "the National Weather Service."
+        )
+        if summary:
+            message += f" Change summary: {summary}"
+        return NotificationEvent(
+            event_type="daily_climate_report_update",
+            title="Daily Climate Report Updated",
+            message=message,
+            sound_event="discussion_update",
+        )
+
+    @staticmethod
+    def _summarize_daily_climate_change(
+        previous_text: str | None,
+        current_text: str | None,
+    ) -> str | None:
+        previous_lines = {
+            " ".join(line.split()) for line in (previous_text or "").splitlines() if line.strip()
+        }
+        interesting = ("MAXIMUM", "MINIMUM", "AVERAGE", "PRECIPITATION", "SNOWFALL")
+        changed: list[str] = []
+        for raw_line in (current_text or "").splitlines():
+            line = " ".join(raw_line.split())
+            if not line or line in previous_lines:
+                continue
+            if any(token in line.upper() for token in interesting):
+                changed.append(line)
+            if len(changed) == 3:
+                break
+        if changed:
+            return "; ".join(changed)
+        return summarize_discussion_change(previous_text, current_text)
+
     def _check_hwo_update(
         self,
         location: Location,

--- a/src/accessiweather/notifications/notification_event_state.py
+++ b/src/accessiweather/notifications/notification_event_state.py
@@ -22,6 +22,9 @@ class NotificationState:
 
     last_discussion_issuance_time: datetime | None = None
     last_discussion_text: str | None = None
+    last_daily_climate_report_issuance_time: datetime | None = None
+    last_daily_climate_report_text: str | None = None
+    last_daily_climate_report_station: str | None = None
     last_severe_risk: int | None = None
     last_minutely_transition_signature: str | None = None
     last_minutely_likelihood_signature: str | None = None
@@ -40,6 +43,13 @@ class NotificationState:
                 else None
             ),
             "last_discussion_text": self.last_discussion_text,
+            "last_daily_climate_report_issuance_time": (
+                self.last_daily_climate_report_issuance_time.isoformat()
+                if self.last_daily_climate_report_issuance_time
+                else None
+            ),
+            "last_daily_climate_report_text": self.last_daily_climate_report_text,
+            "last_daily_climate_report_station": self.last_daily_climate_report_station,
             "last_severe_risk": self.last_severe_risk,
             "last_minutely_transition_signature": self.last_minutely_transition_signature,
             "last_minutely_likelihood_signature": self.last_minutely_likelihood_signature,
@@ -57,6 +67,7 @@ class NotificationState:
         """Create from dictionary."""
         last_check = data.get("last_check_time")
         last_issuance = data.get("last_discussion_issuance_time")
+        last_cli_issuance = data.get("last_daily_climate_report_issuance_time")
         last_hwo_issuance = data.get("last_hwo_issuance_time")
         sps_ids = data.get("last_sps_product_ids") or []
         return cls(
@@ -64,6 +75,11 @@ class NotificationState:
                 datetime.fromisoformat(last_issuance) if last_issuance else None
             ),
             last_discussion_text=data.get("last_discussion_text"),
+            last_daily_climate_report_issuance_time=(
+                datetime.fromisoformat(last_cli_issuance) if last_cli_issuance else None
+            ),
+            last_daily_climate_report_text=data.get("last_daily_climate_report_text"),
+            last_daily_climate_report_station=data.get("last_daily_climate_report_station"),
             last_severe_risk=data.get("last_severe_risk"),
             last_minutely_transition_signature=data.get("last_minutely_transition_signature"),
             last_minutely_likelihood_signature=data.get("last_minutely_likelihood_signature"),
@@ -80,6 +96,7 @@ class NotificationState:
 def runtime_section_to_legacy_shape(section: dict) -> dict:
     """Convert unified runtime state to the legacy notification-state shape."""
     discussion = section.get("discussion", {})
+    daily_climate = section.get("daily_climate_report", {})
     severe_risk = section.get("severe_risk", {})
     minutely_precipitation = section.get("minutely_precipitation", {})
     hwo = section.get("hwo", {})
@@ -87,6 +104,9 @@ def runtime_section_to_legacy_shape(section: dict) -> dict:
     return {
         "last_discussion_issuance_time": discussion.get("last_issuance_time"),
         "last_discussion_text": discussion.get("last_text"),
+        "last_daily_climate_report_issuance_time": daily_climate.get("last_issuance_time"),
+        "last_daily_climate_report_text": daily_climate.get("last_text"),
+        "last_daily_climate_report_station": daily_climate.get("last_station"),
         "last_severe_risk": severe_risk.get("last_value"),
         "last_minutely_transition_signature": minutely_precipitation.get(
             "last_transition_signature"
@@ -112,6 +132,12 @@ def legacy_shape_to_runtime_section(data: dict) -> dict:
         "discussion": {
             "last_issuance_time": data.get("last_discussion_issuance_time"),
             "last_text": data.get("last_discussion_text"),
+            "last_check_time": last_check_time,
+        },
+        "daily_climate_report": {
+            "last_issuance_time": data.get("last_daily_climate_report_issuance_time"),
+            "last_text": data.get("last_daily_climate_report_text"),
+            "last_station": data.get("last_daily_climate_report_station"),
             "last_check_time": last_check_time,
         },
         "severe_risk": {

--- a/src/accessiweather/services/forecast_product_service.py
+++ b/src/accessiweather/services/forecast_product_service.py
@@ -32,6 +32,7 @@ from ..iem_client import (
 from ..models import TextProduct
 from ..weather_client_nws import (
     TextProductFetchError,
+    get_nws_daily_climate_report,
     get_nws_text_product,
     get_nws_text_product_history,
 )
@@ -51,6 +52,7 @@ _PRODUCT_TTLS: dict[str, int] = {
 FetcherResult = TextProduct | list[TextProduct] | None
 Fetcher = Callable[..., Awaitable[FetcherResult]]
 HistoryFetcher = Callable[..., Awaitable[list[TextProduct]]]
+DailyClimateFetcher = Callable[..., Awaitable[TextProduct | None]]
 
 
 class ForecastProductService:
@@ -64,6 +66,7 @@ class ForecastProductService:
         *,
         fetcher: Fetcher | None = None,
         history_fetcher: HistoryFetcher | None = None,
+        daily_climate_fetcher: DailyClimateFetcher | None = None,
     ) -> None:
         """
         Initialize the service.
@@ -76,11 +79,16 @@ class ForecastProductService:
                 function. Injected primarily for unit tests.
             history_fetcher: Optional async callable with the same signature as
                 :func:`get_nws_text_product_history`.
+            daily_climate_fetcher: Optional async callable with the same
+                signature as :func:`get_nws_daily_climate_report`.
 
         """
         self._cache = cache
         self._fetcher: Fetcher = fetcher or get_nws_text_product
         self._history_fetcher: HistoryFetcher = history_fetcher or get_nws_text_product_history
+        self._daily_climate_fetcher: DailyClimateFetcher = (
+            daily_climate_fetcher or get_nws_daily_climate_report
+        )
 
     @staticmethod
     def _cache_key(product_type: str, cwa_office: str) -> str:
@@ -102,6 +110,54 @@ class ForecastProductService:
     def _iem_cache_key(product_type: str, *parts: object) -> str:
         joined = ":".join(str(part) for part in parts)
         return f"iem_text_product:{product_type}:{joined}"
+
+    @staticmethod
+    def _normalize_daily_climate_station(station_id: str | None) -> str:
+        station = (station_id or "").strip().upper()
+        if station.startswith("K") and len(station) == 4:
+            station = station[1:]
+        return station
+
+    @classmethod
+    def daily_climate_station_candidates(cls, location: object) -> list[str]:
+        """Return likely CLI station identifiers for a saved/current location."""
+        candidates: list[str] = []
+        for value in (
+            getattr(location, "radar_station", None),
+            getattr(location, "cwa_office", None),
+        ):
+            station = cls._normalize_daily_climate_station(value)
+            if station and station not in candidates:
+                candidates.append(station)
+        return candidates
+
+    async def get_daily_climate_report(
+        self, station_id: str, **fetcher_kwargs: Any
+    ) -> TextProduct | None:
+        """Return cached or freshly fetched latest daily climate report text."""
+        station = self._normalize_daily_climate_station(station_id)
+        if not station:
+            return None
+        key = self._iem_cache_key("CLI", station, "latest")
+        if self._cache.has_key(key):
+            cached = self._cache.get(key)
+            if cached is None or isinstance(cached, TextProduct):
+                return cached
+        result = await self._daily_climate_fetcher(station, **fetcher_kwargs)
+        self._cache.set(key, result, ttl=self._TTLS.get("CLI", 3600))
+        return result
+
+    async def get_daily_climate_report_for_location(
+        self,
+        location: object,
+        **fetcher_kwargs: Any,
+    ) -> TextProduct | None:
+        """Try likely CLI stations for a location until a report is found."""
+        for station in self.daily_climate_station_candidates(location):
+            product = await self.get_daily_climate_report(station, **fetcher_kwargs)
+            if product is not None:
+                return product
+        return None
 
     async def get(
         self,

--- a/src/accessiweather/services/forecast_product_service.py
+++ b/src/accessiweather/services/forecast_product_service.py
@@ -33,6 +33,7 @@ from ..models import TextProduct
 from ..weather_client_nws import (
     TextProductFetchError,
     get_nws_daily_climate_report,
+    get_nws_observation_station_ids_for_point,
     get_nws_text_product,
     get_nws_text_product_history,
 )
@@ -53,6 +54,7 @@ FetcherResult = TextProduct | list[TextProduct] | None
 Fetcher = Callable[..., Awaitable[FetcherResult]]
 HistoryFetcher = Callable[..., Awaitable[list[TextProduct]]]
 DailyClimateFetcher = Callable[..., Awaitable[TextProduct | None]]
+ObservationStationFetcher = Callable[[float, float], Awaitable[list[str]]]
 
 
 class ForecastProductService:
@@ -67,6 +69,7 @@ class ForecastProductService:
         fetcher: Fetcher | None = None,
         history_fetcher: HistoryFetcher | None = None,
         daily_climate_fetcher: DailyClimateFetcher | None = None,
+        observation_station_fetcher: ObservationStationFetcher | None = None,
     ) -> None:
         """
         Initialize the service.
@@ -81,6 +84,8 @@ class ForecastProductService:
                 :func:`get_nws_text_product_history`.
             daily_climate_fetcher: Optional async callable with the same
                 signature as :func:`get_nws_daily_climate_report`.
+            observation_station_fetcher: Optional async callable used to find
+                nearby NWS observation stations for daily climate fallback.
 
         """
         self._cache = cache
@@ -88,6 +93,9 @@ class ForecastProductService:
         self._history_fetcher: HistoryFetcher = history_fetcher or get_nws_text_product_history
         self._daily_climate_fetcher: DailyClimateFetcher = (
             daily_climate_fetcher or get_nws_daily_climate_report
+        )
+        self._observation_station_fetcher: ObservationStationFetcher = (
+            observation_station_fetcher or get_nws_observation_station_ids_for_point
         )
 
     @staticmethod
@@ -153,9 +161,26 @@ class ForecastProductService:
         **fetcher_kwargs: Any,
     ) -> TextProduct | None:
         """Try likely CLI stations for a location until a report is found."""
-        for station in self.daily_climate_station_candidates(location):
+        primary_candidates = self.daily_climate_station_candidates(location)
+        candidates = list(primary_candidates)
+        latitude = getattr(location, "latitude", None)
+        longitude = getattr(location, "longitude", None)
+        if isinstance(latitude, int | float) and isinstance(longitude, int | float):
+            try:
+                for station in await self._observation_station_fetcher(latitude, longitude):
+                    normalized_station = self._normalize_daily_climate_station(station)
+                    if normalized_station and normalized_station not in candidates:
+                        candidates.append(normalized_station)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Daily climate observation-station lookup failed: %s", exc)
+
+        for station in candidates:
             product = await self.get_daily_climate_report(station, **fetcher_kwargs)
             if product is not None:
+                ttl = self._TTLS.get("CLI", 3600)
+                for primary_station in primary_candidates:
+                    key = self._iem_cache_key("CLI", primary_station, "latest")
+                    self._cache.set(key, product, ttl=ttl)
                 return product
         return None
 

--- a/src/accessiweather/services/forecast_product_service.py
+++ b/src/accessiweather/services/forecast_product_service.py
@@ -32,6 +32,7 @@ from ..iem_client import (
 from ..models import TextProduct
 from ..weather_client_nws import (
     TextProductFetchError,
+    get_nws_daily_climate_locations,
     get_nws_daily_climate_report,
     get_nws_observation_station_ids_for_point,
     get_nws_text_product,
@@ -55,6 +56,7 @@ Fetcher = Callable[..., Awaitable[FetcherResult]]
 HistoryFetcher = Callable[..., Awaitable[list[TextProduct]]]
 DailyClimateFetcher = Callable[..., Awaitable[TextProduct | None]]
 ObservationStationFetcher = Callable[[float, float], Awaitable[list[str]]]
+DailyClimateLocationFetcher = Callable[[], Awaitable[set[str]]]
 
 
 class ForecastProductService:
@@ -70,6 +72,7 @@ class ForecastProductService:
         history_fetcher: HistoryFetcher | None = None,
         daily_climate_fetcher: DailyClimateFetcher | None = None,
         observation_station_fetcher: ObservationStationFetcher | None = None,
+        daily_climate_location_fetcher: DailyClimateLocationFetcher | None = None,
     ) -> None:
         """
         Initialize the service.
@@ -86,6 +89,8 @@ class ForecastProductService:
                 signature as :func:`get_nws_daily_climate_report`.
             observation_station_fetcher: Optional async callable used to find
                 nearby NWS observation stations for daily climate fallback.
+            daily_climate_location_fetcher: Optional async callable used to fetch
+                the NWS CLI-capable location index.
 
         """
         self._cache = cache
@@ -96,6 +101,9 @@ class ForecastProductService:
         )
         self._observation_station_fetcher: ObservationStationFetcher = (
             observation_station_fetcher or get_nws_observation_station_ids_for_point
+        )
+        self._daily_climate_location_fetcher: DailyClimateLocationFetcher = (
+            daily_climate_location_fetcher or get_nws_daily_climate_locations
         )
 
     @staticmethod
@@ -120,6 +128,13 @@ class ForecastProductService:
         return f"iem_text_product:{product_type}:{joined}"
 
     @staticmethod
+    def _location_cache_key(location: object) -> str:
+        latitude = getattr(location, "latitude", "")
+        longitude = getattr(location, "longitude", "")
+        name = getattr(location, "name", "")
+        return f"daily_climate_location_station:{name}:{latitude}:{longitude}"
+
+    @staticmethod
     def _normalize_daily_climate_station(station_id: str | None) -> str:
         station = (station_id or "").strip().upper()
         if station.startswith("K") and len(station) == 4:
@@ -138,6 +153,16 @@ class ForecastProductService:
             if station and station not in candidates:
                 candidates.append(station)
         return candidates
+
+    async def _get_daily_climate_locations(self) -> set[str]:
+        key = self._iem_cache_key("CLI", "locations")
+        if self._cache.has_key(key):
+            cached = self._cache.get(key)
+            if isinstance(cached, set):
+                return cached
+        result = await self._daily_climate_location_fetcher()
+        self._cache.set(key, result, ttl=86400)
+        return result
 
     async def get_daily_climate_report(
         self, station_id: str, **fetcher_kwargs: Any
@@ -165,6 +190,13 @@ class ForecastProductService:
         candidates = list(primary_candidates)
         latitude = getattr(location, "latitude", None)
         longitude = getattr(location, "longitude", None)
+        location_key = self._location_cache_key(location)
+        if self._cache.has_key(location_key):
+            cached_station = self._cache.get(location_key)
+            if isinstance(cached_station, str) and cached_station:
+                product = await self.get_daily_climate_report(cached_station, **fetcher_kwargs)
+                if product is not None:
+                    return product
         if isinstance(latitude, int | float) and isinstance(longitude, int | float):
             try:
                 for station in await self._observation_station_fetcher(latitude, longitude):
@@ -174,10 +206,21 @@ class ForecastProductService:
             except Exception as exc:  # noqa: BLE001
                 logger.debug("Daily climate observation-station lookup failed: %s", exc)
 
+        try:
+            cli_locations = await self._get_daily_climate_locations()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Daily climate location-index lookup failed: %s", exc)
+            cli_locations = set()
+        if cli_locations:
+            indexed_candidates = [station for station in candidates if station in cli_locations]
+            if indexed_candidates:
+                candidates = indexed_candidates
+
         for station in candidates:
             product = await self.get_daily_climate_report(station, **fetcher_kwargs)
             if product is not None:
                 ttl = self._TTLS.get("CLI", 3600)
+                self._cache.set(location_key, station, ttl=86400)
                 for primary_station in primary_candidates:
                     key = self._iem_cache_key("CLI", primary_station, "latest")
                     self._cache.set(key, product, ttl=ttl)

--- a/src/accessiweather/ui/dialogs/forecast_products_dialog.py
+++ b/src/accessiweather/ui/dialogs/forecast_products_dialog.py
@@ -65,6 +65,7 @@ class ForecastProductsDialog(wx.Dialog):
         TextProductTab("AFD", "Area Forecast Discussion", "current", requires_cwa=True),
         TextProductTab("HWO", "Hazardous Weather Outlook", "current", requires_cwa=True),
         TextProductTab("SPS", "Special Weather Statement", "current", requires_cwa=True),
+        TextProductTab("CLI", "Daily Climate Report", "daily_climate"),
         TextProductTab("SPC_OUTLOOK", "SPC Outlook (Storm Prediction Center)", "spc_outlook"),
         TextProductTab("SPC_MCD", "SPC MCD (Mesoscale Discussion)", "spc_mcd"),
         TextProductTab(
@@ -305,6 +306,10 @@ class ForecastProductsDialog(wx.Dialog):
                 return await self._service.get(cast(Any, tab.product_type), str(cwa_office))
             if tab.loader_kind == "nws_history":
                 return await self._service.get_history(tab.product_type, str(cwa_office), limit=1)
+            if tab.loader_kind == "daily_climate":
+                product = await self._service.get_daily_climate_report_for_location(self._location)
+                self._check_daily_climate_notification(product)
+                return product
             if latitude is None or longitude is None:
                 return None
             if tab.loader_kind == "spc_outlook":
@@ -359,6 +364,39 @@ class ForecastProductsDialog(wx.Dialog):
             return None
 
         return _loader
+
+    def _check_daily_climate_notification(self, product: TextProduct | None) -> None:
+        """Pipe loaded CLI reports through the opt-in event notification path."""
+        if product is None or self._app is None:
+            return
+        try:
+            app = cast(Any, self._app)
+            settings = app.config_manager.get_settings()
+            if not getattr(settings, "notify_daily_climate_report_update", False):
+                return
+            manager_getter = getattr(self.GetParent(), "_get_notification_event_manager", None)
+            manager = manager_getter() if callable(manager_getter) else None
+            if manager is None:
+                return
+            event = cast(Any, manager).check_daily_climate_report(
+                product,
+                settings,
+                self._location.name,
+            )
+            if event is None:
+                return
+            notifier = getattr(app, "notifier", None)
+            if notifier is None:
+                return
+            notifier.send_notification(
+                title=event.title,
+                message=event.message,
+                timeout=10,
+                sound_event=event.sound_event,
+                play_sound=bool(getattr(settings, "sound_enabled", False)),
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("Daily climate report notification check skipped", exc_info=True)
 
     def _make_advanced_lookup_opener(self, product_type: str):
         """Bind an advanced lookup opener for ``product_type``."""

--- a/src/accessiweather/ui/dialogs/forecast_products_dialog.py
+++ b/src/accessiweather/ui/dialogs/forecast_products_dialog.py
@@ -181,7 +181,7 @@ class ForecastProductsDialog(wx.Dialog):
 
             loader = _override_loader
 
-        panel_cwa = cwa_office if tab.requires_cwa else "IEM"
+        panel_cwa = cwa_office if tab.requires_cwa or tab.loader_kind == "daily_climate" else "IEM"
         panel = ForecastProductPanel(
             parent=self.notebook,
             product_type=tab.product_type,

--- a/src/accessiweather/ui/dialogs/forecast_products_dialog.py
+++ b/src/accessiweather/ui/dialogs/forecast_products_dialog.py
@@ -139,7 +139,7 @@ class ForecastProductsDialog(wx.Dialog):
                 pending_iem_tabs.append(tab)
                 continue
             is_first_tab = len(self.panels) == 0
-            self._add_tab_panel(tab, autoload=is_first_tab)
+            self._add_tab_panel(tab, autoload=self._should_autoload_tab(tab, is_first_tab))
         self._pending_iem_tabs = tuple(pending_iem_tabs)
 
         main_sizer.Add(self.notebook, 1, wx.ALL | wx.EXPAND, 8)
@@ -160,6 +160,11 @@ class ForecastProductsDialog(wx.Dialog):
         main_sizer.Add(button_sizer, 0, wx.ALL | wx.EXPAND, 8)
 
         self.SetSizer(main_sizer)
+
+    @staticmethod
+    def _should_autoload_tab(tab: TextProductTab, is_first_tab: bool) -> bool:
+        """Return whether a tab should begin loading when the dialog opens."""
+        return is_first_tab or tab.loader_kind == "daily_climate"
 
     def _add_tab_panel(
         self,

--- a/src/accessiweather/ui/dialogs/settings_tabs/notifications.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/notifications.py
@@ -136,6 +136,16 @@ class NotificationsTab:
             wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
             10,
         )
+        controls["notify_daily_climate_report_update"] = wx.CheckBox(
+            panel,
+            label="Notify when a Daily Climate Report changes (NWS US only)",
+        )
+        event_section.Add(
+            controls["notify_daily_climate_report_update"],
+            0,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
+            10,
+        )
         controls["notify_hwo_update"] = wx.CheckBox(
             panel,
             label="Notify on Hazardous Weather Outlook updates",
@@ -302,6 +312,9 @@ class NotificationsTab:
         controls["notify_discussion_update"].SetValue(
             getattr(settings, "notify_discussion_update", True)
         )
+        controls["notify_daily_climate_report_update"].SetValue(
+            getattr(settings, "notify_daily_climate_report_update", False)
+        )
         controls["notify_hwo_update"].SetValue(getattr(settings, "notify_hwo_update", True))
         controls["notify_sps_issued"].SetValue(getattr(settings, "notify_sps_issued", True))
         controls["notify_severe_risk_change"].SetValue(
@@ -344,6 +357,9 @@ class NotificationsTab:
             "alert_freshness_window_minutes": controls["freshness_window"].GetValue(),
             "alert_max_notifications_per_hour": controls["max_notifications"].GetValue(),
             "notify_discussion_update": controls["notify_discussion_update"].GetValue(),
+            "notify_daily_climate_report_update": controls[
+                "notify_daily_climate_report_update"
+            ].GetValue(),
             "notify_hwo_update": controls["notify_hwo_update"].GetValue(),
             "notify_sps_issued": controls["notify_sps_issued"].GetValue(),
             "notify_severe_risk_change": controls["notify_severe_risk_change"].GetValue(),
@@ -381,6 +397,7 @@ class NotificationsTab:
             "notify_unknown": "Uncategorized alerts",
             "immediate_alert_details_popups": "Open alert details immediately while AccessiWeather is running",
             "notify_discussion_update": "Notify when the Area Forecast Discussion changes",
+            "notify_daily_climate_report_update": ("Notify when a Daily Climate Report changes"),
             "notify_hwo_update": "Notify on Hazardous Weather Outlook updates",
             "notify_sps_issued": "Notify on Special Weather Statement (informational)",
             "notify_severe_risk_change": "Notify when severe weather risk changes",

--- a/src/accessiweather/ui/main_window_notification_events.py
+++ b/src/accessiweather/ui/main_window_notification_events.py
@@ -214,6 +214,56 @@ def _check_sps_from_cache(
         logger.debug("[events] SPS check skipped: %s", e)
 
 
+def _check_daily_climate_from_cache(
+    window: MainWindow,
+    manager: NotificationEventManager,
+    location,
+    settings,
+) -> None:
+    """Feed a cache-warm Daily Climate Report into the opt-in update check."""
+    try:
+        if getattr(settings, "notify_daily_climate_report_update", False) is not True:
+            return
+        service = getattr(window, "_forecast_product_service", None)
+        if service is None:
+            getter = getattr(window, "_get_forecast_product_service", None)
+            if getter is None:
+                return
+            service = getter()
+        cache = getattr(service, "_cache", None)
+        if cache is None:
+            return
+        candidates_getter = getattr(service, "daily_climate_station_candidates", None)
+        if not callable(candidates_getter):
+            return
+        for station in candidates_getter(location):
+            key = f"iem_text_product:CLI:{station}:latest"
+            if not cache.has_key(key):
+                continue
+            product = cache.get(key)
+            if product is None:
+                continue
+            event = manager.check_daily_climate_report(product, settings, location.name)
+            if event is None:
+                return
+            notifier = getattr(window.app, "notifier", None) or get_fallback_notifier(window)
+            _log_reviewable_event_text(window, event.title, event.message)
+            notifier.send_notification(
+                title=event.title,
+                message=event.message,
+                timeout=10,
+                sound_event=event.sound_event,
+                play_sound=bool(getattr(settings, "sound_enabled", False)),
+                activation_arguments=serialize_activation_request(
+                    NotificationActivationRequest(kind="generic_fallback")
+                ),
+            )
+            logger.info("[events] Sent daily_climate_report_update notification for %s", station)
+            return
+    except Exception as e:  # noqa: BLE001
+        logger.debug("[events] Daily Climate Report check skipped: %s", e)
+
+
 def _filter_sps_products_for_location(products: list, location) -> list:
     """
     Keep only SPS products whose UGC zones include the saved location zones.
@@ -393,10 +443,12 @@ def process_notification_events(window: MainWindow, weather_data) -> None:
             and not getattr(settings, "notify_precipitation_likelihood", False)
             and not getattr(settings, "notify_hwo_update", True)
             and not getattr(settings, "notify_sps_issued", True)
+            and not getattr(settings, "notify_daily_climate_report_update", False)
         ):
             logger.debug(
                 "[events] _process_notification_events: discussion=%s severe_risk=%s "
-                "minutely_start=%s minutely_stop=%s likelihood=%s hwo=%s sps=%s disabled -- skipping",
+                "minutely_start=%s minutely_stop=%s likelihood=%s hwo=%s sps=%s cli=%s "
+                "disabled -- skipping",
                 settings.notify_discussion_update,
                 settings.notify_severe_risk_change,
                 settings.notify_minutely_precipitation_start,
@@ -404,6 +456,7 @@ def process_notification_events(window: MainWindow, weather_data) -> None:
                 getattr(settings, "notify_precipitation_likelihood", False),
                 getattr(settings, "notify_hwo_update", True),
                 getattr(settings, "notify_sps_issued", True),
+                getattr(settings, "notify_daily_climate_report_update", False),
             )
             return
 
@@ -436,6 +489,7 @@ def process_notification_events(window: MainWindow, weather_data) -> None:
         # Dedupes against currently-cached active alerts for this location so
         # event-style SPS (already on /alerts/active) don't double-notify.
         _check_sps_from_cache(window, event_manager, location, settings)
+        _check_daily_climate_from_cache(window, event_manager, location, settings)
 
         logger.debug(
             "[events] check_for_events returned %d event(s) for location %r",

--- a/src/accessiweather/ui/main_window_refresh.py
+++ b/src/accessiweather/ui/main_window_refresh.py
@@ -143,7 +143,7 @@ class MainWindowRefreshMixin:
 
     async def _pre_warm_products_for_location(self, location: Location) -> None:
         """
-        Pre-warm AFD/HWO/SPS caches for a single location.
+        Pre-warm AFD/HWO/SPS/CLI caches for a single location.
 
         Non-US locations and US locations without a populated ``cwa_office``
         are skipped. Each product fetch is wrapped in its own try/except so
@@ -183,6 +183,21 @@ class MainWindowRefreshMixin:
                     location.name,
                     exc_info=True,
                 )
+
+        try:
+            await service.get_daily_climate_report_for_location(location)
+        except TextProductFetchError:
+            logger.debug(
+                "Pre-warm daily climate report for %s (%s) failed",
+                location.name,
+                location.cwa_office,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "Unexpected pre-warm failure for daily climate report at %s",
+                location.name,
+                exc_info=True,
+            )
 
     def _on_weather_data_received(self, weather_data, *, play_refresh_sound: bool = True) -> None:
         """Handle received weather data (called on main thread)."""

--- a/src/accessiweather/ui/main_window_refresh.py
+++ b/src/accessiweather/ui/main_window_refresh.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from .main_window_shared import *  # noqa: F403
 
 
@@ -166,7 +168,7 @@ class MainWindowRefreshMixin:
             logger.debug("ForecastProductService unavailable for pre-warm", exc_info=True)
             return
 
-        for product_type in ("AFD", "HWO", "SPS"):
+        async def _pre_warm_text_product(product_type: str) -> None:
             try:
                 await service.get(product_type, location.cwa_office)
             except TextProductFetchError:
@@ -184,20 +186,26 @@ class MainWindowRefreshMixin:
                     exc_info=True,
                 )
 
-        try:
-            await service.get_daily_climate_report_for_location(location)
-        except TextProductFetchError:
-            logger.debug(
-                "Pre-warm daily climate report for %s (%s) failed",
-                location.name,
-                location.cwa_office,
-            )
-        except Exception:  # noqa: BLE001
-            logger.debug(
-                "Unexpected pre-warm failure for daily climate report at %s",
-                location.name,
-                exc_info=True,
-            )
+        async def _pre_warm_daily_climate() -> None:
+            try:
+                await service.get_daily_climate_report_for_location(location)
+            except TextProductFetchError:
+                logger.debug(
+                    "Pre-warm daily climate report for %s (%s) failed",
+                    location.name,
+                    location.cwa_office,
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "Unexpected pre-warm failure for daily climate report at %s",
+                    location.name,
+                    exc_info=True,
+                )
+
+        await asyncio.gather(
+            *(_pre_warm_text_product(product_type) for product_type in ("AFD", "HWO", "SPS")),
+            _pre_warm_daily_climate(),
+        )
 
     def _on_weather_data_received(self, weather_data, *, play_refresh_sound: bool = True) -> None:
         """Handle received weather data (called on main thread)."""

--- a/src/accessiweather/weather_client_nws.py
+++ b/src/accessiweather/weather_client_nws.py
@@ -31,6 +31,7 @@ from .weather_client_nws_current import (
 )
 from .weather_client_nws_forecast import (
     TextProductFetchError,
+    get_nws_daily_climate_report,
     get_nws_discussion,
     get_nws_discussion_only,
     get_nws_forecast_and_discussion,

--- a/src/accessiweather/weather_client_nws.py
+++ b/src/accessiweather/weather_client_nws.py
@@ -35,6 +35,7 @@ from .weather_client_nws_forecast import (
     get_nws_discussion,
     get_nws_discussion_only,
     get_nws_forecast_and_discussion,
+    get_nws_observation_station_ids_for_point,
     get_nws_text_product,
     get_nws_text_product_history,
 )

--- a/src/accessiweather/weather_client_nws.py
+++ b/src/accessiweather/weather_client_nws.py
@@ -31,6 +31,7 @@ from .weather_client_nws_current import (
 )
 from .weather_client_nws_forecast import (
     TextProductFetchError,
+    get_nws_daily_climate_locations,
     get_nws_daily_climate_report,
     get_nws_discussion,
     get_nws_discussion_only,

--- a/src/accessiweather/weather_client_nws_forecast.py
+++ b/src/accessiweather/weather_client_nws_forecast.py
@@ -422,6 +422,32 @@ async def get_nws_text_product_history(
         return await _run(new_client)
 
 
+async def get_nws_daily_climate_report(
+    station_id: str | None,
+    *,
+    nws_base_url: str = "https://api.weather.gov",
+    client: httpx.AsyncClient | None = None,
+    timeout: float = 10.0,
+    user_agent: str = "AccessiWeather (github.com/orinks/accessiweather)",
+) -> TextProduct | None:
+    """Fetch the latest official NWS daily climate report for a climate station."""
+    station = (station_id or "").strip().upper()
+    if station.startswith("K") and len(station) == 4:
+        station = station[1:]
+    if not station:
+        return None
+    products = await get_nws_text_product_history(
+        "CLI",
+        station,
+        nws_base_url=nws_base_url,
+        client=client,
+        timeout=timeout,
+        user_agent=user_agent,
+        limit=1,
+    )
+    return products[0] if products else None
+
+
 async def get_nws_discussion(
     client: httpx.AsyncClient,
     headers: dict[str, str],

--- a/src/accessiweather/weather_client_nws_forecast.py
+++ b/src/accessiweather/weather_client_nws_forecast.py
@@ -448,6 +448,36 @@ async def get_nws_daily_climate_report(
     return products[0] if products else None
 
 
+async def get_nws_daily_climate_locations(
+    *,
+    nws_base_url: str = "https://api.weather.gov",
+    client: httpx.AsyncClient | None = None,
+    timeout: float = 10.0,
+    user_agent: str = "AccessiWeather (github.com/orinks/accessiweather)",
+) -> set[str]:
+    """Fetch NWS location identifiers that currently support CLI products."""
+    headers = {"User-Agent": user_agent}
+    locations_url = f"{nws_base_url}/products/types/CLI/locations"
+
+    async def _run(http_client: httpx.AsyncClient) -> set[str]:
+        try:
+            response = await _client_get(http_client, locations_url, headers=headers)
+            if response.status_code != 200:
+                return set()
+            locations = response.json().get("locations") or {}
+        except (httpx.TimeoutException, httpx.TransportError, httpx.RequestError, ValueError):
+            return set()
+        if not isinstance(locations, dict):
+            return set()
+        return {str(station).strip().upper() for station in locations if str(station).strip()}
+
+    if client is not None:
+        return await _run(client)
+
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as new_client:
+        return await _run(new_client)
+
+
 async def get_nws_observation_station_ids_for_point(
     latitude: float,
     longitude: float,

--- a/src/accessiweather/weather_client_nws_forecast.py
+++ b/src/accessiweather/weather_client_nws_forecast.py
@@ -448,6 +448,53 @@ async def get_nws_daily_climate_report(
     return products[0] if products else None
 
 
+async def get_nws_observation_station_ids_for_point(
+    latitude: float,
+    longitude: float,
+    *,
+    nws_base_url: str = "https://api.weather.gov",
+    client: httpx.AsyncClient | None = None,
+    timeout: float = 10.0,
+    user_agent: str = "AccessiWeather (github.com/orinks/accessiweather)",
+    limit: int = 12,
+) -> list[str]:
+    """Fetch nearby NWS observation station identifiers for a point."""
+    headers = {"User-Agent": user_agent}
+    point_url = f"{nws_base_url}/points/{latitude:.4f},{longitude:.4f}"
+
+    async def _run(http_client: httpx.AsyncClient) -> list[str]:
+        try:
+            point_response = await _client_get(http_client, point_url, headers=headers)
+            if point_response.status_code != 200:
+                return []
+            stations_url = point_response.json().get("properties", {}).get("observationStations")
+            if not isinstance(stations_url, str) or not stations_url:
+                return []
+            stations_response = await _client_get(http_client, stations_url, headers=headers)
+            if stations_response.status_code != 200:
+                return []
+        except (httpx.TimeoutException, httpx.TransportError, httpx.RequestError, ValueError):
+            return []
+
+        station_urls = stations_response.json().get("observationStations") or []
+        candidates: list[str] = []
+        for station_url in station_urls:
+            if not isinstance(station_url, str):
+                continue
+            station_id = station_url.rstrip("/").rsplit("/", 1)[-1].strip().upper()
+            if station_id and station_id not in candidates:
+                candidates.append(station_id)
+            if len(candidates) >= limit:
+                break
+        return candidates
+
+    if client is not None:
+        return await _run(client)
+
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as new_client:
+        return await _run(new_client)
+
+
 async def get_nws_discussion(
     client: httpx.AsyncClient,
     headers: dict[str, str],

--- a/tests/gui/test_forecast_products_dialog.py
+++ b/tests/gui/test_forecast_products_dialog.py
@@ -280,8 +280,9 @@ class TestForecastProductsDialog:
         )
 
         types = [entry["product_type"] for entry in panel_factory]
-        assert types == ["AFD", "HWO", "SPS"]
-        assert len(dlg.panels) == 3
+        assert types == ["AFD", "HWO", "SPS", "CLI"]
+        assert dlg.notebook.AddPage.call_args_list[3].args[1] == "Daily Climate Report"
+        assert len(dlg.panels) == 4
 
         # Each panel got wired to the same service + explainer.
         for entry in panel_factory:

--- a/tests/gui/test_forecast_products_dialog.py
+++ b/tests/gui/test_forecast_products_dialog.py
@@ -290,7 +290,9 @@ class TestForecastProductsDialog:
             assert entry["cwa_office"] == "RAH"
             assert entry["location_name"] == "Raleigh, NC"
         assert panel_factory[0]["autoload"] is True
-        assert all(entry["autoload"] is False for entry in panel_factory[1:])
+        assert panel_factory[1]["autoload"] is False
+        assert panel_factory[2]["autoload"] is False
+        assert panel_factory[3]["autoload"] is True
 
     def test_loader_invokes_service_get(self, notebook_factory, panel_factory, sample_us_location):
         """Each panel's bound loader calls service.get(product_type, cwa_office)."""

--- a/tests/gui/test_forecast_products_dialog.py
+++ b/tests/gui/test_forecast_products_dialog.py
@@ -430,7 +430,7 @@ class TestForecastProductsDialog:
         )
 
         openers = [entry["advanced_lookup_opener"] for entry in panel_factory]
-        assert len(openers) == 3
+        assert len(openers) == 4
         for opener in openers:
             assert callable(opener)
 

--- a/tests/test_daily_climate_reports.py
+++ b/tests/test_daily_climate_reports.py
@@ -45,6 +45,7 @@ async def test_daily_climate_for_location_falls_back_to_observation_stations():
         Cache(),
         daily_climate_fetcher=fetcher,
         observation_station_fetcher=station_fetcher,
+        daily_climate_location_fetcher=AsyncMock(return_value=set()),
     )
     location = Location(
         name="Lumberton, NJ",
@@ -61,6 +62,69 @@ async def test_daily_climate_for_location_falls_back_to_observation_stations():
     assert fetcher.await_args_list == [call("DIX"), call("PHI"), call("VAY"), call("TTN")]
     station_fetcher.assert_awaited_once_with(39.965, -74.805)
     assert service._cache.get("iem_text_product:CLI:DIX:latest") is product
+
+
+@pytest.mark.asyncio
+async def test_daily_climate_for_location_uses_cli_location_index_to_skip_dead_candidates():
+    issued = datetime(2026, 5, 23, 5, 53, tzinfo=UTC)
+    product = _climate_product("cli-ttn", "CLIMATE REPORT FOR TRENTON", issued)
+    fetcher = AsyncMock(return_value=product)
+    station_fetcher = AsyncMock(return_value=["KVAY", "KWRI", "KPNE", "KTTN", "KPHL"])
+    cli_location_fetcher = AsyncMock(return_value={"TTN", "PHL", "ACY"})
+    service = ForecastProductService(
+        Cache(),
+        daily_climate_fetcher=fetcher,
+        observation_station_fetcher=station_fetcher,
+        daily_climate_location_fetcher=cli_location_fetcher,
+    )
+    location = Location(
+        name="Lumberton, NJ",
+        latitude=39.965,
+        longitude=-74.805,
+        country_code="US",
+        cwa_office="PHI",
+        radar_station="KDIX",
+    )
+
+    result = await service.get_daily_climate_report_for_location(location)
+
+    assert result is product
+    fetcher.assert_awaited_once_with("TTN")
+    station_fetcher.assert_awaited_once_with(39.965, -74.805)
+    cli_location_fetcher.assert_awaited_once()
+    assert service._cache.get("iem_text_product:CLI:DIX:latest") is product
+
+
+@pytest.mark.asyncio
+async def test_daily_climate_for_location_caches_resolved_cli_station():
+    issued = datetime(2026, 5, 23, 5, 53, tzinfo=UTC)
+    product = _climate_product("cli-ttn", "CLIMATE REPORT FOR TRENTON", issued)
+    fetcher = AsyncMock(return_value=product)
+    station_fetcher = AsyncMock(return_value=["KTTN", "KPHL"])
+    cli_location_fetcher = AsyncMock(return_value={"TTN", "PHL"})
+    service = ForecastProductService(
+        Cache(),
+        daily_climate_fetcher=fetcher,
+        observation_station_fetcher=station_fetcher,
+        daily_climate_location_fetcher=cli_location_fetcher,
+    )
+    location = Location(
+        name="Lumberton, NJ",
+        latitude=39.965,
+        longitude=-74.805,
+        country_code="US",
+        cwa_office="PHI",
+        radar_station="KDIX",
+    )
+
+    first = await service.get_daily_climate_report_for_location(location)
+    second = await service.get_daily_climate_report_for_location(location)
+
+    assert first is product
+    assert second is product
+    fetcher.assert_awaited_once_with("TTN")
+    station_fetcher.assert_awaited_once()
+    cli_location_fetcher.assert_awaited_once()
 
 
 def test_location_daily_climate_station_candidates_prefer_radar_then_office():

--- a/tests/test_daily_climate_reports.py
+++ b/tests/test_daily_climate_reports.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, call
 
 import pytest
 
@@ -33,6 +33,34 @@ async def test_forecast_product_service_caches_daily_climate_by_station():
 
     assert first is second
     fetcher.assert_awaited_once_with("RDU")
+
+
+@pytest.mark.asyncio
+async def test_daily_climate_for_location_falls_back_to_observation_stations():
+    issued = datetime(2026, 5, 23, 5, 53, tzinfo=UTC)
+    product = _climate_product("cli-ttn", "CLIMATE REPORT FOR TRENTON", issued)
+    fetcher = AsyncMock(side_effect=[None, None, None, product])
+    station_fetcher = AsyncMock(return_value=["KVAY", "KTTN", "KPHL"])
+    service = ForecastProductService(
+        Cache(),
+        daily_climate_fetcher=fetcher,
+        observation_station_fetcher=station_fetcher,
+    )
+    location = Location(
+        name="Lumberton, NJ",
+        latitude=39.965,
+        longitude=-74.805,
+        country_code="US",
+        cwa_office="PHI",
+        radar_station="KDIX",
+    )
+
+    result = await service.get_daily_climate_report_for_location(location)
+
+    assert result is product
+    assert fetcher.await_args_list == [call("DIX"), call("PHI"), call("VAY"), call("TTN")]
+    station_fetcher.assert_awaited_once_with(39.965, -74.805)
+    assert service._cache.get("iem_text_product:CLI:DIX:latest") is product
 
 
 def test_location_daily_climate_station_candidates_prefer_radar_then_office():

--- a/tests/test_daily_climate_reports.py
+++ b/tests/test_daily_climate_reports.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from accessiweather.cache import Cache
+from accessiweather.models import AppSettings, Location, TextProduct
+from accessiweather.notifications.notification_event_manager import NotificationEventManager
+from accessiweather.services.forecast_product_service import ForecastProductService
+
+
+def _climate_product(product_id: str, text: str, issued: datetime) -> TextProduct:
+    return TextProduct(
+        product_type="CLI",
+        product_id=product_id,
+        cwa_office="RDU",
+        issuance_time=issued,
+        product_text=text,
+        headline="Daily Climate Report",
+    )
+
+
+@pytest.mark.asyncio
+async def test_forecast_product_service_caches_daily_climate_by_station():
+    issued = datetime(2026, 5, 22, 20, 54, tzinfo=UTC)
+    fetcher = AsyncMock(return_value=_climate_product("cli-rdu", "CLIMATE REPORT", issued))
+    service = ForecastProductService(Cache(), daily_climate_fetcher=fetcher)
+
+    first = await service.get_daily_climate_report("KRDU")
+    second = await service.get_daily_climate_report("KRDU")
+
+    assert first is second
+    fetcher.assert_awaited_once_with("RDU")
+
+
+def test_location_daily_climate_station_candidates_prefer_radar_then_office():
+    location = Location(
+        name="Raleigh",
+        latitude=35.7796,
+        longitude=-78.6382,
+        country_code="US",
+        cwa_office="RAH",
+        radar_station="KRDU",
+    )
+
+    assert ForecastProductService.daily_climate_station_candidates(location) == ["RDU", "RAH"]
+
+
+def test_daily_climate_update_notification_is_baselined_then_summarized():
+    manager = NotificationEventManager(state_file=None)
+    settings = AppSettings()
+    settings.notify_daily_climate_report_update = True
+    first_time = datetime(2026, 5, 22, 20, 54, tzinfo=UTC)
+
+    first = _climate_product(
+        "cli-rdu-1",
+        "CLIMATE REPORT\nMAXIMUM         65\nPRECIPITATION   0.25",
+        first_time,
+    )
+    second = _climate_product(
+        "cli-rdu-2",
+        "CLIMATE REPORT\nMAXIMUM         70\nPRECIPITATION   0.40",
+        first_time + timedelta(hours=24),
+    )
+
+    assert manager.check_daily_climate_report(first, settings, "Raleigh") is None
+    event = manager.check_daily_climate_report(second, settings, "Raleigh")
+
+    assert event is not None
+    assert event.event_type == "daily_climate_report_update"
+    assert event.sound_event == "discussion_update"
+    assert "Daily Climate Report" in event.title
+    assert "MAXIMUM" in event.message
+    assert "PRECIPITATION" in event.message

--- a/tests/test_forecast_products_dialog_availability.py
+++ b/tests/test_forecast_products_dialog_availability.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from accessiweather.ui.dialogs.forecast_products_dialog import ForecastProductsDialog
+from accessiweather.ui.dialogs.forecast_products_dialog import (
+    ForecastProductsDialog,
+    TextProductTab,
+)
 
 
 def _dialog_stub(product_types: list[str]):
@@ -38,3 +41,15 @@ def test_available_optional_product_keeps_tab():
 
     dlg.notebook.DeletePage.assert_not_called()
     assert [panel.product_type for panel in dlg.panels] == ["AFD", "HWO", "SPS"]
+
+
+def test_daily_climate_autoloads_when_dialog_opens():
+    assert ForecastProductsDialog._should_autoload_tab(
+        TextProductTab("AFD", "Area Forecast Discussion", "current"), is_first_tab=True
+    )
+    assert ForecastProductsDialog._should_autoload_tab(
+        TextProductTab("CLI", "Daily Climate Report", "daily_climate"), is_first_tab=False
+    )
+    assert not ForecastProductsDialog._should_autoload_tab(
+        TextProductTab("HWO", "Hazardous Weather Outlook", "current"), is_first_tab=False
+    )

--- a/tests/test_main_window_product_prewarm.py
+++ b/tests/test_main_window_product_prewarm.py
@@ -75,6 +75,38 @@ def test_pre_warm_fetches_text_products_and_daily_climate_for_us_location():
     service.get_daily_climate_report_for_location.assert_awaited_once()
 
 
+def test_pre_warm_starts_daily_climate_without_waiting_for_other_products():
+    """CLI pre-warm should begin beside AFD/HWO/SPS so the tab opens warm."""
+    started: list[str] = []
+    release_products = asyncio.Event()
+
+    async def _get(product_type: str, _cwa: str, **_kw):
+        started.append(product_type)
+        await release_products.wait()
+
+    async def _get_daily_climate(_location):
+        started.append("CLI")
+
+    service = MagicMock()
+    service.get = AsyncMock(side_effect=_get)
+    service.get_daily_climate_report_for_location = AsyncMock(side_effect=_get_daily_climate)
+
+    async def _run_prewarm():
+        win = _make_window(service)
+        task = asyncio.create_task(
+            win._pre_warm_products_for_location(_us_location("Philadelphia"))
+        )
+        for _ in range(5):
+            await asyncio.sleep(0)
+            if "CLI" in started:
+                break
+        assert "CLI" in started
+        release_products.set()
+        await task
+
+    asyncio.run(_run_prewarm())
+
+
 def test_pre_warm_skips_non_us_location():
     """Non-US locations never hit the service."""
     service = MagicMock()

--- a/tests/test_main_window_product_prewarm.py
+++ b/tests/test_main_window_product_prewarm.py
@@ -60,10 +60,11 @@ def _run(coro):
     return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
 
 
-def test_pre_warm_fetches_three_products_for_us_location():
-    """Happy path: a single US location triggers three product fetches."""
+def test_pre_warm_fetches_text_products_and_daily_climate_for_us_location():
+    """Happy path: a single US location triggers text products and CLI fetches."""
     service = MagicMock()
     service.get = AsyncMock(return_value=None)
+    service.get_daily_climate_report_for_location = AsyncMock(return_value=None)
 
     win = _make_window(service)
     asyncio.run(win._pre_warm_products_for_location(_us_location("Philadelphia")))
@@ -71,28 +72,33 @@ def test_pre_warm_fetches_three_products_for_us_location():
     assert service.get.await_count == 3
     fetched_types = {call.args[0] for call in service.get.await_args_list}
     assert fetched_types == {"AFD", "HWO", "SPS"}
+    service.get_daily_climate_report_for_location.assert_awaited_once()
 
 
 def test_pre_warm_skips_non_us_location():
     """Non-US locations never hit the service."""
     service = MagicMock()
     service.get = AsyncMock(return_value=None)
+    service.get_daily_climate_report_for_location = AsyncMock(return_value=None)
 
     win = _make_window(service)
     asyncio.run(win._pre_warm_products_for_location(_non_us_location()))
 
     service.get.assert_not_awaited()
+    service.get_daily_climate_report_for_location.assert_not_awaited()
 
 
 def test_pre_warm_skips_us_location_without_cwa_office():
     """US location with ``cwa_office=None`` yields zero fetches."""
     service = MagicMock()
     service.get = AsyncMock(return_value=None)
+    service.get_daily_climate_report_for_location = AsyncMock(return_value=None)
 
     win = _make_window(service)
     asyncio.run(win._pre_warm_products_for_location(_us_location("Nowhere", cwa=None)))
 
     service.get.assert_not_awaited()
+    service.get_daily_climate_report_for_location.assert_not_awaited()
 
 
 def test_pre_warm_fetch_error_isolated_to_single_product():

--- a/tests/test_split_notification_timers.py
+++ b/tests/test_split_notification_timers.py
@@ -457,11 +457,37 @@ class TestNotificationEventHelpers:
         settings.notify_precipitation_likelihood = False
         settings.notify_hwo_update = False
         settings.notify_sps_issued = False
+        settings.notify_daily_climate_report_update = False
         win.app.config_manager.get_settings.return_value = settings
 
         win._process_notification_events(MagicMock())
 
         win.app.config_manager.get_current_location.assert_not_called()
+
+    def test_process_notification_events_runs_when_daily_climate_enabled(self):
+        win = self._make_window()
+        settings = MagicMock()
+        settings.notify_discussion_update = False
+        settings.notify_severe_risk_change = False
+        settings.notify_minutely_precipitation_start = False
+        settings.notify_minutely_precipitation_stop = False
+        settings.notify_precipitation_likelihood = False
+        settings.notify_hwo_update = False
+        settings.notify_sps_issued = False
+        settings.notify_daily_climate_report_update = True
+        settings.sound_enabled = False
+        win.app.config_manager.get_settings.return_value = settings
+        location = MagicMock()
+        location.name = "PHI"
+        win.app.config_manager.get_current_location.return_value = location
+        win._forecast_product_service = MagicMock()
+        win._forecast_product_service.get_daily_climate_report_for_location = AsyncMock(
+            return_value=None
+        )
+
+        win._process_notification_events(MagicMock())
+
+        win.app.config_manager.get_current_location.assert_called_once()
 
     def test_process_notification_events_uses_fallback_notifier(self):
         win = self._make_window()

--- a/tests/test_weather_client_nws_text_product.py
+++ b/tests/test_weather_client_nws_text_product.py
@@ -18,7 +18,10 @@ import pytest
 from accessiweather.models import TextProduct
 from accessiweather.weather_client_nws import (
     TextProductFetchError,
+    get_nws_daily_climate_locations,
+    get_nws_daily_climate_report,
     get_nws_discussion,
+    get_nws_observation_station_ids_for_point,
     get_nws_text_product,
     get_nws_text_product_history,
 )
@@ -250,8 +253,6 @@ class TestGetNwsDailyClimateReport:
             }
         )
 
-        from accessiweather.weather_client_nws import get_nws_daily_climate_report
-
         result = await get_nws_daily_climate_report("RDU", nws_base_url=NWS_BASE, client=client)
 
         assert isinstance(result, TextProduct)
@@ -260,6 +261,110 @@ class TestGetNwsDailyClimateReport:
         assert result.cwa_office == "RDU"
         assert result.issuance_time == datetime(2026, 5, 22, 20, 54, 0, tzinfo=UTC)
         assert "CLIMATE REPORT" in result.product_text
+
+    @pytest.mark.asyncio
+    async def test_daily_climate_report_normalizes_k_station_prefix(self):
+        client = _client_for(
+            {
+                f"{NWS_BASE}/products?location=TTN&type=CLI&limit=1": _resp({"@graph": []}),
+            }
+        )
+
+        result = await get_nws_daily_climate_report("KTTN", nws_base_url=NWS_BASE, client=client)
+
+        assert result is None
+        client.get.assert_called_once()
+        assert client.get.call_args.args[0] == f"{NWS_BASE}/products?location=TTN&type=CLI&limit=1"
+
+    @pytest.mark.asyncio
+    async def test_daily_climate_report_empty_station_skips_http(self):
+        client = MagicMock(spec=httpx.AsyncClient)
+
+        result = await get_nws_daily_climate_report("", nws_base_url=NWS_BASE, client=client)
+
+        assert result is None
+        client.get.assert_not_called()
+
+
+class TestGetNwsDailyClimateLocations:
+    @pytest.mark.asyncio
+    async def test_daily_climate_locations_returns_station_ids(self):
+        client = _client_for(
+            {
+                f"{NWS_BASE}/products/types/CLI/locations": _resp(
+                    {"locations": {"TTN": None, "phl": "Philadelphia", "": None}}
+                ),
+            }
+        )
+
+        result = await get_nws_daily_climate_locations(nws_base_url=NWS_BASE, client=client)
+
+        assert result == {"TTN", "PHL"}
+
+    @pytest.mark.asyncio
+    async def test_daily_climate_locations_non_200_returns_empty_set(self):
+        client = _client_for(
+            {f"{NWS_BASE}/products/types/CLI/locations": _resp({}, status_code=503)}
+        )
+
+        result = await get_nws_daily_climate_locations(nws_base_url=NWS_BASE, client=client)
+
+        assert result == set()
+
+    @pytest.mark.asyncio
+    async def test_daily_climate_locations_malformed_payload_returns_empty_set(self):
+        client = _client_for({f"{NWS_BASE}/products/types/CLI/locations": _resp({"locations": []})})
+
+        result = await get_nws_daily_climate_locations(nws_base_url=NWS_BASE, client=client)
+
+        assert result == set()
+
+
+class TestGetNwsObservationStationIdsForPoint:
+    @pytest.mark.asyncio
+    async def test_observation_station_ids_for_point_returns_limited_station_ids(self):
+        stations_url = f"{NWS_BASE}/gridpoints/PHI/62,81/stations"
+        client = _client_for(
+            {
+                f"{NWS_BASE}/points/39.9650,-74.8050": _resp(
+                    {"properties": {"observationStations": stations_url}}
+                ),
+                stations_url: _resp(
+                    {
+                        "observationStations": [
+                            f"{NWS_BASE}/stations/KVAY",
+                            f"{NWS_BASE}/stations/KTTN",
+                            f"{NWS_BASE}/stations/KTTN",
+                            123,
+                            f"{NWS_BASE}/stations/KPHL",
+                        ]
+                    }
+                ),
+            }
+        )
+
+        result = await get_nws_observation_station_ids_for_point(
+            39.965,
+            -74.805,
+            nws_base_url=NWS_BASE,
+            client=client,
+            limit=2,
+        )
+
+        assert result == ["KVAY", "KTTN"]
+
+    @pytest.mark.asyncio
+    async def test_observation_station_ids_for_point_missing_station_url_returns_empty_list(self):
+        client = _client_for({f"{NWS_BASE}/points/39.9650,-74.8050": _resp({"properties": {}})})
+
+        result = await get_nws_observation_station_ids_for_point(
+            39.965,
+            -74.805,
+            nws_base_url=NWS_BASE,
+            client=client,
+        )
+
+        assert result == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_weather_client_nws_text_product.py
+++ b/tests/test_weather_client_nws_text_product.py
@@ -227,6 +227,41 @@ class TestGetNwsTextProductHistory:
         assert result == []
 
 
+class TestGetNwsDailyClimateReport:
+    @pytest.mark.asyncio
+    async def test_daily_climate_report_uses_station_location(self):
+        graph = {
+            "@graph": [
+                {
+                    "id": "cli-rdu",
+                    "issuanceTime": "2026-05-22T20:54:00+00:00",
+                    "issuingOffice": "KRAH",
+                }
+            ]
+        }
+        product = {
+            "productText": "CLIMATE REPORT\n...THE RALEIGH NC CLIMATE SUMMARY...\n",
+            "issuanceTime": "2026-05-22T20:54:00+00:00",
+        }
+        client = _client_for(
+            {
+                f"{NWS_BASE}/products?location=RDU&type=CLI&limit=1": _resp(graph),
+                f"{NWS_BASE}/products/cli-rdu": _resp(product),
+            }
+        )
+
+        from accessiweather.weather_client_nws import get_nws_daily_climate_report
+
+        result = await get_nws_daily_climate_report("RDU", nws_base_url=NWS_BASE, client=client)
+
+        assert isinstance(result, TextProduct)
+        assert result.product_type == "CLI"
+        assert result.product_id == "cli-rdu"
+        assert result.cwa_office == "RDU"
+        assert result.issuance_time == datetime(2026, 5, 22, 20, 54, 0, tzinfo=UTC)
+        assert "CLIMATE REPORT" in result.product_text
+
+
 # ---------------------------------------------------------------------------
 # SPS — always returns a list, possibly empty, sorted newest-first
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds Daily Climate Report access in Forecaster Notes for supported US locations.
- Resolves the right CLI station from the official NWS CLI location index plus nearby observation stations, then caches the station choice so reports load quickly on repeat opens.
- Autoloads the Daily Climate tab alongside AFD and prewarms CLI reports with other text products to avoid the tab sitting on Loading.
- Adds opt-in update notifications with a short change summary when a newer report is loaded.

## Source decision
Live examples showed IEM AFOS plain text and direct NWS `/products` both return the official CLI report text. This PR uses direct NWS because it is authoritative, practical in the existing NWS text-product architecture, supports current/history lookup, and exposes `/products/types/CLI/locations` so AccessiWeather can avoid blind fallback probing. IEM remains available through Advanced Lookup for AFOS/PIL searches.

## Verification
- `pytest tests/test_forecast_products_dialog_availability.py tests/test_daily_climate_reports.py tests/test_main_window_product_prewarm.py tests/test_split_notification_timers.py tests/gui/test_forecast_products_dialog.py -q`
- `pytest tests/test_daily_climate_reports.py tests/test_main_window_product_prewarm.py tests/test_split_notification_timers.py tests/gui/test_forecast_products_dialog.py tests/test_weather_client_nws_text_product.py -q`
- `pytest -n auto -q`
- `ruff check .`