### PR TITLE
feat(noaa-radio): make radio standalone with station finder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- NOAA Weather Radio now opens independently of saved weather locations, lets you search or browse stations directly, and keeps playing when you close the player until you press Stop or exit the app.
+
 ## [0.7.2] - 2026-05-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- NOAA Weather Radio now opens independently of saved weather locations, lets you search or browse stations directly, and keeps playing when you close the player until you press Stop or exit the app.
+- NOAA Weather Radio now opens independently of saved weather locations, has a clearer Station Finder for searching all stations, browsing by state, or finding nearby stations by coordinates, and keeps playing when you close the player until you press Stop or exit the app.
 
 ## [0.7.2] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- NOAA Weather Radio now opens independently of saved weather locations, has a clearer Station Finder for searching all stations, browsing by state, or finding nearby stations by coordinates, and keeps playing when you close the player until you press Stop or exit the app.
+- NOAA Weather Radio now opens independently of saved weather locations and keeps playing after you close the player until you press Stop or exit the app.
+- The NOAA Weather Radio Station Finder now has clearer modes for searching all stations, browsing by full state or territory name, and finding nearby stations by coordinates.
 
 ## [0.7.2] - 2026-05-30
 

--- a/src/accessiweather/app_lifecycle.py
+++ b/src/accessiweather/app_lifecycle.py
@@ -319,6 +319,13 @@ class AppLifecycleMixin:
         if activation_handoff_timer:
             activation_handoff_timer.Stop()
 
+        try:
+            from .noaa_radio.session import stop_shared_radio_session
+
+            stop_shared_radio_session()
+        except Exception:
+            logger.debug("Could not stop NOAA radio session during shutdown", exc_info=True)
+
         # Play exit sound without blocking shutdown.
         try:
             settings = self.config_manager.get_settings()

--- a/src/accessiweather/noaa_radio/session.py
+++ b/src/accessiweather/noaa_radio/session.py
@@ -1,0 +1,102 @@
+"""Shared NOAA Weather Radio playback session."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from accessiweather.noaa_radio.player import RadioPlayer
+from accessiweather.noaa_radio.stations import Station
+
+
+class RadioSession:
+    """Owns radio stream state independently from any one dialog."""
+
+    def __init__(self) -> None:
+        """Initialize the shared playback session."""
+        self.playing_station: Station | None = None
+        self.current_urls: list[str] = []
+        self.current_url_index = 0
+        self._on_playing: Callable[[], None] | None = None
+        self._on_stopped: Callable[[], None] | None = None
+        self._on_error: Callable[[str], None] | None = None
+        self._on_stalled: Callable[[], None] | None = None
+        self._on_reconnecting: Callable[[int], None] | None = None
+        self.player = RadioPlayer(
+            on_playing=self._handle_playing,
+            on_stopped=self._handle_stopped,
+            on_error=self._handle_error,
+            on_stalled=self._handle_stalled,
+            on_reconnecting=self._handle_reconnecting,
+        )
+
+    def bind_callbacks(
+        self,
+        *,
+        on_playing: Callable[[], None],
+        on_stopped: Callable[[], None],
+        on_error: Callable[[str], None],
+        on_stalled: Callable[[], None],
+        on_reconnecting: Callable[[int], None],
+    ) -> None:
+        """Attach UI callbacks for the currently visible dialog."""
+        self._on_playing = on_playing
+        self._on_stopped = on_stopped
+        self._on_error = on_error
+        self._on_stalled = on_stalled
+        self._on_reconnecting = on_reconnecting
+
+    def unbind_callbacks(self) -> None:
+        """Detach UI callbacks when the dialog is dismissed."""
+        self._on_playing = None
+        self._on_stopped = None
+        self._on_error = None
+        self._on_stalled = None
+        self._on_reconnecting = None
+
+    def is_playing(self) -> bool:
+        """Return whether a stream is currently active."""
+        return self.player.is_playing()
+
+    def stop(self, *, notify: bool = True) -> None:
+        """Stop playback and clear session state."""
+        self.player.stop(notify=notify)
+        self.playing_station = None
+
+    def _handle_playing(self) -> None:
+        if self._on_playing is not None:
+            self._on_playing()
+
+    def _handle_stopped(self) -> None:
+        self.playing_station = None
+        if self._on_stopped is not None:
+            self._on_stopped()
+
+    def _handle_error(self, message: str) -> None:
+        self.playing_station = None
+        if self._on_error is not None:
+            self._on_error(message)
+
+    def _handle_stalled(self) -> None:
+        if self._on_stalled is not None:
+            self._on_stalled()
+
+    def _handle_reconnecting(self, attempt: int) -> None:
+        if self._on_reconnecting is not None:
+            self._on_reconnecting(attempt)
+
+
+_shared_session: RadioSession | None = None
+
+
+def get_shared_radio_session() -> RadioSession:
+    """Return the app-wide NOAA radio playback session."""
+    global _shared_session
+    if _shared_session is None:
+        _shared_session = RadioSession()
+    return _shared_session
+
+
+def stop_shared_radio_session() -> None:
+    """Stop the app-wide NOAA radio session, if it exists."""
+    if _shared_session is not None:
+        _shared_session.stop()

--- a/src/accessiweather/noaa_radio/station_availability.py
+++ b/src/accessiweather/noaa_radio/station_availability.py
@@ -53,7 +53,7 @@ class StationAvailabilityService:
                     StationAvailabilityEntry(
                         station=station,
                         available=False,
-                        label=f"{label} - {TEMPORARILY_UNAVAILABLE}",
+                        label=f"{label} - Temporarily unavailable",
                         unavailable_reason=TEMPORARILY_UNAVAILABLE,
                     )
                 )
@@ -63,11 +63,15 @@ class StationAvailabilityService:
                 StationAvailabilityEntry(
                     station=station,
                     available=True,
-                    label=label,
+                    label=f"{label} - Available",
                 )
             )
         return entries
 
     @staticmethod
     def _base_label(station: Station) -> str:
-        return f"{station.call_sign} - {station.name} ({station.frequency} MHz)"
+        location = station.name.strip()
+        state = station.state.strip().upper()
+        if state and not location.upper().endswith(f", {state}"):
+            location = f"{location}, {state}"
+        return f"{station.call_sign} - {location} - {station.frequency:.3f} MHz"

--- a/src/accessiweather/noaa_radio/station_db.py
+++ b/src/accessiweather/noaa_radio/station_db.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import math
+import re
 from dataclasses import dataclass
 
 from accessiweather.noaa_radio.stations import Station
 
 # Earth's mean radius in kilometres
 _EARTH_RADIUS_KM = 6371.0
+_COORDINATE_QUERY_RE = re.compile(
+    r"^\s*(?P<lat>[+-]?\d+(?:\.\d+)?)\s*,\s*(?P<lon>[+-]?\d+(?:\.\d+)?)\s*$"
+)
 
 
 @dataclass
@@ -252,6 +256,31 @@ class StationDatabase:
         """Return stations filtered by US state abbreviation (case-insensitive)."""
         state_upper = state.upper()
         return [s for s in self._stations if s.state.upper() == state_upper]
+
+    def search(self, query: str, limit: int | None = None) -> list[Station]:
+        """Search stations by call sign, city/name, state, or explicit lat/lon."""
+        normalized = query.strip()
+        if not normalized:
+            stations = self.get_all_stations()
+            return stations if limit is None else stations[:limit]
+
+        coordinate_match = _COORDINATE_QUERY_RE.match(normalized)
+        if coordinate_match:
+            lat = float(coordinate_match.group("lat"))
+            lon = float(coordinate_match.group("lon"))
+            if -90 <= lat <= 90 and -180 <= lon <= 180:
+                return [result.station for result in self.find_nearest(lat, lon, limit=limit)]
+
+        normalized_upper = normalized.upper()
+        normalized_lower = normalized.lower()
+        matches = [
+            station
+            for station in self._stations
+            if normalized_upper in station.call_sign.upper()
+            or normalized_upper == station.state.upper()
+            or normalized_lower in station.name.lower()
+        ]
+        return matches if limit is None else matches[:limit]
 
     def find_nearest(self, lat: float, lon: float, limit: int | None = 5) -> list[StationResult]:
         """Return the nearest stations sorted by distance ascending."""

--- a/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
+++ b/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
@@ -28,6 +28,15 @@ logger = logging.getLogger(__name__)
 SUPPRESSION_TTL_SECONDS = 1800
 STATION_LIMIT_PRESETS: tuple[int | None, ...] = (10, 25, 50, 100, None)
 STATION_LIMIT_LABELS: tuple[str, ...] = ("10", "25", "50", "100", "All")
+FINDER_MODE_SEARCH_ALL = "Search all stations"
+FINDER_MODE_BROWSE_STATE = "Browse by state"
+FINDER_MODE_NEAREST = "Nearest by coordinates"
+FINDER_MODE_LABELS: tuple[str, ...] = (
+    FINDER_MODE_SEARCH_ALL,
+    FINDER_MODE_BROWSE_STATE,
+    FINDER_MODE_NEAREST,
+)
+STATE_ALL_CHOICE = "All states and territories"
 
 
 def show_noaa_radio_dialog(
@@ -135,7 +144,15 @@ class NOAARadioDialog(wx.Dialog):
 
     def _init_ui(self) -> None:
         """Create and layout all UI controls."""
-        create_noaa_radio_widgets(self, STATION_LIMIT_LABELS)
+        create_noaa_radio_widgets(
+            self,
+            STATION_LIMIT_LABELS,
+            FINDER_MODE_LABELS,
+            self._get_state_choices(),
+            self._get_initial_finder_mode_index(),
+        )
+        self._apply_initial_finder_values()
+        self._update_finder_mode_controls()
 
     def _load_stations_async(self) -> None:
         """Load stations in a background thread to not block UI initialization."""
@@ -145,11 +162,13 @@ class NOAARadioDialog(wx.Dialog):
         show_unavailable = self._show_unavailable_enabled()
         station_limit = self._get_selected_station_limit()
         search_query = self._get_search_query()
+        finder_mode = self._get_finder_mode()
+        state_code = self._get_selected_state_code()
 
         # Run station loading in background thread
         thread = threading.Thread(
             target=self._load_stations_worker,
-            args=(show_unavailable, station_limit, search_query),
+            args=(show_unavailable, station_limit, search_query, finder_mode, state_code),
             daemon=True,
         )
         thread.start()
@@ -159,15 +178,37 @@ class NOAARadioDialog(wx.Dialog):
         show_unavailable: bool = False,
         station_limit: int | None = DEFAULT_STATION_LIMIT,
         search_query: str = "",
+        finder_mode: str | None = None,
+        state_code: str = "",
     ) -> None:
         """Worker method that loads stations in background thread."""
         try:
             db = StationDatabase()
-            if search_query:
+            active_mode = finder_mode or (
+                FINDER_MODE_SEARCH_ALL if search_query else self._get_finder_mode()
+            )
+            if active_mode == FINDER_MODE_BROWSE_STATE:
+                if state_code:
+                    candidates = db.get_stations_by_state(state_code)
+                    if station_limit is not None:
+                        candidates = candidates[:station_limit]
+                else:
+                    candidates = db.search("", limit=station_limit)
+            elif active_mode == FINDER_MODE_NEAREST:
+                coordinates = self._parse_coordinate_query(search_query)
+                if (
+                    coordinates is None
+                    and getattr(self, "_lat", None) is not None
+                    and getattr(self, "_lon", None) is not None
+                ):
+                    coordinates = (self._lat, self._lon)
+                if coordinates is None:
+                    candidates = []
+                else:
+                    results = db.find_nearest(*coordinates, limit=station_limit)
+                    candidates = [r.station for r in results]
+            elif search_query:
                 candidates = db.search(search_query, limit=station_limit)
-            elif self._lat is not None and self._lon is not None:
-                results = db.find_nearest(self._lat, self._lon, limit=station_limit)
-                candidates = [r.station for r in results]
             else:
                 candidates = db.search("", limit=station_limit)
             entries = self._station_availability.build_entries(
@@ -451,14 +492,30 @@ class NOAARadioDialog(wx.Dialog):
         self._load_stations_async()
         event.Skip()
 
-    def _on_search(self, event: wx.CommandEvent) -> None:
-        """Reload stations using the current station search text."""
+    def _on_finder_mode_changed(self, event: wx.CommandEvent) -> None:
+        """Update finder controls when the station finder mode changes."""
+        self._update_finder_mode_controls()
+        event.Skip()
+
+    def _on_find(self, event: wx.CommandEvent) -> None:
+        """Reload stations using the selected station finder mode."""
         self._load_stations_async()
         event.Skip()
 
+    def _on_search(self, event: wx.CommandEvent) -> None:
+        """Compatibility alias for older tests and callers."""
+        self._on_find(event)
+
     def _on_clear_search(self, event: wx.CommandEvent) -> None:
-        """Clear the station search and browse the default station list."""
+        """Clear the station finder and browse the default station list."""
+        finder_choice = getattr(self, "_finder_mode_choice", None)
+        if finder_choice is not None:
+            finder_choice.SetSelection(FINDER_MODE_LABELS.index(FINDER_MODE_SEARCH_ALL))
+        state_choice = getattr(self, "_state_choice", None)
+        if state_choice is not None:
+            state_choice.SetSelection(0)
         self._search_ctrl.SetValue("")
+        self._update_finder_mode_controls()
         self._load_stations_async()
         event.Skip()
 
@@ -519,6 +576,98 @@ class NOAARadioDialog(wx.Dialog):
         if search_ctrl is None:
             return ""
         return str(search_ctrl.GetValue()).strip()
+
+    def _get_finder_mode(self) -> str:
+        """Return the selected station finder mode."""
+        choice = getattr(self, "_finder_mode_choice", None)
+        if choice is None:
+            if getattr(self, "_lat", None) is not None and getattr(self, "_lon", None) is not None:
+                return FINDER_MODE_NEAREST
+            return FINDER_MODE_SEARCH_ALL
+
+        selection = choice.GetSelection()
+        if selection == wx.NOT_FOUND or selection >= len(FINDER_MODE_LABELS):
+            return FINDER_MODE_SEARCH_ALL
+        return FINDER_MODE_LABELS[selection]
+
+    def _get_selected_state_code(self) -> str:
+        """Return the selected state/territory code, or an empty string for all."""
+        choice = getattr(self, "_state_choice", None)
+        state_choices = getattr(self, "_state_choices", ())
+        if choice is None or not state_choices:
+            return ""
+
+        selection = choice.GetSelection()
+        if selection <= 0 or selection >= len(state_choices):
+            return ""
+        return state_choices[selection]
+
+    def _update_finder_mode_controls(self) -> None:
+        """Show and label the finder controls for the active mode."""
+        mode = self._get_finder_mode()
+        search_label = getattr(self, "_search_label", None)
+        search_ctrl = getattr(self, "_search_ctrl", None)
+        state_label = getattr(self, "_state_label", None)
+        state_choice = getattr(self, "_state_choice", None)
+
+        state_mode = mode == FINDER_MODE_BROWSE_STATE
+        coordinate_mode = mode == FINDER_MODE_NEAREST
+
+        if search_label is not None:
+            label = (
+                "Coordinates (latitude, longitude):"
+                if coordinate_mode
+                else "Search text (call sign, city, or state):"
+            )
+            search_label.SetLabel(label)
+            search_label.Show(not state_mode)
+        if search_ctrl is not None:
+            hint = "Example: 30.2672, -97.7431" if coordinate_mode else "Call sign, city, or state"
+            search_ctrl.SetHint(hint)
+            search_ctrl.Show(not state_mode)
+        if state_label is not None:
+            state_label.Show(state_mode)
+        if state_choice is not None:
+            state_choice.Show(state_mode)
+
+        finder_panel = getattr(self, "_finder_panel", None)
+        if finder_panel is not None:
+            finder_panel.Layout()
+
+    def _apply_initial_finder_values(self) -> None:
+        """Prefill coordinate mode when the dialog is opened for a point."""
+        if getattr(self, "_lat", None) is None or getattr(self, "_lon", None) is None:
+            return
+        search_ctrl = getattr(self, "_search_ctrl", None)
+        if search_ctrl is not None:
+            search_ctrl.SetValue(f"{self._lat:.4f}, {self._lon:.4f}")
+
+    def _get_initial_finder_mode_index(self) -> int:
+        """Return the mode index to use when building the dialog."""
+        if getattr(self, "_lat", None) is not None and getattr(self, "_lon", None) is not None:
+            return FINDER_MODE_LABELS.index(FINDER_MODE_NEAREST)
+        return FINDER_MODE_LABELS.index(FINDER_MODE_SEARCH_ALL)
+
+    @staticmethod
+    def _get_state_choices() -> tuple[str, ...]:
+        """Return state/territory choices from the local station database."""
+        states = sorted({station.state for station in StationDatabase().get_all_stations()})
+        return (STATE_ALL_CHOICE, *states)
+
+    @staticmethod
+    def _parse_coordinate_query(query: str) -> tuple[float, float] | None:
+        """Parse a latitude, longitude query for nearest-station mode."""
+        parts = [part.strip() for part in query.split(",", 1)]
+        if len(parts) != 2:
+            return None
+        try:
+            lat = float(parts[0])
+            lon = float(parts[1])
+        except ValueError:
+            return None
+        if -90 <= lat <= 90 and -180 <= lon <= 180:
+            return lat, lon
+        return None
 
     def _get_selected_station_limit(self) -> int | None:
         """Return the chosen nearby-station limit, or None for all stations."""

--- a/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
+++ b/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
@@ -15,8 +15,8 @@ from accessiweather.noaa_radio import (
     StationDatabase,
     StreamURLProvider,
 )
-from accessiweather.noaa_radio.player import RadioPlayer
 from accessiweather.noaa_radio.preferences import DEFAULT_STATION_LIMIT, RadioPreferences
+from accessiweather.noaa_radio.session import RadioSession, get_shared_radio_session
 
 from .noaa_radio_clients import get_clients as _get_clients
 from .noaa_radio_widgets import create_noaa_radio_widgets
@@ -30,7 +30,11 @@ STATION_LIMIT_PRESETS: tuple[int | None, ...] = (10, 25, 50, 100, None)
 STATION_LIMIT_LABELS: tuple[str, ...] = ("10", "25", "50", "100", "All")
 
 
-def show_noaa_radio_dialog(parent: wx.Window, lat: float, lon: float) -> NOAARadioDialog:
+def show_noaa_radio_dialog(
+    parent: wx.Window,
+    lat: float | None = None,
+    lon: float | None = None,
+) -> NOAARadioDialog:
     """
     Show the NOAA Weather Radio player dialog.
 
