### PR TITLE
Unify AI text-product prompting for all NWS products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Alert sounds and sound-pack creation now focus on alert severity instead of a long list of specific alert names, while existing packs can keep their older mappings.
 
 ### Fixed
+- Plain Language Summary now works for Daily Climate Reports and other Forecaster Notes text products, not just AFD, HWO, and SPS.
 - Weather Assistant now avoids a removed OpenRouter free model, so automatic free mode no longer fails with a 404 before answering.
 - Opening AccessiWeather no longer sends catch-up notifications for older Forecaster Notes updates; text-product notifications now start from the current session, and HWO/SPS checks run after their latest products are loaded.
 - Default soundpack now includes specific sounds for mapped weather alert types.

--- a/src/accessiweather/ai_explainer_models.py
+++ b/src/accessiweather/ai_explainer_models.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Literal
+from typing import Any
 
-# Product-type literal used by explain_text_product. Keep in sync with
-# ai_explainer_prompts.SYSTEM_PROMPTS keys.
-TextProductType = Literal["AFD", "HWO", "SPS"]
+# NWS/IEM text products are open-ended product IDs such as AFD, CLI, SWODY1,
+# PMDMRD, and future products that should not require code changes to explain.
+TextProductType = str
 
 
 class AIExplainerError(Exception):

--- a/src/accessiweather/ai_explainer_text_products.py
+++ b/src/accessiweather/ai_explainer_text_products.py
@@ -40,7 +40,7 @@ class AIExplainerTextProductMixin:
     }
 
     # Product-wide style instructions appended to the user prompt. Shared
