### PR TITLE
fix: cover unknown alert sounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - NOAA Weather Radio stations can now be saved as favorites, with a Favorites finder mode and optional nearby-station lookup from your saved AccessiWeather locations.
 
 ### Fixed
+- Unknown or uncategorized weather alerts now have a mappable default sound, and missing custom-pack event sounds fall back to the matching default sound before generic notification audio.
 - NOAA Weather Radio Station Finder now repopulates stations when leaving an empty Favorites view, so you no longer need to reopen the radio dialog.
 
 ## [0.7.2] - 2026-05-30

--- a/soundpacks/default/pack.json
+++ b/soundpacks/default/pack.json
@@ -20,6 +20,7 @@
     "severe": "severe.ogg",
     "moderate": "moderate.ogg",
     "minor": "minor.ogg",
+    "unknown": "alert.ogg",
     "warning": "critical_alert.ogg",
     "watch": "watch.ogg",
     "severe_risk": "critical_alert.ogg",

--- a/src/accessiweather/notifications/alert_sound_mapper.py
+++ b/src/accessiweather/notifications/alert_sound_mapper.py
@@ -25,6 +25,7 @@ KNOWN_SEVERITY_KEYS = [
     "severe",
     "moderate",
     "minor",
+    "unknown",
 ]
 
 # Ultimate fallbacks for weather alerts
@@ -53,8 +54,10 @@ def _extract_alert_type(alert: WeatherAlert) -> str | None:
 
 def _normalize_severity(sev: str | None) -> str | None:
     if not sev:
-        return None
+        return "unknown"
     s = sev.strip().lower()
+    if not s:
+        return "unknown"
     if s in KNOWN_SEVERITY_KEYS:
         return s
     # Accept common provider aliases in addition to the canonical severity keys.
@@ -64,7 +67,7 @@ def _normalize_severity(sev: str | None) -> str | None:
         "low": "minor",
         "critical": "extreme",
     }.get(s)
-    return alias if alias in KNOWN_SEVERITY_KEYS else None
+    return alias if alias in KNOWN_SEVERITY_KEYS else "unknown"
 
 
 HAZARD_KEYWORDS = {

--- a/src/accessiweather/notifications/sound_pack_helpers.py
+++ b/src/accessiweather/notifications/sound_pack_helpers.py
@@ -51,6 +51,22 @@ def get_sound_entry(
 
         sound_file = pack_path / filename
         if not sound_file.exists():
+            if pack_dir != default_pack:
+                default_sound_file, default_volume = get_sound_entry(
+                    event,
+                    default_pack,
+                    soundpacks_dir=soundpacks_dir,
+                    default_pack=default_pack,
+                    logger=logger,
+                )
+                if default_sound_file:
+                    logger.warning(
+                        "Sound file %s not found, using %s from default pack.",
+                        sound_file,
+                        default_sound_file,
+                    )
+                    return default_sound_file, default_volume
+
             if pack_dir != default_pack and event != "notify":
                 fallback_file, fallback_volume = parse_sound_entry(
                     sounds.get("notify", "notify.ogg"),
@@ -66,15 +82,7 @@ def get_sound_entry(
                     )
                     return fallback_path, fallback_volume
 
-            logger.warning(f"Sound file {sound_file} not found, falling back to default pack.")
-            if pack_dir != default_pack:
-                return get_sound_entry(
-                    event,
-                    default_pack,
-                    soundpacks_dir=soundpacks_dir,
-                    default_pack=default_pack,
-                    logger=logger,
-                )
+            logger.warning(f"Sound file {sound_file} not found.")
             return None, 1.0
         return sound_file, volume
     except Exception as e:

--- a/src/accessiweather/sound_events.py
+++ b/src/accessiweather/sound_events.py
@@ -39,6 +39,7 @@ SOUND_EVENT_SECTIONS: tuple[tuple[str, str, tuple[tuple[str, str], ...]], ...] =
             ("severe", "Severe severity"),
             ("moderate", "Moderate severity"),
             ("minor", "Minor severity"),
+            ("unknown", "Unknown/uncategorized severity"),
         ),
     ),
 )

