### PR TITLE
test(integration): audit cassette API errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,18 @@ jobs:
             -n 0 -v --tb=short -m "not integration"
         fi
 
+    - name: Run integration tests (cassette replay)
+      if: matrix.primary
+      timeout-minutes: 10
+      env:
+        PYTHONPATH: src
+        ACCESSIWEATHER_TEST_MODE: "1"
+        HYPOTHESIS_PROFILE: ci
+        VCR_RECORD_MODE: "none"
+      run: |
+        xvfb-run -a pytest tests/integration/ \
+          -n 0 -v --tb=short --record-mode=none
+
     - name: Install diff-cover
       if: matrix.primary && github.event_name == 'pull_request'
       run: pip install diff-cover>=9.0.0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -94,6 +94,18 @@ jobs:
           VCR_RECORD_MODE: "all"
         timeout-minutes: 15
 
+      - name: Audit refreshed cassettes for API errors
+        if: ${{ github.event.inputs.update_cassettes == 'true' }}
+        run: |
+          pytest tests/integration/test_cassette_quality.py \
+            -n 0 \
+            -v \
+            --tb=short \
+            --record-mode=none
+        env:
+          VCR_RECORD_MODE: "none"
+        timeout-minutes: 5
+
       - name: Commit and push new cassettes (if any)
         if: ${{ success() && github.event.inputs.update_cassettes == 'true' }}
         env:

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -23,6 +23,9 @@ Integration tests verify actual API behavior by recording HTTP interactions as "
 # Default: Run integration tests with recorded cassettes (fast)
 pytest tests/integration/ -v
 
+# Audit recorded cassettes for accidental API errors
+pytest tests/integration/test_cassette_quality.py -v -n 0
+
 # Run all integration tests except live_only tests
 pytest tests/integration/ -v -m "integration and not live_only"
 
@@ -64,6 +67,7 @@ tests/integration/cassettes/
 ├── nws/               # National Weather Service API tests
 ├── openmeteo/         # OpenMeteo weather API tests
 ├── pirate_weather/    # Pirate Weather API tests