-    # across AFD/HWO/SPS so customization lives in one place.
+    # across all text products so customization lives in one place.
     _PRODUCT_STYLE_INSTRUCTIONS: dict[ExplanationStyle, str] = {
         ExplanationStyle.BRIEF: "Provide a 2-3 sentence summary of the key points.",
         ExplanationStyle.STANDARD: "Provide a clear 1-2 paragraph summary.",
@@ -62,10 +62,51 @@ class AIExplainerTextProductMixin:
 
         Key shape: ``ai_text_product:<TYPE>:<location>:<sha256>:<style>``.
         Hashing the product text keeps the key bounded and deterministic for
-        long AFDs/HWOs/SPSs.
+        long NWS text products.
         """
         text_hash = hashlib.sha256(product_text.encode("utf-8")).hexdigest()
         return f"ai_text_product:{product_type}:{location_name}:{text_hash}:{style.value}"
+
+    def _text_product_system_prompt(
+        self,
+        product_type: str,
+        style: ExplanationStyle,
+    ) -> str:
+        """Return the system prompt for any text product."""
+        if self.custom_system_prompt:
+            return self.custom_system_prompt
+        if product_default := _SYSTEM_PROMPTS.get(product_type):
+            return product_default
+        return self.get_effective_system_prompt(style)
+
+    def _text_product_user_intro(self, product_type: str, location_name: str) -> str:
+        """Return the user-prompt lead-in for any text product."""
+        if intro_template := self._PRODUCT_USER_INTRO.get(product_type):
+            return intro_template.format(location=location_name)
+        product_label = product_type or "unknown type"
+        return (
+            "Please explain this National Weather Service text product "
+            f"({product_label}) for {location_name} in plain language:"
+        )
+
+    def _build_text_product_user_prompt(
+        self,
+        product_text: str,
+        product_type: str,
+        location_name: str,
+        style: ExplanationStyle,
+    ) -> str:
+        """Build the user prompt for any text product."""
+        intro = self._text_product_user_intro(product_type, location_name)
+        style_instruction = self._PRODUCT_STYLE_INSTRUCTIONS.get(
+            style, self._PRODUCT_STYLE_INSTRUCTIONS[ExplanationStyle.DETAILED]
+        )
+        user_prompt = f"{intro}\n\n{product_text}\n\n{style_instruction}"
+
+        if self.custom_instructions and self.custom_instructions.strip():
+            user_prompt += f"\n\nAdditional Instructions: {self.custom_instructions}"
+
+        return user_prompt
 
     async def explain_text_product(
         self,
@@ -79,16 +120,16 @@ class AIExplainerTextProductMixin:
         """
         Generate a plain-language explanation of an NWS text product.
 
-        Supports AFD (Area Forecast Discussion), HWO (Hazardous Weather
-        Outlook), and SPS (Special Weather Statement). The system prompt is
-        selected per product type from :data:`_SYSTEM_PROMPTS`. A per-product
-        result cache (300 s TTL) avoids re-invoking the LLM for identical
-        inputs. LLM errors propagate and are not cached — a retry will
-        re-hit the model.
+        Supports any NWS/IEM text product ID. System prompts are selected the
+        same way for every product: user custom prompt first, product default
+        when available, then the app default AI explanation prompt. A
+        per-product result cache (300 s TTL) avoids re-invoking the LLM for
+        identical inputs. LLM errors propagate and are not cached — a retry
+        will re-hit the model.
 
         Args:
             product_text: Raw product text as issued by NWS.
-            product_type: One of ``"AFD"``, ``"HWO"``, ``"SPS"``.
+            product_type: NWS/IEM text product ID, such as ``"AFD"`` or ``"CLI"``.
             location_name: Human-readable location the product covers.
             style: Explanation style (brief, standard, detailed).
             preserve_markdown: Keep markdown in the response when True.
@@ -99,11 +140,6 @@ class AIExplainerTextProductMixin:
 
         """
         import asyncio
-
-        if product_type not in _SYSTEM_PROMPTS:
-            raise ValueError(
-                f"Unknown product_type {product_type!r}; expected one of {sorted(_SYSTEM_PROMPTS)}"
-            )
 
         # Cache lookup (custom prompts + instructions are applied per-instance
         # and already reflected in the request; keying off product_type /
@@ -122,21 +158,10 @@ class AIExplainerTextProductMixin:
                     timestamp=datetime.fromisoformat(cached["timestamp"]),
                 )
 
-        # System prompt: custom overrides the default (preserves existing
-        # explain_afd semantics — replace, not append).
-        system_prompt = self.custom_system_prompt or _SYSTEM_PROMPTS[product_type]
-
-        # User prompt: product-type-aware lead-in + raw product + style hint.
-        intro_template = self._PRODUCT_USER_INTRO[product_type]
-        intro = intro_template.format(location=location_name)
-        style_instruction = self._PRODUCT_STYLE_INSTRUCTIONS.get(
-            style, self._PRODUCT_STYLE_INSTRUCTIONS[ExplanationStyle.DETAILED]
+        system_prompt = self._text_product_system_prompt(product_type, style)
+        user_prompt = self._build_text_product_user_prompt(
+            product_text, product_type, location_name, style
         )
-        user_prompt = f"{intro}\n\n{product_text}\n\n{style_instruction}"
-
-        # Custom per-user instructions apply identically to all product types.
-        if self.custom_instructions and self.custom_instructions.strip():
-            user_prompt += f"\n\nAdditional Instructions: {self.custom_instructions}"
 
         # Build list of models to try: primary first, then fallbacks
         primary_model = self.get_effective_model()

--- a/tests/test_ai_explainer_text_product.py
+++ b/tests/test_ai_explainer_text_product.py
@@ -6,12 +6,14 @@ Covers the seven scenarios defined in the Forecast Products PR 1 plan (B-R6):
 1. Happy path AFD: system prompt is byte-identical to the current AFD prompt.
 2. Happy path HWO: uses the HWO system prompt.
 3. Happy path SPS: uses the SPS system prompt.
-4. Cache: repeated call with identical inputs returns cached=True without
+4. Other text products use the app default system prompt.
+5. Custom prompts and instructions apply to all text products.
+6. Cache: repeated call with identical inputs returns cached=True without
    re-invoking the LLM.
-5. Custom prompt: custom_system_prompt replaces the default (existing
+7. Custom prompt: custom_system_prompt replaces the default (existing
    explain_afd semantics).
-6. Wrapper: explain_afd delegates to explain_text_product("AFD", ...).
-7. Error path: LLM errors propagate; failures are not cached.
+8. Wrapper: explain_afd delegates to explain_text_product("AFD", ...).
+9. Error path: LLM errors propagate; failures are not cached.
 """
 
 from __future__ import annotations
@@ -60,6 +62,15 @@ def sample_sps_text():
         "...SPECIAL WEATHER STATEMENT...\n"
         "A strong thunderstorm will affect portions of the area through 4 PM.\n"
         "Locations impacted include Springfield and surrounding communities.\n"
+    )
+
+
+@pytest.fixture
+def sample_cli_text():
+    return (
+        "CLIMATE REPORT\n"
+        "...THE RALEIGH NC CLIMATE SUMMARY FOR MAY 23 2026...\n"
+        "HIGH TEMPERATURE 82. LOW TEMPERATURE 61. PRECIPITATION 0.12 INCHES.\n"
     )
 
 
