### PR TITLE
fix(geocoding): replay comma-qualified location searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Starting AccessiWeather again now brings the running window forward instead of opening a force-start prompt or leaving behind lock-file state.
+- Open-Meteo location searches now handle common city/state or city/country entries like "New York, NY" and "London, UK" when adding locations.
 - The Windows installer now waits for any running AccessiWeather copy before replacing files, including portable copies launched from a folder.
 - Plain Language Summary now works for Daily Climate Reports and other Forecaster Notes text products, not just AFD, HWO, and SPS.
 - Weather Assistant now avoids a removed OpenRouter free model, so automatic free mode no longer fails with a 404 before answering.

--- a/src/accessiweather/openmeteo_geocoding_client.py
+++ b/src/accessiweather/openmeteo_geocoding_client.py
@@ -13,13 +13,16 @@ import logging
 import re
 import time
 import unicodedata
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
 import httpx
 
+_unidecode: Callable[[str], str]
+
 try:
-    from unidecode import unidecode
+    from unidecode import unidecode as _imported_unidecode
 except ImportError:  # pragma: no cover - exercised when the dependency is unavailable locally
     FALLBACK_TRANSLITERATION_MAP = str.maketrans(
         {
@@ -82,13 +85,26 @@ except ImportError:  # pragma: no cover - exercised when the dependency is unava
         }
     )
 
-    def unidecode(value: str) -> str:
+    def _fallback_unidecode(value: str) -> str:
         """Best-effort ASCII transliteration when Unidecode is unavailable."""
         normalized = value.translate(FALLBACK_TRANSLITERATION_MAP)
         return unicodedata.normalize("NFKD", normalized).encode("ascii", "ignore").decode("ascii")
 
+    _unidecode = _fallback_unidecode
+else:
+
+    def _call_unidecode(value: str) -> str:
+        return _imported_unidecode(value)
+
+    _unidecode = _call_unidecode
+
 
 logger = logging.getLogger(__name__)
+
+
+def _transliterate(value: str) -> str:
+    """Return a best-effort ASCII transliteration for matching location names."""
+    return _unidecode(value)
 
 
 class OpenMeteoGeocodingError(Exception):
@@ -296,7 +312,11 @@ class OpenMeteoGeocodingClient:
 
         for fallback_query in self._build_fallback_queries(search_name):
             fallback_results = self._search_once(fallback_query, params)
-            matched_results = self._filter_matching_results(search_name, fallback_results)
+            matched_results = self._filter_matching_results(
+                search_name,
+                fallback_results,
+                fallback_query=fallback_query,
+            )
             if matched_results:
                 logger.info(
                     "Geocoding fallback matched '%s' using retry query '%s'",
@@ -325,6 +345,9 @@ class OpenMeteoGeocodingClient:
         fallback_queries: list[str] = []
         seen: set[str] = {name.casefold()}
 
+        for simplified_query in self._build_simplified_location_queries(name):
+            self._append_unique_query(fallback_queries, seen, simplified_query)
+
         for variant in self._generate_unicode_variants(name):
             self._append_unique_query(fallback_queries, seen, variant)
 
@@ -340,6 +363,18 @@ class OpenMeteoGeocodingClient:
                     )
 
         return fallback_queries
+
+    def _build_simplified_location_queries(self, name: str) -> list[str]:
+        """Build simpler retry queries from comma-qualified place names."""
+        parts = [part.strip() for part in name.split(",") if part.strip()]
+        if len(parts) < 2:
+            return []
+
+        place_name = parts[0]
+        if not place_name or place_name.casefold() == name.casefold():
+            return []
+
+        return [place_name]
 
     def _append_unique_query(
         self,
@@ -389,16 +424,27 @@ class OpenMeteoGeocodingClient:
         self,
         original_query: str,
         results: list[GeocodingResult],
+        fallback_query: str | None = None,
     ) -> list[GeocodingResult]:
         """Keep fallback results that still match the user's original query."""
-        normalized_query = self._normalize_text(original_query)
+        normalized_queries = [self._normalize_text(original_query)]
+        if fallback_query is not None:
+            normalized_fallback = self._normalize_text(fallback_query)
+            if normalized_fallback not in normalized_queries:
+                normalized_queries.append(normalized_fallback)
+
         scored_results: list[tuple[int, GeocodingResult]] = []
 
         for result in results:
-            if not self._result_matches_query(normalized_query, result):
+            matching_scores = [
+                self._score_result_match(normalized_query, result)
+                for normalized_query in normalized_queries
+                if self._result_matches_query(normalized_query, result)
+            ]
+            if not matching_scores:
                 continue
 