@@ -38,8 +42,8 @@ def show_noaa_radio_dialog(parent: wx.Window, lat: float, lon: float) -> NOAARad
 
     Args:
         parent: Parent window.
-        lat: Latitude for finding nearest stations.
-        lon: Longitude for finding nearest stations.
+        lat: Optional latitude for finding nearest stations.
+        lon: Optional longitude for finding nearest stations.
 
     Returns:
         The dialog instance (non-modal, caller may keep a reference).
@@ -53,14 +57,22 @@ def show_noaa_radio_dialog(parent: wx.Window, lat: float, lon: float) -> NOAARad
 class NOAARadioDialog(wx.Dialog):
     """Non-modal dialog for streaming NOAA Weather Radio stations."""
 
-    def __init__(self, parent: wx.Window, lat: float, lon: float) -> None:
+    def __init__(
+        self,
+        parent: wx.Window,
+        lat: float | None = None,
+        lon: float | None = None,
+        *,
+        session: RadioSession | None = None,
+    ) -> None:
         """
         Initialize the NOAA Radio dialog.
 
         Args:
             parent: Parent window.
-            lat: Latitude for station lookup.
-            lon: Longitude for station lookup.
+            lat: Optional latitude for station lookup.
+            lon: Optional longitude for station lookup.
+            session: Optional playback session, injected by tests.
 
         """
         super().__init__(
@@ -73,13 +85,15 @@ class NOAARadioDialog(wx.Dialog):
         self._lat = lat
         self._lon = lon
         self._stations: list[Station] = []
-        self._player = RadioPlayer(
+        self._session = session or get_shared_radio_session()
+        self._session.bind_callbacks(
             on_playing=self._on_playing,
             on_stopped=self._on_stopped,
             on_error=self._on_error,
             on_stalled=self._on_stalled,
             on_reconnecting=self._on_reconnecting,
         )
+        self._player = self._session.player
         # Use cached clients to leverage HTTP response caching across dialog opens
         wxradio, weatherindex = _get_clients()
         self._url_provider = StreamURLProvider(
@@ -104,9 +118,9 @@ class NOAARadioDialog(wx.Dialog):
             weatherindex_client=weatherindex,
             availability_cache=self._availability_cache,
         )
-        self._current_urls: list[str] = []
-        self._current_url_index: int = 0
-        self._playing_station: Station | None = None
+        self._current_urls: list[str] = self._session.current_urls
+        self._current_url_index: int = self._session.current_url_index
+        self._playing_station: Station | None = self._session.playing_station
         # Set once the dialog is closed so background-thread completion handlers
         # (delivered via wx.CallAfter) don't touch destroyed widgets.
         self._closed = False
@@ -115,6 +129,7 @@ class NOAARadioDialog(wx.Dialog):
 
         self._init_ui()
         self.Bind(wx.EVT_CHAR_HOOK, self._on_char_hook)
+        self._sync_playback_state_from_session()
         # Start station loading in background thread to not block UI initialization
         self._load_stations_async()
 
@@ -126,14 +141,15 @@ class NOAARadioDialog(wx.Dialog):
         """Load stations in a background thread to not block UI initialization."""
         # Show loading state immediately
         self._station_choice.Set(["Loading stations..."])
-        self._set_status("Finding nearest stations...")
+        self._set_status("Finding stations...")
         show_unavailable = self._show_unavailable_enabled()
         station_limit = self._get_selected_station_limit()
+        search_query = self._get_search_query()
 
         # Run station loading in background thread
         thread = threading.Thread(
             target=self._load_stations_worker,
-            args=(show_unavailable, station_limit),
+            args=(show_unavailable, station_limit, search_query),
             daemon=True,
         )
         thread.start()
@@ -142,14 +158,20 @@ class NOAARadioDialog(wx.Dialog):
         self,
         show_unavailable: bool = False,
         station_limit: int | None = DEFAULT_STATION_LIMIT,
+        search_query: str = "",
     ) -> None:
         """Worker method that loads stations in background thread."""
         try:
             db = StationDatabase()
-            results = db.find_nearest(self._lat, self._lon, limit=station_limit)
-            nearby = [r.station for r in results]
+            if search_query:
+                candidates = db.search(search_query, limit=station_limit)
+            elif self._lat is not None and self._lon is not None:
+                results = db.find_nearest(self._lat, self._lon, limit=station_limit)
+                candidates = [r.station for r in results]
+            else:
+                candidates = db.search("", limit=station_limit)
             entries = self._station_availability.build_entries(
-                nearby,
+                candidates,
                 show_unavailable=show_unavailable,
             )
             stations = [entry.station for entry in entries]
@@ -203,10 +225,19 @@ class NOAARadioDialog(wx.Dialog):
                     if station.call_sign == previous_call_sign:
                         selection = index
                         break
+            elif self._session.playing_station is not None:
+                for index, station in enumerate(stations):
+                    if station.call_sign == self._session.playing_station.call_sign:
+                        selection = index
+                        break
             self._station_choice.SetSelection(selection)
-            self._set_status("Ready")
+            self._sync_playback_state_from_session()
+            if not self._session.is_playing():
+                self._set_status("Ready")
         else:
-            self._set_status("No stations with streams available")
+            self._sync_playback_state_from_session()
+            if not self._session.is_playing():
+                self._set_status("No stations with streams available")
 
     def _get_selected_station(self) -> Station | None:
         """Return the currently selected station, or None."""
@@ -228,14 +259,13 @@ class NOAARadioDialog(wx.Dialog):
             self._on_play(event)
         else:
             selected = self._get_selected_station()
-            if (
-                selected is not None
-                and self._playing_station is not None
+            if selected is None or (
+                self._playing_station is not None
                 and selected.call_sign == self._playing_station.call_sign
             ):
                 self._on_stop(event)
             else:
-                # Different station (or unknown) — switch without a second press
+                # Different station — switch without a second press
                 self._on_play(event)
 
     def _on_play(self, _event: wx.CommandEvent) -> None:
@@ -243,7 +273,7 @@ class NOAARadioDialog(wx.Dialog):
         # Stop any currently playing stream
         if self._player.is_playing():
             self._health_timer.Stop()
-            self._player.stop()
+            self._player.stop(notify=False)
 
         station = self._get_selected_station()
         if station is None:
@@ -265,8 +295,11 @@ class NOAARadioDialog(wx.Dialog):
             )
             return
 
+        self._session.playing_station = station
         self._playing_station = station
-        self._current_urls = self._prefs.reorder_urls(station.call_sign, urls)
+        self._session.current_urls = self._prefs.reorder_urls(station.call_sign, urls)
+        self._current_urls = self._session.current_urls
+        self._session.current_url_index = 0
         self._current_url_index = 0
         self._try_play_current(station.call_sign)
 
@@ -283,7 +316,8 @@ class NOAARadioDialog(wx.Dialog):
             self._prefer_btn.Enable(True)
         elif total > 1:
             # Auto-advance to next stream on connection failure
-            self._current_url_index = (idx + 1) % total
+            self._session.current_url_index = (idx + 1) % total
+            self._current_url_index = self._session.current_url_index
             if self._current_url_index == 0:
                 # Wrapped around, all streams failed
                 self._mark_current_station_unavailable()
@@ -297,7 +331,7 @@ class NOAARadioDialog(wx.Dialog):
     def _on_stop(self, _event: wx.CommandEvent) -> None:
         """Handle Stop action."""
         self._health_timer.Stop()
-        self._player.stop()
+        self._session.stop()
         self._play_stop_btn.SetLabel("Play")
 
     def _on_volume_change(self, _event: wx.CommandEvent) -> None:
@@ -307,6 +341,9 @@ class NOAARadioDialog(wx.Dialog):
 
     def _on_playing(self) -> None:
         """Handle playback started event."""
+        self._current_urls = self._session.current_urls
+        self._current_url_index = self._session.current_url_index
+        self._playing_station = self._session.playing_station or self._get_selected_station()
         station = self._playing_station or self._get_selected_station()
         self._clear_station_suppression(station)
         name = station.call_sign if station else "Unknown"
@@ -321,6 +358,7 @@ class NOAARadioDialog(wx.Dialog):
     def _on_stopped(self) -> None:
         """Handle playback stopped event."""
         self._playing_station = None
+        self._session.playing_station = None
         self._set_status("Stopped")
         self._play_stop_btn.Enable(True)
         self._play_stop_btn.SetLabel("Play")
@@ -330,6 +368,7 @@ class NOAARadioDialog(wx.Dialog):
     def _on_error(self, message: str) -> None:
         """Handle playback error event."""
         self._playing_station = None
+        self._session.playing_station = None
         self._health_timer.Stop()
         self._set_status(f"Error: {message}")
         self._play_stop_btn.Enable(True)
@@ -363,7 +402,8 @@ class NOAARadioDialog(wx.Dialog):
         self._health_timer.Stop()
         self._player.stop(notify=False)  # Don't reset button states mid-switch
 
-        self._current_url_index = (self._current_url_index + 1) % len(self._current_urls)
+        self._session.current_url_index = (self._current_url_index + 1) % len(self._current_urls)
+        self._current_url_index = self._session.current_url_index
         url = self._current_urls[self._current_url_index]
         station = self._get_selected_station()
         name = station.call_sign if station else "Unknown"
@@ -382,7 +422,8 @@ class NOAARadioDialog(wx.Dialog):
         if not self._current_urls or len(self._current_urls) <= 1:
             self._set_status("Stream has no audio")
             return
-        self._current_url_index = (self._current_url_index + 1) % len(self._current_urls)
+        self._session.current_url_index = (self._current_url_index + 1) % len(self._current_urls)
+        self._current_url_index = self._session.current_url_index
         url = self._current_urls[self._current_url_index]
         station = self._get_selected_station()
         name = station.call_sign if station else "Unknown"
@@ -410,6 +451,17 @@ class NOAARadioDialog(wx.Dialog):
         self._load_stations_async()
         event.Skip()
 
+    def _on_search(self, event: wx.CommandEvent) -> None:
+        """Reload stations using the current station search text."""
+        self._load_stations_async()
+        event.Skip()
+
+    def _on_clear_search(self, event: wx.CommandEvent) -> None:
+        """Clear the station search and browse the default station list."""
+        self._search_ctrl.SetValue("")
+        self._load_stations_async()
+        event.Skip()
+
     def _on_station_changed(self, event: wx.CommandEvent) -> None:
         """Update button label when the user picks a different station."""
         self._update_play_btn_label()
@@ -434,9 +486,8 @@ class NOAARadioDialog(wx.Dialog):
             self._play_stop_btn.SetLabel("Play")
             return
         selected = self._get_selected_station()
-        if (
-            selected is not None
-            and self._playing_station is not None
+        if selected is None or (
+            self._playing_station is not None
             and selected.call_sign == self._playing_station.call_sign
         ):
             self._play_stop_btn.SetLabel("Stop")
@@ -451,16 +502,23 @@ class NOAARadioDialog(wx.Dialog):
         event.Skip()
 
     def _on_close(self, _event: wx.Event) -> None:
-        """Handle dialog close."""
+        """Dismiss the dialog while leaving any active stream playing."""
         self._closed = True
         self._health_timer.Stop()
-        self._player.stop()
+        self._session.unbind_callbacks()
         self.Destroy()
 
     def _show_unavailable_enabled(self) -> bool:
         """Return the current state of the unavailable-station filter."""
         checkbox = getattr(self, "_show_unavailable_checkbox", None)
         return bool(checkbox.GetValue()) if checkbox is not None else False
+
+    def _get_search_query(self) -> str:
+        """Return the current station search query."""
+        search_ctrl = getattr(self, "_search_ctrl", None)
+        if search_ctrl is None:
+            return ""
+        return str(search_ctrl.GetValue()).strip()
 
     def _get_selected_station_limit(self) -> int | None:
         """Return the chosen nearby-station limit, or None for all stations."""
@@ -497,3 +555,26 @@ class NOAARadioDialog(wx.Dialog):
         if current_station is None:
             return
         self._availability_cache.clear(current_station.call_sign)
+
+    def _sync_playback_state_from_session(self) -> None:
+        """Refresh dialog controls from the shared playback session."""
+        if not hasattr(self, "_volume_slider"):
+            return
+        self._current_urls = self._session.current_urls
+        self._current_url_index = self._session.current_url_index
+        self._playing_station = self._session.playing_station
+        self._volume_slider.SetValue(round(self._player.get_volume() * 100))
+        if self._session.is_playing() and self._playing_station is not None:
+            total = len(self._current_urls)
+            idx = self._current_url_index + 1
+            stream_info = f" (stream {idx} of {total})" if total > 1 else ""
+            self._set_status(f"Playing: {self._playing_station.call_sign}{stream_info}")
+            self._play_stop_btn.Enable(True)
+            self._update_play_btn_label()
+            self._next_stream_btn.Enable(total > 1)
+            self._prefer_btn.Enable(bool(self._current_urls))
+            self._health_timer.Start(5000)
+        else:
+            self._play_stop_btn.SetLabel("Play")
+            self._next_stream_btn.Enable(False)
+            self._prefer_btn.Enable(False)

--- a/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
+++ b/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
@@ -37,6 +37,64 @@ FINDER_MODE_LABELS: tuple[str, ...] = (
     FINDER_MODE_NEAREST,
 )
 STATE_ALL_CHOICE = "All states and territories"
+STATE_TERRITORY_NAMES: dict[str, str] = {
+    "AL": "Alabama",
+    "AK": "Alaska",
+    "AZ": "Arizona",
+    "AR": "Arkansas",
+    "CA": "California",
+    "CO": "Colorado",
+    "CT": "Connecticut",
+    "DE": "Delaware",
+    "DC": "District of Columbia",
+    "FL": "Florida",
+    "GA": "Georgia",
+    "HI": "Hawaii",
+    "ID": "Idaho",
+    "IL": "Illinois",
+    "IN": "Indiana",
+    "IA": "Iowa",
+    "KS": "Kansas",
+    "KY": "Kentucky",
+    "LA": "Louisiana",
+    "ME": "Maine",
+    "MD": "Maryland",
+    "MA": "Massachusetts",
+    "MI": "Michigan",
+    "MN": "Minnesota",
+    "MS": "Mississippi",
+    "MO": "Missouri",
+    "MT": "Montana",
+    "NE": "Nebraska",
+    "NV": "Nevada",
+    "NH": "New Hampshire",
+    "NJ": "New Jersey",
+    "NM": "New Mexico",
+    "NY": "New York",
+    "NC": "North Carolina",
+    "ND": "North Dakota",
+    "OH": "Ohio",
+    "OK": "Oklahoma",
+    "OR": "Oregon",
+    "PA": "Pennsylvania",
+    "RI": "Rhode Island",
+    "SC": "South Carolina",
+    "SD": "South Dakota",
+    "TN": "Tennessee",
+    "TX": "Texas",
+    "UT": "Utah",
+    "VT": "Vermont",
+    "VA": "Virginia",
+    "WA": "Washington",
+    "WV": "West Virginia",
+    "WI": "Wisconsin",
+    "WY": "Wyoming",
+    "AS": "American Samoa",
+    "GU": "Guam",
+    "MP": "Northern Mariana Islands",
+    "PR": "Puerto Rico",
+    "VI": "U.S. Virgin Islands",
+}
 
 
 def show_noaa_radio_dialog(
@@ -600,7 +658,7 @@ class NOAARadioDialog(wx.Dialog):
         selection = choice.GetSelection()
         if selection <= 0 or selection >= len(state_choices):
             return ""
-        return state_choices[selection]
+        return self._state_choice_code(state_choices[selection])
 
     def _update_finder_mode_controls(self) -> None:
         """Show and label the finder controls for the active mode."""
@@ -652,7 +710,23 @@ class NOAARadioDialog(wx.Dialog):
     def _get_state_choices() -> tuple[str, ...]:
         """Return state/territory choices from the local station database."""
         states = sorted({station.state for station in StationDatabase().get_all_stations()})
-        return (STATE_ALL_CHOICE, *states)
+        return (
+            STATE_ALL_CHOICE,
+            *(NOAARadioDialog._format_state_choice(state) for state in states),
+        )
+
+    @staticmethod
+    def _format_state_choice(state_code: str) -> str:
+        """Return a user-friendly state/territory choice label."""
+        name = STATE_TERRITORY_NAMES.get(state_code)
+        return f"{name} ({state_code})" if name else state_code
+
+    @staticmethod
+    def _state_choice_code(choice_label: str) -> str:
+        """Return the station database code from a state choice label."""
+        if choice_label.endswith(")") and "(" in choice_label:
+            return choice_label.rsplit("(", 1)[1].rstrip(")")
+        return choice_label
 
     @staticmethod
     def _parse_coordinate_query(query: str) -> tuple[float, float] | None:

--- a/src/accessiweather/ui/dialogs/noaa_radio_widgets.py
+++ b/src/accessiweather/ui/dialogs/noaa_radio_widgets.py
@@ -7,32 +7,63 @@ from typing import Any
 import wx
 
 
-def create_noaa_radio_widgets(dialog: Any, station_limit_labels: tuple[str, ...]) -> None:
+def create_noaa_radio_widgets(
+    dialog: Any,
+    station_limit_labels: tuple[str, ...],
+    finder_mode_labels: tuple[str, ...],
+    state_choices: tuple[str, ...],
+    initial_finder_mode_index: int = 0,
+) -> None:
     """Create and layout all NOAA radio dialog controls."""
     panel = wx.Panel(dialog)
     sizer = wx.BoxSizer(wx.VERTICAL)
 
-    sizer.Add(wx.StaticText(panel, label="Find station:"), 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
+    dialog._finder_panel = panel
+    dialog._finder_sizer = sizer
 
-    search_sizer = wx.BoxSizer(wx.HORIZONTAL)
+    finder_heading = wx.StaticText(panel, label="Station Finder")
+    sizer.Add(finder_heading, 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
+
+    sizer.Add(wx.StaticText(panel, label="Search mode:"), 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
+    dialog._finder_mode_labels = finder_mode_labels
+    dialog._finder_mode_choice = wx.Choice(panel, choices=list(finder_mode_labels))
+    dialog._finder_mode_choice.SetSelection(initial_finder_mode_index)
+    dialog._finder_mode_choice.Bind(wx.EVT_CHOICE, dialog._on_finder_mode_changed)
+    sizer.Add(dialog._finder_mode_choice, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 10)
+
+    dialog._search_label = wx.StaticText(
+        panel,
+        label="Search text (call sign, city, or state):",
+    )
+    sizer.Add(dialog._search_label, 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
+
+    find_sizer = wx.BoxSizer(wx.HORIZONTAL)
     dialog._search_ctrl = wx.TextCtrl(
         panel,
         style=wx.TE_PROCESS_ENTER,
-        name="NOAA radio station search",
+        name="NOAA radio station finder text",
     )
-    dialog._search_ctrl.Bind(wx.EVT_TEXT_ENTER, dialog._on_search)
-    search_sizer.Add(dialog._search_ctrl, 1, wx.RIGHT, 5)
+    dialog._search_ctrl.SetHint("Call sign, city, state, or latitude, longitude")
+    dialog._search_ctrl.Bind(wx.EVT_TEXT_ENTER, dialog._on_find)
+    find_sizer.Add(dialog._search_ctrl, 1, wx.RIGHT, 5)
 
-    search_btn = wx.Button(panel, label="Search")
-    search_btn.Bind(wx.EVT_BUTTON, dialog._on_search)
-    search_sizer.Add(search_btn, 0, wx.RIGHT, 5)
+    find_btn = wx.Button(panel, label="Find")
+    find_btn.Bind(wx.EVT_BUTTON, dialog._on_find)
+    find_sizer.Add(find_btn, 0, wx.RIGHT, 5)
 
     clear_btn = wx.Button(panel, label="Clear")
     clear_btn.Bind(wx.EVT_BUTTON, dialog._on_clear_search)
-    search_sizer.Add(clear_btn, 0)
-    sizer.Add(search_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 10)
+    find_sizer.Add(clear_btn, 0)
+    sizer.Add(find_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 10)
 
-    sizer.Add(wx.StaticText(panel, label="Station:"), 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
+    dialog._state_label = wx.StaticText(panel, label="State or territory:")
+    sizer.Add(dialog._state_label, 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
+    dialog._state_choices = state_choices
+    dialog._state_choice = wx.Choice(panel, choices=list(state_choices))
+    dialog._state_choice.SetSelection(0)
+    sizer.Add(dialog._state_choice, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 10)
+
+    sizer.Add(wx.StaticText(panel, label="Station results:"), 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
 
     dialog._station_choice = wx.Choice(panel, choices=[])
     dialog._station_choice.Bind(wx.EVT_CHOICE, dialog._on_station_changed)
@@ -40,7 +71,7 @@ def create_noaa_radio_widgets(dialog: Any, station_limit_labels: tuple[str, ...]
     sizer.Add(dialog._station_choice, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 10)
 
     sizer.Add(
-        wx.StaticText(panel, label="Station count:"),
+        wx.StaticText(panel, label="Maximum results:"),
         0,
         wx.LEFT | wx.RIGHT | wx.TOP,
         10,

--- a/src/accessiweather/ui/dialogs/noaa_radio_widgets.py
+++ b/src/accessiweather/ui/dialogs/noaa_radio_widgets.py
@@ -12,6 +12,26 @@ def create_noaa_radio_widgets(dialog: Any, station_limit_labels: tuple[str, ...]
     panel = wx.Panel(dialog)
     sizer = wx.BoxSizer(wx.VERTICAL)
 
+    sizer.Add(wx.StaticText(panel, label="Find station:"), 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
+
+    search_sizer = wx.BoxSizer(wx.HORIZONTAL)
+    dialog._search_ctrl = wx.TextCtrl(
+        panel,
+        style=wx.TE_PROCESS_ENTER,
+        name="NOAA radio station search",
+    )
+    dialog._search_ctrl.Bind(wx.EVT_TEXT_ENTER, dialog._on_search)
+    search_sizer.Add(dialog._search_ctrl, 1, wx.RIGHT, 5)
+
+    search_btn = wx.Button(panel, label="Search")
+    search_btn.Bind(wx.EVT_BUTTON, dialog._on_search)
+    search_sizer.Add(search_btn, 0, wx.RIGHT, 5)
+
+    clear_btn = wx.Button(panel, label="Clear")
+    clear_btn.Bind(wx.EVT_BUTTON, dialog._on_clear_search)
+    search_sizer.Add(clear_btn, 0)
+    sizer.Add(search_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 10)
+
     sizer.Add(wx.StaticText(panel, label="Station:"), 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
 
     dialog._station_choice = wx.Choice(panel, choices=[])
@@ -20,7 +40,7 @@ def create_noaa_radio_widgets(dialog: Any, station_limit_labels: tuple[str, ...]
     sizer.Add(dialog._station_choice, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 10)
 
     sizer.Add(
-        wx.StaticText(panel, label="Nearby station count:"),
+        wx.StaticText(panel, label="Station count:"),
         0,
         wx.LEFT | wx.RIGHT | wx.TOP,
         10,

--- a/src/accessiweather/ui/main_window.py
+++ b/src/accessiweather/ui/main_window.py
@@ -51,8 +51,7 @@ ALL_LOCATIONS_SENTINEL = "All Locations"
 # AppendSeparator
 # "Weather Assistan&t"
 # def _on_noaa_radio(self)
-# _on_noaa_radio calls get_current_location, MessageBox with "select a location",
-# show_noaa_radio_dialog, latitude, and longitude.
+# _on_noaa_radio calls show_noaa_radio_dialog as a standalone feature.
 # "Weather Assistant"
 
 

--- a/src/accessiweather/ui/main_window_commands.py
+++ b/src/accessiweather/ui/main_window_commands.py
@@ -120,18 +120,9 @@ class MainWindowCommandMixin:
 
     def _on_noaa_radio(self) -> None:
         """Open NOAA Weather Radio dialog."""
-        location = self.app.config_manager.get_current_location()
-        if not location:
-            wx.MessageBox(
-                "Please select a location first.",
-                "No Location Selected",
-                wx.OK | wx.ICON_WARNING,
-            )
-            return
-
         from .dialogs import show_noaa_radio_dialog
 
-        show_noaa_radio_dialog(self, location.latitude, location.longitude)
+        show_noaa_radio_dialog(self)
 
     def _on_weather_chat(self) -> None:
         """Open Weather Assistant dialog."""

--- a/tests/test_app_auto_update_checks.py
+++ b/tests/test_app_auto_update_checks.py
@@ -218,6 +218,33 @@ def test_request_exit_stops_timers_when_present():
     app.ExitMainLoop.assert_called_once()
 
 
+def test_request_exit_continues_when_noaa_radio_shutdown_fails(monkeypatch):
+    app = AccessiWeatherApp.__new__(AccessiWeatherApp)
+    app._update_timer = None
+    app._event_check_timer = None
+    app._auto_update_check_timer = None
+    app._activation_handoff_timer = None
+    app.config_manager = MagicMock()
+    app.config_manager.get_settings.return_value = SimpleNamespace(sound_enabled=False)
+    app.tray_icon = None
+    app.single_instance_manager = None
+    app._async_loop = None
+    app.main_window = None
+    app.ExitMainLoop = MagicMock()
+
+    import accessiweather.noaa_radio.session as session_module
+
+    monkeypatch.setattr(
+        session_module,
+        "stop_shared_radio_session",
+        MagicMock(side_effect=RuntimeError("audio cleanup failed")),
+    )
+
+    app.request_exit()
+
+    app.ExitMainLoop.assert_called_once()
+
+
 def test_refresh_runtime_settings_restarts_auto_update_checks():
     app = AccessiWeatherApp.__new__(AccessiWeatherApp)
     alert_settings = object()

--- a/tests/test_noaa_radio_dialog.py
+++ b/tests/test_noaa_radio_dialog.py
@@ -184,7 +184,7 @@ def _make_dialog_instance(module):
     dlg._finder_mode_choice.GetSelection.return_value = 0
     dlg._state_choice = MagicMock()
     dlg._state_choice.GetSelection.return_value = 0
-    dlg._state_choices = ("All states and territories", "NY", "PA")
+    dlg._state_choices = ("All states and territories", "New York (NY)", "Pennsylvania (PA)")
     dlg._auto_advance_stream = True
     dlg._playing_station = None
     return dlg
@@ -610,6 +610,30 @@ class TestStationFinderControls:
         dlg._state_choice.GetSelection.return_value = 2
 
         assert dlg._get_selected_state_code() == "PA"
+
+    def test_get_state_choices_uses_full_state_names(self, noaa_dialog_module):
+        stations = [
+            Station("WXK27", 162.4, "Austin", 0.0, 0.0, "TX"),
+            Station("KEC49", 162.55, "New York", 0.0, 0.0, "NY"),
+        ]
+
+        with patch.object(noaa_dialog_module, "StationDatabase") as mock_db_cls:
+            mock_db_cls.return_value.get_all_stations.return_value = stations
+
+            choices = noaa_dialog_module.NOAARadioDialog._get_state_choices()
+
+        assert choices == (
+            "All states and territories",
+            "New York (NY)",
+            "Texas (TX)",
+        )
+
+    def test_get_selected_state_code_supports_legacy_code_labels(self, noaa_dialog_module):
+        dlg = _make_dialog_instance(noaa_dialog_module)
+        dlg._state_choices = ("All states and territories", "NY", "PA")
+        dlg._state_choice.GetSelection.return_value = 1
+
+        assert dlg._get_selected_state_code() == "NY"
 
     def test_parse_coordinate_query(self, noaa_dialog_module):
         parse = noaa_dialog_module.NOAARadioDialog._parse_coordinate_query

--- a/tests/test_noaa_radio_dialog.py
+++ b/tests/test_noaa_radio_dialog.py
@@ -50,10 +50,12 @@ def _create_wx_mock():
         "ICON_INFORMATION",
         "SL_HORIZONTAL",
         "ID_CLOSE",
+        "TE_PROCESS_ENTER",
     ]:
         setattr(wx_mock, attr, 0)
     wx_mock.NOT_FOUND = -1
     wx_mock.EVT_CHECKBOX = MagicMock()
+    wx_mock.EVT_TEXT_ENTER = MagicMock()
 
     # Use real classes for inheritance
     wx_mock.Window = _FakeWxWindow
@@ -72,6 +74,10 @@ def _create_wx_mock():
     checkbox_inst = MagicMock()
     checkbox_inst.GetValue.return_value = False
     wx_mock.CheckBox.return_value = checkbox_inst
+
+    text_ctrl_inst = MagicMock()
+    text_ctrl_inst.GetValue.return_value = ""
+    wx_mock.TextCtrl.return_value = text_ctrl_inst
 
     return wx_mock
 
@@ -143,6 +149,16 @@ def _make_dialog_instance(module):
         ),
     ]
     dlg._player = MagicMock()
+    dlg._player.get_volume.return_value = 1.0
+    dlg._session = MagicMock()
+    dlg._session.player = dlg._player
+    dlg._session.current_urls = dlg._current_urls = [
+        "http://example.com/stream1",
+        "http://example.com/stream2",
+    ]
+    dlg._session.current_url_index = 0
+    dlg._session.playing_station = None
+    dlg._session.is_playing.return_value = False
     dlg._url_provider = MagicMock()
     dlg._station_choice = MagicMock()
     dlg._station_choice.GetSelection.return_value = 0
@@ -162,6 +178,8 @@ def _make_dialog_instance(module):
     dlg._prefer_btn = MagicMock()
     dlg._show_unavailable_checkbox = MagicMock()
     dlg._show_unavailable_checkbox.GetValue.return_value = False
+    dlg._search_ctrl = MagicMock()
+    dlg._search_ctrl.GetValue.return_value = ""
     dlg._auto_advance_stream = True
     dlg._playing_station = None
     return dlg
@@ -192,7 +210,7 @@ class TestNOAARadioDialogModule:
 
         with (
             patch.object(noaa_dialog_module.wx, "GetApp", return_value=fake_app),
-            patch.object(noaa_dialog_module, "RadioPlayer"),
+            patch.object(noaa_dialog_module, "get_shared_radio_session", return_value=MagicMock()),
             patch.object(noaa_dialog_module, "StreamURLProvider"),
             patch.object(
                 noaa_dialog_module, "_get_clients", return_value=(MagicMock(), MagicMock())
@@ -216,7 +234,7 @@ class TestNOAARadioDialogModule:
 
         with (
             patch.object(noaa_dialog_module.wx, "GetApp", return_value=fake_app),
-            patch.object(noaa_dialog_module, "RadioPlayer"),
+            patch.object(noaa_dialog_module, "get_shared_radio_session", return_value=MagicMock()),
             patch.object(noaa_dialog_module, "StreamURLProvider"),
             patch.object(
                 noaa_dialog_module, "_get_clients", return_value=(MagicMock(), MagicMock())
@@ -291,7 +309,7 @@ class TestPlaybackControls:
         """Test Stop triggers player.stop."""
         dlg = _make_dialog_instance(noaa_dialog_module)
         dlg._on_stop(MagicMock())
-        dlg._player.stop.assert_called_once()
+        dlg._session.stop.assert_called_once()
 
     def test_on_volume_change(self, noaa_dialog_module):
         """Test volume slider change updates player."""
@@ -347,13 +365,44 @@ class TestCallbacks:
 class TestDialogLifecycle:
     """Tests for dialog open/close behavior."""
 
-    def test_on_close_stops_and_destroys(self, noaa_dialog_module):
-        """Test closing dialog stops player and destroys window."""
+    def test_on_close_dismisses_without_stopping(self, noaa_dialog_module):
+        """Test closing dialog leaves the shared player alone."""
         dlg = _make_dialog_instance(noaa_dialog_module)
         dlg.Destroy = MagicMock()
         dlg._on_close(MagicMock())
-        dlg._player.stop.assert_called_once()
+        dlg._player.stop.assert_not_called()
+        dlg._session.unbind_callbacks.assert_called_once()
         dlg.Destroy.assert_called_once()
+
+    def test_escape_dismisses_without_stopping(self, noaa_dialog_module):
+        """Test Escape follows the same dismiss-only path as Close."""
+        import wx
+
+        dlg = _make_dialog_instance(noaa_dialog_module)
+        dlg.Destroy = MagicMock()
+        event = MagicMock()
+        event.GetKeyCode.return_value = wx.WXK_ESCAPE
+
+        dlg._on_char_hook(event)
+
+        dlg._player.stop.assert_not_called()
+        dlg._session.unbind_callbacks.assert_called_once()
+        event.Skip.assert_not_called()
+
+    def test_reopen_syncs_active_stream_state(self, noaa_dialog_module):
+        """Test a reopened dialog reflects the already-playing station."""
+        dlg = _make_dialog_instance(noaa_dialog_module)
+        dlg._session.is_playing.return_value = True
+        dlg._session.playing_station = dlg._stations[0]
+        dlg._session.current_urls = ["https://example.com/1", "https://example.com/2"]
+        dlg._session.current_url_index = 1
+
+        dlg._sync_playback_state_from_session()
+
+        dlg._status_text.SetLabel.assert_called_with("Playing: KEC49 (stream 2 of 2)")
+        dlg._play_stop_btn.SetLabel.assert_called_with("Stop")
+        dlg._next_stream_btn.Enable.assert_called_with(True)
+        dlg._prefer_btn.Enable.assert_called_with(True)
 
     def test_show_noaa_radio_dialog_creates_and_shows(self, noaa_dialog_module):
         """Test convenience function creates and shows dialog."""
@@ -489,7 +538,19 @@ class TestPlayStopSwitch:
         dlg._playing_station = dlg._stations[0]
         dlg._station_choice.GetSelection.return_value = 0
         dlg._on_play_stop(MagicMock())
-        dlg._player.stop.assert_called()
+        dlg._session.stop.assert_called()
+        dlg._player.play.assert_not_called()
+
+    def test_playing_without_selection_triggers_stop(self, noaa_dialog_module):
+        """When playback is active but no station is selected, the button still stops."""
+        dlg = _make_dialog_instance(noaa_dialog_module)
+        dlg._player.is_playing.return_value = True
+        dlg._playing_station = dlg._stations[0]
+        dlg._station_choice.GetSelection.return_value = -1
+
+        dlg._on_play_stop(MagicMock())
+
+        dlg._session.stop.assert_called_once()
         dlg._player.play.assert_not_called()
 
     def test_different_station_playing_triggers_switch(self, noaa_dialog_module):

--- a/tests/test_noaa_radio_dialog.py
+++ b/tests/test_noaa_radio_dialog.py
@@ -180,6 +180,11 @@ def _make_dialog_instance(module):
     dlg._show_unavailable_checkbox.GetValue.return_value = False
     dlg._search_ctrl = MagicMock()
     dlg._search_ctrl.GetValue.return_value = ""
+    dlg._finder_mode_choice = MagicMock()
+    dlg._finder_mode_choice.GetSelection.return_value = 0
+    dlg._state_choice = MagicMock()
+    dlg._state_choice.GetSelection.return_value = 0
+    dlg._state_choices = ("All states and territories", "NY", "PA")
     dlg._auto_advance_stream = True
     dlg._playing_station = None
     return dlg
@@ -468,14 +473,61 @@ class TestUnavailableStations:
         dlg._on_close = MagicMock()
         dlg._on_show_unavailable_changed = MagicMock()
         dlg._on_station_limit_changed = MagicMock()
+        dlg._on_finder_mode_changed = MagicMock()
+        dlg._on_find = MagicMock()
+        dlg._on_clear_search = MagicMock()
         dlg._prefs = MagicMock()
         dlg._prefs.get_station_limit.return_value = 25
 
         noaa_dialog_module.NOAARadioDialog._init_ui(dlg)
 
-        assert noaa_dialog_module.wx.Choice.call_count == 2
-        station_limit_choice = noaa_dialog_module.wx.Choice.call_args_list[1]
+        assert noaa_dialog_module.wx.Choice.call_count == 4
+        station_limit_choice = noaa_dialog_module.wx.Choice.call_args_list[3]
         assert station_limit_choice.kwargs["choices"] == ["10", "25", "50", "100", "All"]
+
+    def test_station_finder_widgets_are_created(self, noaa_dialog_module):
+        dlg = object.__new__(noaa_dialog_module.NOAARadioDialog)
+        dlg.Bind = MagicMock()
+        dlg._lat = None
+        dlg._lon = None
+        dlg._on_health_check = MagicMock()
+        dlg._on_station_changed = MagicMock()
+        dlg._on_choice_key = MagicMock()
+        dlg._on_play_stop = MagicMock()
+        dlg._on_next_stream = MagicMock()
+        dlg._on_set_preferred = MagicMock()
+        dlg._on_volume_change = MagicMock()
+        dlg._on_close = MagicMock()
+        dlg._on_show_unavailable_changed = MagicMock()
+        dlg._on_station_limit_changed = MagicMock()
+        dlg._on_finder_mode_changed = MagicMock()
+        dlg._on_find = MagicMock()
+        dlg._on_clear_search = MagicMock()
+        dlg._prefs = MagicMock()
+        dlg._prefs.get_station_limit.return_value = 10
+
+        noaa_dialog_module.NOAARadioDialog._init_ui(dlg)
+
+        static_labels = [
+            call.kwargs["label"]
+            for call in noaa_dialog_module.wx.StaticText.call_args_list
+            if "label" in call.kwargs
+        ]
+        button_labels = [
+            call.kwargs["label"]
+            for call in noaa_dialog_module.wx.Button.call_args_list
+            if "label" in call.kwargs
+        ]
+        assert "Station Finder" in static_labels
+        assert "Search mode:" in static_labels
+        assert "State or territory:" in static_labels
+        assert "Station results:" in static_labels
+        assert "Maximum results:" in static_labels
+        assert "Find" in button_labels
+        assert "Search" not in button_labels
+
+        mode_choice = noaa_dialog_module.wx.Choice.call_args_list[0]
+        assert mode_choice.kwargs["choices"] == list(noaa_dialog_module.FINDER_MODE_LABELS)
 
     def test_show_unavailable_toggle_refreshes_station_list(self, noaa_dialog_module):
         dlg = _make_dialog_instance(noaa_dialog_module)
@@ -510,12 +562,61 @@ class TestUnavailableStations:
 
         dlg._on_stations_loaded(
             [station],
-            ["WXK27 - Austin (162.4 MHz) - temporarily unavailable"],
+            ["WXK27 - Austin, TX - 162.400 MHz - Temporarily unavailable"],
         )
 
         dlg._station_choice.Set.assert_called_with(
-            ["WXK27 - Austin (162.4 MHz) - temporarily unavailable"]
+            ["WXK27 - Austin, TX - 162.400 MHz - Temporarily unavailable"]
         )
+
+
+class TestStationFinderControls:
+    """Tests for NOAA radio finder mode controls."""
+
+    def test_clear_resets_finder_to_search_all(self, noaa_dialog_module):
+        dlg = _make_dialog_instance(noaa_dialog_module)
+        dlg._load_stations_async = MagicMock()
+        event = MagicMock()
+
+        dlg._on_clear_search(event)
+
+        dlg._finder_mode_choice.SetSelection.assert_called_once_with(0)
+        dlg._state_choice.SetSelection.assert_called_once_with(0)
+        dlg._search_ctrl.SetValue.assert_called_once_with("")
+        dlg._load_stations_async.assert_called_once()
+        event.Skip.assert_called_once()
+
+    def test_on_find_reloads_station_list(self, noaa_dialog_module):
+        dlg = _make_dialog_instance(noaa_dialog_module)
+        dlg._load_stations_async = MagicMock()
+        event = MagicMock()
+
+        dlg._on_find(event)
+
+        dlg._load_stations_async.assert_called_once()
+        event.Skip.assert_called_once()
+
+    def test_get_finder_mode_defaults_to_nearest_when_opened_with_coordinates(
+        self,
+        noaa_dialog_module,
+    ):
+        dlg = _make_dialog_instance(noaa_dialog_module)
+        del dlg._finder_mode_choice
+
+        assert dlg._get_finder_mode() == noaa_dialog_module.FINDER_MODE_NEAREST
+
+    def test_get_selected_state_code(self, noaa_dialog_module):
+        dlg = _make_dialog_instance(noaa_dialog_module)
+        dlg._state_choice.GetSelection.return_value = 2
+
+        assert dlg._get_selected_state_code() == "PA"
+
+    def test_parse_coordinate_query(self, noaa_dialog_module):
+        parse = noaa_dialog_module.NOAARadioDialog._parse_coordinate_query
+
+        assert parse("30.2672, -97.7431") == (30.2672, -97.7431)
+        assert parse("Austin") is None
+        assert parse("91, 0") is None
 
 
 class TestPlayStopSwitch:

--- a/tests/test_noaa_radio_dialog_integration.py
+++ b/tests/test_noaa_radio_dialog_integration.py
@@ -55,10 +55,12 @@ def _create_wx_mock():
         "ICON_INFORMATION",
         "SL_HORIZONTAL",
         "ID_CLOSE",
+        "TE_PROCESS_ENTER",
     ]:
         setattr(wx_mock, attr, 0)
     wx_mock.NOT_FOUND = -1
     wx_mock.EVT_CHECKBOX = MagicMock()
+    wx_mock.EVT_TEXT_ENTER = MagicMock()
     wx_mock.Window = _FakeWxWindow
     wx_mock.Dialog = _FakeWxDialog
 
@@ -73,6 +75,10 @@ def _create_wx_mock():
     checkbox_inst = MagicMock()
     checkbox_inst.GetValue.return_value = False
     wx_mock.CheckBox.return_value = checkbox_inst
+
+    text_ctrl_inst = MagicMock()
+    text_ctrl_inst.GetValue.return_value = ""
+    wx_mock.TextCtrl.return_value = text_ctrl_inst
 
     return wx_mock
 
@@ -128,7 +134,17 @@ def _make_dialog(module):
         Station("WXJ76", 162.40, "Philadelphia", 39.95, -75.17, "PA"),
     ]
     dlg._player = MagicMock()
+    dlg._player.get_volume.return_value = 1.0
     dlg._player.is_playing.return_value = False
+    dlg._session = MagicMock()
+    dlg._session.player = dlg._player
+    dlg._session.current_urls = dlg._current_urls = [
+        "http://example.com/stream1",
+        "http://example.com/stream2",
+    ]
+    dlg._session.current_url_index = 0
+    dlg._session.playing_station = None
+    dlg._session.is_playing.return_value = False
     dlg._url_provider = MagicMock()
     dlg._station_choice = MagicMock()
     dlg._station_choice.GetSelection.return_value = 0
@@ -148,6 +164,8 @@ def _make_dialog(module):
     dlg._prefer_btn = MagicMock()
     dlg._show_unavailable_checkbox = MagicMock()
     dlg._show_unavailable_checkbox.GetValue.return_value = False
+    dlg._search_ctrl = MagicMock()
+    dlg._search_ctrl.GetValue.return_value = ""
     dlg._auto_advance_stream = True
     dlg._playing_station = None
     return dlg
@@ -173,7 +191,7 @@ class TestFullPlaybackFlow:
 
         # Stop
         dlg._on_stop(MagicMock())
-        dlg._player.stop.assert_called_once()
+        dlg._session.stop.assert_called_once()
 
         # Simulate stopped callback
         dlg._on_stopped()
@@ -238,7 +256,7 @@ class TestDialogCleanup:
     """Test dialog close cleanup."""
 
     def test_close_during_playback(self, noaa_dialog_module):
-        """Test closing dialog during active playback stops player."""
+        """Test closing dialog during active playback keeps player running."""
         dlg = _make_dialog(noaa_dialog_module)
         dlg.Destroy = MagicMock()
 
@@ -247,15 +265,17 @@ class TestDialogCleanup:
 
         # Close
         dlg._on_close(MagicMock())
-        dlg._player.stop.assert_called_once()
+        dlg._player.stop.assert_not_called()
+        dlg._session.unbind_callbacks.assert_called_once()
         dlg.Destroy.assert_called_once()
 
     def test_close_when_stopped(self, noaa_dialog_module):
-        """Test closing dialog when not playing still calls stop (safe)."""
+        """Test closing dialog when stopped just dismisses the UI."""
         dlg = _make_dialog(noaa_dialog_module)
         dlg.Destroy = MagicMock()
         dlg._on_close(MagicMock())
-        dlg._player.stop.assert_called_once()
+        dlg._player.stop.assert_not_called()
+        dlg._session.unbind_callbacks.assert_called_once()
         dlg.Destroy.assert_called_once()
 
 
@@ -349,6 +369,40 @@ class TestLoadStations:
             [entry.station],
             show_unavailable=True,
         )
+
+    def test_load_stations_without_coordinates_browses_station_database(self, noaa_dialog_module):
+        dlg = _make_dialog(noaa_dialog_module)
+        dlg._lat = None
+        dlg._lon = None
+        entry = MagicMock()
+        entry.station = Station("WXK27", 162.4, "Austin, TX", 30.2672, -97.7431, "TX")
+        entry.label = "WXK27 - Austin, TX (162.4 MHz)"
+        dlg._station_availability.build_entries.return_value = [entry]
+
+        with patch("accessiweather.ui.dialogs.noaa_radio_dialog.StationDatabase") as mock_db_cls:
+            mock_db_cls.return_value.search.return_value = [entry.station]
+            dlg._load_stations_worker(station_limit=25)
+
+        mock_db_cls.return_value.search.assert_called_once_with("", limit=25)
+        mock_db_cls.return_value.find_nearest.assert_not_called()
+        dlg._station_availability.build_entries.assert_called_once_with(
+            [entry.station],
+            show_unavailable=False,
+        )
+
+    def test_load_stations_uses_search_query(self, noaa_dialog_module):
+        dlg = _make_dialog(noaa_dialog_module)
+        entry = MagicMock()
+        entry.station = Station("WXK27", 162.4, "Austin, TX", 30.2672, -97.7431, "TX")
+        entry.label = "WXK27 - Austin, TX (162.4 MHz)"
+        dlg._station_availability.build_entries.return_value = [entry]
+
+        with patch("accessiweather.ui.dialogs.noaa_radio_dialog.StationDatabase") as mock_db_cls:
+            mock_db_cls.return_value.search.return_value = [entry.station]
+            dlg._load_stations_worker(station_limit=10, search_query="Austin")
+
+        mock_db_cls.return_value.search.assert_called_once_with("Austin", limit=10)
+        mock_db_cls.return_value.find_nearest.assert_not_called()
 
 
 class TestSuppressionIntegration:

--- a/tests/test_noaa_radio_dialog_integration.py
+++ b/tests/test_noaa_radio_dialog_integration.py
@@ -166,6 +166,13 @@ def _make_dialog(module):
     dlg._show_unavailable_checkbox.GetValue.return_value = False
     dlg._search_ctrl = MagicMock()
     dlg._search_ctrl.GetValue.return_value = ""
+    dlg._finder_mode_choice = MagicMock()
+    dlg._finder_mode_choice.GetSelection.return_value = module.FINDER_MODE_LABELS.index(
+        module.FINDER_MODE_NEAREST
+    )
+    dlg._state_choice = MagicMock()
+    dlg._state_choice.GetSelection.return_value = 0
+    dlg._state_choices = ("All states and territories", "NY", "PA", "TX")
     dlg._auto_advance_stream = True
     dlg._playing_station = None
     return dlg
@@ -374,6 +381,9 @@ class TestLoadStations:
         dlg = _make_dialog(noaa_dialog_module)
         dlg._lat = None
         dlg._lon = None
+        dlg._finder_mode_choice.GetSelection.return_value = (
+            noaa_dialog_module.FINDER_MODE_LABELS.index(noaa_dialog_module.FINDER_MODE_SEARCH_ALL)
+        )
         entry = MagicMock()
         entry.station = Station("WXK27", 162.4, "Austin, TX", 30.2672, -97.7431, "TX")
         entry.label = "WXK27 - Austin, TX (162.4 MHz)"
@@ -403,6 +413,77 @@ class TestLoadStations:
 
         mock_db_cls.return_value.search.assert_called_once_with("Austin", limit=10)
         mock_db_cls.return_value.find_nearest.assert_not_called()
+
+    def test_load_stations_browse_by_state_uses_state_database_filter(self, noaa_dialog_module):
+        dlg = _make_dialog(noaa_dialog_module)
+        tx_station = Station("WXK27", 162.4, "Austin, TX", 30.2672, -97.7431, "TX")
+        entry = MagicMock()
+        entry.station = tx_station
+        entry.label = "WXK27 - Austin, TX - 162.400 MHz - Available"
+        dlg._station_availability.build_entries.return_value = [entry]
+
+        with patch("accessiweather.ui.dialogs.noaa_radio_dialog.StationDatabase") as mock_db_cls:
+            mock_db_cls.return_value.get_stations_by_state.return_value = [tx_station]
+            dlg._load_stations_worker(
+                station_limit=25,
+                finder_mode=noaa_dialog_module.FINDER_MODE_BROWSE_STATE,
+                state_code="TX",
+            )
+
+        mock_db_cls.return_value.get_stations_by_state.assert_called_once_with("TX")
+        mock_db_cls.return_value.search.assert_not_called()
+        mock_db_cls.return_value.find_nearest.assert_not_called()
+        dlg._station_availability.build_entries.assert_called_once_with(
+            [tx_station],
+            show_unavailable=False,
+        )
+
+    def test_load_stations_coordinate_mode_uses_nearest_lookup(self, noaa_dialog_module):
+        dlg = _make_dialog(noaa_dialog_module)
+        station = Station("WXK27", 162.4, "Austin, TX", 30.2672, -97.7431, "TX")
+        entry = MagicMock()
+        entry.station = station
+        entry.label = "WXK27 - Austin, TX - 162.400 MHz - Available"
+        dlg._station_availability.build_entries.return_value = [entry]
+        results = [StationResult(station=station, distance_km=0.0)]
+
+        with patch("accessiweather.ui.dialogs.noaa_radio_dialog.StationDatabase") as mock_db_cls:
+            mock_db_cls.return_value.find_nearest.return_value = results
+            dlg._load_stations_worker(
+                station_limit=10,
+                search_query="30.2672, -97.7431",
+                finder_mode=noaa_dialog_module.FINDER_MODE_NEAREST,
+            )
+
+        mock_db_cls.return_value.find_nearest.assert_called_once_with(
+            30.2672,
+            -97.7431,
+            limit=10,
+        )
+        mock_db_cls.return_value.search.assert_not_called()
+
+    def test_load_stations_coordinate_mode_rejects_non_coordinate_text(
+        self,
+        noaa_dialog_module,
+    ):
+        dlg = _make_dialog(noaa_dialog_module)
+        dlg._lat = None
+        dlg._lon = None
+        dlg._station_availability.build_entries.return_value = []
+
+        with patch("accessiweather.ui.dialogs.noaa_radio_dialog.StationDatabase") as mock_db_cls:
+            dlg._load_stations_worker(
+                station_limit=10,
+                search_query="Austin",
+                finder_mode=noaa_dialog_module.FINDER_MODE_NEAREST,
+            )
+
+        mock_db_cls.return_value.find_nearest.assert_not_called()
+        mock_db_cls.return_value.search.assert_not_called()
+        dlg._station_availability.build_entries.assert_called_once_with(
+            [],
+            show_unavailable=False,
+        )
 
 
 class TestSuppressionIntegration:

--- a/tests/test_noaa_radio_dialog_integration.py
+++ b/tests/test_noaa_radio_dialog_integration.py
@@ -172,7 +172,12 @@ def _make_dialog(module):
     )
     dlg._state_choice = MagicMock()
     dlg._state_choice.GetSelection.return_value = 0
-    dlg._state_choices = ("All states and territories", "NY", "PA", "TX")
+    dlg._state_choices = (
+        "All states and territories",
+        "New York (NY)",
+        "Pennsylvania (PA)",
+        "Texas (TX)",
+    )
     dlg._auto_advance_stream = True
     dlg._playing_station = None
     return dlg

--- a/tests/test_noaa_radio_menu_item.py
+++ b/tests/test_noaa_radio_menu_item.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pathlib
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -43,24 +44,22 @@ class TestNoaaRadioMenuItemSource:
         assert "_noaa_radio_id" in source
 
     def test_no_location_check(self, source):
-        """Test that handler checks for no location."""
-        assert "get_current_location" in source
-        # Find the _on_noaa_radio method and check it has location check
+        """Test that handler does not require a weather location."""
         method_start = source.index("def _on_noaa_radio")
         method_end = source.index("\n    def ", method_start + 1)
         method_body = source[method_start:method_end]
-        assert "get_current_location" in method_body
-        assert "MessageBox" in method_body
-        assert "select a location" in method_body.lower()
+        assert "get_current_location" not in method_body
+        assert "MessageBox" not in method_body
+        assert "select a location" not in method_body.lower()
 
     def test_show_noaa_radio_dialog_called(self, source):
-        """Test that show_noaa_radio_dialog is called with lat/lon."""
+        """Test that show_noaa_radio_dialog is called standalone."""
         method_start = source.index("def _on_noaa_radio")
         method_end = source.index("\n    def ", method_start + 1)
         method_body = source[method_start:method_end]
         assert "show_noaa_radio_dialog" in method_body
-        assert "latitude" in method_body
-        assert "longitude" in method_body
+        assert "latitude" not in method_body
+        assert "longitude" not in method_body
 
     def test_menu_item_after_uv_index(self, source):
         """Test that NOAA Radio item appears after UV Index."""
@@ -74,3 +73,20 @@ class TestNoaaRadioMenuItemSource:
         noaa_pos = source.index("NOAA Weather &Radio")
         chat_pos = source.index("Weather Assistan&t")
         assert noaa_pos < chat_pos
+
+
+def test_noaa_radio_opens_without_saved_location(monkeypatch):
+    """NOAA Weather Radio is standalone and does not require a selected location."""
+    from accessiweather.ui import dialogs
+    from accessiweather.ui.main_window_commands import MainWindowCommandMixin
+
+    window = object.__new__(MainWindowCommandMixin)
+    window.app = MagicMock()
+    window.app.config_manager.get_current_location.return_value = None
+    show_dialog = MagicMock()
+    monkeypatch.setattr(dialogs, "show_noaa_radio_dialog", show_dialog)
+
+    window._on_noaa_radio()
+
+    show_dialog.assert_called_once_with(window)
+    window.app.config_manager.get_current_location.assert_not_called()

--- a/tests/test_noaa_radio_session.py
+++ b/tests/test_noaa_radio_session.py
@@ -1,5 +1,6 @@
 """Tests for shared NOAA Weather Radio playback session."""
 
+import importlib
 from unittest.mock import MagicMock, patch
 
 from accessiweather.noaa_radio import Station
@@ -41,3 +42,61 @@ def test_session_stop_clears_station_when_player_reports_stopped() -> None:
         callbacks["on_stopped"]()
 
     assert session.playing_station is None
+
+
+def test_session_forwards_callbacks_and_player_state() -> None:
+    callbacks = {}
+    player = MagicMock()
+    player.is_playing.return_value = True
+
+    def make_player(**kwargs):
+        callbacks.update(kwargs)
+        return player
+
+    with patch("accessiweather.noaa_radio.session.RadioPlayer", side_effect=make_player):
+        from accessiweather.noaa_radio.session import RadioSession
+
+        session = RadioSession()
+        on_playing = MagicMock()
+        on_stopped = MagicMock()
+        on_error = MagicMock()
+        on_stalled = MagicMock()
+        on_reconnecting = MagicMock()
+        session.bind_callbacks(
+            on_playing=on_playing,
+            on_stopped=on_stopped,
+            on_error=on_error,
+            on_stalled=on_stalled,
+            on_reconnecting=on_reconnecting,
+        )
+        session.playing_station = Station("WXK27", 162.4, "Austin", 30.2672, -97.7431, "TX")
+
+        assert session.is_playing() is True
+        session.stop(notify=False)
+        callbacks["on_playing"]()
+        callbacks["on_stopped"]()
+        callbacks["on_error"]("lost")
+        callbacks["on_stalled"]()
+        callbacks["on_reconnecting"](2)
+
+    player.stop.assert_called_once_with(notify=False)
+    assert session.playing_station is None
+    on_playing.assert_called_once_with()
+    on_stopped.assert_called_once_with()
+    on_error.assert_called_once_with("lost")
+    on_stalled.assert_called_once_with()
+    on_reconnecting.assert_called_once_with(2)
+
+
+def test_shared_session_helpers_create_and_stop_existing_session() -> None:
+    import accessiweather.noaa_radio.session as session_module
+
+    session_module = importlib.reload(session_module)
+    fake_session = MagicMock()
+
+    with patch.object(session_module, "RadioSession", return_value=fake_session):
+        assert session_module.get_shared_radio_session() is fake_session
+        assert session_module.get_shared_radio_session() is fake_session
+        session_module.stop_shared_radio_session()
+
+    fake_session.stop.assert_called_once_with()

--- a/tests/test_noaa_radio_session.py
+++ b/tests/test_noaa_radio_session.py
@@ -1,0 +1,43 @@
+"""Tests for shared NOAA Weather Radio playback session."""
+
+from unittest.mock import MagicMock, patch
+
+from accessiweather.noaa_radio import Station
+
+
+def test_session_unbinds_callbacks_without_stopping_player() -> None:
+    with patch("accessiweather.noaa_radio.session.RadioPlayer") as player_cls:
+        from accessiweather.noaa_radio.session import RadioSession
+
+        session = RadioSession()
+        session.bind_callbacks(
+            on_playing=MagicMock(),
+            on_stopped=MagicMock(),
+            on_error=MagicMock(),
+            on_stalled=MagicMock(),
+            on_reconnecting=MagicMock(),
+        )
+
+        session.unbind_callbacks()
+
+    player_cls.return_value.stop.assert_not_called()
+
+
+def test_session_stop_clears_station_when_player_reports_stopped() -> None:
+    callbacks = {}
+
+    def make_player(**kwargs):
+        callbacks.update(kwargs)
+        player = MagicMock()
+        player.is_playing.return_value = True
+        return player
+
+    with patch("accessiweather.noaa_radio.session.RadioPlayer", side_effect=make_player):
+        from accessiweather.noaa_radio.session import RadioSession
+
+        session = RadioSession()
+        session.playing_station = Station("WXK27", 162.4, "Austin", 30.2672, -97.7431, "TX")
+
+        callbacks["on_stopped"]()
+
+    assert session.playing_station is None

--- a/tests/test_noaa_radio_station_availability.py
+++ b/tests/test_noaa_radio_station_availability.py
@@ -28,7 +28,7 @@ def test_filters_out_station_without_weatherindex_feeds():
     entries = service.build_entries(stations)
 
     assert [entry.station.call_sign for entry in entries] == ["WXK27"]
-    assert entries[0].label == "WXK27 - Austin (162.4 MHz)"
+    assert entries[0].label == "WXK27 - Austin, TX - 162.400 MHz - Available"
     assert entries[0].available is True
 
 
@@ -64,4 +64,4 @@ def test_includes_suppressed_station_when_show_unavailable_enabled():
     assert len(entries) == 1
     assert entries[0].available is False
     assert entries[0].unavailable_reason == "temporarily unavailable"
-    assert entries[0].label == "WXK27 - Austin (162.4 MHz) - temporarily unavailable"
+    assert entries[0].label == "WXK27 - Austin, TX - 162.400 MHz - Temporarily unavailable"

--- a/tests/test_noaa_radio_station_db.py
+++ b/tests/test_noaa_radio_station_db.py
@@ -91,6 +91,14 @@ class TestStationDatabase:
         results = db.search("wxk27")
         assert [station.call_sign for station in results] == ["WXK27"]
 
+    def test_search_empty_query_browses_stations(self) -> None:
+        db = StationDatabase()
+        all_results = db.search("")
+        limited_results = db.search("   ", limit=3)
+
+        assert len(all_results) == len(db.get_all_stations())
+        assert limited_results == db.get_all_stations()[:3]
+
     def test_search_by_city_or_state(self) -> None:
         db = StationDatabase()
         city_results = db.search("Austin")

--- a/tests/test_noaa_radio_station_db.py
+++ b/tests/test_noaa_radio_station_db.py
@@ -86,6 +86,25 @@ class TestStationDatabase:
         assert isinstance(results[0].station, Station)
         assert isinstance(results[0].distance_km, float)
 
+    def test_search_by_call_sign(self) -> None:
+        db = StationDatabase()
+        results = db.search("wxk27")
+        assert [station.call_sign for station in results] == ["WXK27"]
+
+    def test_search_by_city_or_state(self) -> None:
+        db = StationDatabase()
+        city_results = db.search("Austin")
+        assert any(station.call_sign == "WXK27" for station in city_results)
+
+        state_results = db.search("TX", limit=2)
+        assert len(state_results) == 2
+        assert all(station.state == "TX" for station in state_results)
+
+    def test_search_by_coordinates_returns_nearest_stations(self) -> None:
+        db = StationDatabase()
+        results = db.search("40.7128, -74.0060", limit=1)
+        assert results[0].call_sign == "KWO35"
+
     def test_custom_stations(self) -> None:
         custom = [Station("TEST1", 162.5, "Test", 0.0, 0.0, "XX")]
         db = StationDatabase(stations=custom)


### PR DESCRIPTION
## Summary
- Make NOAA Weather Radio open as a standalone feature without requiring a saved/current AccessiWeather location.
- Add a clearer Station Finder with explicit modes for searching all stations, browsing by state/territory, and finding nearest stations by coordinates, backed by the local NOAA/NWR station database.
- Show full state/territory names in the Browse by state picker, such as `Texas (TX)`, while still filtering by the underlying station code.
- Keep WeatherIndex as the stream availability/feed source and show screen-reader-friendly station result labels with call sign, location/state, frequency, and availability.
- Move playback ownership into a shared NOAA radio session so Escape/Close dismisses the dialog while playback continues; explicit Stop and app shutdown still stop playback.

## Automated test evidence
- `uv run pytest tests/test_noaa_radio_dialog.py tests/test_noaa_radio_dialog_integration.py` - 75 passed after the state-name follow-up.
- `uv run ruff check src/accessiweather/ui/dialogs/noaa_radio_dialog.py tests/test_noaa_radio_dialog.py tests/test_noaa_radio_dialog_integration.py` - passed.
- `uv run ruff format --check src/accessiweather/ui/dialogs/noaa_radio_dialog.py tests/test_noaa_radio_dialog.py tests/test_noaa_radio_dialog_integration.py` - passed.
- `uv run python scripts/changelog_tools.py check --base origin/dev` - passed after the changelog cleanup.
- `uv run pytest tests/test_noaa_radio_station_db.py tests/test_noaa_radio_session.py tests/test_noaa_radio_dialog.py tests/test_noaa_radio_dialog_integration.py tests/test_noaa_radio_menu_item.py tests/test_noaa_radio_station_availability.py -q` - focused NOAA dialog/finder coverage passed before the state-name follow-up.
- Relevant NOAA/lifecycle regression slice - 274 passed.
- Broad non-integration CI-style run - 4001 passed, 1 skipped, coverage XML generated.
- Appended alert-dialog coverage tests - 9 passed.
- Local `diff-cover` against `origin/dev` - 100% diff coverage.
- Changelog gate against `origin/dev` - passed.

## Computer Use desktop E2E evidence
- Launched AccessiWeather from `C:\Users\joshu\.codex\worktrees\2c1d\accessiweather`.
- Opened NOAA Weather Radio; it opened without a saved-location prompt.
- Confirmed the Station Finder modes: `Search all stations`, `Browse by state`, and `Nearest by coordinates`.
- Search all stations: `Austin` returned `WXK27 - Austin, TX - 162.400 MHz - Available`.
- Browse by state: verified the state/territory picker appears in place of the text field.
- Nearest by coordinates: `30.2672, -97.7431` resolved to Austin/WXK27.
- Started playback: button changed from `Play` to `Stop`, status changed to `Playing: ...`.
- Pressed Escape; dialog dismissed and main window regained focus while playback ownership stayed outside the dialog.
- Reopened NOAA Weather Radio; active session persisted with `Stop` and `Playing: KEC61`.
- Pressed explicit Stop; button returned to `Play`, status changed to `Stopped`.

## Latest PR checks
- Validate (Ubuntu, Python 3.12) - success on latest commit.
- Validate (Ubuntu, Python 3.13) - success on latest commit.
- GitGuardian Security Checks - success on latest commit.
- Merge state: clean.

## Notes
- No new external station APIs were added. Station discovery uses the local NOAA/NWR station database; WeatherIndex remains the stream availability source.
- Includes an Unreleased changelog entry because the feature changes user-visible `src/` behavior.