### PR TITLE
feat(noaa-radio): add station favorites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - NOAA Weather Radio now opens independently of saved weather locations and keeps playing after you close the player until you press Stop or exit the app.
 - The NOAA Weather Radio Station Finder now has clearer modes for searching all stations, browsing by full state or territory name, and finding nearby stations by coordinates.
+- NOAA Weather Radio stations can now be saved as favorites, with a Favorites finder mode and optional nearby-station lookup from your saved AccessiWeather locations.
 
 ## [0.7.2] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
 - The NOAA Weather Radio Station Finder now has clearer modes for searching all stations, browsing by full state or territory name, and finding nearby stations by coordinates.
 - NOAA Weather Radio stations can now be saved as favorites, with a Favorites finder mode and optional nearby-station lookup from your saved AccessiWeather locations.
 
+### Fixed
+- NOAA Weather Radio Station Finder now repopulates stations when leaving an empty Favorites view, so you no longer need to reopen the radio dialog.
+
 ## [0.7.2] - 2026-05-30
 
 ### Added

--- a/src/accessiweather/noaa_radio/preferences.py
+++ b/src/accessiweather/noaa_radio/preferences.py
@@ -20,6 +20,7 @@ class RadioPreferences:
     ) -> None:
         """Initialize with an optional canonical preferences file path."""
         self._prefs: dict[str, str] = {}
+        self._favorite_stations: list[str] = []
         self._station_limit: int | None = DEFAULT_STATION_LIMIT
         if path is not None:
             self._path = Path(path)
@@ -46,6 +47,9 @@ class RadioPreferences:
                         for call_sign, url in preferred_streams.items()
                         if isinstance(url, str)
                     }
+                self._favorite_stations = self._normalize_favorite_stations(
+                    data.get("favorite_stations", [])
+                )
                 station_limit = data.get("station_limit", DEFAULT_STATION_LIMIT)
                 self._station_limit = self._normalize_station_limit(station_limit)
             else:
@@ -54,6 +58,7 @@ class RadioPreferences:
                     for call_sign, url in data.items()
                     if isinstance(url, str)
                 }
+                self._favorite_stations = []
                 self._station_limit = DEFAULT_STATION_LIMIT
         except Exception as e:
             logger.warning(f"Failed to load radio preferences: {e}")
@@ -66,6 +71,7 @@ class RadioPreferences:
             payload = {
                 "preferred_streams": self._prefs,
                 "station_limit": self._station_limit,
+                "favorite_stations": self._favorite_stations,
             }
             self._path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         except Exception as e:
@@ -80,6 +86,20 @@ class RadioPreferences:
         if isinstance(value, int) and value > 0:
             return value
         return DEFAULT_STATION_LIMIT
+
+    def _normalize_favorite_stations(self, value: object) -> list[str]:
+        """Return unique uppercase favorite call signs while preserving order."""
+        if not isinstance(value, list):
+            return []
+        favorites: list[str] = []
+        seen: set[str] = set()
+        for item in value:
+            call_sign = str(item).strip().upper() if item is not None else ""
+            if not call_sign or call_sign in seen:
+                continue
+            favorites.append(call_sign)
+            seen.add(call_sign)
+        return favorites
 
     def get_preferred_url(self, call_sign: str) -> str | None:
         """Get the preferred stream URL for a station, or None."""
@@ -102,6 +122,37 @@ class RadioPreferences:
         if preferred and preferred in urls:
             return [preferred] + [u for u in urls if u != preferred]
         return list(urls)
+
+    def get_favorite_stations(self) -> list[str]:
+        """Return favorite station call signs in saved order."""
+        return list(self._favorite_stations)
+
+    def is_favorite_station(self, call_sign: str) -> bool:
+        """Return whether the given station call sign is favorited."""
+        return call_sign.strip().upper() in self._favorite_stations
+
+    def set_favorite_stations(self, call_signs: list[str]) -> None:
+        """Replace favorite stations with a normalized, duplicate-free list."""
+        self._favorite_stations = self._normalize_favorite_stations(call_signs)
+        self._save()
+
+    def add_favorite_station(self, call_sign: str) -> None:
+        """Add a station to favorites if it is not already present."""
+        normalized = call_sign.strip().upper()
+        if not normalized or normalized in self._favorite_stations:
+            return
+        self._favorite_stations.append(normalized)
+        self._save()
+
+    def remove_favorite_station(self, call_sign: str) -> None:
+        """Remove a station from favorites if present."""
+        normalized = call_sign.strip().upper()
+        if normalized not in self._favorite_stations:
+            return
+        self._favorite_stations = [
+            favorite for favorite in self._favorite_stations if favorite != normalized
+        ]
+        self._save()
 
     def get_station_limit(self) -> int | None:
         """Return the preferred nearby-station limit, or None for all stations."""

--- a/src/accessiweather/noaa_radio/station_db.py
+++ b/src/accessiweather/noaa_radio/station_db.py
@@ -257,6 +257,22 @@ class StationDatabase:
         state_upper = state.upper()
         return [s for s in self._stations if s.state.upper() == state_upper]
 
+    def get_stations_by_call_signs(self, call_signs: list[str]) -> list[Station]:
+        """Return stations matching call signs in caller-provided order."""
+        station_by_call_sign = {station.call_sign.upper(): station for station in self._stations}
+        stations: list[Station] = []
+        seen: set[str] = set()
+        for call_sign in call_signs:
+            normalized = call_sign.strip().upper()
+            if not normalized or normalized in seen:
+                continue
+            station = station_by_call_sign.get(normalized)
+            if station is None:
+                continue
+            stations.append(station)
+            seen.add(normalized)
+        return stations
+
     def search(self, query: str, limit: int | None = None) -> list[Station]:
         """Search stations by call sign, city/name, state, or explicit lat/lon."""
         normalized = query.strip()

--- a/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
+++ b/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
@@ -192,6 +192,7 @@ class NOAARadioDialog(wx.Dialog):
             availability_cache=self._availability_cache,
         )
         self._station_base_labels: list[str] = []
+        self._station_load_generation = 0
         self._current_urls: list[str] = self._session.current_urls
         self._current_url_index: int = self._session.current_url_index
         self._playing_station: Station | None = self._session.playing_station
