### PR TITLE
chore(dev): update lint and type-check tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       # explicit pip cache) saves ~10s per CI run while keeping
       # the same fail-before-install-deps ordering.
       run: |
-        pip install --quiet 'ruff>=0.9.0'
+        pip install --quiet 'ruff>=0.15.14'
         ruff format --check .
         ruff check .
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     -   id: debug-statements
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.3
+    rev: v0.15.14
     hooks:
     -   id: ruff
         args: [--fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,9 @@ dev = [
     "pytest-rerunfailures>=12.0",
     "hypothesis>=6.0.0",
     "vcrpy>=6.0.0",
-    "ruff>=0.9.0",
+    "ruff>=0.15.14",
     "mypy>=1.0.0",
-    "pyright",
+    "pyright>=1.1.409",
 ]
 build = [
     "nuitka>=4.0.8",

--- a/scripts/changelog_tools.py
+++ b/scripts/changelog_tools.py
@@ -21,6 +21,7 @@ USER_FACING_PATHS = {
 USER_FACING_SUFFIXES = (".spec",)
 SECTION_ORDER = ("Added", "Changed", "Fixed", "Improved", "Removed", "Deprecated", "Security")
 PYPROJECT_METADATA_FIELDS_WITHOUT_CHANGELOG = {"version", "description"}
+PYPROJECT_TOOLING_REQUIREMENTS_WITHOUT_CHANGELOG = {"pyright", "ruff"}
 
 
 @dataclass(frozen=True)
@@ -44,6 +45,13 @@ def is_user_facing_path(path: str) -> bool:
 
 def pyproject_changed_lines_require_changelog(changed_lines: list[str]) -> bool:
     for line in changed_lines:
+        requirement_match = re.match(r'"([A-Za-z0-9_.-]+)', line)
+        if (
+            requirement_match
+            and requirement_match.group(1).casefold()
+            in PYPROJECT_TOOLING_REQUIREMENTS_WITHOUT_CHANGELOG
+        ):
+            continue
         field = line.split("=", 1)[0].strip()
         if field not in PYPROJECT_METADATA_FIELDS_WITHOUT_CHANGELOG:
             return True

--- a/tests/test_changelog_tools.py
+++ b/tests/test_changelog_tools.py
@@ -91,6 +91,17 @@ def test_pyproject_dependency_changes_need_changelog() -> None:
     )
 
 
+def test_pyproject_tooling_dependency_changes_do_not_need_changelog() -> None:
+    assert not pyproject_changed_lines_require_changelog(
+        [
+            '"ruff>=0.9.0",',
+            '"ruff>=0.15.14",',
+            '"pyright",',
+            '"pyright>=1.1.409",',
+        ]
+    )
+
+
 def test_normalize_entry_matches_curated_release_body_wording() -> None:
     changelog_entry = (
         "- **National Products in Forecaster Notes** — Forecaster Notes now opens a dedicated "


### PR DESCRIPTION
## Summary
- Raise the dev Ruff minimum to 0.15.14 and Pyright minimum to 1.1.409.
- Pin the pre-commit Ruff hook to 0.15.14.
- Match the CI Ruff install floor to the version that passed the PR formatting checks.

## Testing
- `uv run --extra dev ruff format --check .`
- `uv run --extra dev ruff check .`
- `uv run --extra dev pyright`
- `pre-commit run --all-files`