--- a/src/accessiweather/ui/dialogs/soundpack_wizard_dialog.py
+++ b/src/accessiweather/ui/dialogs/soundpack_wizard_dialog.py
@@ -186,6 +186,7 @@ class SoundPackWizardDialog(wx.Dialog):
             "severe",
             "moderate",
             "minor",
+            "unknown",
         }
         for key, cb in self.category_checks:
             cb.SetValue(key in common)

--- a/tests/test_alert_notification_system.py
+++ b/tests/test_alert_notification_system.py
@@ -235,6 +235,28 @@ class TestAlertNotificationSoundControl:
         assert call_kwargs["sound_candidates"] == ["moderate", "alert", "notify"]
 
     @pytest.mark.asyncio
+    async def test_send_notification_with_unknown_severity_uses_unknown_sound(
+        self, notification_system, mock_notifier
+    ):
+        """Uncategorized alert severities should get the unknown sound candidate."""
+        alert = WeatherAlert(
+            id="test-unknown",
+            title="Air Quality Alert",
+            description="Air quality may be unhealthy for sensitive groups.",
+            severity="Unknown",
+            event="Air Quality Alert",
+        )
+
+        with patch(
+            "accessiweather.notifications.sound_player.sound_pack_uses_specific_alert_sounds",
+            return_value=False,
+        ):
+            await notification_system._send_alert_notification(alert, "new_alert", play_sound=True)
+
+        call_kwargs = mock_notifier.send_notification.call_args.kwargs
+        assert call_kwargs["sound_candidates"] == ["unknown", "alert", "notify"]
+
+    @pytest.mark.asyncio
     async def test_send_notification_can_use_specific_alert_sounds(
         self, alert_manager, mock_notifier
     ):
@@ -274,6 +296,27 @@ class TestAlertNotificationSoundControl:
         mock_notifier.send_notification.assert_called_once()
         call_kwargs = mock_notifier.send_notification.call_args.kwargs
         assert call_kwargs.get("play_sound") is False
+
+    @pytest.mark.asyncio
+    async def test_unknown_severity_below_threshold_does_not_send_notification_or_sound(
+        self, notification_system, mock_notifier
+    ):
+        """Sound fallback coverage should not bypass alert notification severity filters."""
+        alert = WeatherAlert(
+            id="test-unknown-filtered",
+            title="Air Quality Alert",
+            description="Air quality may be unhealthy for sensitive groups.",
+            severity="Unknown",
+            urgency="Expected",
+            certainty="Likely",
+            event="Air Quality Alert",
+            expires=datetime.now(UTC) + timedelta(hours=1),
+        )
+
+        result = await notification_system.process_and_notify(WeatherAlerts(alerts=[alert]))
+
+        assert result == 0
+        mock_notifier.send_notification.assert_not_called()
 
 
 class TestImmediateAlertPopupOptIn:

--- a/tests/test_alert_sound_mapper.py
+++ b/tests/test_alert_sound_mapper.py
@@ -61,15 +61,15 @@ class TestGetCandidateSoundEvents:
 
         assert candidates == [expected_key, "alert", "notify"]
 
-    def test_unknown_severity_uses_generic_fallbacks(self):
+    def test_unknown_severity_uses_unknown_sound_before_generic_fallbacks(self):
         candidates = get_candidate_sound_events(_alert("Unknown", event="Excessive Heat Watch"))
 
-        assert candidates == ["alert", "notify"]
+        assert candidates == ["unknown", "alert", "notify"]
 
-    def test_missing_severity_uses_generic_fallbacks(self):
+    def test_missing_severity_uses_unknown_sound_before_generic_fallbacks(self):
         candidates = get_candidate_sound_events(_alert(None))
 
-        assert candidates == ["alert", "notify"]
+        assert candidates == ["unknown", "alert", "notify"]
 
     def test_alert_text_does_not_generate_specific_candidates(self):
         candidates = get_candidate_sound_events(_alert("Extreme", event="Tornado Warning"))
@@ -117,6 +117,15 @@ class TestGetCandidateSoundEvents:
             "thunderstorm_severe",
         ]
         assert candidates[-3:] == ["severe", "alert", "notify"]
