### PR TITLE
fix(location): name international current locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Alert sounds and sound-pack creation now focus on alert severity instead of a long list of specific alert names, while existing packs can keep their older mappings.
 
 ### Fixed
+- Detected current locations outside the US now get an editable place name when reverse geocoding can identify the coordinates.
 - Editing a location after using "Use my current location" now refreshes the editable name and saved US metadata for the detected point, so locations don't quietly fall back to metric defaults.
 - Notification sounds now recover after Windows sleep or hibernation, so update
   notifications don't fall back to only the generic Windows toast sound.

--- a/src/accessiweather/location_manager.py
+++ b/src/accessiweather/location_manager.py
@@ -39,6 +39,7 @@ class LocationManager:
         self.timeout = 10.0
         self.geocoding_base_url = "https://geocoding-api.open-meteo.com/v1"
         self.census_geocoding_base_url = "https://geocoding.geo.census.gov/geocoder"
+        self.nominatim_base_url = "https://nominatim.openstreetmap.org"
 
     @async_retry_with_backoff(max_attempts=3, base_delay=1.0, timeout=15.0)
     async def search_locations(self, query: str, limit: int = 5) -> list[Location]:
@@ -174,6 +175,18 @@ class LocationManager:
         longitude: float,
     ) -> Location | None:
         """Resolve coordinates to a friendly location label when a native source can name them."""
+        location = await self._reverse_geocode_with_nws(latitude, longitude)
+        if location is not None:
+            return location
+
+        return await self._reverse_geocode_with_nominatim(latitude, longitude)
+
+    async def _reverse_geocode_with_nws(
+        self,
+        latitude: float,
+        longitude: float,
+    ) -> Location | None:
+        """Resolve US coordinates through the National Weather Service points endpoint."""
         url = f"https://api.weather.gov/points/{latitude},{longitude}"
         headers = {
             "User-Agent": "AccessiWeather/1.0 (AccessiWeather)",
@@ -217,6 +230,122 @@ class LocationManager:
             timezone=properties.get("timeZone") or None,
             country_code="US",
         )