@@ -188,6 +199,58 @@ class TestExplainTextProductPrompts:
             assert system_prompt != _SYSTEM_PROMPTS["AFD"]
             assert system_prompt != _SYSTEM_PROMPTS["HWO"]
             assert "Special Weather Statement" in system_prompt
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("product_type", ["CLI", "SWODY1", "PMDMRD"])
+    async def test_text_products_without_product_default_use_app_default_system_prompt(
+        self, product_type, sample_cli_text, mock_response
+    ):
+        """Products with no product default use the app default system prompt."""
+        explainer = AIExplainer(api_key="test-key")
+        with patch.object(explainer, "_call_openrouter") as mock_call:
+            mock_call.return_value = mock_response
+
+            result = await explainer.explain_text_product(
+                sample_cli_text,
+                product_type,
+                "Test City",
+                style=ExplanationStyle.STANDARD,
+            )
+
+            assert isinstance(result, ExplanationResult)
+            args, _ = mock_call.call_args
+            system_prompt = args[0]
+            user_prompt = args[1]
+            assert system_prompt == explainer.get_effective_system_prompt(ExplanationStyle.STANDARD)
+            assert (
+                f"Please explain this National Weather Service text product ({product_type})"
+                in user_prompt
+            )
+            assert sample_cli_text in user_prompt
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("product_type", ["AFD", "HWO", "SPS", "CLI", "SWODY1"])
+    async def test_custom_prompt_and_instructions_apply_to_all_text_products(
+        self, product_type, sample_cli_text, mock_response
+    ):
+        """User custom prompts and instructions apply to every text product."""
+        custom_prompt = "Use the user's preferred weather-summary voice."
+        custom_instructions = "Mention records and departures from normal."
+        explainer = AIExplainer(
+            api_key="test-key",
+            custom_system_prompt=custom_prompt,
+            custom_instructions=custom_instructions,
+        )
+        with patch.object(explainer, "_call_openrouter") as mock_call:
+            mock_call.return_value = mock_response
+
+            await explainer.explain_text_product(sample_cli_text, product_type, "Test City")
+
+            args, _ = mock_call.call_args
+            system_prompt = args[0]
+            user_prompt = args[1]
+            assert system_prompt == custom_prompt
+            assert f"Additional Instructions: {custom_instructions}" in user_prompt
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Routes every text product through the same AI prompting flow, with user custom system prompts taking priority, then product-specific defaults when available, then the app default prompt.
- Keeps AFD, HWO, and SPS working with their existing defaults while allowing custom system prompts and custom instructions to apply everywhere.
- Adds regression coverage for CLI and other non-specialized text products, plus dialog-level coverage for the Weather Assistant path.
- Updates the changelog with the user-visible fix.

## Testing
- Added and updated unit coverage for text-product prompt selection and custom instruction behavior.
- Added dialog regression coverage for the Weather Assistant text-product flow.
- `ruff` formatting and lint checks passed.
- `pyright` passed with no errors.
- Targeted and broader pytest runs passed.