+
+    def test_specific_air_quality_unknown_keeps_exact_and_hazard_before_unknown(self):
+        candidates = get_candidate_sound_events(
+            _alert("Unknown", event="Air Quality Alert"),
+            include_specific_events=True,
+        )
+
+        assert candidates[:3] == ["air_quality_alert", "air_quality_unknown", "air_quality"]
+        assert candidates[-3:] == ["unknown", "alert", "notify"]
 
     def test_primary_alert_event_takes_priority_over_description_hazard_terms(self):
         alert = WeatherAlert(
@@ -175,8 +184,8 @@ class TestChooseSoundEvent:
         assert chosen == get_candidate_sound_events(alert)[0]
         assert chosen == "extreme"
 
-    def test_choose_with_unknown_severity_returns_alert(self):
-        assert choose_sound_event(_alert("Unknown")) == "alert"
+    def test_choose_with_unknown_severity_returns_unknown(self):
+        assert choose_sound_event(_alert("Unknown")) == "unknown"
 
     def test_choose_with_specific_alert_sounds_returns_exact_event(self):
         assert (
@@ -203,7 +212,7 @@ class TestKnownConstants:
     """Tests to verify the constants are properly defined."""
 
     def test_known_severity_keys(self):
-        assert KNOWN_SEVERITY_KEYS == ["extreme", "severe", "moderate", "minor"]
+        assert KNOWN_SEVERITY_KEYS == ["extreme", "severe", "moderate", "minor", "unknown"]
 
     def test_generic_fallbacks(self):
         assert GENERIC_FALLBACKS == ["alert", "notify"]

--- a/tests/test_settings_dialog_audio_events.py
+++ b/tests/test_settings_dialog_audio_events.py
@@ -262,6 +262,7 @@ def test_visible_audio_events_are_core_lifecycle_and_severity_only():
         "severe",
         "moderate",
         "minor",
+        "unknown",
     } == USER_MUTABLE_SOUND_EVENT_KEYS
     assert "tornado_warning" not in USER_MUTABLE_SOUND_EVENT_KEYS
     assert "warning" not in USER_MUTABLE_SOUND_EVENT_KEYS

--- a/tests/test_sound_player.py
+++ b/tests/test_sound_player.py
@@ -566,6 +566,46 @@ class TestGetSoundEntry:
             finally:
                 sp.SOUNDPACKS_DIR = original_dir
 
+    def test_get_sound_entry_uses_default_event_before_selected_pack_notify(self):
+        """A custom pack missing an event should use the default event before generic notify."""
+        from accessiweather.notifications.sound_player import get_sound_entry
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            import accessiweather.notifications.sound_player as sp
+
+            original_dir = sp.SOUNDPACKS_DIR
+            sp.SOUNDPACKS_DIR = Path(tmpdir)
+
+            try:
+                pack_path = Path(tmpdir) / "custom"
+                pack_path.mkdir()
+                default_path = Path(tmpdir) / "default"
+                default_path.mkdir()
+
+                pack_data = {"name": "Custom", "sounds": {"notify": "custom_notify.wav"}}
+                (pack_path / "pack.json").write_text(json.dumps(pack_data))
+                (pack_path / "custom_notify.wav").touch()
+
+                default_data = {
+                    "name": "Default",
+                    "sounds": {
+                        "data_updated": "default_data_updated.wav",
+                        "notify": "default_notify.wav",
+                    },
+                }
+                (default_path / "pack.json").write_text(json.dumps(default_data))
+                (default_path / "default_data_updated.wav").touch()
+                (default_path / "default_notify.wav").touch()
+
+                sound_file, volume = get_sound_entry("data_updated", "custom")
+
+                assert sound_file is not None
+                assert sound_file.parent == default_path
+                assert sound_file.name == "default_data_updated.wav"
+                assert volume == 1.0
+            finally:
+                sp.SOUNDPACKS_DIR = original_dir
+
     def test_get_sound_entry_for_candidates_falls_back_within_pack(self):
         """Candidate lookup should use the next available event in the selected pack."""
         from accessiweather.notifications.sound_player import get_sound_entry_for_candidates
@@ -597,6 +637,74 @@ class TestGetSoundEntry:
                 assert sound_file is not None
                 assert sound_file.parent == pack_path
                 assert sound_file.name == "alert.wav"
+                assert volume == 1.0
+            finally:
+                sp.SOUNDPACKS_DIR = original_dir
+
+    def test_get_sound_entry_for_candidates_uses_default_pack_when_custom_lacks_candidates(self):
+        """Candidate lookup should use default-pack event coverage when a custom pack lacks it."""
+        from accessiweather.notifications.sound_player import get_sound_entry_for_candidates
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            import accessiweather.notifications.sound_player as sp
+
+            original_dir = sp.SOUNDPACKS_DIR
+            sp.SOUNDPACKS_DIR = Path(tmpdir)
+
+            try:
+                pack_path = Path(tmpdir) / "custom"
+                pack_path.mkdir()
+                default_path = Path(tmpdir) / "default"
+                default_path.mkdir()
+
+                (pack_path / "pack.json").write_text(json.dumps({"name": "Custom", "sounds": {}}))
+
+                default_data = {"name": "Default", "sounds": {"unknown": "alert.ogg"}}
+                (default_path / "pack.json").write_text(json.dumps(default_data))
+                (default_path / "alert.ogg").touch()
+
+                sound_file, volume = get_sound_entry_for_candidates(
+                    ["unknown", "alert", "notify"], "custom"
+                )
+
+                assert sound_file is not None
+                assert sound_file.parent == default_path
+                assert sound_file.name == "alert.ogg"
+                assert volume == 1.0
+            finally:
+                sp.SOUNDPACKS_DIR = original_dir
+
+    def test_get_sound_entry_for_candidates_preserves_selected_pack_precedence(self):
+        """Selected-pack candidate sounds should win before default-pack fallback."""
+        from accessiweather.notifications.sound_player import get_sound_entry_for_candidates
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            import accessiweather.notifications.sound_player as sp
+
+            original_dir = sp.SOUNDPACKS_DIR
+            sp.SOUNDPACKS_DIR = Path(tmpdir)
+
+            try:
+                pack_path = Path(tmpdir) / "custom"
+                pack_path.mkdir()
+                default_path = Path(tmpdir) / "default"
+                default_path.mkdir()
+
+                pack_data = {"name": "Custom", "sounds": {"unknown": "custom_unknown.wav"}}
+                (pack_path / "pack.json").write_text(json.dumps(pack_data))
+                (pack_path / "custom_unknown.wav").touch()
+
+                default_data = {"name": "Default", "sounds": {"unknown": "default_unknown.wav"}}
+                (default_path / "pack.json").write_text(json.dumps(default_data))
+                (default_path / "default_unknown.wav").touch()
+
+                sound_file, volume = get_sound_entry_for_candidates(
+                    ["unknown", "alert", "notify"], "custom"
+                )
+
+                assert sound_file is not None
+                assert sound_file.parent == pack_path
+                assert sound_file.name == "custom_unknown.wav"
                 assert volume == 1.0
             finally:
                 sp.SOUNDPACKS_DIR = original_dir
@@ -918,6 +1026,19 @@ class TestUserLevelMute:
                 "default",
                 logical_event="discussion_update",
                 muted_events=["discussion_update"],
+            )
+
+        mock_play.assert_not_called()
+
+    def test_play_notification_sound_candidates_does_not_bypass_muted_primary_with_fallbacks(self):
+        """A muted primary candidate should not play selected or default fallback sounds."""
+        from accessiweather.notifications.sound_player import play_notification_sound_candidates
+
+        with patch("accessiweather.notifications.sound_player._play_sound_file") as mock_play:
+            play_notification_sound_candidates(
+                ["unknown", "alert", "notify"],
+                "default",
+                muted_events=["unknown"],
             )
 
         mock_play.assert_not_called()