-            scored_results.append((self._score_result_match(normalized_query, result), result))
+            scored_results.append((min(matching_scores), result))
 
         scored_results.sort(
             key=lambda item: (
@@ -439,7 +485,7 @@ class OpenMeteoGeocodingClient:
 
     def _normalize_text(self, text: str) -> str:
         """Normalize text for accent-insensitive comparisons."""
-        ascii_text = unidecode(text).casefold()
+        ascii_text = _transliterate(text).casefold()
         return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", ascii_text)).strip()
 
     def _parse_results(self, data: dict[str, Any]) -> list[GeocodingResult]:

--- a/tests/gui/test_dialog_system_colors.py
+++ b/tests/gui/test_dialog_system_colors.py
@@ -30,6 +30,7 @@ for _attr, _val in {
     "TE_READONLY": 0x0010,
     "TE_RICH2": 0x8000,
     "TE_PROCESS_ENTER": 0x0400,
+    "TE_PASSWORD": 0x0800,
     "LEFT": 0x0010,
     "RIGHT": 0x0020,
     "TOP": 0x0040,
@@ -168,7 +169,7 @@ def _widget_factories():
     """Replace wx widget constructors with spec-free factories."""
     saved = {}
 
-    for name in ("StaticText", "BoxSizer", "Panel", "ListCtrl", "FlexGridSizer"):
+    for name in ("StaticText", "BoxSizer", "ListCtrl", "FlexGridSizer"):
         saved[name] = getattr(_wx, name, None)
         setattr(_wx, name, lambda *a, **kw: MagicMock())
 
@@ -215,7 +216,9 @@ def _make_environmental(*, has_data_val=True, has_hourly=True):
 class TestSystemColorsUsedAtRuntime:
     """Verify wx.SystemSettings.GetColour is called during dialog init."""
 
-    _USING_STUB = not hasattr(sys.modules.get("wx", None), "App")
+    _USING_STUB = getattr(sys.modules.get("wx", None), "App", object).__module__.endswith(
+        "conftest"
+    )
     _skip_when_real_wx = pytest.mark.skipif(
         not _USING_STUB,
         reason="Dialog instantiation tests require wx stub mode; real wx needs real parent window",

--- a/tests/integration/cassettes/geocoding/geocode_london.yaml
+++ b/tests/integration/cassettes/geocoding/geocode_london.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate, zstd
+      - gzip, deflate
       Connection:
       - keep-alive
       Host:
@@ -14,18 +14,53 @@ interactions:
     uri: https://geocoding-api.open-meteo.com/v1/search?count=5&format=json&language=en&name=London%2C+UK
   response:
     body:
-      string: '{"generationtime_ms":0.64218044}'
+      string: '{"generationtime_ms":0.6494522}'
     headers:
       Connection:
       - keep-alive
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 19 Jan 2026 05:03:58 GMT
+      - Sun, 24 May 2026 21:14:26 GMT
       X-Encoding-Time:
-      - 0.0018835067749023438 ms
+      - 0.0013232231140136719 ms
       content-length:
-      - '32'
+      - '31'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - geocoding-api.open-meteo.com
+    method: GET
+    uri: https://geocoding-api.open-meteo.com/v1/search?count=5&format=json&language=en&name=London
+  response:
+    body:
+      string: '{"results":[{"id":2643743,"name":"London","latitude":51.50853,"longitude":-0.12574,"elevation":25.0,"feature_code":"PPLC","country_code":"GB","admin1_id":6269131,"admin2_id":2648110,"timezone":"Europe/London","population":8961989,"country_id":2635167,"country":"United
+        Kingdom","admin1":"England","admin2":"Greater London"},{"id":6058560,"name":"London","latitude":42.98339,"longitude":-81.23304,"elevation":252.0,"feature_code":"PPL","country_code":"CA","admin1_id":6093943,"admin2_id":6073256,"timezone":"America/Toronto","population":422324,"country_id":6251999,"country":"Canada","admin1":"Ontario","admin2":"Middlesex
+        County"},{"id":4517009,"name":"London","latitude":39.88645,"longitude":-83.44825,"elevation":321.0,"feature_code":"PPLA2","country_code":"US","admin1_id":5165418,"admin2_id":4517365,"admin3_id":4517024,"timezone":"America/New_York","population":10060,"postcodes":["43140"],"country_id":6252001,"country":"United
+        States","admin1":"Ohio","admin2":"Madison","admin3":"City of London"},{"id":4298960,"name":"London","latitude":37.12898,"longitude":-84.08326,"elevation":378.0,"feature_code":"PPLA2","country_code":"US","admin1_id":6254925,"admin2_id":4297480,"timezone":"America/New_York","population":8126,"postcodes":["40741","40742","40743","40744","40745"],"country_id":6252001,"country":"United
+        States","admin1":"Kentucky","admin2":"Laurel"},{"id":4119617,"name":"London","latitude":35.32897,"longitude":-93.25296,"elevation":116.0,"feature_code":"PPL","country_code":"US","admin1_id":4099753,"admin2_id":4127100,"admin3_id":4105863,"timezone":"America/Chicago","population":1046,"postcodes":["72847"],"country_id":6252001,"country":"United
+        States","admin1":"Arkansas","admin2":"Pope","admin3":"Clark Township"}],"generationtime_ms":0.6765127}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 24 May 2026 21:14:26 GMT
+      X-Encoding-Time:
+      - 0.0033974647521972656 ms
+      content-length:
+      - '1767'
     status:
       code: 200
       message: OK

--- a/tests/integration/cassettes/geocoding/geocode_nyc.yaml
+++ b/tests/integration/cassettes/geocoding/geocode_nyc.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate, zstd
+      - gzip, deflate
       Connection:
       - keep-alive
       Host:
@@ -14,18 +14,55 @@ interactions:
     uri: https://geocoding-api.open-meteo.com/v1/search?count=5&format=json&language=en&name=New+York%2C+NY
   response:
     body:
-      string: '{"generationtime_ms":1.2426376}'
+      string: '{"generationtime_ms":1.2571812}'
     headers:
       Connection:
       - keep-alive
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 19 Jan 2026 05:03:57 GMT
+      - Sun, 24 May 2026 21:14:25 GMT
       X-Encoding-Time:
-      - 0.005602836608886719 ms
+      - 0.004208087921142578 ms
       content-length:
       - '31'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - geocoding-api.open-meteo.com
+    method: GET
+    uri: https://geocoding-api.open-meteo.com/v1/search?count=5&format=json&language=en&name=New+York
+  response:
+    body:
+      string: '{"results":[{"id":5128581,"name":"New York","latitude":40.71427,"longitude":-74.00597,"elevation":10.0,"feature_code":"PPL","country_code":"US","admin1_id":5128638,"timezone":"America/New_York","population":8804190,"postcodes":["10001","10002","10003","10004","10005","10006","10007","10008","10009","10010","10011","10012","10013","10014","10016","10017","10018","10019","10020","10021","10022","10023","10024","10025","10026","10027","10028","10029","10030","10031","10032","10033","10034","10035","10036","10037","10038","10039","10040","10041","10043","10044","10045","10055","10060","10065","10069","10080","10081","10087","10090","10101","10102","10103","10104","10105","10106","10107","10108","10109","10110","10111","10112","10113","10114","10115","10116","10117","10118","10119","10120","10121","10122","10123","10124","10125","10126","10128","10129","10130","10131","10132","10133","10138","10150","10151","10152","10153","10154","10155","10156","10157","10158","10159","10160","10161","10162","10163","10164","10165","10166","10167","10168","10169","10170","10171","10172","10173","10174","10175","10176","10177","10178","10179","10185","10199","10203","10211","10212","10213","10242","10249","10256","10258","10259","10260","10261","10265","10268","10269","10270","10271","10272","10273","10274","10275","10276","10277","10278","10279","10280","10281","10282","10285","10286"],"country_id":6252001,"country":"United
+        States","admin1":"New York"},{"id":5082331,"name":"York","latitude":40.86807,"longitude":-97.592,"elevation":488.0,"feature_code":"PPLA2","country_code":"US","admin1_id":5073708,"admin2_id":5082335,"admin3_id":7317456,"timezone":"America/Chicago","population":7864,"postcodes":["68467"],"country_id":6252001,"country":"United
+        States","admin1":"Nebraska","admin2":"York","admin3":"City of York"},{"id":4257559,"name":"Florence","latitude":38.78423,"longitude":-84.92439,"elevation":145.0,"feature_code":"PPL","country_code":"US","admin1_id":4921868,"admin2_id":4265618,"admin3_id":4267282,"timezone":"America/Indiana/Vevay","population":80,"postcodes":["47020"],"country_id":6252001,"country":"United
+        States","admin1":"Indiana","admin2":"Switzerland","admin3":"York Township"},{"id":2641508,"name":"New
+        York","latitude":53.07897,"longitude":-0.14008,"elevation":7.0,"feature_code":"PPL","country_code":"GB","admin1_id":6269131,"admin2_id":2644486,"admin3_id":7290589,"admin4_id":7298672,"timezone":"Europe/London","country_id":2635167,"country":"United
+        Kingdom","admin1":"England","admin2":"Lincolnshire","admin3":"East Lindsey
+        District","admin4":"Wildmore"},{"id":3489274,"name":"New York","latitude":18.25397,"longitude":-77.17683,"elevation":586.0,"feature_code":"PPL","country_code":"JM","admin1_id":3488715,"admin2_id":11495178,"timezone":"America/Jamaica","country_id":3489940,"country":"Jamaica","admin1":"Saint
+        Ann Parish","admin2":"Moneague"}],"generationtime_ms":0.9393692}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 24 May 2026 21:14:25 GMT
+      X-Encoding-Time:
+      - 0.004315376281738281 ms
+      content-length:
+      - '2910'
     status:
       code: 200
       message: OK

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -115,10 +115,15 @@ def _is_openmeteo_forecast(uri: str) -> bool:
     return parts.netloc.endswith("open-meteo.com") and parts.path.endswith("/v1/forecast")
 
 
+def _is_openmeteo_geocoding(uri: str) -> bool:
+    parts = urlsplit(uri)
+    return parts.netloc == "geocoding-api.open-meteo.com" and parts.path.endswith("/v1/search")
+
+
 def _is_query_sensitive_provider(uri: str) -> bool:
     parts = urlsplit(uri)
     host = parts.netloc.lower()
-    if _is_openmeteo_forecast(uri):
+    if _is_openmeteo_forecast(uri) or _is_openmeteo_geocoding(uri):
         return True
     return host.endswith(("api.weather.gov", "api.pirateweather.net"))
 

--- a/tests/integration/test_geocoding_integration.py
+++ b/tests/integration/test_geocoding_integration.py
@@ -25,7 +25,6 @@ class TestGeocodingAddressLookup:
     Mark as live_only if the API is rate-limited or unavailable.
     """
 
-    @pytest.mark.live_only
     @integration_vcr.use_cassette("geocoding/geocode_nyc.yaml")
     def test_geocode_us_city(self):
         """Test geocoding a US city."""
@@ -42,7 +41,6 @@ class TestGeocodingAddressLookup:
         assert 40.0 < lat < 41.0
         assert -75.0 < lon < -73.0
 
-    @pytest.mark.live_only
     @integration_vcr.use_cassette("geocoding/geocode_london.yaml")
     def test_geocode_international_city(self):
         """Test geocoding an international city with auto data source."""

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -198,6 +198,37 @@ class TestGeocodeAddress:
         # Verify the search was called with formatted ZIP
         service.client.search.assert_called_with("10001, USA", count=5)
 
+    def test_geocode_retries_comma_qualified_city_with_place_name(self, service, mock_us_result):
+        """Test city/state searches retry with the place name when the API returns no results."""
+        service.data_source = "nws"
+
+        def make_request(_endpoint, params):
+            if params["name"] == "New York":
+                return {
+                    "results": [
+                        {
+                            "name": mock_us_result.name,
+                            "latitude": mock_us_result.latitude,
+                            "longitude": mock_us_result.longitude,
+                            "country": mock_us_result.country,
+                            "country_code": mock_us_result.country_code,
+                            "timezone": mock_us_result.timezone,
+                            "admin1": mock_us_result.admin1,
+                        }
+                    ]
+                }
+            return {"results": []}
+
+        service.client._make_request = MagicMock(side_effect=make_request)
+
+        result = service.geocode_address("New York, NY")
+
+        assert result == (40.7128, -74.006, "New York, New York, United States")
+        queried_names = [
+            call.args[1]["name"] for call in service.client._make_request.call_args_list
+        ]
+        assert queried_names[:2] == ["New York, NY", "New York"]
+
     @pytest.mark.parametrize(
         ("query", "fallback_query", "name", "country", "admin1"),
         [


### PR DESCRIPTION
## Summary
- replay cassette-backed NYC/London geocoding integration tests instead of leaving them live-only
- make Open-Meteo geocoding retry comma-qualified place searches with the simpler place name
- tighten VCR query matching for Open-Meteo geocoding and let wx dialog color tests run under the stub backend

## Verification
- uv run ruff check src/accessiweather/openmeteo_geocoding_client.py tests/test_geocoding.py tests/integration/conftest.py tests/integration/test_geocoding_integration.py tests/gui/test_dialog_system_colors.py
- uv run ruff format --check src/accessiweather/openmeteo_geocoding_client.py tests/test_geocoding.py tests/integration/conftest.py tests/integration/test_geocoding_integration.py tests/gui/test_dialog_system_colors.py
- uv run pyright src/accessiweather/openmeteo_geocoding_client.py
- uv run pytest tests/test_geocoding.py tests/gui/test_dialog_system_colors.py tests/integration/test_geocoding_integration.py tests/integration/test_openmeteo_integration.py::TestOpenMeteoGeocoding -q --tb=short -n 0 -rs
- uv run pytest tests/integration -q --collect-only -m live_only
- uv run pytest -q -rs