### PR TITLE
test: isolate desktop backends during suite runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to this project will be documented in this file.
 - Forecaster Notes now starts with NWS discussion tabs only and adds IEM-backed tabs only when active SPC/WPC products apply to your selected location.
 - Pirate Weather now requests API v2 data and carries v2 precipitation types like freezing rain and wintry mix into current, daily, and hourly forecasts.
 - Forecaster Notes now hides Hazardous Weather Outlook and Special Weather Statement tabs when NWS confirms there is no matching product for the selected office.
+- Forecaster Notes now avoids stray background task warnings when a product-tab check runs without the normal app scheduler.
 - Nightly builds now report the dev package version consistently instead of using stale generated build metadata.
 
 ## [0.6.0] - 2026-04-24

--- a/src/accessiweather/ui/dialogs/forecast_products_dialog.py
+++ b/src/accessiweather/ui/dialogs/forecast_products_dialog.py
@@ -229,10 +229,12 @@ class ForecastProductsDialog(wx.Dialog):
             runner(coro)
             return
         try:
-            asyncio.ensure_future(coro)
+            loop = asyncio.get_running_loop()
         except RuntimeError:
             coro.close()
             self._finish_active_iem_tab_check()
+            return
+        loop.create_task(coro)
 
     async def _resolve_active_iem_tabs(self) -> None:
         """Resolve active IEM products without touching wx objects off-thread."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,12 +19,17 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from hypothesis import settings as hypothesis_settings
 
+# Set test environment variables before any application imports.
+os.environ["ACCESSIWEATHER_TEST_MODE"] = "1"
+os.environ["PYTEST_CURRENT_TEST"] = "true"
+
 # ---------------------------------------------------------------------------
-# Provide stub wx module when wxPython is not installed (headless servers).
-# This allows tests that mock wx to import accessiweather.ui submodules
-# without requiring a full wxPython build.
+# Provide a stub wx module by default. This keeps local pytest runs from
+# constructing real wxPython windows when wx is installed on the developer box.
 # ---------------------------------------------------------------------------
-_force_wx_stub = os.environ.get("ACCESSIWEATHER_FORCE_WX_STUB") == "1"
+_allow_real_wx = os.environ.get("ACCESSIWEATHER_ALLOW_REAL_WX_IN_TESTS") == "1"
+_force_wx_stub = os.environ.get("ACCESSIWEATHER_FORCE_WX_STUB", "1") == "1"
+_force_wx_stub = _force_wx_stub and not _allow_real_wx
 if _force_wx_stub:
     for _module_name in list(sys.modules):
         if _module_name == "wx" or _module_name.startswith("wx."):
@@ -364,10 +369,6 @@ if "sound_lib" not in sys.modules:
         sys.modules["sound_lib.output"] = _sl_output
         sys.modules["sound_lib.stream"] = _sl_stream
 
-# Set test environment variables before any imports
-os.environ["ACCESSIWEATHER_TEST_MODE"] = "1"
-os.environ["PYTEST_CURRENT_TEST"] = "true"
-
 # Configure hypothesis for fast CI runs
 hypothesis_settings.register_profile("ci", max_examples=25, deadline=None)
 hypothesis_settings.register_profile("dev", max_examples=50, deadline=None)
@@ -641,3 +642,27 @@ def _isolate_keyring_from_real_backend():
     finally:
         ss._keyring_module = original_module
         ss._keyring_checked = original_checked
+
+
+@pytest.fixture(autouse=True)
+def _suppress_real_notification_backends(monkeypatch):
+    """Keep pytest from reaching OS toast backends unless a test installs fakes."""
+    import accessiweather.notifications.toast_notifier as toast_notifier
+
+    monkeypatch.setattr(toast_notifier, "TOASTED_AVAILABLE", False)
+    monkeypatch.setattr(toast_notifier, "WINRT_AVAILABLE", False)
+    monkeypatch.setattr(toast_notifier, "DESKTOP_NOTIFIER_AVAILABLE", False)
+    monkeypatch.setattr(toast_notifier, "NOTIFIER_AVAILABLE", False)
+    monkeypatch.setattr(toast_notifier, "_Toast", None)
+    monkeypatch.setattr(toast_notifier, "_Text", None)
+    monkeypatch.setattr(toast_notifier, "_WinRT_XmlDocument", None)
+    monkeypatch.setattr(toast_notifier, "_WinRT_ToastActivatedEventArgs", None)
+    monkeypatch.setattr(toast_notifier, "_WinRT_ToastNotification", None)
+    monkeypatch.setattr(toast_notifier, "_WinRT_ToastNotificationManager", None)
+    monkeypatch.setattr(toast_notifier, "DesktopNotifier", None)
+    monkeypatch.setattr(
+        toast_notifier,
+        "_WINDOWS_BACKEND_IMPORTS",
+        (None, None, None, None, None, None),
+    )
+    monkeypatch.setattr(toast_notifier, "SafeDesktopNotifier", toast_notifier._TestModeNotifier)

--- a/tests/gui/test_forecast_products_dialog.py
+++ b/tests/gui/test_forecast_products_dialog.py
@@ -8,6 +8,7 @@ rename, and the non-US adjacent-StaticText pattern.
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from datetime import UTC, datetime
 from types import SimpleNamespace
@@ -566,6 +567,23 @@ class TestForecastProductsDialog:
         panel_factory[1]["instance"].ensure_loaded.assert_called_once()
         panel_factory[1]["instance"].product_textctrl.SetFocus.assert_not_called()
         event.Skip.assert_called_once()
+
+    def test_active_iem_check_without_app_runner_does_not_leave_pending_coroutine(self):
+        dlg = object.__new__(ForecastProductsDialog)
+        dlg._app = None
+        dlg._pending_iem_tabs = (MagicMock(name="pending_tab"),)
+        dlg._finish_active_iem_tab_check = MagicMock()
+
+        async def _fake_resolve():
+            return None
+
+        with patch.object(asyncio, "ensure_future") as ensure_future:
+            dlg._resolve_active_iem_tabs = MagicMock(return_value=_fake_resolve())
+
+            dlg._schedule_active_iem_tab_check()
+
+        ensure_future.assert_not_called()
+        dlg._finish_active_iem_tab_check.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_test_environment_safety.py
+++ b/tests/test_test_environment_safety.py
@@ -1,0 +1,25 @@
+"""Regression tests for keeping the test process away from desktop backends."""
+
+from __future__ import annotations
+
+import wx
+
+from accessiweather.notifications import toast_notifier
+
+
+def test_pytest_uses_wx_stub_by_default():
+    """The default pytest run should not construct real wxPython windows."""
+    assert wx.App.__module__.endswith("conftest")
+    assert wx.Frame.__module__.endswith("conftest")
+    assert wx.Dialog.__module__.endswith("conftest")
+
+
+def test_pytest_suppresses_real_notification_backends():
+    """The default pytest run should not reach real OS notification backends."""
+    assert toast_notifier.TOASTED_AVAILABLE is False
+    assert toast_notifier.WINRT_AVAILABLE is False
+    assert toast_notifier.DESKTOP_NOTIFIER_AVAILABLE is False
+    assert toast_notifier.NOTIFIER_AVAILABLE is False
+    assert toast_notifier._Toast is None
+    assert toast_notifier.DesktopNotifier is None
+    assert toast_notifier.SafeDesktopNotifier is toast_notifier._TestModeNotifier


### PR DESCRIPTION
## Summary
- force pytest to use the in-repo wx stub by default so local full-suite runs cannot create real wxPython windows
- suppress real toast, WinRT, and desktop notification backends in pytest unless a test explicitly installs fakes
- avoid orphaned forecast-product async checks when no app runner or running loop exists

## Verification
- uv run ruff check src/accessiweather/ui/dialogs/forecast_products_dialog.py tests/conftest.py tests/test_test_environment_safety.py tests/gui/test_forecast_products_dialog.py
- uv run pytest tests/test_test_environment_safety.py tests/test_toasted_windows_notifier.py tests/test_alert_dialog_dispatch.py tests/test_alert_dialog_copy_integration.py tests/gui/test_forecast_products_dialog.py -q --tb=short -n 0
- uv run pytest -> 3932 passed, 5 skipped