### PR TITLE
fix(notifications): suppress startup text product toasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Alert sounds and sound-pack creation now focus on alert severity instead of a long list of specific alert names, while existing packs can keep their older mappings.
 
 ### Fixed
+- Opening AccessiWeather no longer sends catch-up notifications for older Forecaster Notes updates; text-product notifications now start from the current session, and HWO/SPS checks run after their latest products are loaded.
 - Default soundpack now includes specific sounds for mapped weather alert types.
 - Pirate Weather minute-by-minute precipitation notifications now wait until start/stop changes are near-term and no longer count down repeatedly for the same rain event.
 - Saving Settings no longer waits on the Windows startup shortcut check unless you actually change the launch-at-startup checkbox.

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -99,6 +99,7 @@ class MainWindow(
         self.app = app
         self._escape_id = None
         self._fetch_generation = 0  # Tracks which fetch is current (prevents stale updates)
+        self._suppress_startup_text_product_notifications = True
         # Persistent map of alert_id -> lifecycle label ("New", "Updated", "Escalated", "Extended").
         # Updated on each successful weather fetch; cleared when the location changes.
         self._alert_lifecycle_labels: dict[str, str] = {}

--- a/src/accessiweather/ui/main_window_notification_events.py
+++ b/src/accessiweather/ui/main_window_notification_events.py
@@ -113,6 +113,8 @@ def _check_hwo_from_cache(
     manager: NotificationEventManager,
     location,
     settings,
+    *,
+    suppress_notification: bool = False,
 ) -> None:
     """Feed a cache-warm HWO product (if any) to the manager's HWO update check."""
     try:
@@ -138,7 +140,16 @@ def _check_hwo_from_cache(
             product = product[0] if product else None
         if product is None:
             return
-        manager._check_hwo_update(location, product, settings)
+        if not suppress_notification:
+            manager._check_hwo_update(location, product, settings)
+            return
+
+        dispatch = manager._dispatch_hwo_notification
+        try:
+            manager._dispatch_hwo_notification = lambda **_: None  # type: ignore[method-assign]
+            manager._check_hwo_update(location, product, settings)
+        finally:
+            manager._dispatch_hwo_notification = dispatch  # type: ignore[method-assign]
     except Exception as e:  # noqa: BLE001
         logger.debug("[events] HWO check skipped: %s", e)
 
@@ -179,6 +190,8 @@ def _check_sps_from_cache(
     manager: NotificationEventManager,
     location,
     settings,
+    *,
+    suppress_notification: bool = False,
 ) -> None:
     """Feed cache-warm SPS products (plus cached active alerts) into the check."""
     try:
@@ -209,7 +222,16 @@ def _check_sps_from_cache(
 
         products = _filter_sps_products_for_location(products, location)
         active_alerts = _active_alerts_for_current_location(window)
-        manager._check_sps_new(location, products, active_alerts, settings)
+        if not suppress_notification:
+            manager._check_sps_new(location, products, active_alerts, settings)
+            return
+
+        dispatch = manager._dispatch_sps_notification
+        try:
+            manager._dispatch_sps_notification = lambda **_: None  # type: ignore[method-assign]
+            manager._check_sps_new(location, products, active_alerts, settings)
+        finally:
+            manager._dispatch_sps_notification = dispatch  # type: ignore[method-assign]
     except Exception as e:  # noqa: BLE001
         logger.debug("[events] SPS check skipped: %s", e)
 
@@ -219,6 +241,8 @@ def _check_daily_climate_from_cache(
     manager: NotificationEventManager,
     location,
     settings,
+    *,
+    suppress_notification: bool = False,
 ) -> None:
     """Feed a cache-warm Daily Climate Report into the opt-in update check."""
     try:
@@ -245,6 +269,12 @@ def _check_daily_climate_from_cache(
                 continue
             event = manager.check_daily_climate_report(product, settings, location.name)
             if event is None:
+                return
+            if suppress_notification:
+                logger.info(
+                    "[events] Suppressed startup daily climate report notification; "
+                    "stored current report as baseline"
+                )
                 return
             notifier = getattr(window.app, "notifier", None) or get_fallback_notifier(window)
             _log_reviewable_event_text(window, event.title, event.message)
@@ -479,17 +509,51 @@ def process_notification_events(window: MainWindow, weather_data) -> None:
 
         event_manager = get_notification_event_manager(window)
         events = event_manager.check_for_events(weather_data, settings, location.name)
+        suppress_startup_text_products = getattr(
+            window, "_suppress_startup_text_product_notifications", False
+        )
+        if suppress_startup_text_products:
+            discussion_events = [
+                event for event in events if event.event_type == "discussion_update"
+            ]
+            if discussion_events:
+                events = [event for event in events if event.event_type != "discussion_update"]
+                logger.info(
+                    "[events] Suppressed %d startup discussion notification(s); "
+                    "stored current discussion as baseline",
+                    len(discussion_events),
+                )
 
         # Unit 10 — Hazardous Weather Outlook change detection. Pre-warm in
         # _pre_warm_products_for_location already populated the shared cache,
         # so a cache-hit lookup here is sync and cheap. A miss (e.g. non-US
         # location or failed pre-warm) silently no-ops.
-        _check_hwo_from_cache(window, event_manager, location, settings)
+        _check_hwo_from_cache(
+            window,
+            event_manager,
+            location,
+            settings,
+            suppress_notification=suppress_startup_text_products,
+        )
         # Unit 11 — informational Special Weather Statement notifications.
         # Dedupes against currently-cached active alerts for this location so
         # event-style SPS (already on /alerts/active) don't double-notify.
-        _check_sps_from_cache(window, event_manager, location, settings)
-        _check_daily_climate_from_cache(window, event_manager, location, settings)
+        _check_sps_from_cache(
+            window,
+            event_manager,
+            location,
+            settings,
+            suppress_notification=suppress_startup_text_products,
+        )
+        _check_daily_climate_from_cache(
+            window,
+            event_manager,
+            location,
+            settings,
+            suppress_notification=suppress_startup_text_products,
+        )
+        if suppress_startup_text_products:
+            window._suppress_startup_text_product_notifications = False
 
         logger.debug(
             "[events] check_for_events returned %d event(s) for location %r",

--- a/src/accessiweather/ui/main_window_refresh.py
+++ b/src/accessiweather/ui/main_window_refresh.py
@@ -82,13 +82,14 @@ class MainWindowRefreshMixin:
                 )
                 return
 
-            # Update UI on main thread
-            wx.CallAfter(self._on_weather_data_received, weather_data)
-
             # Pre-warm NWS text products (AFD/HWO/SPS) for the active location
             # so the Forecast Products dialog and Unit 10/11 notification
             # checks see fresh data without issuing an on-demand fetch.
             await self._pre_warm_products_for_location(location)
+
+            # Update UI on main thread after active-location text products are
+            # warm so HWO/SPS/CLI notification checks can read the cache.
+            wx.CallAfter(self._on_weather_data_received, weather_data)
 
             # Pre-warm cache for other locations in background (non-blocking)
             if not force_refresh:

--- a/tests/test_main_window_product_prewarm.py
+++ b/tests/test_main_window_product_prewarm.py
@@ -202,6 +202,39 @@ def _window_with_app(service: MagicMock, locations: list[Location]):
 
 
 @pytest.mark.asyncio
+async def test_fetch_weather_data_warms_active_products_before_ui_delivery():
+    """HWO/SPS notification checks need active text products cached before UI processing."""
+    from accessiweather.ui.main_window import MainWindow
+
+    with patch.object(MainWindow, "__init__", lambda self, *a, **kw: None):
+        win = MainWindow.__new__(MainWindow)
+
+    location = _us_location("Philadelphia")
+    weather_data = MagicMock()
+    order: list[str] = []
+
+    win.app = MagicMock()
+    win.app.config_manager.get_current_location.return_value = location
+    win.app.weather_client.get_weather_data = AsyncMock(return_value=weather_data)
+    win._fetch_generation = 1
+    win._pre_warm_products_for_location = AsyncMock(side_effect=lambda _loc: order.append("warm"))
+    win._pre_warm_other_locations = AsyncMock(side_effect=lambda _loc: order.append("others"))
+    win._on_weather_data_received = MagicMock()
+    win._on_weather_error = MagicMock()
+
+    def _call_after(callback, *args):
+        order.append("ui")
+        callback(*args)
+
+    with patch("accessiweather.ui.main_window_refresh.wx.CallAfter", side_effect=_call_after):
+        await win._fetch_weather_data(force_refresh=False, generation=1)
+
+    assert order == ["warm", "ui", "others"]
+    win._pre_warm_products_for_location.assert_awaited_once_with(location)
+    win._on_weather_data_received.assert_called_once_with(weather_data)
+
+
+@pytest.mark.asyncio
 async def test_pre_warm_other_locations_iterates_saved_us_locations():
     """With three saved US locations, the non-active two each get three fetches."""
     service = MagicMock()

--- a/tests/test_split_notification_timers.py
+++ b/tests/test_split_notification_timers.py
@@ -571,6 +571,146 @@ class TestNotificationEventHelpers:
             category="Updated discussion",
         )
 
+    def test_process_notification_events_suppresses_startup_discussion_toast(self):
+        win = self._make_window()
+        win._suppress_startup_text_product_notifications = True
+        settings = MagicMock()
+        settings.notify_discussion_update = True
+        settings.notify_severe_risk_change = False
+        settings.notify_minutely_precipitation_start = False
+        settings.notify_minutely_precipitation_stop = False
+        settings.sound_enabled = True
+        win.app.config_manager.get_settings.return_value = settings
+        location = MagicMock()
+        location.name = "PHI"
+        win.app.config_manager.get_current_location.return_value = location
+        win.app.notifier = MagicMock()
+
+        event = MagicMock()
+        event.event_type = "discussion_update"
+        event.title = "Updated discussion"
+        event.message = "Summary"
+        event.sound_event = "discussion_update"
+
+        with patch(
+            "accessiweather.ui.main_window_notification_events.NotificationEventManager"
+        ) as manager_cls:
+            manager_cls.return_value.check_for_events.return_value = [event]
+
+            win._process_notification_events(MagicMock())
+
+        win.app.notifier.send_notification.assert_not_called()
+        win.append_event_center_entry.assert_not_called()
+        assert win._suppress_startup_text_product_notifications is False
+
+    def test_startup_suppression_keeps_non_discussion_events(self):
+        win = self._make_window()
+        win._suppress_startup_text_product_notifications = True
+        settings = MagicMock()
+        settings.notify_discussion_update = True
+        settings.notify_severe_risk_change = True
+        settings.notify_minutely_precipitation_start = False
+        settings.notify_minutely_precipitation_stop = False
+        settings.sound_enabled = False
+        win.app.config_manager.get_settings.return_value = settings
+        location = MagicMock()
+        location.name = "PHI"
+        win.app.config_manager.get_current_location.return_value = location
+        win.app.notifier = MagicMock()
+        win.app.notifier.send_notification.return_value = True
+
+        discussion_event = MagicMock()
+        discussion_event.event_type = "discussion_update"
+        risk_event = MagicMock()
+        risk_event.event_type = "severe_risk_change"
+        risk_event.title = "Severe risk changed"
+        risk_event.message = "Risk increased"
+        risk_event.sound_event = "notify"
+
+        with patch(
+            "accessiweather.ui.main_window_notification_events.NotificationEventManager"
+        ) as manager_cls:
+            manager_cls.return_value.check_for_events.return_value = [
+                discussion_event,
+                risk_event,
+            ]
+
+            win._process_notification_events(MagicMock())
+
+        win.app.notifier.send_notification.assert_called_once_with(
+            title="Severe risk changed",
+            message="Risk increased",
+            timeout=10,
+            sound_event="notify",
+            play_sound=False,
+            activation_arguments="accessiweather-toast:kind=generic_fallback",
+        )
+        win.append_event_center_entry.assert_called_once_with(
+            "Risk increased",
+            category="Severe risk changed",
+        )
+        assert win._suppress_startup_text_product_notifications is False
+
+    def test_startup_suppression_applies_to_cached_text_product_checks(self):
+        win = self._make_window()
+        win._suppress_startup_text_product_notifications = True
+        settings = MagicMock()
+        settings.notify_discussion_update = False
+        settings.notify_severe_risk_change = False
+        settings.notify_minutely_precipitation_start = False
+        settings.notify_minutely_precipitation_stop = False
+        settings.notify_precipitation_likelihood = False
+        settings.notify_hwo_update = True
+        settings.notify_sps_issued = True
+        settings.notify_daily_climate_report_update = True
+        settings.sound_enabled = False
+        win.app.config_manager.get_settings.return_value = settings
+        location = MagicMock()
+        location.name = "PHI"
+        win.app.config_manager.get_current_location.return_value = location
+
+        with (
+            patch(
+                "accessiweather.ui.main_window_notification_events.NotificationEventManager"
+            ) as manager_cls,
+            patch(
+                "accessiweather.ui.main_window_notification_events._check_hwo_from_cache"
+            ) as hwo_check,
+            patch(
+                "accessiweather.ui.main_window_notification_events._check_sps_from_cache"
+            ) as sps_check,
+            patch(
+                "accessiweather.ui.main_window_notification_events._check_daily_climate_from_cache"
+            ) as climate_check,
+        ):
+            manager = manager_cls.return_value
+            manager.check_for_events.return_value = []
+
+            win._process_notification_events(MagicMock())
+
+        hwo_check.assert_called_once_with(
+            win,
+            manager,
+            location,
+            settings,
+            suppress_notification=True,
+        )
+        sps_check.assert_called_once_with(
+            win,
+            manager,
+            location,
+            settings,
+            suppress_notification=True,
+        )
+        climate_check.assert_called_once_with(
+            win,
+            manager,
+            location,
+            settings,
+            suppress_notification=True,
+        )
+        assert win._suppress_startup_text_product_notifications is False
+
 
 class TestSpsProductLocationFiltering:
     """SPS product notifications must honor the user's saved NWS zones."""


### PR DESCRIPTION
## Summary
- suppress startup-only text product notifications for AFD, HWO, SPS, and Daily Climate Report updates while preserving baselines
- warm active-location text products before event notification checks so HWO/SPS/CLI checks can see the cache
- add regression coverage for startup suppression and pre-warm ordering

## Tests
- pytest tests/test_split_notification_timers.py tests/test_notification_hwo_update.py tests/test_settings_notification_toggles.py -q
- pytest tests/test_main_window_product_prewarm.py tests/test_notification_hwo_update.py tests/test_split_notification_timers.py -q
- ruff check src/accessiweather/ui/main_window.py src/accessiweather/ui/main_window_notification_events.py tests/test_split_notification_timers.py
- ruff check src/accessiweather/ui/main_window_refresh.py tests/test_main_window_product_prewarm.py