@@ -222,6 +223,8 @@ class NOAARadioDialog(wx.Dialog):
 
     def _load_stations_async(self) -> None:
         """Load stations in a background thread to not block UI initialization."""
+        self._station_load_generation += 1
+        load_generation = self._station_load_generation
         # Show loading state immediately
         self._station_choice.Set(["Loading stations..."])
         self._set_status("Finding stations...")
@@ -244,6 +247,7 @@ class NOAARadioDialog(wx.Dialog):
                 state_code,
                 saved_location,
                 empty_status,
+                load_generation,
             ),
             daemon=True,
         )
@@ -258,6 +262,7 @@ class NOAARadioDialog(wx.Dialog):
         state_code: str = "",
         saved_location: Location | None = None,
         empty_status: str | None = None,
+        load_generation: int | None = None,
     ) -> None:
         """Worker method that loads stations in background thread."""
         try:
@@ -314,7 +319,13 @@ class NOAARadioDialog(wx.Dialog):
             choices = [entry.label for entry in entries]
 
             # Update UI on main thread
-            wx.CallAfter(self._on_stations_loaded, stations, choices, empty_status)
+            wx.CallAfter(
+                self._on_stations_loaded,
+                stations,
+                choices,
+                empty_status,
+                load_generation,
+            )
 
             # Pre-warm the stream cache in background for faster play button response
             # This runs after UI is shown so user sees stations immediately
@@ -350,10 +361,15 @@ class NOAARadioDialog(wx.Dialog):
         stations: list[Station],
         choices: list[str],
         empty_status: str | None = None,
+        load_generation: int | None = None,
     ) -> None:
         """Handle stations loaded in background thread."""
         # Check if dialog was closed while background thread was running
         if getattr(self, "_closed", False):
+            return
+        if load_generation is not None and load_generation != getattr(
+            self, "_station_load_generation", load_generation
+        ):
             return
         previous_station = self._get_selected_station()
         previous_call_sign = previous_station.call_sign if previous_station is not None else None
@@ -625,6 +641,7 @@ class NOAARadioDialog(wx.Dialog):
     def _on_finder_mode_changed(self, event: wx.CommandEvent) -> None:
         """Update finder controls when the station finder mode changes."""
         self._update_finder_mode_controls()
+        self._load_stations_async()
         event.Skip()
 
     def _on_find(self, event: wx.CommandEvent) -> None:

--- a/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
+++ b/src/accessiweather/ui/dialogs/noaa_radio_dialog.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import wx
 
+from accessiweather.location_sorting import sort_locations_for_display
 from accessiweather.noaa_radio import (
     Station,
     StationAvailabilityCache,
@@ -22,19 +23,23 @@ from .noaa_radio_clients import get_clients as _get_clients
 from .noaa_radio_widgets import create_noaa_radio_widgets
 
 if TYPE_CHECKING:
-    pass
+    from accessiweather.models import Location
 
 logger = logging.getLogger(__name__)
 SUPPRESSION_TTL_SECONDS = 1800
 STATION_LIMIT_PRESETS: tuple[int | None, ...] = (10, 25, 50, 100, None)
 STATION_LIMIT_LABELS: tuple[str, ...] = ("10", "25", "50", "100", "All")
 FINDER_MODE_SEARCH_ALL = "Search all stations"
+FINDER_MODE_FAVORITES = "Favorites"
 FINDER_MODE_BROWSE_STATE = "Browse by state"
 FINDER_MODE_NEAREST = "Nearest by coordinates"
+FINDER_MODE_SAVED_LOCATION = "Nearby saved location"
 FINDER_MODE_LABELS: tuple[str, ...] = (
     FINDER_MODE_SEARCH_ALL,
+    FINDER_MODE_FAVORITES,
     FINDER_MODE_BROWSE_STATE,
     FINDER_MODE_NEAREST,
+    FINDER_MODE_SAVED_LOCATION,
 )
 STATE_ALL_CHOICE = "All states and territories"
 STATE_TERRITORY_NAMES: dict[str, str] = {
@@ -180,11 +185,13 @@ class NOAARadioDialog(wx.Dialog):
             else None
         )
         self._prefs = RadioPreferences(path=prefs_path)
+        self._saved_locations = self._load_saved_locations_from_app(app)
         self._availability_cache = StationAvailabilityCache(path=availability_path)
         self._station_availability = StationAvailabilityService(
             weatherindex_client=weatherindex,
             availability_cache=self._availability_cache,
         )
+        self._station_base_labels: list[str] = []
         self._current_urls: list[str] = self._session.current_urls
         self._current_url_index: int = self._session.current_url_index
         self._playing_station: Station | None = self._session.playing_station
@@ -207,6 +214,7 @@ class NOAARadioDialog(wx.Dialog):
             STATION_LIMIT_LABELS,
             FINDER_MODE_LABELS,
             self._get_state_choices(),
+            self._get_saved_location_choices(),
             self._get_initial_finder_mode_index(),
         )
         self._apply_initial_finder_values()
@@ -222,11 +230,21 @@ class NOAARadioDialog(wx.Dialog):
         search_query = self._get_search_query()
         finder_mode = self._get_finder_mode()
         state_code = self._get_selected_state_code()
+        saved_location = self._get_selected_saved_location()
+        empty_status = self._get_empty_station_status(finder_mode)
 
         # Run station loading in background thread
         thread = threading.Thread(
             target=self._load_stations_worker,
-            args=(show_unavailable, station_limit, search_query, finder_mode, state_code),
+            args=(
+                show_unavailable,
+                station_limit,
+                search_query,
+                finder_mode,
+                state_code,
+                saved_location,
+                empty_status,
+            ),
             daemon=True,
         )
         thread.start()
@@ -238,6 +256,8 @@ class NOAARadioDialog(wx.Dialog):
         search_query: str = "",
         finder_mode: str | None = None,
         state_code: str = "",
+        saved_location: Location | None = None,
+        empty_status: str | None = None,
     ) -> None:
         """Worker method that loads stations in background thread."""
         try:
@@ -245,7 +265,14 @@ class NOAARadioDialog(wx.Dialog):
             active_mode = finder_mode or (
                 FINDER_MODE_SEARCH_ALL if search_query else self._get_finder_mode()
             )
