### PR TITLE
fix: harden update, notification, and dialog reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Alert sounds and sound-pack creation now focus on alert severity instead of a long list of specific alert names, while existing packs can keep their older mappings.
 
 ### Fixed
+- Reliability fixes now prevent several update, notification, tray tooltip, dialog, NOAA radio, and alert-refresh edge cases from interrupting normal use.
 - Detected current locations outside the US now get an editable place name when reverse geocoding can identify the coordinates.
 - Editing a location after using "Use my current location" now refreshes the editable name and saved US metadata for the detected point, so locations don't quietly fall back to metric defaults.
 - Notification sounds now recover after Windows sleep or hibernation, so update

--- a/src/accessiweather/alert_manager.py
+++ b/src/accessiweather/alert_manager.py
@@ -425,6 +425,9 @@ class AlertManager:
         # Update global notification time if we're sending any notifications
         if notifications_to_send:
             self.last_global_notification = current_time
+            # Roll the hourly counter over at the hour boundary so it reflects
+            # notifications in the current hour, not a lifetime total.
+            self._reset_hourly_counter()
             self.notifications_this_hour += len(notifications_to_send)
 
         # Save state changes - always save to persist any alert state modifications

--- a/src/accessiweather/alert_manager_state.py
+++ b/src/accessiweather/alert_manager_state.py
@@ -157,4 +157,7 @@ class AlertSettings:
         """Check if we should notify for this event category."""
         if not event:
             return True
-        return event.lower() not in self.ignored_categories
+        # Compare case-insensitively: ignored_categories is populated from
+        # settings/imports without case normalization, so a stored value like
+        # "Tornado Warning" must still match the lowercased event.
+        return event.lower() not in {category.lower() for category in self.ignored_categories}

--- a/src/accessiweather/api_client/core_client.py
+++ b/src/accessiweather/api_client/core_client.py
@@ -157,6 +157,9 @@ class NoaaApiClient(AlertsAndProductsMixin):
                         response = client.get(
                             request_url, headers=self.headers, params=params, timeout=10
                         )