--- a/tests/test_soundpack_event_catalog.py
+++ b/tests/test_soundpack_event_catalog.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from accessiweather.notifications.sound_pack_helpers import get_sound_entry
 from accessiweather.sound_events import (
     FRIENDLY_SOUND_EVENT_CHOICES,
+    KNOWN_SOUND_EVENT_KEYS,
     LEGACY_SOUND_EVENT_KEYS,
     USER_MUTABLE_SOUND_EVENT_KEYS,
 )
@@ -50,6 +51,8 @@ def test_default_pack_supports_all_visible_events_and_legacy_keys():
     pack_data = json.loads(pack_json.read_text(encoding="utf-8"))
     sounds = pack_data["sounds"]
 
+    assert "unknown" in USER_MUTABLE_SOUND_EVENT_KEYS
+    assert set(sounds) >= KNOWN_SOUND_EVENT_KEYS
     assert set(sounds) >= USER_MUTABLE_SOUND_EVENT_KEYS
     assert set(sounds) >= LEGACY_SOUND_EVENT_KEYS
     assert "severe_thunderstorm_watch" in sounds
@@ -62,7 +65,7 @@ def test_default_pack_supports_all_visible_events_and_legacy_keys():
         assert sound_path.exists(), f"{key} maps to missing file {filename}"
 
 