-            if active_mode == FINDER_MODE_BROWSE_STATE:
+            if active_mode == FINDER_MODE_FAVORITES:
+                favorite_call_signs = self._prefs.get_favorite_stations()
+                candidates = (
+                    db.get_stations_by_call_signs(favorite_call_signs)
+                    if favorite_call_signs
+                    else []
+                )
+            elif active_mode == FINDER_MODE_BROWSE_STATE:
                 if state_code:
                     candidates = db.get_stations_by_state(state_code)
                     if station_limit is not None:
@@ -265,6 +292,16 @@ class NOAARadioDialog(wx.Dialog):
                 else:
                     results = db.find_nearest(*coordinates, limit=station_limit)
                     candidates = [r.station for r in results]
+            elif active_mode == FINDER_MODE_SAVED_LOCATION:
+                if saved_location is None:
+                    candidates = []
+                else:
+                    results = db.find_nearest(
+                        float(saved_location.latitude),
+                        float(saved_location.longitude),
+                        limit=station_limit,
+                    )
+                    candidates = [r.station for r in results]
             elif search_query:
                 candidates = db.search(search_query, limit=station_limit)
             else:
@@ -277,7 +314,7 @@ class NOAARadioDialog(wx.Dialog):
             choices = [entry.label for entry in entries]
 
             # Update UI on main thread
-            wx.CallAfter(self._on_stations_loaded, stations, choices)
+            wx.CallAfter(self._on_stations_loaded, stations, choices, empty_status)
 
             # Pre-warm the stream cache in background for faster play button response
             # This runs after UI is shown so user sees stations immediately
@@ -308,7 +345,12 @@ class NOAARadioDialog(wx.Dialog):
         except Exception as e:
             logger.debug(f"Failed to pre-warm stream cache: {e}")
 
-    def _on_stations_loaded(self, stations: list[Station], choices: list[str]) -> None:
+    def _on_stations_loaded(
+        self,
+        stations: list[Station],
+        choices: list[str],
+        empty_status: str | None = None,
+    ) -> None:
         """Handle stations loaded in background thread."""
         # Check if dialog was closed while background thread was running
         if getattr(self, "_closed", False):
@@ -316,7 +358,12 @@ class NOAARadioDialog(wx.Dialog):
         previous_station = self._get_selected_station()
         previous_call_sign = previous_station.call_sign if previous_station is not None else None
         self._stations = stations
-        self._station_choice.Set(choices)
+        self._station_base_labels = list(choices)
+        display_choices = [
+            self._format_station_choice_label(station, label)
+            for station, label in zip(stations, choices, strict=True)
+        ]
+        self._station_choice.Set(display_choices)
         if choices:
             selection = 0
             if previous_call_sign is not None:
@@ -331,12 +378,14 @@ class NOAARadioDialog(wx.Dialog):
                         break
             self._station_choice.SetSelection(selection)
             self._sync_playback_state_from_session()
+            self._update_favorite_button_state()
             if not self._session.is_playing():
                 self._set_status("Ready")
         else:
             self._sync_playback_state_from_session()
+            self._update_favorite_button_state()
             if not self._session.is_playing():
-                self._set_status("No stations with streams available")
+                self._set_status(empty_status or "No stations with streams available")
 
     def _get_selected_station(self) -> Station | None:
         """Return the currently selected station, or None."""
@@ -463,6 +512,7 @@ class NOAARadioDialog(wx.Dialog):
         self._play_stop_btn.SetLabel("Play")
         self._next_stream_btn.Enable(False)
         self._prefer_btn.Enable(False)
+        self._update_favorite_button_state()
 
     def _on_error(self, message: str) -> None:
         """Handle playback error event."""
@@ -474,6 +524,7 @@ class NOAARadioDialog(wx.Dialog):
         self._play_stop_btn.SetLabel("Play")
         self._next_stream_btn.Enable(len(self._current_urls) > 1)
         self._prefer_btn.Enable(False)
+        self._update_favorite_button_state()
 
     def _on_stalled(self) -> None:
         """Handle stream stall (buffering)."""
@@ -493,6 +544,27 @@ class NOAARadioDialog(wx.Dialog):
         idx = self._current_url_index + 1
         total = len(self._current_urls)
         self._set_status(f"Preferred stream {idx} of {total} saved for {station.call_sign}")
+
+    def _on_toggle_favorite(self, event: wx.CommandEvent) -> None:
+        """Add or remove the selected station from NOAA radio favorites."""
+        station = self._get_selected_station()
+        if station is None:
+            self._set_status("No station selected")
+            event.Skip()
+            return
+
+        if self._prefs.is_favorite_station(station.call_sign):
+            self._prefs.remove_favorite_station(station.call_sign)
+            self._set_status(f"{station.call_sign} removed from favorites")
+            if self._get_finder_mode() == FINDER_MODE_FAVORITES:
+                self._load_stations_async()
+        else:
+            self._prefs.add_favorite_station(station.call_sign)
+            self._set_status(f"{station.call_sign} added to favorites")
+
+        self._refresh_station_choice_labels()
+        self._update_favorite_button_state()
+        event.Skip()
 
     def _on_next_stream(self, _event: wx.CommandEvent) -> None:
         """Switch to the next available stream URL for the current station."""
@@ -572,6 +644,9 @@ class NOAARadioDialog(wx.Dialog):
         state_choice = getattr(self, "_state_choice", None)
         if state_choice is not None:
             state_choice.SetSelection(0)
+        saved_location_choice = getattr(self, "_saved_location_choice", None)
+        if saved_location_choice is not None and self._saved_locations:
+            saved_location_choice.SetSelection(0)
         self._search_ctrl.SetValue("")
         self._update_finder_mode_controls()
         self._load_stations_async()
@@ -580,6 +655,7 @@ class NOAARadioDialog(wx.Dialog):
     def _on_station_changed(self, event: wx.CommandEvent) -> None:
         """Update button label when the user picks a different station."""
         self._update_play_btn_label()
+        self._update_favorite_button_state()
         event.Skip()
 
     def _on_choice_key(self, event: wx.KeyEvent) -> None:
@@ -660,6 +736,17 @@ class NOAARadioDialog(wx.Dialog):
             return ""
         return self._state_choice_code(state_choices[selection])
 