+                        # Buffer the body while the client is still open; .json()
+                        # and .text are accessed below after the client closes.
+                        response.read()
                     logger.debug(
                         f"Received response from {request_url} with status code: "
                         f"{response.status_code}"

--- a/src/accessiweather/cache_serialization.py
+++ b/src/accessiweather/cache_serialization.py
@@ -436,6 +436,7 @@ def _serialize_weather_data(weather: WeatherData) -> dict:
         "forecast": _serialize_forecast(weather.forecast),
         "hourly_forecast": _serialize_hourly(weather.hourly_forecast),
         "discussion": weather.discussion,
+        "discussion_issuance_time": _serialize_datetime(weather.discussion_issuance_time),
         "alerts": _serialize_alerts(weather.alerts),
         "environmental": _serialize_environmental(weather.environmental),
         "trend_insights": _serialize_trends(weather.trend_insights),

--- a/src/accessiweather/config/locations.py
+++ b/src/accessiweather/config/locations.py
@@ -43,6 +43,21 @@ class LocationOperations:
     def logger(self) -> logging.Logger:
         return self._manager._get_logger()
 
+    def _valid_coordinates(self, name: str, latitude: float, longitude: float) -> bool:
+        """Return True if the coordinates are within valid geographic bounds."""
+        try:
+            lat = float(latitude)
+            lon = float(longitude)
+        except (TypeError, ValueError):
+            self.logger.warning(f"Location {name} has non-numeric coordinates; rejecting")
+            return False
+        if not (-90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0):
+            self.logger.warning(
+                f"Location {name} has out-of-range coordinates ({latitude}, {longitude}); rejecting"
+            )
+            return False
+        return True
+
     def add_location(
         self,
         name: str,
@@ -52,6 +67,9 @@ class LocationOperations:
         marine_mode: bool = False,
     ) -> bool:
         """Add a new location if it doesn't already exist."""
+        if not self._valid_coordinates(name, latitude, longitude):
+            return False
+
         config = self._manager.get_config()
 
         for existing_location in config.locations:
@@ -95,6 +113,9 @@ class LocationOperations:
         those cases the zone fields remain null and the location is still
         saved.
         """
+        if not self._valid_coordinates(name, latitude, longitude):
+            return False
+
         config = self._manager.get_config()
 
         for existing_location in config.locations:

--- a/src/accessiweather/config/settings.py
+++ b/src/accessiweather/config/settings.py
@@ -187,9 +187,11 @@ class SettingsOperations:
         }
         if is_portable:
             secure_keys -= portable_api_keys
-        # These keys should be redacted in logs
+        # These keys should be redacted in logs (everything stored as a secret)
         redacted_keys = {
             "github_app_private_key",
+            "github_app_id",
+            "github_app_installation_id",
             "pirate_weather_api_key",
             "openrouter_api_key",
             "avwx_api_key",

--- a/src/accessiweather/forecast_confidence.py
+++ b/src/accessiweather/forecast_confidence.py
@@ -71,6 +71,24 @@ def _valid_sources(sources: list[SourceData]) -> list[SourceData]:
     return [s for s in sources if s.success and s.forecast is not None and s.forecast.has_data()]
 
 
+def _representative_period(forecast):
+    """
+    Pick a comparable period: the first daytime high, not an overnight low.
+
+    Sources don't agree on whether ``periods[0]`` is a daytime "Today" high or
+    an overnight "Tonight" low (it depends on the time of day a source is
+    fetched), so comparing ``periods[0]`` blindly can pit a high against a low
+    and produce a falsely large spread. Prefer the first period that has a
+    temperature and isn't named like a night period; fall back to the first
+    period when nothing better is found.
+    """
+    periods = forecast.periods
+    for period in periods:
+        if period.temperature is not None and "night" not in (period.name or "").lower():
+            return period
+    return periods[0] if periods else None
+
+
 def calculate_forecast_confidence(sources: list[SourceData]) -> ForecastConfidence:
     """
     Compute a confidence level by comparing the first forecast period across sources.
@@ -111,12 +129,12 @@ def calculate_forecast_confidence(sources: list[SourceData]) -> ForecastConfiden
 
     for s in valid:
         assert s.forecast is not None  # already filtered above
-        if s.forecast.periods:
-            p0 = s.forecast.periods[0]
-            if p0.temperature is not None:
-                temps.append(p0.temperature)
-            if p0.precipitation_probability is not None:
-                precips.append(p0.precipitation_probability)
+        period = _representative_period(s.forecast)
+        if period is not None:
+            if period.temperature is not None:
+                temps.append(period.temperature)
+            if period.precipitation_probability is not None:
+                precips.append(period.precipitation_probability)
 
     temp_spread = (max(temps) - min(temps)) if len(temps) >= 2 else 0.0
     precip_spread = (max(precips) - min(precips)) if len(precips) >= 2 else None

--- a/src/accessiweather/impact_summary.py
+++ b/src/accessiweather/impact_summary.py
@@ -17,6 +17,7 @@ Allergy
 
 from __future__ import annotations
 
+import math
 import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -76,7 +77,7 @@ def _outdoor_from_conditions(
     3. Appends precipitation warning when condition text implies active precipitation.
     """
     ref_temp = feels_like_f if feels_like_f is not None else temp_f
-    if ref_temp is None:
+    if ref_temp is None or not math.isfinite(ref_temp):
         return None
 
     comfort = next(label for upper, label in _OUTDOOR_TEMP_BANDS if ref_temp < upper)

--- a/src/accessiweather/models/config_serialization.py
+++ b/src/accessiweather/models/config_serialization.py
@@ -159,8 +159,8 @@ class AppSettingsSerializationMixin:
             notify_precipitation_likelihood=settings_cls._as_bool(
                 data.get("notify_precipitation_likelihood"), False
             ),
-            precipitation_likelihood_threshold=float(
-                data.get("precipitation_likelihood_threshold", 0.5)
+            precipitation_likelihood_threshold=settings_cls._as_float(
+                data.get("precipitation_likelihood_threshold"), 0.5
             ),
             github_backend_url=data.get("github_backend_url", ""),
             alert_radius_type=data.get("alert_radius_type", "county"),

--- a/src/accessiweather/models/config_validation.py
+++ b/src/accessiweather/models/config_validation.py
@@ -70,8 +70,13 @@ class AppSettingsValidationMixin:
                 setattr(settings, setting_name, "standard")
 
         elif setting_name == "update_channel":
-            valid_channels = {"stable", "beta", "dev"}
-            if value not in valid_channels:
+            # Canonical channels are "stable" and "nightly". "dev"/"beta" are
+            # legacy aliases for the non-stable channel — migrate them to
+            # "nightly" rather than resetting to stable (which would silently
+            # downgrade a nightly user).
+            if value in {"dev", "beta"}:
+                setattr(settings, setting_name, "nightly")
+            elif value not in {"stable", "nightly"}:
                 setattr(settings, setting_name, "stable")
 
         elif setting_name == "time_display_mode":

--- a/src/accessiweather/noaa_radio/stream_url.py
+++ b/src/accessiweather/noaa_radio/stream_url.py
@@ -423,4 +423,17 @@ class StreamURLProvider:
 
         # WeatherIndex requires call sign specific queries, so we can't
         # pre-warm all at once - this would require knowing all station
-        # call signs ahead of time. The cache will warm on first play.
+        # call signs ahead of time. Use prewarm_stations() to warm a known set.
+
+    def prewarm_stations(self, call_signs: list[str]) -> None:
+        """
+        Pre-warm per-call-sign stream URL caches for a set of stations.
+
+        Resolves stream URLs for each call sign so a later, main-thread
+        ``get_stream_urls`` lookup (e.g. when the user presses Play) hits a warm
+        cache instead of blocking on a network request. Intended to be called
+        from a background thread. Safe to call multiple times.
+        """
+        for call_sign in call_signs:
+            with suppress(Exception):
+                self.get_stream_urls(call_sign)

--- a/src/accessiweather/notifications/toast_notifier_windows.py
+++ b/src/accessiweather/notifications/toast_notifier_windows.py
@@ -74,6 +74,9 @@ class ToastedWindowsNotifier:
         logger.info("ToastedWindowsNotifier initialized (app_id=%s)", WINDOWS_APP_USER_MODEL_ID)
         # Eagerly start worker thread to avoid first-notification delay
         self._ensure_worker()
+        # Start the watchdog so a dead worker thread is detected and restarted;
+        # without this, toasts silently stop until the app is relaunched.
+        self._start_watchdog()
 
     # -- worker thread management ------------------------------------------
 

--- a/src/accessiweather/notifications/weather_notifier.py
+++ b/src/accessiweather/notifications/weather_notifier.py
@@ -348,6 +348,10 @@ class WeatherNotifier:
                 sent_time = isoparse(sent_str) if sent_str else datetime.min.replace(tzinfo=UTC)
             except Exception:
                 sent_time = datetime.min.replace(tzinfo=UTC)
+            # Normalize to tz-aware so sorting never mixes naive and aware
+            # datetimes (which raises TypeError and would drop all notifications).
+            if sent_time.tzinfo is None:
+                sent_time = sent_time.replace(tzinfo=UTC)
 
             # Return tuple for sorting: (severity_score, sent_time)
             # Higher severity score and more recent time are preferred

--- a/src/accessiweather/openmeteo_forecast_mapper.py
+++ b/src/accessiweather/openmeteo_forecast_mapper.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, timezone
 from typing import Any
 
 from .openmeteo_client import OpenMeteoApiClient
@@ -38,18 +38,25 @@ def map_forecast(
 
         for i, date_str in enumerate(dates):
             try:
-                # Parse the date - convert from local time to UTC
-                date_str_utc = parse_datetime(date_str, utc_offset_seconds)
-                if date_str_utc:
-                    date_obj = datetime.fromisoformat(date_str_utc)
-                else:
-                    # Fallback to treating as UTC if parsing fails
+                # Open-Meteo daily "time" values are calendar dates (e.g.
+                # "2026-05-28") already in the location's local timezone. Treat
+                # them as local dates so the weekday label and the 6am/6pm
+                # period boundaries are correct. Converting to UTC (as the
+                # hourly path does) would shift the day backwards for locations
+                # east of UTC and place the boundaries in UTC rather than local.
+                try:
+                    date_obj = datetime.fromisoformat(date_str)
+                except ValueError:
                     date_obj = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+                if date_obj.tzinfo is None and utc_offset_seconds is not None:
+                    date_obj = date_obj.replace(
+                        tzinfo=timezone(timedelta(seconds=utc_offset_seconds))
+                    )
 
                 # Create day and night periods (NWS style)
                 day_period = {
                     "number": i * 2 + 1,
-                    "name": date_obj.strftime("%A") if i == 0 else date_obj.strftime("%A"),
+                    "name": date_obj.strftime("%A"),
                     "startTime": date_obj.replace(hour=6).isoformat(),
                     "endTime": date_obj.replace(hour=18).isoformat(),
                     "isDaytime": True,

--- a/src/accessiweather/services/community_soundpack_service.py
+++ b/src/accessiweather/services/community_soundpack_service.py
@@ -422,6 +422,11 @@ class CommunitySoundPackService:
                     continue
                 rel_path = item.get("path") or ""
                 target_path = staging_dir / rel_path
+                # Defense-in-depth: ensure a malicious/unexpected tree path can't
+                # escape the staging directory (path traversal / zip-slip).
+                staging_root = staging_dir.resolve()
+                if not target_path.resolve().is_relative_to(staging_root):
+                    raise RuntimeError(f"Unsafe path in repository tree: {rel_path!r}")
                 target_path.parent.mkdir(parents=True, exist_ok=True)
                 raw_url = (
                     f"https://raw.githubusercontent.com/{self.repo_owner}/{self.repo_name}/"

--- a/src/accessiweather/services/simple_update.py
+++ b/src/accessiweather/services/simple_update.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import tempfile
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -76,6 +76,11 @@ class UpdateInfo:
     commit_hash: str | None
     is_nightly: bool
     is_prerelease: bool
+    # The originating GitHub release dict, retained so download_update() can
+    # locate the checksum asset and verify integrity without the caller having
+    # to thread the release through. Excluded from equality/hash/repr because
+    # it is large and not part of the update's identity.
+    release: dict[str, Any] | None = field(default=None, compare=False, repr=False)
 
 
 def parse_commit_hash(release_notes: str) -> str | None:
@@ -360,6 +365,7 @@ class UpdateService:
             commit_hash=commit_hash,
             is_nightly=release_type == "nightly",
             is_prerelease=bool(latest.get("prerelease")),
+            release=latest,
         )
 
     async def download_update(
@@ -407,48 +413,72 @@ class UpdateService:
 
         logger.info("Downloaded update to %s", dest_path)
 
-        # Verify integrity if a checksum asset is available
-        if release is not None:
-            checksum_asset = find_checksum_asset(release, update_info.artifact_name)
-            if checksum_asset:
-                checksum_url = checksum_asset.get("browser_download_url", "")
-                if checksum_url:
-                    try:
-                        checksum_response = await self.http_client.get(checksum_url)
-                        checksum_response.raise_for_status()
-                        checksum_content = checksum_response.text
+        # Verify integrity. Fall back to the release attached to the UpdateInfo
+        # so the integrity check runs even when the caller does not pass one.
+        if release is None:
+            release = update_info.release
 
-                        parsed = parse_checksum_file(checksum_content, update_info.artifact_name)
-                        if parsed:
-                            algo, expected_hash = parsed
-                            if not verify_file_checksum(dest_path, algo, expected_hash):
-                                # Remove the corrupt/tampered file
-                                dest_path.unlink(missing_ok=True)
-                                raise ChecksumVerificationError(
-                                    f"Checksum verification failed for {update_info.artifact_name}. "
-                                    f"Expected {algo}:{expected_hash}. "
-                                    "The downloaded file may be corrupted or tampered with."
-                                )
-                            logger.info(
-                                "Checksum verified (%s) for %s",
-                                algo,
-                                update_info.artifact_name,
-                            )
-                        else:
-                            logger.warning(
-                                "Could not parse checksum for %s from checksum file",
-                                update_info.artifact_name,
-                            )
-                    except httpx.HTTPError:
-                        logger.warning(
-                            "Failed to download checksum file for %s; skipping verification",
-                            update_info.artifact_name,
-                        )
-            else:
-                logger.warning(
-                    "No checksum file found for %s; integrity not verified",
-                    update_info.artifact_name,
-                )
+        if release is None:
+            # We cannot identify the source release, so we cannot prove the
+            # artifact is genuine. Refuse to hand back an unverifiable update.
+            dest_path.unlink(missing_ok=True)
+            raise ChecksumVerificationError(
+                f"Cannot verify {update_info.artifact_name}: no release metadata available. "
+                "Refusing to install an unverified update."
+            )
+
+        checksum_asset = find_checksum_asset(release, update_info.artifact_name)
+        if checksum_asset is None:
+            # No checksum was published for this release. This is unusual for
+            # current releases (the build pipeline always uploads checksums.txt)
+            # so treat a missing checksum as a soft failure: warn loudly but do
+            # not block, to stay forward-compatible with releases that omit it.
+            logger.warning(
+                "No checksum asset found for %s; integrity could not be verified",
+                update_info.artifact_name,
+            )
+            return dest_path
+
+        # A checksum asset exists, so verification is mandatory. Any failure to
+        # download, parse, or match it is treated as a verification failure and
+        # the downloaded file is discarded (fail-closed).
+        checksum_url = checksum_asset.get("browser_download_url", "")
+        if not checksum_url:
+            dest_path.unlink(missing_ok=True)
+            raise ChecksumVerificationError(
+                f"Checksum asset for {update_info.artifact_name} has no download URL; "
+                "cannot verify integrity."
+            )
+
+        try:
+            checksum_response = await self.http_client.get(checksum_url)
+            checksum_response.raise_for_status()
+            checksum_content = checksum_response.text
+        except httpx.HTTPError as err:
+            dest_path.unlink(missing_ok=True)
+            raise ChecksumVerificationError(
+                f"Failed to download checksum file for {update_info.artifact_name}; "
+                "cannot verify integrity."
+            ) from err
+
+        parsed = parse_checksum_file(checksum_content, update_info.artifact_name)
+        if parsed is None:
+            dest_path.unlink(missing_ok=True)
+            raise ChecksumVerificationError(
+                f"Could not find a checksum for {update_info.artifact_name} in the "
+                "published checksum file; cannot verify integrity."
+            )
+
+        algo, expected_hash = parsed
+        if not verify_file_checksum(dest_path, algo, expected_hash):
+            # Remove the corrupt/tampered file
+            dest_path.unlink(missing_ok=True)
+            raise ChecksumVerificationError(
+                f"Checksum verification failed for {update_info.artifact_name}. "
+                f"Expected {algo}:{expected_hash}. "
+                "The downloaded file may be corrupted or tampered with."
+            )
+        logger.info("Checksum verified (%s) for %s", algo, update_info.artifact_name)
 
         return dest_path
 

--- a/src/accessiweather/services/update_restart.py
+++ b/src/accessiweather/services/update_restart.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import platform
+import shlex
 import sys
 import tempfile
 import textwrap
@@ -22,21 +23,37 @@ def build_macos_update_script(
     update_path: Path,
     app_path: Path,
 ) -> str:
-    """Build a shell script to apply a macOS update."""
+    """
+    Build a shell script to apply a macOS update.
+
+    Paths are shell-quoted so spaces or shell metacharacters in the install
+    location cannot break or inject into the generated script. The DMG branch
+    mounts to a specific mountpoint reported by ``hdiutil`` instead of globbing
+    ``/Volumes/*``, which could otherwise pick up an unrelated mounted volume.
+    """
     app_dir = app_path.parent
+    q_update = shlex.quote(str(update_path))
+    q_app_dir = shlex.quote(str(app_dir))
+    q_app_path = shlex.quote(str(app_path))
     return textwrap.dedent(
         f"""
         #!/bin/bash
         sleep 2
-        if [[ "{update_path}" == *.zip ]]; then
-            unzip -o "{update_path}" -d "{app_dir}"
-        elif [[ "{update_path}" == *.dmg ]]; then
-            hdiutil attach "{update_path}" -nobrowse -quiet
-            cp -R /Volumes/*/*.app "{app_dir}/"
-            hdiutil detach /Volumes/* -quiet
+        UPDATE_PATH={q_update}
+        APP_DIR={q_app_dir}
+        APP_PATH={q_app_path}
+        if [[ "$UPDATE_PATH" == *.zip ]]; then
+            unzip -o "$UPDATE_PATH" -d "$APP_DIR"
+        elif [[ "$UPDATE_PATH" == *.dmg ]]; then
+            MOUNT_DIR=$(hdiutil attach "$UPDATE_PATH" -nobrowse -quiet \
+                | grep -oE '/Volumes/[^[:cntrl:]]+' | tail -1)
+            if [[ -n "$MOUNT_DIR" ]]; then
+                cp -R "$MOUNT_DIR"/*.app "$APP_DIR/"
+                hdiutil detach "$MOUNT_DIR" -quiet
+            fi
         fi
-        open "{app_path}" --args --updated
-        rm -f "$0" "{update_path}"
+        open "$APP_PATH" --args --updated
+        rm -f "$0" "$UPDATE_PATH"
         """
     ).strip()
 

--- a/src/accessiweather/services/update_service/releases.py
+++ b/src/accessiweather/services/update_service/releases.py
@@ -19,7 +19,8 @@ logger = logging.getLogger(__name__)
 
 GITHUB_API_URL = "https://api.github.com/repos/{owner}/{repo}/releases"
 CACHE_EXPIRY_SECONDS = 3600  # 1 hour
-VALID_CHANNELS = {"stable", "dev"}
+# "nightly" is the canonical non-stable channel; "dev" is kept as a legacy alias.
+VALID_CHANNELS = {"stable", "nightly", "dev"}
 
 
 class ReleaseManager:
@@ -198,8 +199,8 @@ class ReleaseManager:
                 if not prerelease and not is_nightly:
                     filtered.append(release)
 
-            elif channel == "dev":
-                # Dev: all releases
+            else:
+                # Non-stable ("nightly"/"dev"): all releases
                 filtered.append(release)
 
         return filtered

--- a/src/accessiweather/taskbar_icon_updater.py
+++ b/src/accessiweather/taskbar_icon_updater.py
@@ -287,6 +287,10 @@ class TaskbarIconUpdater:
             parts.append(formatted_direction)
         if speed_str != PLACEHOLDER_NA:
             parts.append(f"at {speed_str}")
+        else:
+            legacy_speed = getattr(current, "wind_speed", None)
+            if legacy_speed is not None:
+                parts.append(f"at {legacy_speed:.0f} mph")
 
         return " ".join(parts) if parts else PLACEHOLDER_NA
 

--- a/src/accessiweather/taskbar_icon_updater.py
+++ b/src/accessiweather/taskbar_icon_updater.py
@@ -463,7 +463,10 @@ class TaskbarIconUpdater:
 
         result = self.parser.format_string(format_string, data)
 
-        if "Error" in result:
+        # The parser signals failure with a string starting with "Error:".
+        # Match the prefix so a legitimate value containing the word "error"
+        # doesn't blank the tooltip.
+        if result.startswith("Error:"):
             logger.warning("Format error: %s", result)
             return DEFAULT_TOOLTIP_TEXT
 

--- a/src/accessiweather/taskbar_icon_updater.py
+++ b/src/accessiweather/taskbar_icon_updater.py
@@ -277,17 +277,16 @@ class TaskbarIconUpdater:
     def _format_wind(self, current: Any) -> str:
         """Format wind direction and speed."""
         direction = getattr(current, "wind_direction", None)
-        speed = getattr(current, "wind_speed", None)
-
-        if direction is None and speed is None:
-            return PLACEHOLDER_NA
+        # Format the speed through the unit-aware helper rather than assuming
+        # mph: wind_speed may carry km/h for metric-only sources.
+        speed_str = self._format_wind_speed(current)
 
         parts = []
         formatted_direction = self._format_wind_direction(direction)
         if formatted_direction != PLACEHOLDER_NA:
             parts.append(formatted_direction)
-        if speed is not None:
-            parts.append(f"at {speed:.0f} mph")
+        if speed_str != PLACEHOLDER_NA:
+            parts.append(f"at {speed_str}")
 
         return " ".join(parts) if parts else PLACEHOLDER_NA
 

--- a/src/accessiweather/ui/dialogs/advanced_text_product_dialog.py
+++ b/src/accessiweather/ui/dialogs/advanced_text_product_dialog.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, Any
 
 import wx
 
+from .async_guard import guard_destroyed
+
 if TYPE_CHECKING:
     from ...models import Location, TextProduct
     from ...services.forecast_product_service import ForecastProductService
@@ -538,7 +540,12 @@ class AdvancedTextProductDialog(wx.Dialog):
         except Exception as exc:  # noqa: BLE001
             logger.warning("Advanced text product lookup failed: %s", exc)
             text = f"Lookup failed: {exc}"
-        wx.CallAfter(self.result_text.SetValue, text)
+        wx.CallAfter(self._apply_lookup_result, text)
+
+    @guard_destroyed
+    def _apply_lookup_result(self, text: str) -> None:
+        """Apply the lookup result to the UI (guarded against dialog close)."""
+        self.result_text.SetValue(text)
 
     def _run_lookup_sync(self) -> str:
         """Run a lookup synchronously for stub GUI tests."""

--- a/src/accessiweather/ui/dialogs/async_guard.py
+++ b/src/accessiweather/ui/dialogs/async_guard.py
@@ -1,0 +1,38 @@
+"""
+Guard helpers for wx.CallAfter completion handlers.
+
+Background work in the dialogs marshals its result back onto the main thread
+via ``wx.CallAfter``. If the user closes the dialog before that callback runs,
+the queued handler touches widgets whose underlying C++ objects have already
+been destroyed, which raises ``RuntimeError: wrapped C/C++ object of type ...
+has been deleted``. The :func:`guard_destroyed` decorator swallows exactly that
+case so a closed dialog can never crash the app, while re-raising any other
+``RuntimeError`` so genuine bugs stay visible.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+logger = logging.getLogger(__name__)
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def guard_destroyed(method: F) -> F:
+    """Skip a wx completion handler if its dialog/widgets were already destroyed."""
+
+    @functools.wraps(method)
+    def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+        try:
+            return method(self, *args, **kwargs)
+        except RuntimeError as exc:
+            if "has been deleted" in str(exc):
+                logger.debug("Skipping %s: window destroyed before callback ran", method.__name__)
+                return None
+            raise
+
+    return wrapper  # type: ignore[return-value]

--- a/src/accessiweather/ui/dialogs/discussion_dialog.py
+++ b/src/accessiweather/ui/dialogs/discussion_dialog.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import wx
 
 from ...screen_reader import ScreenReaderAnnouncer
+from .async_guard import guard_destroyed
 
 if TYPE_CHECKING:
     from ...app import AccessiWeatherApp
@@ -235,6 +236,7 @@ class DiscussionDialog(wx.Dialog):
             logger.error(f"Discussion fetch failed: {e}")
             wx.CallAfter(self._on_fetch_error, str(e))
 
+    @guard_destroyed
     def _on_fetch_complete(self, location_name: str, discussion: str | None) -> None:
         """Handle fetch completion."""
         self._is_loading = False
@@ -253,6 +255,7 @@ class DiscussionDialog(wx.Dialog):
             )
             self.explain_button.Disable()
 
+    @guard_destroyed
     def _on_fetch_error(self, error: str) -> None:
         """Handle fetch error."""
         self._is_loading = False
@@ -319,6 +322,7 @@ class DiscussionDialog(wx.Dialog):
         # Run async explanation
         self.app.run_async(self._do_explain())
 
+    @guard_destroyed
     def _on_explain_status(self, message: str) -> None:
         """Show model-selection progress while the summary is running."""
         DiscussionDialog._show_ai_summary_section(self)
@@ -412,6 +416,7 @@ class DiscussionDialog(wx.Dialog):
             info_lines.append("Cached: Yes")
         return "\n".join(info_lines)
 
+    @guard_destroyed
     def _on_explain_complete(
         self,
         explanation: str,
@@ -452,6 +457,7 @@ class DiscussionDialog(wx.Dialog):
             cache.clear()
         self._on_explain(event)
 
+    @guard_destroyed
     def _on_explain_error(self, error: str) -> None:
         """Handle explanation error."""
         self._is_explaining = False

--- a/src/accessiweather/ui/dialogs/discussion_dialog.py
+++ b/src/accessiweather/ui/dialogs/discussion_dialog.py
@@ -479,6 +479,9 @@ class DiscussionDialog(wx.Dialog):
 
     def _on_close(self, event) -> None:
         """Handle close button press."""
+        announcer = getattr(self, "_announcer", None)
+        if announcer is not None:
+            announcer.shutdown()
         self.EndModal(wx.ID_CLOSE)
 
 

--- a/src/accessiweather/ui/dialogs/forecast_product_panel.py
+++ b/src/accessiweather/ui/dialogs/forecast_product_panel.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, cast
 import wx
 
 from ...screen_reader import ScreenReaderAnnouncer
+from .async_guard import guard_destroyed
 from .forecast_product_ai import (
     build_explainer,
     has_openrouter_key,
@@ -269,6 +270,7 @@ class ForecastProductPanel(wx.Panel):
         self._hide_ai_summary_section()
         self.explain_button.Disable()
 
+    @guard_destroyed
     def _on_load_complete(
         self,
         result: TextProduct | list[TextProduct] | None,
@@ -352,6 +354,7 @@ class ForecastProductPanel(wx.Panel):
         self._hide_ai_summary_section()
         self._set_post_explain_buttons(has_attempted=False)
 
+    @guard_destroyed
     def _on_load_error(self, exc: Exception) -> None:
         """Render the fetch-failed state."""
         del exc
@@ -425,6 +428,7 @@ class ForecastProductPanel(wx.Panel):
         )
         self._schedule_explain(self._current_text)
 
+    @guard_destroyed
     def _on_explain_status(self, message: str) -> None:
         """Show model-selection progress while the summary is running."""
         self._show_ai_summary_section()
@@ -527,6 +531,7 @@ class ForecastProductPanel(wx.Panel):
             info_lines.append("Cached: Yes")
         return "\n".join(info_lines)
 
+    @guard_destroyed
     def _on_explain_complete(
         self,
         summary: str,
@@ -560,6 +565,7 @@ class ForecastProductPanel(wx.Panel):
             completion_message = f"Plain Language Summary generated using {model_used}."
         self._announce_explain_status(completion_message)
 
+    @guard_destroyed
     def _on_explain_error(self, message: str) -> None:
         """Populate the AI summary TextCtrl with an error message."""
         self._is_explaining = False

--- a/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
+++ b/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
@@ -107,6 +107,9 @@ class NOAARadioDialog(wx.Dialog):
         self._current_urls: list[str] = []
         self._current_url_index: int = 0
         self._playing_station: Station | None = None
+        # Set once the dialog is closed so background-thread completion handlers
+        # (delivered via wx.CallAfter) don't touch destroyed widgets.
+        self._closed = False
         self._health_timer = wx.Timer(self)
         self.Bind(wx.EVT_TIMER, self._on_health_check, self._health_timer)
 
@@ -175,6 +178,11 @@ class NOAARadioDialog(wx.Dialog):
         """Worker that pre-warms stream cache."""
         try:
             self._url_provider.prewarm_cache()
+            # Also warm the per-call-sign WeatherIndex cache for the displayed
+            # stations so the synchronous lookup in _on_play doesn't block the
+            # UI thread on first play.
+            call_signs = [station.call_sign for station in stations]
+            self._url_provider.prewarm_stations(call_signs)
             logger.debug("Pre-warmed stream cache")
         except Exception as e:
             logger.debug(f"Failed to pre-warm stream cache: {e}")
@@ -182,7 +190,7 @@ class NOAARadioDialog(wx.Dialog):
     def _on_stations_loaded(self, stations: list[Station], choices: list[str]) -> None:
         """Handle stations loaded in background thread."""
         # Check if dialog was closed while background thread was running
-        if self._station_choice is None:
+        if getattr(self, "_closed", False):
             return
         previous_station = self._get_selected_station()
         previous_call_sign = previous_station.call_sign if previous_station is not None else None
@@ -242,6 +250,9 @@ class NOAARadioDialog(wx.Dialog):
             self._set_status("No station selected")
             return
 
+        # Stream URLs for the displayed stations are warmed in the background by
+        # _prewarm_stream_cache_worker after the list loads, so this lookup
+        # normally hits a warm per-call-sign cache instead of blocking on HTTP.
         urls = self._url_provider.get_stream_urls(station.call_sign)
         if not urls:
             self._set_status(f"No stream available for {station.call_sign}")
@@ -385,6 +396,8 @@ class NOAARadioDialog(wx.Dialog):
 
     def _set_status(self, text: str) -> None:
         """Update the status text."""
+        if getattr(self, "_closed", False):
+            return
         self._status_text.SetLabel(text)
 
     def _on_show_unavailable_changed(self, _event: wx.CommandEvent) -> None:
@@ -439,6 +452,7 @@ class NOAARadioDialog(wx.Dialog):
 
     def _on_close(self, _event: wx.Event) -> None:
         """Handle dialog close."""
+        self._closed = True
         self._health_timer.Stop()
         self._player.stop()
         self.Destroy()

--- a/src/accessiweather/ui/dialogs/settings_tabs/updates.py
+++ b/src/accessiweather/ui/dialogs/settings_tabs/updates.py
@@ -101,7 +101,11 @@ class UpdatesTab:
         controls = self.dialog._controls
         return {
             "auto_update_enabled": controls["auto_update"].GetValue(),
-            "update_channel": "stable" if controls["update_channel"].GetSelection() == 0 else "dev",
+            # The canonical non-stable channel is "nightly" (matches the build
+            # migration default, select_latest_release, and the startup guard).
+            "update_channel": (
+                "stable" if controls["update_channel"].GetSelection() == 0 else "nightly"
+            ),
             "update_check_interval_hours": controls["update_check_interval"].GetValue(),
         }
 

--- a/src/accessiweather/ui/dialogs/soundpack_wizard_dialog.py
+++ b/src/accessiweather/ui/dialogs/soundpack_wizard_dialog.py
@@ -42,6 +42,9 @@ class SoundPackWizardDialog(wx.Dialog):
 
         self._create_ui()
         self.Bind(wx.EVT_CHAR_HOOK, self._on_char_hook)
+        # Route the title-bar close button through the same cancel/cleanup path
+        # so the staging temp directory isn't leaked when closed via the "X".
+        self.Bind(wx.EVT_CLOSE, self._on_close)
         self._render_step()
         self.Centre()
 
@@ -421,37 +424,48 @@ class SoundPackWizardDialog(wx.Dialog):
             suffix += 1
 
         pack_dir = self.soundpacks_dir / pack_id
-        pack_dir.mkdir(parents=True)
 
-        # Copy sound files
-        sounds_mapping = {}
-        for key, src_path_str in self.state.sound_mappings.items():
-            if not src_path_str:
-                continue
-            src_path = Path(src_path_str)
-            if src_path.exists():
-                dest = pack_dir / src_path.name
-                shutil.copy2(src_path, dest)
-                sounds_mapping[key] = src_path.name
+        try:
+            pack_dir.mkdir(parents=True)
 
-        # Create pack.json
-        pack_data = {
-            "name": self.state.pack_name,
-            "author": self.state.author or "Unknown",
-            "description": self.state.description,
-            "version": "1.0.0",
-            "sounds": sounds_mapping,
-        }
+            # Copy sound files
+            sounds_mapping = {}
+            for key, src_path_str in self.state.sound_mappings.items():
+                if not src_path_str:
+                    continue
+                src_path = Path(src_path_str)
+                if src_path.exists():
+                    dest = pack_dir / src_path.name
+                    shutil.copy2(src_path, dest)
+                    sounds_mapping[key] = src_path.name
 
-        pack_json = pack_dir / "pack.json"
-        with open(pack_json, "w", encoding="utf-8") as f:
-            json.dump(pack_data, f, indent=2)
+            # Create pack.json
+            pack_data = {
+                "name": self.state.pack_name,
+                "author": self.state.author or "Unknown",
+                "description": self.state.description,
+                "version": "1.0.0",
+                "sounds": sounds_mapping,
+            }
+
+            pack_json = pack_dir / "pack.json"
+            with open(pack_json, "w", encoding="utf-8") as f:
+                json.dump(pack_data, f, indent=2)
+        except OSError as exc:
+            logger.error("Failed to create sound pack %s: %s", pack_id, exc)
+            # Remove the partially written pack directory so it isn't left behind.
+            with contextlib.suppress(Exception):
+                shutil.rmtree(pack_dir)
+            wx.MessageBox(
+                f"Failed to create sound pack:\n{exc}",
+                "Pack Creation Failed",
+                wx.OK | wx.ICON_ERROR,
+            )
+            return
 
         self.created_pack_id = pack_id
 
-        # Clean up staging directory
-        with contextlib.suppress(Exception):
-            shutil.rmtree(self.staging_dir)
+        self._cleanup_staging()
 
         wx.MessageBox(
             f"Sound pack '{self.state.pack_name}' created successfully!",
@@ -460,6 +474,11 @@ class SoundPackWizardDialog(wx.Dialog):
         )
 
         self.EndModal(wx.ID_OK)
+
+    def _cleanup_staging(self) -> None:
+        """Remove the temporary staging directory if it still exists."""
+        with contextlib.suppress(Exception):
+            shutil.rmtree(self.staging_dir)
 
     def _on_char_hook(self, event: wx.KeyEvent) -> None:
         """Handle keyboard shortcuts for the dialog."""
@@ -492,9 +511,7 @@ class SoundPackWizardDialog(wx.Dialog):
             if result != wx.YES:
                 return
 
-        # Clean up staging directory
-        with contextlib.suppress(Exception):
-            shutil.rmtree(self.staging_dir)
+        self._cleanup_staging()
 
         self.EndModal(wx.ID_CANCEL)
 

--- a/src/accessiweather/ui/dialogs/weather_assistant_dialog.py
+++ b/src/accessiweather/ui/dialogs/weather_assistant_dialog.py
@@ -16,6 +16,7 @@ import wx
 
 from ...ai_tools import WeatherToolExecutor, get_tools_for_message
 from ...screen_reader import ScreenReaderAnnouncer
+from .async_guard import guard_destroyed
 from .weather_assistant_context import build_weather_context as _build_weather_context
 from .weather_assistant_prompt import SYSTEM_PROMPT
 from .weather_assistant_widgets import create_weather_assistant_widgets
@@ -439,6 +440,7 @@ class WeatherAssistantDialog(wx.Dialog):
         thread = threading.Thread(target=do_generate, daemon=True)
         thread.start()
 
+    @guard_destroyed
     def _on_response_received(self, text: str, model_used: str) -> None:
         """Handle successful AI response."""
         self._conversation.append({"role": "assistant", "content": text})
@@ -447,6 +449,7 @@ class WeatherAssistantDialog(wx.Dialog):
         self._set_status(f"Model: {model_used}")
         self._set_generating(False)
 
+    @guard_destroyed
     def _on_response_error(self, error: str) -> None:
         """Handle AI response error."""
         error_message = f"Sorry, I couldn't respond: {error}"

--- a/src/accessiweather/ui/system_tray.py
+++ b/src/accessiweather/ui/system_tray.py
@@ -257,14 +257,25 @@ class SystemTrayIcon(wx.adv.TaskBarIcon):
                     import ctypes
 
                     hwnd = frame.GetHandle()
-                    user32 = ctypes.windll.user32
+                    # Use WinDLL with explicit signatures so the 64-bit HWND is
+                    # not truncated to a c_int (see fix #698).
+                    user32 = ctypes.WinDLL("user32", use_last_error=True)
+                    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+                    user32.IsIconic.restype = ctypes.c_bool
+                    user32.IsIconic.argtypes = [ctypes.c_void_p]
+                    user32.ShowWindow.restype = ctypes.c_bool
+                    user32.ShowWindow.argtypes = [ctypes.c_void_p, ctypes.c_int]
+                    user32.AllowSetForegroundWindow.argtypes = [ctypes.c_ulong]
+                    user32.SetForegroundWindow.restype = ctypes.c_bool
+                    user32.SetForegroundWindow.argtypes = [ctypes.c_void_p]
+                    kernel32.GetCurrentProcessId.restype = ctypes.c_ulong
                     SW_RESTORE = 9
                     SW_SHOWNORMAL = 1
                     if user32.IsIconic(hwnd):
                         user32.ShowWindow(hwnd, SW_RESTORE)
                     else:
                         user32.ShowWindow(hwnd, SW_SHOWNORMAL)
-                    user32.AllowSetForegroundWindow(ctypes.windll.kernel32.GetCurrentProcessId())
+                    user32.AllowSetForegroundWindow(kernel32.GetCurrentProcessId())
                     user32.SetForegroundWindow(hwnd)
                 except Exception:
                     frame.Raise()

--- a/src/accessiweather/utils/unit_utils.py
+++ b/src/accessiweather/utils/unit_utils.py
@@ -5,25 +5,30 @@ This module provides utility functions for formatting wind speed, pressure, and 
 copied from the wx version for consistency.
 """
 
-import logging
+from __future__ import annotations
 
-from ..units import DisplayUnitSystem
+import logging
+from typing import TYPE_CHECKING
+
 from .temperature_utils import TemperatureUnit
+
+if TYPE_CHECKING:
+    from ..units import DisplayUnitSystem
 
 logger = logging.getLogger(__name__)
 
 
-def _normalize_unit_system(unit_system: DisplayUnitSystem | str | None) -> DisplayUnitSystem | None:
+def _normalize_unit_system(unit_system: DisplayUnitSystem | str | None) -> str | None:
     """Normalize optional unit-system hints."""
-    if isinstance(unit_system, DisplayUnitSystem):
-        return unit_system
-    if isinstance(unit_system, str):
-        normalized = unit_system.strip().lower()
-        if normalized == "uk2":
-            normalized = "uk"
-        for candidate in DisplayUnitSystem:
-            if candidate.value == normalized:
-                return candidate
+    value = getattr(unit_system, "value", unit_system)
+    if not isinstance(value, str):
+        return None
+
+    normalized = value.strip().lower()
+    if normalized == "uk2":
+        normalized = "uk"
+    if normalized in {"us", "uk", "ca", "si"}:
+        return normalized
     return None
 
 
@@ -62,13 +67,13 @@ def format_wind_speed(
     assert wind_speed_kph is not None
 
     normalized_system = _normalize_unit_system(unit_system)
-    if normalized_system == DisplayUnitSystem.US:
+    if normalized_system == "us":
         return f"{wind_speed_mph:.{precision}f} mph"
-    if normalized_system == DisplayUnitSystem.UK:
+    if normalized_system == "uk":
         return f"{wind_speed_mph:.{precision}f} mph"
-    if normalized_system == DisplayUnitSystem.CA:
+    if normalized_system == "ca":
         return f"{wind_speed_kph:.{precision}f} km/h"
-    if normalized_system == DisplayUnitSystem.SI:
+    if normalized_system == "si":
         wind_speed_mps = wind_speed_kph / 3.6
         return f"{wind_speed_mps:.{precision}f} m/s"
 
@@ -114,9 +119,9 @@ def format_pressure(
         pressure_mb = pressure_inhg * 33.8639
 
     normalized_system = _normalize_unit_system(unit_system)
-    if normalized_system == DisplayUnitSystem.US:
+    if normalized_system == "us":
         return f"{pressure_inhg:.{precision}f} inHg"
-    if normalized_system in {DisplayUnitSystem.UK, DisplayUnitSystem.CA, DisplayUnitSystem.SI}:
+    if normalized_system in {"uk", "ca", "si"}:
         return f"{pressure_mb:.{precision}f} hPa"
 
     # Format based on user preference
@@ -161,9 +166,9 @@ def format_visibility(
         visibility_km = visibility_miles * 1.60934
 
     normalized_system = _normalize_unit_system(unit_system)
-    if normalized_system in {DisplayUnitSystem.US, DisplayUnitSystem.UK}:
+    if normalized_system in {"us", "uk"}:
         return f"{visibility_miles:.{precision}f} mi"
-    if normalized_system in {DisplayUnitSystem.CA, DisplayUnitSystem.SI}:
+    if normalized_system in {"ca", "si"}:
         return f"{visibility_km:.{precision}f} km"
 
     # Format based on user preference
@@ -208,9 +213,9 @@ def format_precipitation(
         precipitation_mm = precipitation_inches * 25.4
 
     normalized_system = _normalize_unit_system(unit_system)
-    if normalized_system == DisplayUnitSystem.US:
+    if normalized_system == "us":
         return f"{precipitation_inches:.{precision}f} in"
-    if normalized_system in {DisplayUnitSystem.UK, DisplayUnitSystem.CA, DisplayUnitSystem.SI}:
+    if normalized_system in {"uk", "ca", "si"}:
         return f"{precipitation_mm:.{precision}f} mm"
 
     # Format based on user preference

--- a/tests/test_community_soundpack_service.py
+++ b/tests/test_community_soundpack_service.py
@@ -1,0 +1,38 @@
+"""Tests for community sound pack download hardening."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from accessiweather.services.community_soundpack_models import CommunityPack
+from accessiweather.services.community_soundpack_service import CommunitySoundPackService
+
+
+def _repo_pack() -> CommunityPack:
+    return CommunityPack(
+        name="Example",
+        author="Tester",
+        description="Test pack",
+        version="1.0",
+        download_url="",
+        file_size=None,
+        repository_url="https://github.com/example/repo",
+        release_tag="",
+        repo_path="packs/example",
+    )
+
+
+@pytest.mark.asyncio
+async def test_download_repo_pack_rejects_path_traversal(tmp_path):
+    service = CommunitySoundPackService(repo_owner="example", repo_name="repo")
+    service._fetch_tree_entries = AsyncMock(
+        return_value=[{"type": "blob", "path": "../escape.wav", "size": 4}]
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="Unsafe path"):
+            await service._download_repo_pack(_repo_pack(), tmp_path / "pack.zip", None)
+    finally:
+        await service.aclose()

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -121,6 +121,13 @@ class TestConfigManager:
         assert len(locations) == 1
         assert locations[0].name == "New York"
 
+    def test_add_location_rejects_non_numeric_coordinates(self, manager):
+        """Invalid coordinate values are rejected before saving."""
+        result = manager.add_location("Bad", "north", -74.0060)  # type: ignore[arg-type]
+
+        assert result is False
+        assert manager.get_all_locations() == []
+
     def test_add_location_persists_marine_mode_roundtrip(self, manager):
         """Marine mode should save and reload with locations."""
         result = manager.add_location(

--- a/tests/test_forecast_confidence.py
+++ b/tests/test_forecast_confidence.py
@@ -80,6 +80,18 @@ class TestZeroAndOneSources:
         result = calculate_forecast_confidence([make_empty_forecast_source()])
         assert result.level == ForecastConfidenceLevel.LOW
 
+    def test_night_only_forecast_falls_back_to_first_period(self):
+        source = SourceData(
+            source="nws",
+            forecast=Forecast(periods=[ForecastPeriod(name="Tonight", temperature=62.0)]),
+            success=True,
+        )
+
+        result = calculate_forecast_confidence([source])
+
+        assert result.level == ForecastConfidenceLevel.MEDIUM
+        assert result.sources_compared == 1
+
     def test_single_valid_source_returns_medium(self):
         result = calculate_forecast_confidence([make_source(72.0)])
         assert result.level == ForecastConfidenceLevel.MEDIUM

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 
+import pytest
+
 from accessiweather.models import (
     AppConfig,
     AppSettings,
@@ -455,6 +457,15 @@ class TestAppSettings:
 
         assert settings.validate_on_access("forecast_time_reference") is True
         assert settings.forecast_time_reference == "location"
+
+    @pytest.mark.parametrize("legacy_channel", ["dev", "beta"])
+    def test_update_channel_legacy_aliases_migrate_to_nightly(self, legacy_channel):
+        """Legacy non-stable update channels should remain on the nightly track."""
+        settings = AppSettings()
+        settings.update_channel = legacy_channel
+
+        assert settings.validate_on_access("update_channel") is True
+        assert settings.update_channel == "nightly"
 
     def test_forecast_duration_days_validation(self):
         """Ensure invalid forecast duration values fall back to default."""

--- a/tests/test_noaa_radio_stream_url.py
+++ b/tests/test_noaa_radio_stream_url.py
@@ -165,3 +165,11 @@ class TestStreamURLProvider:
         assert provider.get_stream_urls("UNKNOWN99") == [
             "https://broadcastify.cdnstream1.com/noaa/UNKNOWN99"
         ]
+
+    def test_prewarm_stations_fetches_each_station_and_suppresses_errors(self) -> None:
+        provider = StreamURLProvider(use_fallback=False)
+        provider.get_stream_urls = MagicMock(side_effect=[["https://example.com/live"], OSError])
+
+        provider.prewarm_stations(["WXJ76", "BAD"])
+
+        assert provider.get_stream_urls.call_count == 2

--- a/tests/test_openmeteo_mapper.py
+++ b/tests/test_openmeteo_mapper.py
@@ -101,6 +101,20 @@ class TestOpenMeteoMapperForecastPairing:
 
         assert "temperature_low" not in periods[0]
 
+    def test_daily_weekday_uses_local_date_for_eastern_hemisphere(self):
+        # 2026-03-19 is a Thursday. With a +10h offset (e.g. Australia), naive
+        # local midnight converts to the previous day in UTC; the period name
+        # must still reflect the local calendar day, not the UTC-shifted one.
+        payload = _make_daily_payload(["2026-03-19"], [54.0], [39.0])
+        payload["utc_offset_seconds"] = 10 * 3600
+
+        periods = OpenMeteoMapper().map_forecast(payload)["properties"]["periods"]
+
+        assert periods[0]["name"] == "Thursday"
+        assert periods[1]["name"] == "Thursday Night"
+        # Day period should start at 6am local (not in UTC).
+        assert periods[0]["startTime"].startswith("2026-03-19T06:00:00")
+
 
 class TestOpenMeteoMapperHourlyFields:
     def test_hourly_mapping_includes_humidity_and_dewpoint(self):

--- a/tests/test_openmeteo_mapper.py
+++ b/tests/test_openmeteo_mapper.py
@@ -115,6 +115,13 @@ class TestOpenMeteoMapperForecastPairing:
         # Day period should start at 6am local (not in UTC).
         assert periods[0]["startTime"].startswith("2026-03-19T06:00:00")
 
+    def test_daily_date_with_z_suffix_uses_value_error_fallback(self):
+        payload = _make_daily_payload(["2026-03-19Z"], [54.0], [39.0])
+
+        periods = OpenMeteoMapper().map_forecast(payload)["properties"]["periods"]
+
+        assert periods[0]["name"] == "Thursday"
+
 
 class TestOpenMeteoMapperHourlyFields:
     def test_hourly_mapping_includes_humidity_and_dewpoint(self):

--- a/tests/test_simple_update.py
+++ b/tests/test_simple_update.py
@@ -211,10 +211,14 @@ def test_is_installed_version_false_for_portable():
 
 @pytest.mark.asyncio
 async def test_simple_update_service_download(tmp_path):
-    """Test download_update method."""
+    """Test download_update method with a valid checksum (happy path)."""
+    import hashlib
     from unittest.mock import AsyncMock, MagicMock
 
     from accessiweather.services.simple_update import UpdateInfo, UpdateService
+
+    artifact_content = b"x" * 100
+    correct_hash = hashlib.sha256(artifact_content).hexdigest()
 
     # Create a mock HTTP client
     mock_response = MagicMock()
@@ -224,6 +228,73 @@ async def test_simple_update_service_download(tmp_path):
     async def mock_aiter_bytes(chunk_size=None):
         yield b"x" * 50
         yield b"x" * 50
+
+    mock_response.aiter_bytes = mock_aiter_bytes
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    checksum_response = MagicMock()
+    checksum_response.raise_for_status = MagicMock()
+    checksum_response.text = f"{correct_hash}  update.zip"
+
+    mock_client = MagicMock()
+    mock_client.stream = MagicMock(return_value=mock_response)
+    mock_client.get = AsyncMock(return_value=checksum_response)
+
+    service = UpdateService("TestApp", http_client=mock_client)
+
+    release = {
+        "assets": [
+            {"name": "update.zip", "browser_download_url": "https://example.com/update.zip"},
+            {
+                "name": "update.zip.sha256",
+                "browser_download_url": "https://example.com/update.zip.sha256",
+            },
+        ]
+    }
+
+    update_info = UpdateInfo(
+        version="1.0.0",
+        download_url="https://example.com/update.zip",
+        artifact_name="update.zip",
+        release_notes="Test release",
+        commit_hash=None,
+        is_nightly=False,
+        is_prerelease=False,
+        release=release,
+    )
+
+    progress_calls = []
+
+    def progress_callback(downloaded, total):
+        progress_calls.append((downloaded, total))
+
+    result = await service.download_update(update_info, tmp_path, progress_callback)
+
+    assert result == tmp_path / "update.zip"
+    assert result.exists()
+    assert result.read_bytes() == b"x" * 100
+    assert len(progress_calls) == 2
+    assert progress_calls[-1] == (100, 100)
+
+
+@pytest.mark.asyncio
+async def test_download_update_refuses_without_release_metadata(tmp_path):
+    """Fail-closed: an update with no release metadata cannot be verified, so it must be rejected."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from accessiweather.services.simple_update import (
+        ChecksumVerificationError,
+        UpdateInfo,
+        UpdateService,
+    )
+
+    mock_response = MagicMock()
+    mock_response.headers = {"content-length": "100"}
+    mock_response.raise_for_status = MagicMock()
+
+    async def mock_aiter_bytes(chunk_size=None):
+        yield b"x" * 100
 
     mock_response.aiter_bytes = mock_aiter_bytes
     mock_response.__aenter__ = AsyncMock(return_value=mock_response)
@@ -242,20 +313,14 @@ async def test_simple_update_service_download(tmp_path):
         commit_hash=None,
         is_nightly=False,
         is_prerelease=False,
+        # No release attached -> integrity cannot be verified.
     )
 
-    progress_calls = []
+    with pytest.raises(ChecksumVerificationError, match="no release metadata"):
+        await service.download_update(update_info, tmp_path)
 
-    def progress_callback(downloaded, total):
-        progress_calls.append((downloaded, total))
-
-    result = await service.download_update(update_info, tmp_path, progress_callback)
-
-    assert result == tmp_path / "update.zip"
-    assert result.exists()
-    assert result.read_bytes() == b"x" * 100
-    assert len(progress_calls) == 2
-    assert progress_calls[-1] == (100, 100)
+    # The unverifiable file must not be left on disk.
+    assert not (tmp_path / "update.zip").exists()
 
 
 class TestApplyUpdateNoShellInjection:

--- a/tests/test_system_tray.py
+++ b/tests/test_system_tray.py
@@ -137,12 +137,15 @@ class TestShowMainWindow:
         kernel32 = SimpleNamespace(GetCurrentProcessId=MagicMock(return_value=67890))
 
         monkeypatch.setattr(system_tray.sys, "platform", "win32")
-        monkeypatch.setattr(
-            ctypes,
-            "windll",
-            SimpleNamespace(user32=user32, kernel32=kernel32),
-            raising=False,
-        )
+
+        def fake_windll(name, *args, **kwargs):
+            if name == "user32":
+                return user32
+            if name == "kernel32":
+                return kernel32
+            raise ValueError(name)
+
+        monkeypatch.setattr(ctypes, "WinDLL", fake_windll, raising=False)
 
         tray.show_main_window()
 

--- a/tests/test_unit_utils.py
+++ b/tests/test_unit_utils.py
@@ -58,6 +58,12 @@ class TestFormatWindSpeed:
         result = format_wind_speed(5.556, unit=TemperatureUnit.FAHRENHEIT, precision=2)
         assert result == "5.56 mph"
 
+    def test_format_wind_speed_accepts_legacy_uk2_unit_system(self) -> None:
+        """Legacy UK2 unit-system values should behave like UK."""
+        result = format_wind_speed(10.0, wind_speed_kph=16.0934, unit_system="uk2")
+
+        assert result == "10.0 mph"
+
 
 class TestFormatPressure:
     """Tests for pressure formatting."""

--- a/tests/test_update_checksum_verification.py
+++ b/tests/test_update_checksum_verification.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from accessiweather.services.simple_update import (
@@ -59,6 +60,33 @@ def test_find_checksum_asset_no_match():
         ]
     }
     assert find_checksum_asset(release, "app.zip") is None
+
+
+def _mock_update_stream(content: bytes) -> MagicMock:
+    response = MagicMock()
+    response.headers = {"content-length": str(len(content))}
+    response.raise_for_status = MagicMock()
+
+    async def aiter_bytes(chunk_size=None):
+        yield content
+
+    response.aiter_bytes = aiter_bytes
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=None)
+    return response
+
+
+def _update_info_with_release(release: dict | None = None) -> UpdateInfo:
+    return UpdateInfo(
+        version="1.0.0",
+        download_url="https://example.com/update.zip",
+        artifact_name="update.zip",
+        release_notes="",
+        commit_hash=None,
+        is_nightly=False,
+        is_prerelease=False,
+        release=release,
+    )
 
 
 def test_find_checksum_asset_generic_checksums_file():
@@ -234,3 +262,80 @@ async def test_download_update_should_accept_valid_artifact(tmp_path):
     result = await service.download_update(update_info, tmp_path, release=release)
     assert result.exists()
     assert result.read_bytes() == artifact_content
+
+
+@pytest.mark.asyncio
+async def test_download_update_allows_release_without_checksum_asset(tmp_path):
+    artifact_content = b"valid artifact content"
+    release = {"assets": [{"name": "update.zip", "browser_download_url": "https://example.com/u"}]}
+    mock_client = MagicMock()
+    mock_client.stream = MagicMock(return_value=_mock_update_stream(artifact_content))
+
+    service = UpdateService("TestApp", http_client=mock_client)
+
+    result = await service.download_update(_update_info_with_release(release), tmp_path)
+
+    assert result.exists()
+    assert result.read_bytes() == artifact_content
+
+
+@pytest.mark.asyncio
+async def test_download_update_rejects_checksum_asset_without_url(tmp_path):
+    release = {"assets": [{"name": "update.zip.sha256"}]}
+    mock_client = MagicMock()
+    mock_client.stream = MagicMock(return_value=_mock_update_stream(b"artifact"))
+
+    service = UpdateService("TestApp", http_client=mock_client)
+
+    with pytest.raises(ChecksumVerificationError, match="no download URL"):
+        await service.download_update(_update_info_with_release(release), tmp_path)
+
+    assert not (tmp_path / "update.zip").exists()
+
+
+@pytest.mark.asyncio
+async def test_download_update_rejects_checksum_download_failure(tmp_path):
+    release = {
+        "assets": [
+            {
+                "name": "update.zip.sha256",
+                "browser_download_url": "https://example.com/update.zip.sha256",
+            }
+        ]
+    }
+    mock_client = MagicMock()
+    mock_client.stream = MagicMock(return_value=_mock_update_stream(b"artifact"))
+    mock_client.get = AsyncMock(side_effect=httpx.ConnectError("no net"))
+
+    service = UpdateService("TestApp", http_client=mock_client)
+
+    with pytest.raises(ChecksumVerificationError, match="Failed to download checksum"):
+        await service.download_update(_update_info_with_release(release), tmp_path)
+
+    assert not (tmp_path / "update.zip").exists()
+
+
+@pytest.mark.asyncio
+async def test_download_update_rejects_checksum_file_without_artifact_entry(tmp_path):
+    release = {
+        "assets": [
+            {
+                "name": "update.zip.sha256",
+                "browser_download_url": "https://example.com/update.zip.sha256",
+            }
+        ]
+    }
+    checksum_response = MagicMock()
+    checksum_response.raise_for_status = MagicMock()
+    checksum_response.text = f"{hashlib.sha256(b'other').hexdigest()}  other.zip"
+
+    mock_client = MagicMock()
+    mock_client.stream = MagicMock(return_value=_mock_update_stream(b"artifact"))
+    mock_client.get = AsyncMock(return_value=checksum_response)
+
+    service = UpdateService("TestApp", http_client=mock_client)
+
+    with pytest.raises(ChecksumVerificationError, match="Could not find a checksum"):
+        await service.download_update(_update_info_with_release(release), tmp_path)
+
+    assert not (tmp_path / "update.zip").exists()

--- a/tests/test_zone_enrichment_service.py
+++ b/tests/test_zone_enrichment_service.py
@@ -422,6 +422,20 @@ class TestAddLocationWithEnrichment:
         mock_service.enrich_location.assert_not_awaited()
         assert manager.save_calls == 0
 
+    async def test_invalid_coordinates_rejected_without_calling_service(self):
+        mock_service = MagicMock(spec=ZoneEnrichmentService)
+        mock_service.enrich_location = AsyncMock(side_effect=lambda loc: loc)
+
+        manager = _FakeConfigManager()
+        ops = LocationOperations(cast(ConfigManager, manager), zone_enrichment_service=mock_service)
+
+        ok = await ops.add_location_with_enrichment("Bad", 91.0, -75.16, country_code="US")
+
+        assert ok is False
+        mock_service.enrich_location.assert_not_awaited()
+        assert manager.get_config().locations == []
+        assert manager.save_calls == 0
+
 
 class TestNoModalDialog:
     """Scenario 6: save flow never spawns a modal dialog on /points failure."""


### PR DESCRIPTION
## Summary
- Harden update, notification, tray tooltip, NOAA radio, alert-refresh, and dialog edge cases from the Claude bug hunt.
- Preserve zero-speed wind text in tray tooltip placeholders when only legacy wind speed data is present.
- Avoid an order-dependent unit formatting circular import and add the required user-facing changelog note.

## Test Plan
- [x] uv run pytest -q --tb=short
- [x] uv run ruff check src/accessiweather/taskbar_icon_updater.py src/accessiweather/utils/unit_utils.py
- [x] uv run ruff format --check src/accessiweather/taskbar_icon_updater.py src/accessiweather/utils/unit_utils.py
- [x] uv run python scripts/changelog_tools.py check --base origin/dev --head HEAD
- [x] uv run pytest tests/test_changelog_tools.py -q --tb=short