### PR TITLE
test: reduce display label test bloat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,22 @@ asyncio.create_task(background_refresh())
 - Integration tests live under `tests/integration/` and should avoid live API dependence unless explicitly intended.
 - Use Hypothesis for broad input-space edge cases.
 
+### Test Quality Conventions
+
+- Prefer behavior and user-contract tests over coverage-padding tests.
+- Name regression tests after the behavior or failure mode, not a PR number,
+  coverage gap, or CI failure. If a temporary coverage/CI test is unavoidable,
+  give it a clear follow-up path.
+- Avoid `inspect.getsource()` and source-string assertions unless there is no
+  practical runtime behavior to assert.
+- If coverage pressure makes a test awkward, first consider whether the code
+  should be refactored, excluded for a reasoned defensive branch, or tested
+  through a public/domain behavior.
+- Large parameterized or matrix tests are fine when they protect real parsing,
+  mapping, provider, accessibility, playback, notification, or user-visible
+  behavior. Avoid duplicating the same contract at multiple layers only for
+  line coverage.
+
 ```bash
 pytest -n auto -v --tb=short
 pytest tests/ -m "not integration" -n auto

--- a/tests/test_display_tab_unit_labels.py
+++ b/tests/test_display_tab_unit_labels.py
@@ -2,74 +2,63 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
-from accessiweather.ui.dialogs.settings_tabs.display import (
-    _TEMP_MAP,
-    _TEMP_VALUES,
-)
+from accessiweather.ui.dialogs.settings_tabs import display as display_module
+from accessiweather.ui.dialogs.settings_tabs.display import _TEMP_MAP, _TEMP_VALUES, DisplayTab
 
 
 class TestTempUnitChoiceLabels:
     """The UI choices must use the new Auto/Imperial/Metric naming convention."""
 
-    def test_choices_list_length(self):
-        # Four options: Auto, Imperial, Metric, Both
-        # (verified via _TEMP_VALUES mapping)
-        assert len(_TEMP_VALUES) == 4
-
-    @pytest.mark.parametrize(
-        "label",
-        [
-            "Fahrenheit only",
-            "Celsius only",
-            "Both (Fahrenheit and Celsius)",
-        ],
-    )
-    def test_old_labels_not_present_in_module(self, label):
-        """Old Fahrenheit/Celsius/Both labels must not appear in display module source."""
-        import inspect
-
-        import accessiweather.ui.dialogs.settings_tabs.display as display_module
-
-        source = inspect.getsource(display_module)
-        assert label not in source, f"Old label '{label}' still present in display module"
-
-    @pytest.mark.parametrize(
-        "label",
-        [
+    def test_temperature_unit_choices_use_public_labels(self, monkeypatch):
+        """Temperature unit choices should be asserted through the constructed UI."""
+        expected_labels = [
+            "Auto (based on location)",
             "Imperial (°F)",
             "Metric (°C)",
             "Both (°F and °C)",
-            "Auto (based on location)",
-        ],
-    )
-    def test_new_labels_present_in_module(self, label):
-        """New labels must appear in the display module source."""
-        import inspect
+        ]
 
-        import accessiweather.ui.dialogs.settings_tabs.display as display_module
+        monkeypatch.setattr(
+            display_module.wx,
+            "ScrolledWindow",
+            MagicMock(return_value=MagicMock()),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            display_module.wx,
+            "SpinCtrl",
+            MagicMock(return_value=MagicMock()),
+            raising=False,
+        )
+        monkeypatch.setattr(display_module.wx, "ALIGN_CENTER_VERTICAL", 0, raising=False)
+        monkeypatch.setattr(display_module.wx, "Choice", MagicMock(return_value=MagicMock()))
 
-        source = inspect.getsource(display_module)
-        assert label in source, f"New label '{label}' not found in display module"
+        dialog = MagicMock()
+        dialog._controls = {}
+        dialog.create_section.return_value = MagicMock()
+
+        def add_labeled_control_row(_panel, _sizer, label, control_factory, **_kwargs):
+            control = control_factory(_panel)
+            dialog._controls[label] = control
+            return control
+
+        dialog.add_labeled_control_row.side_effect = add_labeled_control_row
+
+        DisplayTab(dialog).create()
+
+        temperature_choice_call = display_module.wx.Choice.call_args_list[0]
+        assert temperature_choice_call.kwargs["choices"] == expected_labels
+
+    def test_temperature_unit_values_preserve_saved_config_contract(self):
+        assert _TEMP_VALUES == ["auto", "f", "c", "both"]
 
 
 class TestTempUnitBackwardCompatibility:
     """Internal config values must not change (backward compat with saved settings)."""
-
-    def test_auto_value_unchanged(self):
-        assert _TEMP_VALUES[0] == "auto"
-
-    def test_imperial_maps_to_fahrenheit_value(self):
-        # Index 1 is Imperial — must still save "f" to config
-        assert _TEMP_VALUES[1] == "f"
-
-    def test_metric_maps_to_celsius_value(self):
-        # Index 2 is Metric — must still save "c" to config
-        assert _TEMP_VALUES[2] == "c"
-
-    def test_both_value_unchanged(self):
-        assert _TEMP_VALUES[3] == "both"
 
     @pytest.mark.parametrize(
         "saved_value,expected_index",


### PR DESCRIPTION
## Summary
- Audited the current `dev` test-suite shape for bloat candidates.
- Replaced brittle source-inspection temperature unit label tests with a runtime `DisplayTab.create()` assertion against the public `wx.Choice` labels.
- Consolidated redundant saved-value assertions while preserving backward-compatibility coverage.
- Added concise repo-local `AGENTS.md` testing conventions so future regression tests are named and shaped around behavior, not PR numbers or coverage padding.

## Audit Findings
- Current branch collection after cleanup: 4,067 selected tests, 3 deselected live-only tests.
- Baseline from `origin/dev` before cleanup: 4,077 selected tests, 3 deselected live-only tests.
- The suite is large but not currently slow: the default xdist run completed with 4,066 passed and 1 skipped in about 25 seconds locally.
- Largest collected modules are mostly behavioral matrices: `test_impact_summary.py` (128), `test_taf_decoder.py` (118), `test_current_conditions.py` (111), `test_national_discussion_service.py` (97), `test_pirate_weather_client.py` (79), and `test_presentation_environmental.py` (71).
- The clearest bloat candidates are coverage-gate/source-string files: `tests/test_coverage_gaps.py`, `tests/test_coverage_fix_pr449.py`, `tests/test_pw_coverage.py`, and source inspections such as NOAA radio menu placement tests. Those should be handled in small follow-up PRs, not a suite-wide churn pass.

## Verification
- `uv run pytest tests/test_display_tab_unit_labels.py -q`
- `uv run pytest --collect-only -q`
- `uv run pytest -q --durations=50 --durations-min=0.05`
- `uv run ruff check tests/test_display_tab_unit_labels.py`
- `uv run ruff format --check tests/test_display_tab_unit_labels.py`
- `git diff --check`