+    def _get_selected_saved_location(self) -> Location | None:
+        """Return the selected saved location for nearby radio lookup."""
+        choice = getattr(self, "_saved_location_choice", None)
+        if choice is None:
+            return None
+
+        selection = choice.GetSelection()
+        if selection == wx.NOT_FOUND or selection >= len(self._saved_locations):
+            return None
+        return self._saved_locations[selection]
+
     def _update_finder_mode_controls(self) -> None:
         """Show and label the finder controls for the active mode."""
         mode = self._get_finder_mode()
@@ -667,9 +754,13 @@ class NOAARadioDialog(wx.Dialog):
         search_ctrl = getattr(self, "_search_ctrl", None)
         state_label = getattr(self, "_state_label", None)
         state_choice = getattr(self, "_state_choice", None)
+        saved_location_label = getattr(self, "_saved_location_label", None)
+        saved_location_choice = getattr(self, "_saved_location_choice", None)
 
         state_mode = mode == FINDER_MODE_BROWSE_STATE
         coordinate_mode = mode == FINDER_MODE_NEAREST
+        saved_location_mode = mode == FINDER_MODE_SAVED_LOCATION
+        text_mode = mode in (FINDER_MODE_SEARCH_ALL, FINDER_MODE_NEAREST)
 
         if search_label is not None:
             label = (
@@ -678,15 +769,19 @@ class NOAARadioDialog(wx.Dialog):
                 else "Search text (call sign, city, or state):"
             )
             search_label.SetLabel(label)
-            search_label.Show(not state_mode)
+            search_label.Show(text_mode)
         if search_ctrl is not None:
             hint = "Example: 30.2672, -97.7431" if coordinate_mode else "Call sign, city, or state"
             search_ctrl.SetHint(hint)
-            search_ctrl.Show(not state_mode)
+            search_ctrl.Show(text_mode)
         if state_label is not None:
             state_label.Show(state_mode)
         if state_choice is not None:
             state_choice.Show(state_mode)
+        if saved_location_label is not None:
+            saved_location_label.Show(saved_location_mode)
+        if saved_location_choice is not None:
+            saved_location_choice.Show(saved_location_mode)
 
         finder_panel = getattr(self, "_finder_panel", None)
         if finder_panel is not None:
@@ -727,6 +822,78 @@ class NOAARadioDialog(wx.Dialog):
         if choice_label.endswith(")") and "(" in choice_label:
             return choice_label.rsplit("(", 1)[1].rstrip(")")
         return choice_label
+
+    def _get_saved_location_choices(self) -> tuple[str, ...]:
+        """Return saved location names for the saved-location finder."""
+        saved_locations = getattr(self, "_saved_locations", [])
+        return tuple(location.name for location in saved_locations)
+
+    @staticmethod
+    def _load_saved_locations_from_app(app: object | None) -> list[Location]:
+        """Return saved locations in the same display order used by the main window."""
+        if app is None:
+            return []
+        config_manager = getattr(app, "config_manager", None)
+        if config_manager is None:
+            return []
+        try:
+            locations = config_manager.get_all_locations()
+            settings = config_manager.get_settings()
+            sort_order = getattr(settings, "location_sort_order", "alphabetical")
+            current = config_manager.get_current_location()
+            return sort_locations_for_display(locations, sort_order, anchor=current)
+        except Exception as e:
+            logger.debug(f"Unable to load saved locations for NOAA radio: {e}")
+            return []
+
+    def _get_empty_station_status(self, finder_mode: str) -> str:
+        """Return the empty-state message for the selected finder mode."""
+        if finder_mode == FINDER_MODE_FAVORITES:
+            if self._prefs.get_favorite_stations():
+                return "No favorite stations with streams available"
+            return "No favorite stations yet"
+        if finder_mode == FINDER_MODE_SAVED_LOCATION:
+            if self._saved_locations:
+                return "No stations with streams available near that saved location"
+            return "No saved locations available"
+        return "No stations with streams available"
+
+    def _format_station_choice_label(self, station: Station, label: str) -> str:
+        """Add favorite context to a station result label for screen readers."""
+        if self._prefs.is_favorite_station(station.call_sign) and not label.startswith(
+            "Favorite - "
+        ):
+            return f"Favorite - {label}"
+        return label
+
+    def _refresh_station_choice_labels(self) -> None:
+        """Refresh station result labels after favorite state changes."""
+        if len(self._station_base_labels) != len(self._stations):
+            return
+        selection = self._station_choice.GetSelection()
+        labels = [
+            self._format_station_choice_label(station, label)
+            for station, label in zip(self._stations, self._station_base_labels, strict=True)
+        ]
+        self._station_choice.Set(labels)
+        if selection != wx.NOT_FOUND and selection < len(labels):
+            self._station_choice.SetSelection(selection)
+
+    def _update_favorite_button_state(self) -> None:
+        """Enable and label the favorite action for the selected station."""
+        button = getattr(self, "_favorite_btn", None)
+        if button is None:
+            return
+        station = self._get_selected_station()
+        if station is None:
+            button.Enable(False)
+            button.SetLabel("Favorite")
+            return
+        button.Enable(True)
+        label = (
+            "Remove Favorite" if self._prefs.is_favorite_station(station.call_sign) else "Favorite"
+        )
+        button.SetLabel(label)
 
     @staticmethod
     def _parse_coordinate_query(query: str) -> tuple[float, float] | None:
@@ -796,8 +963,10 @@ class NOAARadioDialog(wx.Dialog):
             self._update_play_btn_label()
             self._next_stream_btn.Enable(total > 1)
             self._prefer_btn.Enable(bool(self._current_urls))
+            self._update_favorite_button_state()
             self._health_timer.Start(5000)
         else:
             self._play_stop_btn.SetLabel("Play")
             self._next_stream_btn.Enable(False)
             self._prefer_btn.Enable(False)
+            self._update_favorite_button_state()

--- a/src/accessiweather/ui/dialogs/noaa_radio_widgets.py
+++ b/src/accessiweather/ui/dialogs/noaa_radio_widgets.py
@@ -12,6 +12,7 @@ def create_noaa_radio_widgets(
     station_limit_labels: tuple[str, ...],
     finder_mode_labels: tuple[str, ...],
     state_choices: tuple[str, ...],
+    saved_location_choices: tuple[str, ...],
     initial_finder_mode_index: int = 0,
 ) -> None:
     """Create and layout all NOAA radio dialog controls."""
