### PR TITLE
fix: dedupe single-instance fallback handoff and relax activation polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - Default AI summaries now stay grounded in the provided weather text or data, so they are less likely to invent forecast details when summarizing reports.
 - Relaunching AccessiWeather on Windows now reliably restores the already-running window from desktop shortcuts, direct EXE launches, and portable copies without relying on the window title.
 - Restoring the running AccessiWeather window on relaunch, and bringing it to the front from a notification, now work reliably on 64-bit Windows where an internal window-handle bug could previously leave the window in the background.
+- Relaunching AccessiWeather no longer briefly activates the already-running window twice in the rare case its primary relaunch signal can't be delivered.
 - Alt+F4 now stays routed through the normal close-to-tray behavior after switching between All Locations and saved locations.
 - Automatic Windows startup now stays in the background when AccessiWeather is already running, and startup shortcuts are recreated with a stable AccessiWeather target for portable copies.
 - The Windows installer now closes running AccessiWeather copies automatically before installing, then can launch the updated app normally when setup exits.

--- a/src/accessiweather/app_activation.py
+++ b/src/accessiweather/app_activation.py
@@ -11,6 +11,11 @@ from .notification_activation import NotificationActivationRequest
 
 logger = logging.getLogger(__name__)
 
+# The handoff file is only a fallback for when the named-pipe IPC channel is
+# unavailable, so it doesn't need sub-second latency. Poll on a relaxed
+# interval to avoid a perpetual high-frequency wakeup for the whole session.
+_ACTIVATION_HANDOFF_POLL_MS = 2000
+
 
 def show_alert_dialog(parent, alert, settings=None) -> None:
     """Lazy wrapper for the single-alert details dialog."""
@@ -90,7 +95,7 @@ class AppActivationMixin:
             self._on_activation_handoff_timer,
             self._activation_handoff_timer,
         )
-        self._activation_handoff_timer.Start(750)
+        self._activation_handoff_timer.Start(_ACTIVATION_HANDOFF_POLL_MS)
 
     def _start_activation_ipc_server(self) -> None:
         """Start duplicate-launch IPC and route requests onto the UI thread."""

--- a/src/accessiweather/single_instance.py
+++ b/src/accessiweather/single_instance.py
@@ -99,6 +99,10 @@ class SingleInstanceManager:
             self._lock_acquired = True
             return True
 
+        # Policy: on any unexpected failure of the mutex check we return True
+        # ("allow startup"). A guard that occasionally permits a second instance
+        # is far better than one that can wedge the app shut, so every error
+        # path below intentionally falls through to launching.
         try:
             kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
             _configure_kernel32_signatures(kernel32)
@@ -140,10 +144,23 @@ class SingleInstanceManager:
         if sys.platform == "win32" and _send_activation_request_ipc(handoff_request):
             return True
 
-        self.write_activation_handoff(handoff_request)
         if sys.platform != "win32":
+            self.write_activation_handoff(handoff_request)
             return False
 
+        shown = self._show_existing_window()
+        # The direct window restore only raises the window; it cannot act on a
+        # specific request. Write the handoff so the primary instance still
+        # routes discussion/alert_details intents — but skip it for a plain
+        # generic_fallback that a successful restore already satisfied, so the
+        # primary doesn't handle the same generic request a second time when it
+        # polls for handoffs.
+        if not shown or handoff_request.kind != "generic_fallback":
+            self.write_activation_handoff(handoff_request)
+        return shown
+
+    def _show_existing_window(self) -> bool:
+        """Restore and foreground the existing main window; True if one was shown."""
         try:
             user32 = ctypes.WinDLL("user32", use_last_error=True)
             _configure_user32_signatures(user32)

--- a/tests/test_app_notification_activation.py
+++ b/tests/test_app_notification_activation.py
@@ -351,3 +351,19 @@ def test_force_foreground_window_uses_win32_handle_apis(monkeypatch) -> None:
     user32.ShowWindow.assert_called_once_with(0x1_0000_4242, 9)
     user32.SetForegroundWindow.assert_called_once_with(0x1_0000_4242)
     frame.Raise.assert_not_called()