+
+    async def _reverse_geocode_with_nominatim(
+        self,
+        latitude: float,
+        longitude: float,
+    ) -> Location | None:
+        """Resolve non-US coordinates through OpenStreetMap Nominatim when available."""
+        url = f"{self.nominatim_base_url}/reverse"
+        params = {
+            "format": "jsonv2",
+            "lat": latitude,
+            "lon": longitude,
+            "zoom": 10,
+            "addressdetails": 1,
+            "accept-language": "en",
+        }
+        headers = {
+            "User-Agent": "AccessiWeather/1.0 (AccessiWeather)",
+            "Accept": "application/json",
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
+                response = await client.get(url, params=params, headers=headers)
+        except Exception as exc:  # noqa: BLE001 - manual location entry must remain available
+            logger.debug(
+                "Nominatim reverse geocoding failed for (%s, %s): %s",
+                latitude,
+                longitude,
+                exc,
+            )
+            return None
+
+        if response.status_code != 200:
+            logger.debug(
+                "Nominatim reverse geocoding returned status %s for (%s, %s)",
+                response.status_code,
+                latitude,
+                longitude,
+            )
+            return None
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            logger.debug("Nominatim reverse geocoding returned invalid JSON: %s", exc)
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        name = self._format_nominatim_location_name(data)
+        if not name:
+            return None
+
+        address = data.get("address", {})
+        country_code = None
+        if isinstance(address, dict):
+            country_code_value = str(address.get("country_code") or "").strip()
+            country_code = country_code_value.upper() or None
+
+        return Location(
+            name=name,
+            latitude=latitude,
+            longitude=longitude,
+            country_code=country_code,
+        )
+
+    def _format_nominatim_location_name(self, data: dict) -> str | None:
+        """Build an editable display label from a Nominatim reverse geocoding response."""
+        address = data.get("address", {})
+        if not isinstance(address, dict):
+            display_name = str(data.get("display_name") or "").strip()
+            return display_name or None
+
+        locality = self._first_non_empty_address_value(
+            address,
+            (
+                "city",
+                "town",
+                "village",
+                "municipality",
+                "hamlet",
+                "suburb",
+                "county",
+            ),
+        )
+        region = self._first_non_empty_address_value(
+            address,
+            (
+                "state",
+                "province",
+                "region",
+                "state_district",
+            ),
+        )
+        country = str(address.get("country") or "").strip()
+
+        parts: list[str] = []
+        for value in (locality, region, country):
+            if value and value.casefold() not in {part.casefold() for part in parts}:
+                parts.append(value)
+
+        if parts:
+            return ", ".join(parts)
+
+        display_name = str(data.get("display_name") or "").strip()
+        return display_name or None
+
+    def _first_non_empty_address_value(self, address: dict, keys: tuple[str, ...]) -> str | None:
+        """Return the first non-empty string value for a set of Nominatim address keys."""
+        for key in keys:
+            value = str(address.get(key) or "").strip()
+            if value:
+                return value
+        return None
 
     def _parse_census_address_match(self, data: dict) -> Location | None:
         """Parse a Census Geocoder address match into a Location."""

--- a/tests/test_location_manager_address_geocoding.py
+++ b/tests/test_location_manager_address_geocoding.py
@@ -173,3 +173,126 @@ async def test_reverse_geocode_coordinates_returns_none_when_nws_cannot_name_poi
         location = await manager.reverse_geocode_coordinates(51.5074, -0.1278)
 
     assert location is None
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_coordinates_uses_nominatim_for_international_point() -> None:
+    manager = LocationManager()
+
+    with patch("accessiweather.location_manager.httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client.get.side_effect = [
+            _make_nws_response({"properties": {}}, status_code=404),
+            _make_nws_response(
+                {
+                    "display_name": "London, Greater London, England, United Kingdom",
+                    "address": {
+                        "city": "London",
+                        "state": "England",
+                        "country": "United Kingdom",
+                        "country_code": "gb",
+                    },
+                }
+            ),
+        ]
+
+        location = await manager.reverse_geocode_coordinates(51.5074, -0.1278)
+
+    assert location is not None
+    assert location.name == "London, England, United Kingdom"
+    assert location.latitude == pytest.approx(51.5074)
+    assert location.longitude == pytest.approx(-0.1278)
+    assert location.country_code == "GB"
+    assert mock_client.get.call_count == 2
+    assert mock_client.get.call_args_list[1].args == (
+        "https://nominatim.openstreetmap.org/reverse",
+    )
+    assert mock_client.get.call_args_list[1].kwargs["params"] == {
+        "format": "jsonv2",
+        "lat": 51.5074,
+        "lon": -0.1278,
+        "zoom": 10,
+        "addressdetails": 1,
+        "accept-language": "en",
+    }
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_coordinates_uses_country_when_no_city_available() -> None:
+    manager = LocationManager()
+
+    with patch("accessiweather.location_manager.httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client.get.side_effect = [
+            _make_nws_response({"properties": {}}, status_code=404),
+            _make_nws_response(
+                {
+                    "display_name": "Iceland",
+                    "address": {
+                        "country": "Iceland",
+                        "country_code": "is",
+                    },
+                }
+            ),
+        ]
+
+        location = await manager.reverse_geocode_coordinates(64.9631, -19.0208)
+
+    assert location is not None
+    assert location.name == "Iceland"
+    assert location.country_code == "IS"
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_coordinates_returns_none_when_nominatim_times_out() -> None:
+    manager = LocationManager()
+
+    with patch("accessiweather.location_manager.httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client.get.side_effect = [
+            _make_nws_response({"properties": {}}, status_code=404),
+            TimeoutError("timed out"),
+        ]
+
+        location = await manager.reverse_geocode_coordinates(51.5074, -0.1278)
+
+    assert location is None
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_coordinates_returns_none_for_bad_nominatim_payload() -> None:
+    manager = LocationManager()
+
+    invalid_json_response = _make_nws_response({}, status_code=200)
+    invalid_json_response.json.side_effect = ValueError("not json")
+    non_object_response = _make_nws_response(["not", "an", "object"], status_code=200)
+    empty_name_response = _make_nws_response({"address": {}}, status_code=200)
+
+    for response in (invalid_json_response, non_object_response, empty_name_response):
+        with patch("accessiweather.location_manager.httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.get.side_effect = [
+                _make_nws_response({"properties": {}}, status_code=404),
+                response,
+            ]
+
+            location = await manager.reverse_geocode_coordinates(51.5074, -0.1278)
+
+        assert location is None
+
+
+def test_format_nominatim_location_name_falls_back_to_display_name() -> None:
+    manager = LocationManager()
+
+    name = manager._format_nominatim_location_name(
+        {
+            "display_name": "Coordinates near Antarctica",
+            "address": None,
+        }
+    )
+
+    assert name == "Coordinates near Antarctica"


### PR DESCRIPTION
## Summary
- Adds an OpenStreetMap Nominatim reverse-geocoding fallback after NWS cannot name detected coordinates
- Builds editable saved-location labels for international detected locations and preserves country codes when available
- Keeps unavailable, timeout, and invalid-response cases graceful so manual entry remains available

## Test Plan
- `.venv\Scripts\python.exe -m pytest tests\test_location_manager_address_geocoding.py tests\test_current_location.py -q`
- `.venv\Scripts\python.exe -m ruff check src\accessiweather\location_manager.py tests\test_location_manager_address_geocoding.py`
- `.venv\Scripts\pyright.exe src\accessiweather\location_manager.py`
- `.venv\Scripts\python.exe -m pytest tests\test_location_manager_address_geocoding.py tests\test_current_location.py tests\test_config_manager.py::TestConfigManager::test_update_location_details_changes_coordinates_and_clears_zone_metadata tests\test_config_manager.py::TestConfigManager::test_update_location_details_keeps_zone_metadata_when_coordinates_match tests\test_config_manager.py::TestConfigManager::test_update_location_details_nonexistent_returns_false tests\test_config_manager.py::TestConfigManager::test_update_location_details_rejects_duplicate_display_name tests\test_all_locations_view.py::TestEditLocation --cov=accessiweather --cov-report=xml:reports\coverage-international-location.xml -q`
- `uvx diff-cover reports\coverage-international-location.xml --compare-branch=origin/dev --fail-under=80 --exclude "*/accessiweather/ui/*"`