@@ -62,6 +63,13 @@ def create_noaa_radio_widgets(
     dialog._state_choice = wx.Choice(panel, choices=list(state_choices))
     dialog._state_choice.SetSelection(0)
     sizer.Add(dialog._state_choice, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 10)
+
+    dialog._saved_location_label = wx.StaticText(panel, label="Saved location:")
+    sizer.Add(dialog._saved_location_label, 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
+    dialog._saved_location_choice = wx.Choice(panel, choices=list(saved_location_choices))
+    if saved_location_choices:
+        dialog._saved_location_choice.SetSelection(0)
+    sizer.Add(dialog._saved_location_choice, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 10)
 
     sizer.Add(wx.StaticText(panel, label="Station results:"), 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
 
@@ -134,5 +142,10 @@ def _add_button_row(dialog: Any, panel: wx.Panel, sizer: wx.BoxSizer) -> None:
     dialog._prefer_btn.Bind(wx.EVT_BUTTON, dialog._on_set_preferred)
     dialog._prefer_btn.Enable(False)
     btn_sizer.Add(dialog._prefer_btn, 0, wx.RIGHT, 5)
+
+    dialog._favorite_btn = wx.Button(panel, label="Favorite")
+    dialog._favorite_btn.Bind(wx.EVT_BUTTON, dialog._on_toggle_favorite)
+    dialog._favorite_btn.Enable(False)
+    btn_sizer.Add(dialog._favorite_btn, 0, wx.RIGHT, 5)
 
     sizer.Add(btn_sizer, 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)

--- a/tests/test_noaa_radio.py
+++ b/tests/test_noaa_radio.py
@@ -256,6 +256,55 @@ class TestRadioPreferences:
         assert prefs.get_preferred_url("WXJ76") == "http://stream.com"
         assert prefs.get_station_limit() == DEFAULT_STATION_LIMIT
 
+    def test_favorite_stations_default_empty(self, tmp_path):
+        prefs = RadioPreferences(config_dir=tmp_path)
+
+        assert prefs.get_favorite_stations() == []
+        assert prefs.is_favorite_station("WXK27") is False
+
+    def test_add_remove_favorite_stations_persist_in_stable_order(self, tmp_path):
+        prefs = RadioPreferences(config_dir=tmp_path)
+
+        prefs.add_favorite_station("wxk27")
+        prefs.add_favorite_station("KEC49")
+        prefs.add_favorite_station("WXK27")
+
+        assert prefs.get_favorite_stations() == ["WXK27", "KEC49"]
+        assert prefs.is_favorite_station("wxk27") is True
+
+        reloaded = RadioPreferences(config_dir=tmp_path)
+        assert reloaded.get_favorite_stations() == ["WXK27", "KEC49"]
+
+        reloaded.remove_favorite_station("WXK27")
+        assert reloaded.get_favorite_stations() == ["KEC49"]
+
+    def test_structured_preferences_load_favorites_without_losing_streams_or_limit(self, tmp_path):
+        prefs_file = tmp_path / "noaa_radio_prefs.json"
+        prefs_file.write_text(
+            json.dumps(
+                {
+                    "preferred_streams": {"wxk27": "http://stream.com"},
+                    "station_limit": 25,
+                    "favorite_stations": ["wxk27", "KEC49", "wxk27", ""],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        prefs = RadioPreferences(config_dir=tmp_path)
+
+        assert prefs.get_preferred_url("WXK27") == "http://stream.com"
+        assert prefs.get_station_limit() == 25
+        assert prefs.get_favorite_stations() == ["WXK27", "KEC49"]
+
+    def test_legacy_preferences_default_favorites_empty(self, tmp_path):
+        prefs_file = tmp_path / "noaa_radio_prefs.json"
+        prefs_file.write_text(json.dumps({"WXJ76": "http://stream.com"}), encoding="utf-8")
+
+        prefs = RadioPreferences(config_dir=tmp_path)
+
+        assert prefs.get_favorite_stations() == []
+
 
 class TestRadioPreferencesEdgeCases:
     """Additional tests for RadioPreferences coverage."""

--- a/tests/test_noaa_radio_dialog.py
+++ b/tests/test_noaa_radio_dialog.py
@@ -193,6 +193,7 @@ def _make_dialog_instance(module):
     dlg._saved_location_choice.GetSelection.return_value = 0
     dlg._saved_locations = []
     dlg._station_base_labels = []
+    dlg._station_load_generation = 0
     dlg._auto_advance_stream = True
     dlg._playing_station = None
     return dlg
@@ -637,6 +638,16 @@ class TestUnavailableStations:
 class TestStationFinderControls:
     """Tests for NOAA radio finder mode controls."""
 
+    def test_finder_mode_change_reloads_station_list(self, noaa_dialog_module):
+        dlg = _make_dialog_instance(noaa_dialog_module)
+        dlg._load_stations_async = MagicMock()
+        event = MagicMock()
+
+        dlg._on_finder_mode_changed(event)
+
+        dlg._load_stations_async.assert_called_once()
+        event.Skip.assert_called_once()
+
     def test_clear_resets_finder_to_search_all(self, noaa_dialog_module):
         dlg = _make_dialog_instance(noaa_dialog_module)
         dlg._load_stations_async = MagicMock()
@@ -659,6 +670,21 @@ class TestStationFinderControls:
 
         dlg._load_stations_async.assert_called_once()
         event.Skip.assert_called_once()
+
+    def test_stale_station_load_does_not_replace_current_results(self, noaa_dialog_module):
+        dlg = _make_dialog_instance(noaa_dialog_module)
+        dlg._station_load_generation = 2
+        stations = [dlg._stations[0]]
+        choices = ["KEC49 - New York, NY - 162.550 MHz - Available"]
+
+        dlg._on_stations_loaded(stations, choices, load_generation=2)
+        dlg._station_choice.Set.reset_mock()
+        dlg._status_text.SetLabel.reset_mock()
+
+        dlg._on_stations_loaded([], [], "No favorite stations yet", load_generation=1)
+
+        dlg._station_choice.Set.assert_not_called()
+        dlg._status_text.SetLabel.assert_not_called()
 
     def test_get_finder_mode_defaults_to_nearest_when_opened_with_coordinates(
         self,

--- a/tests/test_noaa_radio_dialog.py
+++ b/tests/test_noaa_radio_dialog.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from accessiweather.models import Location
 from accessiweather.noaa_radio import Station
 
 
@@ -170,12 +171,15 @@ def _make_dialog_instance(module):
     dlg._status_text = MagicMock()
     dlg._health_timer = MagicMock()
     dlg._prefs = MagicMock()
+    dlg._prefs.is_favorite_station.return_value = False
+    dlg._prefs.get_favorite_stations.return_value = []
     dlg._availability_cache = MagicMock()
     dlg._station_availability = MagicMock()
     dlg._current_urls = ["http://example.com/stream1", "http://example.com/stream2"]
     dlg._current_url_index = 0
     dlg._next_stream_btn = MagicMock()
     dlg._prefer_btn = MagicMock()
+    dlg._favorite_btn = MagicMock()
     dlg._show_unavailable_checkbox = MagicMock()
     dlg._show_unavailable_checkbox.GetValue.return_value = False
     dlg._search_ctrl = MagicMock()
@@ -185,6 +189,10 @@ def _make_dialog_instance(module):
     dlg._state_choice = MagicMock()
     dlg._state_choice.GetSelection.return_value = 0
     dlg._state_choices = ("All states and territories", "New York (NY)", "Pennsylvania (PA)")
+    dlg._saved_location_choice = MagicMock()
+    dlg._saved_location_choice.GetSelection.return_value = 0
+    dlg._saved_locations = []
+    dlg._station_base_labels = []
     dlg._auto_advance_stream = True
     dlg._playing_station = None
     return dlg
@@ -447,6 +455,7 @@ class TestUnavailableStations:
         dlg._on_play_stop = MagicMock()
         dlg._on_next_stream = MagicMock()
         dlg._on_set_preferred = MagicMock()
+        dlg._on_toggle_favorite = MagicMock()
         dlg._on_volume_change = MagicMock()
         dlg._on_close = MagicMock()
         dlg._on_show_unavailable_changed = MagicMock()
@@ -469,6 +478,7 @@ class TestUnavailableStations:
         dlg._on_play_stop = MagicMock()
         dlg._on_next_stream = MagicMock()
         dlg._on_set_preferred = MagicMock()
+        dlg._on_toggle_favorite = MagicMock()
         dlg._on_volume_change = MagicMock()
         dlg._on_close = MagicMock()
         dlg._on_show_unavailable_changed = MagicMock()
@@ -481,8 +491,8 @@ class TestUnavailableStations:
 
         noaa_dialog_module.NOAARadioDialog._init_ui(dlg)
 
-        assert noaa_dialog_module.wx.Choice.call_count == 4
-        station_limit_choice = noaa_dialog_module.wx.Choice.call_args_list[3]
+        assert noaa_dialog_module.wx.Choice.call_count == 5
+        station_limit_choice = noaa_dialog_module.wx.Choice.call_args_list[4]
         assert station_limit_choice.kwargs["choices"] == ["10", "25", "50", "100", "All"]
 
     def test_station_finder_widgets_are_created(self, noaa_dialog_module):
@@ -496,6 +506,7 @@ class TestUnavailableStations:
         dlg._on_play_stop = MagicMock()
         dlg._on_next_stream = MagicMock()
         dlg._on_set_preferred = MagicMock()
+        dlg._on_toggle_favorite = MagicMock()
         dlg._on_volume_change = MagicMock()
         dlg._on_close = MagicMock()
         dlg._on_show_unavailable_changed = MagicMock()
@@ -521,8 +532,10 @@ class TestUnavailableStations:
         assert "Station Finder" in static_labels
         assert "Search mode:" in static_labels
         assert "State or territory:" in static_labels
+        assert "Saved location:" in static_labels
         assert "Station results:" in static_labels
         assert "Maximum results:" in static_labels
+        assert "Favorite" in button_labels
         assert "Find" in button_labels
         assert "Search" not in button_labels
 
@@ -568,6 +581,57 @@ class TestUnavailableStations:
         dlg._station_choice.Set.assert_called_with(
             ["WXK27 - Austin, TX - 162.400 MHz - Temporarily unavailable"]
         )
+
+    def test_favorite_station_label_is_marked_in_loaded_choices(self, noaa_dialog_module):
+        dlg = _make_dialog_instance(noaa_dialog_module)
+        station = Station("WXK27", 162.4, "Austin", 0.0, 0.0, "TX")
+        dlg._prefs.is_favorite_station.side_effect = lambda call_sign: call_sign == "WXK27"
+
+        dlg._on_stations_loaded(
+            [station],
+            ["WXK27 - Austin, TX - 162.400 MHz - Available"],
+        )
+
+        dlg._station_choice.Set.assert_called_with(
+            ["Favorite - WXK27 - Austin, TX - 162.400 MHz - Available"]
+        )
+
+    def test_favorite_button_updates_for_selected_station(self, noaa_dialog_module):
+        dlg = _make_dialog_instance(noaa_dialog_module)
+        dlg._prefs.is_favorite_station.return_value = True
+
+        dlg._update_favorite_button_state()
+
+        dlg._favorite_btn.Enable.assert_called_with(True)
+        dlg._favorite_btn.SetLabel.assert_called_with("Remove Favorite")
+
+    def test_toggle_favorite_adds_selected_station_and_refreshes_label(self, noaa_dialog_module):
+        dlg = _make_dialog_instance(noaa_dialog_module)
+        dlg._station_base_labels = ["WXK27 - Austin, TX - 162.400 MHz - Available"]
+        dlg._stations = [Station("WXK27", 162.4, "Austin", 0.0, 0.0, "TX")]
+        dlg._prefs.is_favorite_station.return_value = False
+        event = MagicMock()
+
+        dlg._on_toggle_favorite(event)
+
+        dlg._prefs.add_favorite_station.assert_called_once_with("WXK27")
+        dlg._status_text.SetLabel.assert_called_with("WXK27 added to favorites")
+        event.Skip.assert_called_once()
+
+    def test_toggle_favorite_in_favorites_mode_removes_and_reloads(self, noaa_dialog_module):
+        dlg = _make_dialog_instance(noaa_dialog_module)
+        dlg._prefs.is_favorite_station.return_value = True
+        dlg._finder_mode_choice.GetSelection.return_value = (
+            noaa_dialog_module.FINDER_MODE_LABELS.index(noaa_dialog_module.FINDER_MODE_FAVORITES)
+        )
+        dlg._load_stations_async = MagicMock()
+        event = MagicMock()
+
+        dlg._on_toggle_favorite(event)
+
+        dlg._prefs.remove_favorite_station.assert_called_once_with("KEC49")
+        dlg._load_stations_async.assert_called_once()
+        event.Skip.assert_called_once()
 
 
 class TestStationFinderControls:
@@ -641,6 +705,31 @@ class TestStationFinderControls:
         assert parse("30.2672, -97.7431") == (30.2672, -97.7431)
         assert parse("Austin") is None
         assert parse("91, 0") is None
+
+    def test_get_selected_saved_location(self, noaa_dialog_module):
+        dlg = _make_dialog_instance(noaa_dialog_module)
+        austin = Location("Austin", 30.2672, -97.7431)
+        boston = Location("Boston", 42.3601, -71.0589)
+        dlg._saved_locations = [austin, boston]
+        dlg._saved_location_choice.GetSelection.return_value = 1
+
+        assert dlg._get_selected_saved_location() is boston
+
+    def test_load_saved_locations_uses_user_display_order(self, noaa_dialog_module):
+        current = Location("Austin", 30.2672, -97.7431)
+        boston = Location("Boston", 42.3601, -71.0589)
+        houston = Location("Houston", 29.7604, -95.3698)
+        fake_app = MagicMock()
+        fake_app.config_manager.get_all_locations.return_value = [boston, houston, current]
+        fake_app.config_manager.get_settings.return_value.location_sort_order = "nearest_current"
+        fake_app.config_manager.get_current_location.return_value = current
+
+        locations = noaa_dialog_module.NOAARadioDialog._load_saved_locations_from_app(fake_app)
+
+        assert [location.name for location in locations] == ["Austin", "Houston", "Boston"]
+
+    def test_load_saved_locations_falls_back_to_empty_without_config(self, noaa_dialog_module):
+        assert noaa_dialog_module.NOAARadioDialog._load_saved_locations_from_app(None) == []
 
 
 class TestPlayStopSwitch:

--- a/tests/test_noaa_radio_dialog_integration.py
+++ b/tests/test_noaa_radio_dialog_integration.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from accessiweather.models import Location
 from accessiweather.noaa_radio import Station
 from accessiweather.noaa_radio.station_db import StationResult
 
@@ -156,12 +157,15 @@ def _make_dialog(module):
     dlg._status_text = MagicMock()
     dlg._health_timer = MagicMock()
     dlg._prefs = MagicMock()
+    dlg._prefs.is_favorite_station.return_value = False
+    dlg._prefs.get_favorite_stations.return_value = []
     dlg._availability_cache = MagicMock()
     dlg._station_availability = MagicMock()
     dlg._current_urls = ["http://example.com/stream1", "http://example.com/stream2"]
     dlg._current_url_index = 0
     dlg._next_stream_btn = MagicMock()
     dlg._prefer_btn = MagicMock()
+    dlg._favorite_btn = MagicMock()
     dlg._show_unavailable_checkbox = MagicMock()
     dlg._show_unavailable_checkbox.GetValue.return_value = False
     dlg._search_ctrl = MagicMock()
@@ -178,6 +182,10 @@ def _make_dialog(module):
         "Pennsylvania (PA)",
         "Texas (TX)",
     )
+    dlg._saved_location_choice = MagicMock()
+    dlg._saved_location_choice.GetSelection.return_value = 0
+    dlg._saved_locations = []
+    dlg._station_base_labels = []
     dlg._auto_advance_stream = True
     dlg._playing_station = None
     return dlg
@@ -481,6 +489,101 @@ class TestLoadStations:
                 station_limit=10,
                 search_query="Austin",
                 finder_mode=noaa_dialog_module.FINDER_MODE_NEAREST,
+            )
+
+        mock_db_cls.return_value.find_nearest.assert_not_called()
+        mock_db_cls.return_value.search.assert_not_called()
+        dlg._station_availability.build_entries.assert_called_once_with(
+            [],
+            show_unavailable=False,
+        )
+
+    def test_load_stations_favorites_mode_uses_saved_favorite_order(self, noaa_dialog_module):
+        dlg = _make_dialog(noaa_dialog_module)
+        dlg._prefs.get_favorite_stations.return_value = ["WXK27", "KEC49"]
+        wxk27 = Station("WXK27", 162.4, "Austin, TX", 30.2672, -97.7431, "TX")
+        kec49 = Station("KEC49", 162.55, "New York, NY", 40.7128, -74.0060, "NY")
+        entries = []
+        for station in (wxk27, kec49):
+            entry = MagicMock()
+            entry.station = station
+            entry.label = f"{station.call_sign} - {station.name} - Available"
+            entries.append(entry)
+        dlg._station_availability.build_entries.return_value = entries
+
+        with patch("accessiweather.ui.dialogs.noaa_radio_dialog.StationDatabase") as mock_db_cls:
+            mock_db_cls.return_value.get_stations_by_call_signs.return_value = [wxk27, kec49]
+            dlg._load_stations_worker(
+                station_limit=10,
+                finder_mode=noaa_dialog_module.FINDER_MODE_FAVORITES,
+            )
+
+        mock_db_cls.return_value.get_stations_by_call_signs.assert_called_once_with(
+            ["WXK27", "KEC49"]
+        )
+        mock_db_cls.return_value.search.assert_not_called()
+        mock_db_cls.return_value.find_nearest.assert_not_called()
+        dlg._station_availability.build_entries.assert_called_once_with(
+            [wxk27, kec49],
+            show_unavailable=False,
+        )
+
+    def test_load_stations_favorites_mode_empty_skips_availability(self, noaa_dialog_module):
+        dlg = _make_dialog(noaa_dialog_module)
+        dlg._prefs.get_favorite_stations.return_value = []
+
+        with patch("accessiweather.ui.dialogs.noaa_radio_dialog.StationDatabase") as mock_db_cls:
+            dlg._load_stations_worker(
+                station_limit=10,
+                finder_mode=noaa_dialog_module.FINDER_MODE_FAVORITES,
+            )
+
+        mock_db_cls.return_value.get_stations_by_call_signs.assert_not_called()
+        dlg._station_availability.build_entries.assert_called_once_with(
+            [],
+            show_unavailable=False,
+        )
+
+    def test_load_stations_saved_location_mode_uses_selected_location_coordinates(
+        self,
+        noaa_dialog_module,
+    ):
+        dlg = _make_dialog(noaa_dialog_module)
+        saved = Location("Austin", 30.2672, -97.7431)
+        station = Station("WXK27", 162.4, "Austin, TX", 30.2672, -97.7431, "TX")
+        entry = MagicMock()
+        entry.station = station
+        entry.label = "WXK27 - Austin, TX - 162.400 MHz - Available"
+        dlg._station_availability.build_entries.return_value = [entry]
+        results = [StationResult(station=station, distance_km=0.0)]
+
+        with patch("accessiweather.ui.dialogs.noaa_radio_dialog.StationDatabase") as mock_db_cls:
+            mock_db_cls.return_value.find_nearest.return_value = results
+            dlg._load_stations_worker(
+                station_limit=10,
+                finder_mode=noaa_dialog_module.FINDER_MODE_SAVED_LOCATION,
+                saved_location=saved,
+            )
+
+        mock_db_cls.return_value.find_nearest.assert_called_once_with(
+            30.2672,
+            -97.7431,
+            limit=10,
+        )
+        mock_db_cls.return_value.search.assert_not_called()
+
+    def test_load_stations_saved_location_mode_without_locations_is_empty(
+        self,
+        noaa_dialog_module,
+    ):
+        dlg = _make_dialog(noaa_dialog_module)
+        dlg._station_availability.build_entries.return_value = []
+
+        with patch("accessiweather.ui.dialogs.noaa_radio_dialog.StationDatabase") as mock_db_cls:
+            dlg._load_stations_worker(
+                station_limit=10,
+                finder_mode=noaa_dialog_module.FINDER_MODE_SAVED_LOCATION,
+                saved_location=None,
             )
 
         mock_db_cls.return_value.find_nearest.assert_not_called()

--- a/tests/test_noaa_radio_station_db.py
+++ b/tests/test_noaa_radio_station_db.py
@@ -118,6 +118,18 @@ class TestStationDatabase:
         db = StationDatabase(stations=custom)
         assert len(db.get_all_stations()) == 1
 
+    def test_get_stations_by_call_signs_preserves_requested_order(self) -> None:
+        stations = [
+            Station("WXK27", 162.4, "Austin", 30.2672, -97.7431, "TX"),
+            Station("KEC49", 162.55, "New York", 40.7128, -74.0060, "NY"),
+            Station("WXJ76", 162.55, "Champaign", 40.1164, -88.2434, "IL"),
+        ]
+        db = StationDatabase(stations)
+
+        results = db.get_stations_by_call_signs(["kec49", "MISSING", "WXK27", "KEC49"])
+
+        assert [station.call_sign for station in results] == ["KEC49", "WXK27"]
+
     def test_all_50_states_covered(self) -> None:
         """Verify every US state has at least one station."""
         db = StationDatabase()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -262,6 +262,7 @@ class TestRuntimeStorageResolution:
 
         assert runtime.config_root == tmp_path / "config"
         assert runtime.portable_mode is True
+        assert runtime.noaa_radio_preferences_file == tmp_path / "config" / "noaa_radio_prefs.json"
 
     def test_frozen_with_portable_marker_uses_exe_dir(self, tmp_path):
         exe = tmp_path / "AccessiWeather.exe"


### PR DESCRIPTION
## Summary
- Persist NOAA Weather Radio favorite station call signs in `noaa_radio_prefs.json` alongside existing preferred streams and station limit settings.
- Add a Favorites finder mode plus a Favorite/Remove Favorite action for the selected station.
- Add optional nearby-station lookup from saved AccessiWeather locations using the same saved-location ordering helper as the main window.

## Tests
- `uv run pytest tests/test_noaa_radio.py tests/test_noaa_radio_dialog.py tests/test_noaa_radio_dialog_integration.py tests/test_noaa_radio_station_db.py tests/test_noaa_radio_session.py -q`
- `uv run pytest tests/test_noaa_radio.py tests/test_noaa_radio_dialog.py tests/test_noaa_radio_dialog_integration.py tests/test_noaa_radio_station_db.py tests/test_noaa_radio_session.py tests/test_all_locations_view.py -q`
- `uv run ruff check src\accessiweather\noaa_radio\preferences.py src\accessiweather\noaa_radio\station_db.py src\accessiweather\ui\dialogs\noaa_radio_dialog.py src\accessiweather\ui\dialogs\noaa_radio_widgets.py tests\test_noaa_radio.py tests\test_noaa_radio_station_db.py tests\test_noaa_radio_dialog.py tests\test_noaa_radio_dialog_integration.py`
- `uv run ruff format --check src\accessiweather\noaa_radio\preferences.py src\accessiweather\noaa_radio\station_db.py src\accessiweather\ui\dialogs\noaa_radio_dialog.py src\accessiweather\ui\dialogs\noaa_radio_widgets.py tests\test_noaa_radio.py tests\test_noaa_radio_station_db.py tests\test_noaa_radio_dialog.py tests\test_noaa_radio_dialog_integration.py`
- `uv run python scripts\changelog_tools.py check --base origin/dev`
- `uv run pytest tests/test_noaa_radio.py tests/test_noaa_radio_station_db.py --cov=src/accessiweather --cov-report=xml:reports/coverage.xml --cov-report=term-missing -q`
- `uv run --with diff-cover diff-cover reports\coverage.xml --compare-branch=origin/dev --fail-under=80 --diff-range-notation=.. --exclude */accessiweather/ui/*`
- `uv run pytest tests/test_noaa_radio_availability_cache.py tests/test_noaa_radio_dialog_integration.py tests/test_noaa_radio_dialog.py tests/test_noaa_radio_menu_item.py tests/test_noaa_radio_player.py tests/test_noaa_radio_session.py tests/test_noaa_radio_station_availability.py tests/test_noaa_radio_station_db.py tests/test_noaa_radio_stream_url.py tests/test_noaa_radio_weatherindex_client.py tests/test_noaa_radio.py tests/test_all_locations_view.py -q`