+
+
+def test_start_activation_handoff_polling_uses_relaxed_interval() -> None:
+    """Handoff polling arms the timer at the relaxed fallback interval."""
+    from accessiweather import app_activation
+
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    app._activation_handoff_timer = None
+    app.Bind = MagicMock()
+
+    with patch("accessiweather.app_activation.wx") as mock_wx:
+        app._start_activation_handoff_polling()
+        timer = mock_wx.Timer.return_value
+
+    assert app_activation._ACTIVATION_HANDOFF_POLL_MS == 2000
+    timer.Start.assert_called_once_with(app_activation._ACTIVATION_HANDOFF_POLL_MS)

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -192,6 +192,52 @@ def test_second_windows_launch_restores_window_with_location_title(monkeypatch, 
     assert user32.foreground_calls == [2468]
 
 
+def test_generic_fallback_skips_handoff_when_window_restore_succeeds(monkeypatch, tmp_path):
+    runtime_paths = RuntimeStoragePaths(config_root=tmp_path / "config")
+    app = SimpleNamespace(runtime_paths=runtime_paths, formal_name="AccessiWeather")
+    kernel32 = _FakeKernel32(last_error=ERROR_ALREADY_EXISTS)
+    user32 = _FakeUser32(hwnd=2468)
+
+    import accessiweather.single_instance as single_instance
+
+    monkeypatch.setattr(single_instance.sys, "platform", "win32")
+    monkeypatch.setattr(single_instance, "ctypes", _FakeCtypes(kernel32, user32))
+    monkeypatch.setattr(single_instance, "_send_activation_request_ipc", lambda request: False)
+
+    manager = SingleInstanceManager(app, runtime_paths=runtime_paths)
+
+    assert manager.try_acquire_lock() is False
+    assert manager.request_existing_instance_show() is True
+    assert user32.foreground_calls == [2468]
+    # A plain generic restore that succeeded must not also leave a handoff for
+    # the primary to consume and act on a second time.
+    assert manager.consume_activation_handoff() is None
+
+
+def test_discussion_request_still_writes_handoff_when_window_restore_succeeds(
+    monkeypatch, tmp_path
+):
+    runtime_paths = RuntimeStoragePaths(config_root=tmp_path / "config")
+    app = SimpleNamespace(runtime_paths=runtime_paths, formal_name="AccessiWeather")
+    kernel32 = _FakeKernel32(last_error=ERROR_ALREADY_EXISTS)
+    user32 = _FakeUser32(hwnd=2468)
+
+    import accessiweather.single_instance as single_instance
+
+    monkeypatch.setattr(single_instance.sys, "platform", "win32")
+    monkeypatch.setattr(single_instance, "ctypes", _FakeCtypes(kernel32, user32))
+    monkeypatch.setattr(single_instance, "_send_activation_request_ipc", lambda request: False)
+
+    manager = SingleInstanceManager(app, runtime_paths=runtime_paths)
+
+    assert manager.try_acquire_lock() is False
+    assert manager.request_existing_instance_show(NotificationActivationRequest(kind="discussion"))
+    assert user32.foreground_calls == [2468]
+    # The window poke can't open the discussion dialog, so the intent must still
+    # be handed off for the primary to route.
+    assert manager.consume_activation_handoff() == NotificationActivationRequest(kind="discussion")
+
+
 def test_second_windows_launch_writes_generic_handoff_when_window_lookup_fails(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
> **Stacked on #698** (base is `fix/single-instance-handle-truncation`, not `dev`). Retarget to `dev` after #698 merges.

Follow-up cleanup to the single-instance activation path. No relation to the ABI fix in #698 beyond touching the same files — kept separate so each PR has one thesis.

## Changes

1. **Dedupe the fallback handoff (correctness).** When the named-pipe IPC is unavailable, `request_existing_instance_show` used to *both* write the handoff file *and* poke the window directly — so the primary instance could act on the same request twice (once via the handoff poll, once via the direct restore). Now the handoff is skipped for a plain `generic_fallback` that a successful window restore already satisfied, while `discussion`/`alert_details` intents — which the window poke can't carry — are still handed off. Window-restore logic extracted into `_show_existing_window`.
2. **Relax the handoff poll 750ms → 2000ms** via a named constant. The file handoff is only a fallback to IPC, so it doesn't need sub-second latency and shouldn't run a perpetual high-frequency timer for the whole session.
3. **Document the "allow startup on any failure" policy** in `try_acquire_lock`.

## Tests

Two new tests assert the dedupe: generic-on-success writes no handoff; `discussion`-on-success still does. 32/32 single-instance + activation tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)