-def test_missing_specific_event_uses_selected_pack_notify_fallback(tmp_path):
+def test_missing_specific_event_uses_default_pack_event_before_selected_pack_notify(tmp_path):
     soundpacks_dir = tmp_path / "soundpacks"
     custom_pack = soundpacks_dir / "custom"
     default_pack = soundpacks_dir / "default"
@@ -92,4 +95,4 @@ def test_missing_specific_event_uses_selected_pack_notify_fallback(tmp_path):
         logger=logging.getLogger(__name__),
     )
 
-    assert sound_file == custom_pack / "notify.wav"
+    assert sound_file == default_pack / "notify.ogg"


### PR DESCRIPTION
## Summary
- add Unknown/uncategorized severity as a first-class alert sound event
- map the default pack's `unknown` event to existing `alert.ogg`
- make missing custom-pack event sounds fall back to the default pack's matching event before generic notification audio
- add regression coverage for resolver fallback order, muted-event behavior, selected-pack precedence, and alert severity filtering

## Tests
- pytest tests/test_alert_sound_mapper.py tests/test_soundpack_event_catalog.py tests/test_alert_notification_system.py::TestAlertNotificationSoundControl -q (red before implementation: expected Unknown/catalog/fallback failures)
- pytest tests/test_alert_sound_mapper.py tests/test_soundpack_event_catalog.py tests/test_sound_player.py::TestGetSoundEntry::test_get_sound_entry_uses_default_event_before_selected_pack_notify tests/test_sound_player.py::TestGetSoundEntry::test_get_sound_entry_for_candidates_uses_default_pack_when_custom_lacks_candidates tests/test_sound_player.py::TestGetSoundEntry::test_get_sound_entry_for_candidates_preserves_selected_pack_precedence tests/test_sound_player.py::TestUserLevelMute tests/test_alert_notification_system.py::TestAlertNotificationSoundControl -q (red before implementation: expected Unknown/catalog/default-event fallback failures)
- pytest tests/test_sound_player.py tests/test_soundpack_event_catalog.py tests/test_alert_sound_mapper.py tests/test_alert_notification_system.py tests/test_toasted_windows_notifier.py tests/test_settings_dialog_audio_events.py -q
- ruff check src/accessiweather/notifications/alert_sound_mapper.py src/accessiweather/notifications/sound_pack_helpers.py src/accessiweather/sound_events.py src/accessiweather/ui/dialogs/soundpack_wizard_dialog.py tests/test_alert_sound_mapper.py tests/test_soundpack_event_catalog.py tests/test_sound_player.py tests/test_alert_notification_system.py tests/test_settings_dialog_audio_events.py
- ruff format --check src/accessiweather/notifications/alert_sound_mapper.py src/accessiweather/notifications/sound_pack_helpers.py src/accessiweather/sound_events.py src/accessiweather/ui/dialogs/soundpack_wizard_dialog.py tests/test_alert_sound_mapper.py tests/test_soundpack_event_catalog.py tests/test_sound_player.py tests/test_alert_notification_system.py tests/test_settings_dialog_audio_events.py
- python scripts/changelog_tools.py check --base origin/dev