+├── weatherindex/      # WeatherIndex NOAA radio API tests
 └── weather_client/    # WeatherClient orchestration tests
 ```
 
@@ -75,6 +79,10 @@ tests/integration/cassettes/
 4. **Match non-secret query params**: Query values often choose provider response shape; API keys are filtered before matching
 5. **Filter headers**: User-Agent and auth headers should be filtered
 6. **Keep cassettes small**: Request only data needed for assertions
+7. **Audit API errors**: Replay runs fail when a cassette records an unexpected
+   HTTP error or provider JSON error. If a test intentionally records an error
+   response, add that cassette to `EXPECTED_ERROR_CASSETTES` in
+   `tests/integration/conftest.py`.
 
 ## Troubleshooting
 

--- a/tests/integration/cassettes/weatherindex/states.yaml
+++ b/tests/integration/cassettes/weatherindex/states.yaml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+    method: GET
+    uri: https://api.wxindex.org/v1/states
+  response:
+    body:
+      string: '[{"state_name":"Alabama","state_slug":"AL","station_count":21,"stations_with_feeds":2},{"state_name":"Alaska","state_slug":"AK","station_count":52,"stations_with_feeds":0},{"state_name":"American
+        Samoa","state_slug":"AS","station_count":2,"stations_with_feeds":0},{"state_name":"Arizona","state_slug":"AZ","station_count":13,"stations_with_feeds":3},{"state_name":"Arkansas","state_slug":"AR","station_count":19,"stations_with_feeds":1},{"state_name":"California","state_slug":"CA","station_count":35,"stations_with_feeds":10},{"state_name":"Colorado","state_slug":"CO","station_count":29,"stations_with_feeds":1},{"state_name":"Connecticut","state_slug":"CT","station_count":4,"stations_with_feeds":1},{"state_name":"Delaware","state_slug":"DE","station_count":2,"stations_with_feeds":0},{"state_name":"Florida","state_slug":"FL","station_count":32,"stations_with_feeds":10},{"state_name":"Georgia","state_slug":"GA","station_count":28,"stations_with_feeds":4},{"state_name":"Guam","state_slug":"GU","station_count":1,"stations_with_feeds":0},{"state_name":"Hawaii","state_slug":"HI","station_count":8,"stations_with_feeds":1},{"state_name":"Idaho","state_slug":"ID","station_count":14,"stations_with_feeds":0},{"state_name":"Illinois","state_slug":"IL","station_count":29,"stations_with_feeds":8},{"state_name":"Indiana","state_slug":"IN","station_count":19,"stations_with_feeds":3},{"state_name":"Iowa","state_slug":"IA","station_count":27,"stations_with_feeds":2},{"state_name":"Kansas","state_slug":"KS","station_count":23,"stations_with_feeds":2},{"state_name":"Kentucky","state_slug":"KY","station_count":41,"stations_with_feeds":3},{"state_name":"Louisiana","state_slug":"LA","station_count":11,"stations_with_feeds":3},{"state_name":"Maine","state_slug":"ME","station_count":11,"stations_with_feeds":1},{"state_name":"Maryland","state_slug":"MD","station_count":5,"stations_with_feeds":1},{"state_name":"Massachusetts","state_slug":"MA","station_count":6,"stations_with_feeds":3},{"state_name":"Michigan","state_slug":"MI","station_count":28,"stations_with_feeds":7},{"state_name":"Minnesota","state_slug":"MN","station_count":37,"stations_with_feeds":5},{"state_name":"Mississippi","state_slug":"MS","station_count":13,"stations_with_feeds":0},{"state_name":"Missouri","state_slug":"MO","station_count":35,"stations_with_feeds":4},{"state_name":"Montana","state_slug":"MT","station_count":31,"stations_with_feeds":1},{"state_name":"Nebraska","state_slug":"NE","station_count":25,"stations_with_feeds":4},{"state_name":"Nevada","state_slug":"NV","station_count":14,"stations_with_feeds":2},{"state_name":"New
+        Hampshire","state_slug":"NH","station_count":7,"stations_with_feeds":0},{"state_name":"New
+        Jersey","state_slug":"NJ","station_count":3,"stations_with_feeds":0},{"state_name":"New
+        Mexico","state_slug":"NM","station_count":12,"stations_with_feeds":2},{"state_name":"New
+        York","state_slug":"NY","station_count":24,"stations_with_feeds":7},{"state_name":"North
+        Carolina","state_slug":"NC","station_count":21,"stations_with_feeds":1},{"state_name":"North
+        Dakota","state_slug":"ND","station_count":18,"stations_with_feeds":2},{"state_name":"Northern
+        Mariana Islands","state_slug":"MP","station_count":1,"stations_with_feeds":0},{"state_name":"Ohio","state_slug":"OH","station_count":18,"stations_with_feeds":8},{"state_name":"Oklahoma","state_slug":"OK","station_count":20,"stations_with_feeds":4},{"state_name":"Oregon","state_slug":"OR","station_count":25,"stations_with_feeds":0},{"state_name":"Pennsylvania","state_slug":"PA","station_count":21,"stations_with_feeds":5},{"state_name":"Puerto
+        Rico","state_slug":"PR","station_count":2,"stations_with_feeds":0},{"state_name":"Rhode
+        Island","state_slug":"RI","station_count":1,"stations_with_feeds":0},{"state_name":"South
+        Carolina","state_slug":"SC","station_count":16,"stations_with_feeds":1},{"state_name":"South
+        Dakota","state_slug":"SD","station_count":18,"stations_with_feeds":0},{"state_name":"Tennessee","state_slug":"TN","station_count":21,"stations_with_feeds":3},{"state_name":"Texas","state_slug":"TX","station_count":79,"stations_with_feeds":13},{"state_name":"U.S.
+        Virgin Islands","state_slug":"VI","station_count":1,"stations_with_feeds":0},{"state_name":"Utah","state_slug":"UT","station_count":17,"stations_with_feeds":0},{"state_name":"Vermont","state_slug":"VT","station_count":4,"stations_with_feeds":0},{"state_name":"Virginia","state_slug":"VA","station_count":13,"stations_with_feeds":2},{"state_name":"Washington","state_slug":"WA","station_count":17,"stations_with_feeds":4},{"state_name":"West
+        Virginia","state_slug":"WV","station_count":12,"stations_with_feeds":3},{"state_name":"Wisconsin","state_slug":"WI","station_count":28,"stations_with_feeds":7},{"state_name":"Wyoming","state_slug":"WY","station_count":21,"stations_with_feeds":1}]'
+    headers:
+      CF-RAY:
+      - a00f2f946aed2e7a-EWR
+      Cache-Control:
+      - public, max-age=60
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 24 May 2026 20:52:44 GMT
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=ypyVxguAsdDuvWglcY8iE7sq2B%2FrHRW7NaRlU5C5SPx6eqkQwnBaXnBVhUiDuit4XLdWNUtRc%2FECq3fMbWaZXsvT%2Br7SLLdNs6yv5R2ii3EjeDVt1E0yMWzn1TSMO9tJad8yhHsrtbCXaFxoGVo%3D"}]}'
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '4829'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/cassettes/weatherindex/station_wxk27.yaml
+++ b/tests/integration/cassettes/weatherindex/station_wxk27.yaml
@@ -1,0 +1,45 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+    method: GET
+    uri: https://api.wxindex.org/v1/stations/WXK27
+  response:
+    body:
+      string: '{"callsign":"WXK27","state_name":"Texas","state_slug":"TX","city":"Austin","frequency":"162.400","wfo":"Austin/San
+        Antonio TX","status":"NORMAL","latitude":30.3219,"longitude":-97.8033,"tower_site":"Austin","power":"1010","served_counties":[{"county":"Bastrop","same_code":"048021","state":"TX","area":"All"},{"county":"Blanco","same_code":"048031","state":"TX","area":"All"},{"county":"Burnet","same_code":"048053","state":"TX","area":"All"},{"county":"Caldwell","same_code":"048055","state":"TX","area":"All"},{"county":"Hays","same_code":"048209","state":"TX","area":"All"},{"county":"Lee","same_code":"048287","state":"TX","area":"All"},{"county":"Travis","same_code":"048453","state":"TX","area":"All"},{"county":"Williamson","same_code":"048491","state":"TX","area":"All"}],"feeds":[]}'
+    headers:
+      CF-RAY:
+      - a00f2f961d2a43c2-EWR
+      Cache-Control:
+      - public, max-age=60
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 24 May 2026 20:52:45 GMT
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=OO81AWOjWpPfmywuHHliVpV%2BLXdM6KHlvFQEww1UApjzCy%2BYRr5w6MRcWVuN38%2FDfQPWdpOTN%2B3PRM5kr9rPlbG%2FUnikYCBpEYHCkAqbMk61KD5VWZWoK7qKPMfapHnMRKb%2FBemaqkqNh8RhemU%3D"}]}'
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '791'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,12 +18,15 @@ Best Practices for API Integration Testing:
 
 from __future__ import annotations
 
+import json
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qsl, urlsplit
 
 import pytest
+import yaml
 
 try:
     import vcr
@@ -67,6 +70,24 @@ LIVE_TESTS = os.environ.get("LIVE_TESTS", "false").lower() == "true"
 
 # API keys from environment (for live tests or recording new cassettes)
 PIRATE_WEATHER_API_KEY = os.environ.get("PIRATE_WEATHER_API_KEY", "test-api-key")
+
+
+@dataclass(frozen=True)
+class CassetteApiError:
+    """Unexpected API-error response recorded in a VCR cassette."""
+
+    relative_path: str
+    interaction_index: int
+    status_code: int | None
+    uri: str
+    reason: str
+
+
+EXPECTED_ERROR_CASSETTES: dict[str, frozenset[int]] = {
+    "nws/error_invalid_coords.yaml": frozenset({404}),
+    "nws/point_international_error.yaml": frozenset({404}),
+    "openmeteo/error_invalid_coords.yaml": frozenset({400}),
+}
 
 
 # =============================================================================
@@ -128,6 +149,89 @@ def _match_provider_query(request_1, request_2):
     query_2 = _scrubbed_query_items(request_2.uri)
     if query_1 != query_2:
         raise AssertionError(f"{query_1} != {query_2}")
+
+
+def _response_body_text(response: dict) -> str:
+    body = response.get("body")
+    if not isinstance(body, dict):
+        return ""
+    value = body.get("string")
+    return value if isinstance(value, str) else ""
+
+
+def _provider_error_reason(response: dict) -> str | None:
+    """Return a provider-error reason from JSON bodies that advertise failure."""
+    body_text = _response_body_text(response).strip()
+    if not body_text:
+        return None
+
+    try:
+        payload = json.loads(body_text)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    if payload.get("error") is True:
+        return "JSON body contains error=true"
+
+    status = payload.get("status")
+    if isinstance(status, int) and status >= 400:
+        return f"JSON body contains status={status}"
+
+    return None
+
+
+def find_unexpected_cassette_api_errors(cassette_dir: Path) -> list[CassetteApiError]:
+    """Find recorded HTTP/provider errors outside cassettes that intentionally test errors."""
+    failures: list[CassetteApiError] = []
+
+    for cassette_path in sorted(cassette_dir.rglob("*.yaml")):
+        relative_path = cassette_path.relative_to(cassette_dir).as_posix()
+        allowed_statuses = EXPECTED_ERROR_CASSETTES.get(relative_path, frozenset())
+
+        cassette = yaml.safe_load(cassette_path.read_text(encoding="utf-8")) or {}
+        interactions = cassette.get("interactions", [])
+        if not isinstance(interactions, list):
+            continue
+
+        for index, interaction in enumerate(interactions, start=1):
+            if not isinstance(interaction, dict):
+                continue
+
+            response = interaction.get("response") or {}
+            request = interaction.get("request") or {}
+            status = response.get("status") if isinstance(response, dict) else {}
+            status_code = status.get("code") if isinstance(status, dict) else None
+            uri = request.get("uri", "") if isinstance(request, dict) else ""
+
+            if isinstance(status_code, int) and status_code >= 400:
+                if status_code not in allowed_statuses:
+                    failures.append(
+                        CassetteApiError(
+                            relative_path=relative_path,
+                            interaction_index=index,
+                            status_code=status_code,
+                            uri=uri,
+                            reason=f"unexpected HTTP {status_code}",
+                        )
+                    )
+                continue
+
+            error_reason = _provider_error_reason(response)
+            if error_reason is not None:
+                failures.append(
+                    CassetteApiError(
+                        relative_path=relative_path,
+                        interaction_index=index,
+                        status_code=status_code if isinstance(status_code, int) else None,
+                        uri=uri,
+                        reason=error_reason,
+                    )
+                )
+
+    return failures
 
 
 integration_vcr = vcr.VCR(

--- a/tests/integration/test_cassette_quality.py
+++ b/tests/integration/test_cassette_quality.py
@@ -1,0 +1,51 @@
+"""Quality checks for recorded integration-test cassettes."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from tests.integration.conftest import find_unexpected_cassette_api_errors
+
+
+@pytest.mark.integration
+def test_recorded_cassettes_do_not_contain_unexpected_api_errors(vcr_cassette_dir):
+    """Guard replay tests against silently accepting provider-side error recordings."""
+    failures = find_unexpected_cassette_api_errors(vcr_cassette_dir)
+
+    assert failures == []
+
+
+@pytest.mark.integration
+def test_cassette_audit_flags_unexpected_http_errors(tmp_path):
+    """A success cassette with an HTTP error response must be reported."""
+    cassette = tmp_path / "provider" / "unexpected_500.yaml"
+    cassette.parent.mkdir()
+    cassette.write_text(
+        textwrap.dedent(
+            """
+            interactions:
+            - request:
+                method: GET
+                uri: https://api.example.test/weather
+              response:
+                body:
+                  string: '{"detail":"upstream failed"}'
+                headers:
+                  Content-Type:
+                  - application/json
+                status:
+                  code: 500
+                  message: Internal Server Error
+            version: 1
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+
+    failures = find_unexpected_cassette_api_errors(tmp_path)
+
+    assert len(failures) == 1
+    assert failures[0].relative_path == "provider/unexpected_500.yaml"
+    assert failures[0].status_code == 500

--- a/tests/integration/test_weatherindex_integration.py
+++ b/tests/integration/test_weatherindex_integration.py
@@ -1,15 +1,18 @@
-"""Focused integration coverage for the live WeatherIndex NOAA radio API."""
+"""Focused integration coverage for the WeatherIndex NOAA radio API."""
 
 from __future__ import annotations
 
 import pytest
 import requests
 
+from tests.integration.conftest import integration_vcr
+
 
 @pytest.mark.integration
 class TestWeatherIndexIntegration:
-    """Verify stable structural contracts for the live WeatherIndex API."""
+    """Verify stable structural contracts for the WeatherIndex API."""
 
+    @integration_vcr.use_cassette("weatherindex/states.yaml")
     def test_states_endpoint_returns_expected_keys(self):
         response = requests.get("https://api.wxindex.org/v1/states", timeout=15)
         response.raise_for_status()
@@ -21,6 +24,7 @@ class TestWeatherIndexIntegration:
         assert isinstance(first, dict)
         assert {"state_name", "state_slug", "station_count", "stations_with_feeds"} <= set(first)
 
+    @integration_vcr.use_cassette("weatherindex/station_wxk27.yaml")
     def test_station_detail_returns_feeds_field(self):
         response = requests.get("https://api.wxindex.org/v1/stations/WXK27", timeout=15)
         response.raise_for_status()


### PR DESCRIPTION
## Summary
- add an integration cassette audit that fails on unexpected HTTP 4xx/5xx responses or provider JSON error bodies
- move WeatherIndex integration checks onto VCR cassettes so replay-mode CI stays deterministic
- run integration cassette replay in PR CI and audit freshly refreshed cassettes before committing them

## Verification
- uv run ruff format --check .
- uv run ruff check .
- uv run pytest tests/integration -q --tb=short -n 0
- actionlint .github/workflows/ci.yml .github/workflows/integration-tests.yml
- uv run python scripts/changelog_tools.py check --base dev --head HEAD
- uv run pytest