### PR TITLE
feat: add surf zone forecast support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- Forecaster Notes can now show official NWS Surf Zone Forecasts for regional beaches where available, with surf/beach condition alternatives from supported global sources when an official SRF product is not available.
 - AccessiWeather can now automatically tune NOAA Weather Radio for qualifying alerts that use Specific Area Message Encoding (SAME) when you turn on the opt-in setting on the Alerts tab, then stop after the duration you choose when a reliable station match is available.
 - NOAA Weather Radio now opens independently of saved weather locations and keeps playing after you close the player until you press Stop or exit the app.
 - The NOAA Weather Radio Station Finder now has clearer modes for searching all stations, browsing by full state or territory name, and finding nearby stations by coordinates.

--- a/src/accessiweather/models/__init__.py
+++ b/src/accessiweather/models/__init__.py
@@ -14,7 +14,7 @@ from .config import AppConfig, AppSettings
 # Error models
 from .errors import ApiError
 
-# Text product models (NWS AFD / HWO / SPS)
+# Text product models (NWS text products and source-labelled summaries)
 from .text_product import TextProduct
 from .weather import (
     AviationData,

--- a/src/accessiweather/models/text_product.py
+++ b/src/accessiweather/models/text_product.py
@@ -1,13 +1,14 @@
 """
-TextProduct dataclass for NWS text-based products (AFD, HWO, SPS).
+TextProduct dataclass for NWS text-based products and source-labelled summaries.
 
 AFD = Area Forecast Discussion
 HWO = Hazardous Weather Outlook
 SPS = Special Weather Statement
+SRF = Surf Zone Forecast
 
 These are fetched from ``/products/types/{TYPE}/locations/{cwa_office}`` and
-``/products/{id}`` on the NWS API. All three endpoints share the same response
-shape, so a single dataclass is sufficient.
+``/products/{id}`` on the NWS API. Derived source summaries can also use this
+shape when they are clearly labelled as non-NWS products.
 """
 
 from __future__ import annotations

--- a/src/accessiweather/services/forecast_product_service.py
+++ b/src/accessiweather/services/forecast_product_service.py
@@ -1,5 +1,5 @@
 """
-Forecast product service — caches NWS text products (AFD / HWO / SPS).
+Forecast product service — caches NWS text products and surf/beach summaries.
 
 Wraps :func:`accessiweather.weather_client_nws.get_nws_text_product` with a
 per-key TTL cache driven by :class:`accessiweather.cache.Cache`. TTLs differ by
@@ -8,6 +8,7 @@ product type:
 - AFD: 3600 s  (discussions update every ~6 h)
 - HWO: 7200 s  (hazardous-weather outlooks update once daily)
 - SPS:  900 s  (special statements are time-sensitive)
+- SRF: 3600 s  (surf forecasts are office-issued regional beach products)
 
 Failed fetches (:class:`TextProductFetchError`) are NOT cached — the caller
 sees the exception and the next call retries.
@@ -30,6 +31,10 @@ from ..iem_client import (
     fetch_iem_wpc_outlook,
 )
 from ..models import TextProduct
+from ..surf_conditions import (
+    fetch_openmeteo_marine_surf_conditions,
+    fetch_pirate_weather_beach_conditions,
+)
 from ..weather_client_nws import (
     TextProductFetchError,
     get_nws_daily_climate_locations,
@@ -41,7 +46,7 @@ from ..weather_client_nws import (
 
 logger = logging.getLogger(__name__)
 
-ProductType = Literal["AFD", "HWO", "SPS"]
+ProductType = Literal["AFD", "HWO", "SPS", "SRF"]
 
 # Per-type cache TTLs in seconds. Keyed by product_type; see module docstring
 # for rationale.
@@ -49,6 +54,8 @@ _PRODUCT_TTLS: dict[str, int] = {
     "AFD": 3600,
     "HWO": 7200,
     "SPS": 900,
+    "SRF": 3600,
+    "SURF_CONDITIONS": 3600,
 }
 
 FetcherResult = TextProduct | list[TextProduct] | None
@@ -57,6 +64,8 @@ HistoryFetcher = Callable[..., Awaitable[list[TextProduct]]]
 DailyClimateFetcher = Callable[..., Awaitable[TextProduct | None]]
 ObservationStationFetcher = Callable[[float, float], Awaitable[list[str]]]
 DailyClimateLocationFetcher = Callable[[], Awaitable[set[str]]]
+OpenMeteoMarineFetcher = Callable[..., Awaitable[TextProduct | None]]
+PirateBeachFetcher = Callable[..., Awaitable[TextProduct | None]]
 
 
 class ForecastProductService:
@@ -73,6 +82,8 @@ class ForecastProductService:
         daily_climate_fetcher: DailyClimateFetcher | None = None,
         observation_station_fetcher: ObservationStationFetcher | None = None,
         daily_climate_location_fetcher: DailyClimateLocationFetcher | None = None,
+        openmeteo_marine_fetcher: OpenMeteoMarineFetcher | None = None,
+        pirate_beach_fetcher: PirateBeachFetcher | None = None,
     ) -> None:
         """
         Initialize the service.
@@ -91,6 +102,10 @@ class ForecastProductService:
                 nearby NWS observation stations for daily climate fallback.
             daily_climate_location_fetcher: Optional async callable used to fetch
                 the NWS CLI-capable location index.
+            openmeteo_marine_fetcher: Optional async callable used for derived
+                global surf/marine conditions.
+            pirate_beach_fetcher: Optional async callable used for Pirate Weather
+                beach-weather context when marine wave data is unavailable.
 
         """
         self._cache = cache
@@ -104,6 +119,12 @@ class ForecastProductService:
         )
         self._daily_climate_location_fetcher: DailyClimateLocationFetcher = (
             daily_climate_location_fetcher or get_nws_daily_climate_locations
+        )
+        self._openmeteo_marine_fetcher: OpenMeteoMarineFetcher = (
+            openmeteo_marine_fetcher or fetch_openmeteo_marine_surf_conditions
+        )
+        self._pirate_beach_fetcher: PirateBeachFetcher = (
+            pirate_beach_fetcher or fetch_pirate_weather_beach_conditions
         )
 
     @staticmethod
@@ -133,6 +154,14 @@ class ForecastProductService:
         longitude = getattr(location, "longitude", "")
         name = getattr(location, "name", "")
         return f"daily_climate_location_station:{name}:{latitude}:{longitude}"
+
+    @staticmethod
+    def _surf_conditions_cache_key(location: object) -> str:
+        latitude = getattr(location, "latitude", "")
+        longitude = getattr(location, "longitude", "")
+        cwa = getattr(location, "cwa_office", "")
+        name = getattr(location, "name", "")
+        return f"surf_conditions:{name}:{latitude}:{longitude}:{cwa}"
 
     @staticmethod
     def _normalize_daily_climate_station(station_id: str | None) -> str:
@@ -227,6 +256,54 @@ class ForecastProductService:
                 return product
         return None
 
+    async def get_surf_conditions_for_location(
+        self,
+        location: object,
+        *,
+        weather_client: object | None = None,
+        **fetcher_kwargs: Any,
+    ) -> TextProduct | None:
+        """
+        Return official NWS SRF when available, otherwise derived surf/beach conditions.
+
+        The official NWS product keeps ``product_type="SRF"``. Derived Open-Meteo
+        or Pirate Weather summaries use ``product_type="SURF_CONDITIONS"`` so the
+        UI can label them as non-official surf/beach context.
+        """
+        key = self._surf_conditions_cache_key(location)
+        if self._cache.has_key(key):
+            cached = self._cache.get(key)
+            if cached is None or isinstance(cached, TextProduct):
+                return cached
+
+        cwa_office = (getattr(location, "cwa_office", None) or "").strip().upper()
+        if cwa_office:
+            try:
+                official = await self.get("SRF", cwa_office, **fetcher_kwargs)
+            except TextProductFetchError:
+                official = None
+            if isinstance(official, TextProduct):
+                self._cache.set(key, official, ttl=self._TTLS.get("SRF", 3600))
+                return official
+
+        try:
+            derived = await self._openmeteo_marine_fetcher(location, **fetcher_kwargs)
+        except Exception:  # noqa: BLE001
+            logger.debug("Open-Meteo surf conditions fallback failed", exc_info=True)
+            derived = None
+        if derived is None:
+            try:
+                derived = await self._pirate_beach_fetcher(
+                    location,
+                    weather_client=weather_client,
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug("Pirate Weather beach conditions fallback failed", exc_info=True)
+                derived = None
+
+        self._cache.set(key, derived, ttl=self._TTLS.get("SURF_CONDITIONS", 3600))
+        return derived
+
     async def get(
         self,
         product_type: ProductType,
@@ -272,7 +349,7 @@ class ForecastProductService:
         Return cached or freshly-fetched NWS text-product history.
 
         History uses a separate cache namespace from the current-product path so
-        current AFD/HWO/SPS fetches never collide with historical listings.
+        current AFD/HWO/SPS/SRF fetches never collide with historical listings.
         """
         key = self._history_cache_key(product_type, cwa_office, limit, start, end)
 

--- a/src/accessiweather/surf_conditions.py
+++ b/src/accessiweather/surf_conditions.py
@@ -1,0 +1,269 @@
+"""Surf and beach-condition helpers for official and derived sources."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from .models import Location, TextProduct
+from .weather_client_parsers import degrees_to_cardinal
+
+logger = logging.getLogger(__name__)
+
+OPENMETEO_MARINE_BASE_URL = "https://marine-api.open-meteo.com/v1"
+_OPENMETEO_CURRENT_VARIABLES = (
+    "wave_height",
+    "wave_direction",
+    "wave_period",
+    "swell_wave_height",
+    "swell_wave_direction",
+    "swell_wave_period",
+    "sea_surface_temperature",
+)
+
+
+@dataclass(frozen=True)
+class SurfConditionReport:
+    """A source-labelled surf/beach conditions summary."""
+
+    source_name: str
+    product_id: str
+    text: str
+    issued_at: datetime | None = None
+    official: bool = False
+
+    def to_text_product(self) -> TextProduct:
+        """Convert the report to the TextProduct shape used by Forecaster Notes."""
+        return TextProduct(
+            product_type="SURF_CONDITIONS",
+            product_id=self.product_id,
+            cwa_office=self.source_name,
+            issuance_time=self.issued_at,
+            product_text=self.text,
+            headline=(
+                f"Surf conditions from {self.source_name}"
+                if not self.official
+                else f"Official surf forecast from {self.source_name}"
+            ),
+        )
+
+
+async def _client_get(
+    client: httpx.AsyncClient,
+    url: str,
+    *,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    """Call AsyncClient.get while tolerating synchronous test doubles."""
+    response = client.get(url, params=params, headers=headers)
+    if inspect.isawaitable(response):
+        return await response
+    return response
+
+
+def _first_present(data: dict[str, Any], key: str) -> Any:
+    value = data.get(key)
+    if isinstance(value, list):
+        return value[0] if value else None
+    return value
+
+
+def _format_value(value: Any, unit: str | None, *, precision: int = 1) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, int | float):
+        text = f"{float(value):.{precision}f}".rstrip("0").rstrip(".")
+    else:
+        text = str(value).strip()
+    if not text:
+        return None
+    return f"{text} {unit}".strip() if unit else text
+
+
+def _format_direction(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        degrees = float(value)
+    except (TypeError, ValueError):
+        return str(value).strip() or None
+    cardinal = degrees_to_cardinal(degrees)
+    return f"{cardinal} ({degrees:.0f} degrees)"
+
+
+def format_openmeteo_marine_report(
+    data: dict[str, Any], location: Location
+) -> SurfConditionReport | None:
+    """Format Open-Meteo Marine API current data as accessible plain text."""
+    current = data.get("current")
+    if not isinstance(current, dict) or not current:
+        return None
+    units = data.get("current_units") if isinstance(data.get("current_units"), dict) else {}
+
+    lines = [
+        f"Surf conditions from Open-Meteo Marine for {location.name}.",
+        "Marine/surf conditions from Open-Meteo Marine; not an official NWS Surf Zone Forecast.",
+    ]
+
+    fields = (
+        (
+            "Wave height",
+            _format_value(_first_present(current, "wave_height"), units.get("wave_height")),
+        ),
+        ("Wave direction", _format_direction(_first_present(current, "wave_direction"))),
+        (
+            "Wave period",
+            _format_value(_first_present(current, "wave_period"), units.get("wave_period")),
+        ),
+        (
+            "Swell height",
+            _format_value(
+                _first_present(current, "swell_wave_height"), units.get("swell_wave_height")
+            ),
+        ),
+        ("Swell direction", _format_direction(_first_present(current, "swell_wave_direction"))),
+        (
+            "Swell period",
+            _format_value(
+                _first_present(current, "swell_wave_period"), units.get("swell_wave_period")
+            ),
+        ),
+        (
+            "Sea surface temperature",
+            _format_value(
+                _first_present(current, "sea_surface_temperature"),
+                units.get("sea_surface_temperature"),
+            ),
+        ),
+    )
+    for label, value in fields:
+        if value:
+            lines.append(f"{label}: {value}.")
+
+    if len(lines) == 2:
+        return None
+
+    issued_at = None
+    current_time = current.get("time")
+    if isinstance(current_time, str) and current_time:
+        try:
+            issued_at = datetime.fromisoformat(current_time.replace("Z", "+00:00"))
+        except ValueError:
+            issued_at = None
+    return SurfConditionReport(
+        source_name="Open-Meteo Marine",
+        product_id="openmeteo-marine-surf-conditions",
+        issued_at=issued_at or datetime.now(UTC),
+        text="\n".join(lines),
+    )
+
+
+async def fetch_openmeteo_marine_surf_conditions(
+    location: Location,
+    *,
+    marine_base_url: str = OPENMETEO_MARINE_BASE_URL,
+    client: httpx.AsyncClient | None = None,
+    timeout: float = 10.0,
+    user_agent: str = "AccessiWeather (github.com/orinks/accessiweather)",
+) -> TextProduct | None:
+    """Fetch a small Open-Meteo Marine surf/beach conditions summary."""
+    if location.latitude is None or location.longitude is None:
+        return None
+
+    url = f"{marine_base_url}/marine"
+    params = {
+        "latitude": location.latitude,
+        "longitude": location.longitude,
+        "current": ",".join(_OPENMETEO_CURRENT_VARIABLES),
+        "timezone": "auto",
+    }
+    headers = {"User-Agent": user_agent}
+
+    async def _run(http_client: httpx.AsyncClient) -> TextProduct | None:
+        try:
+            response = await _client_get(http_client, url, params=params, headers=headers)
+            if response.status_code != 200:
+                logger.debug("Open-Meteo Marine returned HTTP %s", response.status_code)
+                return None
+            report = format_openmeteo_marine_report(response.json(), location)
+            return report.to_text_product() if report is not None else None
+        except (httpx.TimeoutException, httpx.TransportError, httpx.RequestError, ValueError):
+            logger.debug("Open-Meteo Marine surf conditions unavailable", exc_info=True)
+            return None
+
+    if client is not None:
+        return await _run(client)
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as new_client:
+        return await _run(new_client)
+
+
+async def fetch_pirate_weather_beach_conditions(
+    location: Location,
+    weather_client: object | None = None,
+) -> TextProduct | None:
+    """Build beach-weather context from an existing Pirate Weather client when available."""
+    if weather_client is None:
+        return None
+
+    client_getter = getattr(weather_client, "_pirate_weather_client_for_location", None)
+    pirate_client = client_getter(location) if callable(client_getter) else None
+    if pirate_client is None:
+        pirate_client = getattr(weather_client, "pirate_weather_client", None)
+    if pirate_client is None:
+        return None
+
+    try:
+        payload = await pirate_client.get_forecast_data(location)
+    except Exception:  # noqa: BLE001
+        logger.debug("Pirate Weather beach conditions unavailable", exc_info=True)
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    current = payload.get("currently")
+    if not isinstance(current, dict):
+        return None
+
+    lines = [
+        f"Surf conditions from Pirate Weather for {location.name}.",
+        (
+            "Beach-weather context from Pirate Weather; not an official NWS Surf Zone "
+            "Forecast and wave data is not available from this source in AccessiWeather."
+        ),
+    ]
+    for label, key, unit in (
+        ("Conditions", "summary", ""),
+        ("Temperature", "temperature", "degrees"),
+        ("Feels like", "apparentTemperature", "degrees"),
+        ("Wind speed", "windSpeed", "mph"),
+        ("Wind gust", "windGust", "mph"),
+        ("Wind direction", "windBearing", ""),
+        ("UV index", "uvIndex", ""),
+        ("Visibility", "visibility", "miles"),
+    ):
+        value = current.get(key)
+        formatted = _format_direction(value) if key == "windBearing" else _format_value(value, unit)
+        if formatted:
+            lines.append(f"{label}: {formatted}.")
+
+    precip_probability = current.get("precipProbability")
+    if isinstance(precip_probability, int | float):
+        lines.append(f"Precipitation chance: {precip_probability * 100:.0f} percent.")
+
+    if len(lines) == 2:
+        return None
+
+    return TextProduct(
+        product_type="SURF_CONDITIONS",
+        product_id="pirate-weather-beach-conditions",
+        cwa_office="Pirate Weather",
+        issuance_time=datetime.now(UTC),
+        product_text="\n".join(lines),
+        headline="Surf conditions from Pirate Weather",
+    )

--- a/src/accessiweather/ui/dialogs/advanced_text_product_dialog.py
+++ b/src/accessiweather/ui/dialogs/advanced_text_product_dialog.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_NWS_PRODUCT_TYPES = {"AFD", "HWO", "SPS", "CLI", "CF6", "RER", "LSR", "PNS"}
+_NWS_PRODUCT_TYPES = {"AFD", "HWO", "SPS", "SRF", "CLI", "CF6", "RER", "LSR", "PNS"}
 _SOURCE_PREFER_NWS = "Prefer NWS when available"
 _SOURCE_IEM_ONLY = "IEM AFOS only"
 _SOURCE_NWS_ONLY = "NWS history only"
@@ -77,6 +77,12 @@ _PRODUCT_PRESET_ITEMS: tuple[ProductPreset, ...] = (
     ProductPreset("Local office", "Local Area Forecast Discussion", "AFD", True),
     ProductPreset("Local office", "Local Hazardous Weather Outlook", "HWO", True),
     ProductPreset("Local office", "Local Special Weather Statement", "SPS", True),
+    ProductPreset(
+        "Local office",
+        "Official NWS Surf Zone Forecast for regional beaches",
+        "SRF",
+        True,
+    ),
     ProductPreset("Local office", "Local Storm Report", "LSR", True),
     ProductPreset("Local office", "Daily Climate Report", "CLI", True),
     ProductPreset("Local office", "Monthly Climate Report", "CF6", True),
@@ -982,17 +988,25 @@ class AdvancedTextProductDialog(wx.Dialog):
 
         chunks = [f"Source: {source}"]
         for product in products:
+            product_type = getattr(product, "product_type", "unknown")
+            cwa_office = getattr(product, "cwa_office", "")
             headline = getattr(product, "headline", None)
             issuance = getattr(product, "issuance_time", None)
             issued = issuance.isoformat() if isinstance(issuance, datetime) else "unknown"
+            regional_note = ""
+            if product_type == "SRF":
+                regional_note = (
+                    f"Surf Zone Forecast issued by NWS {cwa_office} for regional beaches."
+                )
             chunks.append(
                 "\n".join(
                     part
                     for part in (
                         "",
-                        f"Product: {getattr(product, 'product_type', 'unknown')}",
+                        f"Product: {product_type}",
                         f"Issued: {issued}",
                         f"Headline: {headline}" if headline else "",
+                        regional_note,
                         getattr(product, "product_text", ""),
                     )
                     if part

--- a/src/accessiweather/ui/dialogs/forecast_product_formatting.py
+++ b/src/accessiweather/ui/dialogs/forecast_product_formatting.py
@@ -12,6 +12,9 @@ PRODUCT_FULL_NAMES: dict[str, str] = {
     "AFD": "Area Forecast Discussion",
     "HWO": "Hazardous Weather Outlook",
     "SPS": "Special Weather Statement",
+    "SRF": "Official NWS Surf Zone Forecast",
+    "SURF": "Surf/Beach Conditions",
+    "SURF_CONDITIONS": "Surf/Beach Conditions",
     "LSR": "Local Storm Report",
     "PNS": "Public Information Statement",
     "CLI": "Daily Climate Report",
@@ -36,6 +39,17 @@ EMPTY_COPY: dict[str, str] = {
     "AFD": "Area Forecast Discussion not currently available for {cwa_office}.",
     "HWO": "Hazardous Weather Outlook not currently available for {cwa_office}.",
     "SPS": "No recent Special Weather Statements for {cwa_office}.",
+    "SRF": (
+        "Surf Zone Forecast issued by NWS {cwa_office} for regional beaches is not "
+        "currently available."
+    ),
+    "SURF": (
+        "No official NWS Surf Zone Forecast or derived surf/beach conditions are currently "
+        "available for this location."
+    ),
+    "SURF_CONDITIONS": (
+        "No derived surf/beach conditions are currently available for this location."
+    ),
     "LSR": "No recent Local Storm Reports for {cwa_office}.",
     "PNS": "No recent Public Information Statements for {cwa_office}.",
     "CLI": "Daily Climate Report not currently available for {cwa_office}.",
@@ -66,6 +80,16 @@ EMPTY_COPY: dict[str, str] = {
 }
 
 NO_CWA_COPY = "NWS text products will populate after the next weather refresh."
+
+
+def regional_product_intro(product_type: str, cwa_office: str | None) -> str:
+    """Return a clear official-vs-derived context line for surf products."""
+    if product_type == "SRF":
+        office = (cwa_office or "").strip().upper() or "the selected office"
+        return f"Surf Zone Forecast issued by NWS {office} for regional beaches."
+    if product_type == "SURF_CONDITIONS":
+        return "Marine/surf conditions from a supported source; not an official NWS Surf Zone Forecast."
+    return ""
 
 
 def format_issuance(issuance_time: datetime | None) -> str:

--- a/src/accessiweather/ui/dialogs/forecast_product_panel.py
+++ b/src/accessiweather/ui/dialogs/forecast_product_panel.py
@@ -1,15 +1,17 @@
 """
 Reusable per-tab panel for the Forecast Products dialog.
 
-Each :class:`ForecastProductPanel` renders one NWS text product type (AFD, HWO,
-or SPS) with a shared shape: header, optional SPS-multi chooser, raw-product
+Each :class:`ForecastProductPanel` renders one text product type with a shared
+shape: header, optional SPS-multi chooser, raw-product
 TextCtrl, issuance timestamp StaticText, "Plain Language Summary" AI button
 (hidden until clicked), and a retry button shown only in the fetch-failed
 state.
 
-The panel owns its own content-state machine — AFD/HWO have a single product,
-SPS can have multiple. All empty/error states render inside the content area
-because ``wx.Notebook`` doesn't support per-tab disable on Windows.
+The panel owns its own content-state machine. SPS can have multiple products.
+Regional surf products include an app-owned context line above the raw text so
+they are not mistaken for point forecasts. All empty/error states render inside
+the content area because ``wx.Notebook`` doesn't support per-tab disable on
+Windows.
 
 Accessibility note: screen readers announce adjacent ``wx.StaticText``, NOT
 ``SetName()`` or tooltips (project convention). Descriptive ``label=``
@@ -36,6 +38,7 @@ from .forecast_product_formatting import (
     PRODUCT_FULL_NAMES as _PRODUCT_FULL_NAMES,
     format_issuance as _format_issuance,
     format_sps_choice_entry as _format_sps_choice_entry,
+    regional_product_intro as _regional_product_intro,
 )
 from .forecast_product_widgets import create_product_panel_widgets
 
@@ -73,7 +76,7 @@ class ForecastProductPanel(wx.Panel):
 
         Args:
             parent: Parent window (the ``wx.Notebook``).
-            product_type: One of ``"AFD"``, ``"HWO"``, ``"SPS"``.
+            product_type: A supported text product identifier.
             product_loader: Zero-arg async callable that returns the fetched
                 product(s). May raise ``TextProductFetchError``.
             ai_explainer: Optional explainer; when ``None`` the AI summary
@@ -204,7 +207,7 @@ class ForecastProductPanel(wx.Panel):
     # ------------------------------------------------------------------
     def _trigger_load(self) -> None:
         """Enter the loading state and dispatch the async loader."""
-        if self._cwa_office is None:
+        if self._cwa_office is None and self.product_type not in {"SURF", "SURF_CONDITIONS"}:
             # Nothing we can do — surface the pre-refresh message.
             self._render_no_cwa_state()
             return
@@ -313,8 +316,14 @@ class ForecastProductPanel(wx.Panel):
 
     def _render_single_product(self, product: TextProduct) -> None:
         """Render a single product (AFD / HWO / single SPS)."""
-        self._current_text = product.product_text
-        self.product_textctrl.SetValue(product.product_text)
+        product_type = getattr(product, "product_type", self.product_type)
+        intro = _regional_product_intro(product_type, self._cwa_office)
+        product_text = product.product_text
+        display_text = (
+            f"{intro}\n\n{product_text}" if intro and intro not in product_text else product_text
+        )
+        self._current_text = display_text
+        self.product_textctrl.SetValue(display_text)
         self.issuance_label.SetLabel(_format_issuance(product.issuance_time))
         self._show_sps_chooser(False)
         self._update_explain_button_state()

--- a/src/accessiweather/ui/dialogs/forecast_products_dialog.py
+++ b/src/accessiweather/ui/dialogs/forecast_products_dialog.py
@@ -1,8 +1,8 @@
 """
-Forecast Products dialog — tabbed host for AFD, HWO, and SPS panels.
+Forecast Products dialog — tabbed host for forecaster-note and surf-condition panels.
 
-A ``wx.Notebook`` with three :class:`ForecastProductPanel` pages. Focus lands
-on the AFD TextCtrl when the dialog opens so the user sees content immediately.
+A ``wx.Notebook`` with :class:`ForecastProductPanel` pages for official NWS
+text products and clearly labelled source-derived conditions.
 Tab switches deliberately do NOT grab focus — the notebook tab strip stays
 the active focus level until the user Tabs into content, matching the
 accessible notebook contract.
@@ -59,12 +59,13 @@ class TextProductTab:
 
 
 class ForecastProductsDialog(wx.Dialog):
-    """Tabbed dialog showing available NWS AFD, HWO, and SPS products."""
+    """Tabbed dialog showing available text products and surf/beach conditions."""
 
     _TABS: tuple[TextProductTab, ...] = (
         TextProductTab("AFD", "Area Forecast Discussion", "current", requires_cwa=True),
         TextProductTab("HWO", "Hazardous Weather Outlook", "current", requires_cwa=True),
         TextProductTab("SPS", "Special Weather Statement", "current", requires_cwa=True),
+        TextProductTab("SURF", "Surf/Beach Conditions", "surf_conditions"),
         TextProductTab("CLI", "Daily Climate Report", "daily_climate"),
         TextProductTab("SPC_OUTLOOK", "SPC Outlook (Storm Prediction Center)", "spc_outlook"),
         TextProductTab("SPC_MCD", "SPC MCD (Mesoscale Discussion)", "spc_mcd"),
@@ -134,7 +135,10 @@ class ForecastProductsDialog(wx.Dialog):
         self.panels: list[ForecastProductPanel] = []
 
         pending_iem_tabs: list[TextProductTab] = []
+        cwa_office = getattr(self._location, "cwa_office", None)
         for tab in self._TABS:
+            if tab.requires_cwa and not cwa_office:
+                continue
             if tab.loader_kind in _ACTIVE_IEM_LOADER_KINDS:
                 pending_iem_tabs.append(tab)
                 continue
@@ -186,7 +190,11 @@ class ForecastProductsDialog(wx.Dialog):
 
             loader = _override_loader
 
-        panel_cwa = cwa_office if tab.requires_cwa or tab.loader_kind == "daily_climate" else "IEM"
+        panel_cwa = (
+            cwa_office
+            if tab.requires_cwa or tab.loader_kind in {"daily_climate", "surf_conditions"}
+            else "IEM"
+        )
         panel = ForecastProductPanel(
             parent=self.notebook,
             product_type=tab.product_type,
@@ -311,6 +319,11 @@ class ForecastProductsDialog(wx.Dialog):
                 return None
             if tab.loader_kind == "current":
                 return await self._service.get(cast(Any, tab.product_type), str(cwa_office))
+            if tab.loader_kind == "surf_conditions":
+                return await self._service.get_surf_conditions_for_location(
+                    self._location,
+                    weather_client=getattr(self._app, "weather_client", None),
+                )
             if tab.loader_kind == "nws_history":
                 return await self._service.get_history(tab.product_type, str(cwa_office), limit=1)
             if tab.loader_kind == "daily_climate":
@@ -407,13 +420,14 @@ class ForecastProductsDialog(wx.Dialog):
 
     def _make_advanced_lookup_opener(self, product_type: str):
         """Bind an advanced lookup opener for ``product_type``."""
+        initial_product_type = "SRF" if product_type == "SURF" else product_type
 
         def _open() -> None:
             show_advanced_text_product_dialog(
                 self,
                 self._location,
                 self._service,
-                initial_product_type=product_type,
+                initial_product_type=initial_product_type,
                 app=self._app,
             )
 
@@ -429,8 +443,9 @@ class ForecastProductsDialog(wx.Dialog):
 
         AFD stays visible even when empty because it is the primary forecaster
         notes product and gives users a stable place to retry/read status.
-        HWO and SPS are supplemental; when NWS confirms there is no product for
-        the office, hiding those tabs avoids advertising unavailable content.
+        HWO, SPS, and surf/beach conditions are supplemental; when lookup
+        confirms there is no content, hiding those tabs avoids advertising
+        unavailable content.
         Fetch errors report ``has_product=True`` so the tab remains available
         with its retry button.
         """

--- a/src/accessiweather/ui/main_window_commands.py
+++ b/src/accessiweather/ui/main_window_commands.py
@@ -24,7 +24,7 @@ class MainWindowCommandMixin:
         self._on_forecast_products()
 
     def _on_forecast_products(self) -> None:
-        """Open the Forecast Products dialog (AFD + HWO + SPS) for the active location."""
+        """Open Forecaster Notes and surf/beach conditions for the active location."""
         current = self.app.config_manager.get_current_location()
         if current is None:
             wx.MessageBox(
@@ -60,29 +60,13 @@ class MainWindowCommandMixin:
 
     def _update_forecast_products_button_state(self) -> None:
         """
-        Enable/disable the Forecast Products button based on country.
+        Keep Forecaster Notes reachable for every saved location.
 
-        Non-US locations disable the button and reveal the adjacent
-        "NWS products are US-only" StaticText so screen readers announce the
-        reason. US locations re-enable the button and hide the label.
+        Official NWS text tabs are only populated for US locations with NWS
+        metadata, but Surf/Beach Conditions can use global supported sources.
         """
-        try:
-            current = self.app.config_manager.get_current_location()
-        except Exception:  # noqa: BLE001
-            current = None
-
-        is_us = True  # default: don't needlessly disable
-        if current is not None:
-            country = getattr(current, "country_code", None)
-            if country:
-                is_us = country.upper() == "US"
-
-        if is_us:
-            self.discussion_button.Enable()
-            self.forecast_products_us_only_label.Hide()
-        else:
-            self.discussion_button.Disable()
-            self.forecast_products_us_only_label.Show()
+        self.discussion_button.Enable()
+        self.forecast_products_us_only_label.Hide()
 
     def _get_forecast_product_service(self):
         """Get or lazily build the shared ForecastProductService instance."""

--- a/src/accessiweather/ui/main_window_refresh.py
+++ b/src/accessiweather/ui/main_window_refresh.py
@@ -82,7 +82,7 @@ class MainWindowRefreshMixin:
                 )
                 return
 
-            # Pre-warm NWS text products (AFD/HWO/SPS) for the active location
+            # Pre-warm NWS text products (AFD/HWO/SPS/SRF) for the active location
             # so the Forecast Products dialog and Unit 10/11 notification
             # checks see fresh data without issuing an on-demand fetch.
             await self._pre_warm_products_for_location(location)
@@ -134,7 +134,7 @@ class MainWindowRefreshMixin:
                 logger.debug(f"Pre-warming cache for {len(uncached)} locations")
                 await self.app.weather_client.pre_warm_batch(uncached)
 
-            # Pre-warm NWS text products (AFD/HWO/SPS) for every non-active
+            # Pre-warm NWS text products (AFD/HWO/SPS/SRF) for every non-active
             # saved US location. Failure isolation is per-(product, location):
             # one failure never cascades to other products or other locations.
             for loc in all_locations:
@@ -146,7 +146,7 @@ class MainWindowRefreshMixin:
 
     async def _pre_warm_products_for_location(self, location: Location) -> None:
         """
-        Pre-warm AFD/HWO/SPS/CLI caches for a single location.
+        Pre-warm AFD/HWO/SPS/SRF/CLI caches for a single location.
 
         Non-US locations and US locations without a populated ``cwa_office``
         are skipped. Each product fetch is wrapped in its own try/except so
@@ -204,7 +204,10 @@ class MainWindowRefreshMixin:
                 )
 
         await asyncio.gather(
-            *(_pre_warm_text_product(product_type) for product_type in ("AFD", "HWO", "SPS")),
+            *(
+                _pre_warm_text_product(product_type)
+                for product_type in ("AFD", "HWO", "SPS", "SRF")
+            ),
             _pre_warm_daily_climate(),
         )
 

--- a/src/accessiweather/ui/main_window_ui.py
+++ b/src/accessiweather/ui/main_window_ui.py
@@ -113,12 +113,11 @@ class MainWindowUIMixin:
         self.discussion_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["discussion"])
         self.settings_button = wx.Button(button_panel, label=QUICK_ACTION_LABELS["settings"])
 
-        # Adjacent StaticText explaining why the Forecast Products button is
-        # disabled for non-US locations. Screen readers announce adjacent
-        # StaticText, which is the accessibility affordance for this reason
-        # label (SetName/tooltips are ignored in this project).
+        # Reserved adjacent StaticText for any future availability note near
+        # Forecaster Notes. It stays hidden by default; screen readers announce
+        # adjacent StaticText when it is shown.
         self.forecast_products_us_only_label = wx.StaticText(
-            panel, label="Forecaster Notes are US-only"
+            panel, label="Some official NWS products are US-only"
         )
         self.forecast_products_us_only_label.Hide()
 
@@ -287,7 +286,7 @@ class MainWindowUIMixin:
         discussion_item = view_menu.Append(
             wx.ID_ANY,
             "Forecaster &Notes...",
-            "View NWS forecaster notes (AFD, HWO, SPS)",
+            "View forecaster notes and surf or beach conditions",
         )
         aviation_item = view_menu.Append(wx.ID_ANY, "&Aviation Weather...", "View aviation weather")
         air_quality_item = view_menu.Append(

--- a/src/accessiweather/weather_client_nws_forecast.py
+++ b/src/accessiweather/weather_client_nws_forecast.py
@@ -240,7 +240,7 @@ async def _fetch_text_product_by_id(
 
 
 async def get_nws_text_product(
-    product_type: Literal[AFD, HWO, SPS],
+    product_type: str,
     cwa_office: str | None,
     *,
     nws_base_url: str = "https://api.weather.gov",
@@ -249,7 +249,7 @@ async def get_nws_text_product(
     user_agent: str = "AccessiWeather (github.com/orinks/accessiweather)",
 ) -> TextProduct | list[TextProduct] | None:
     """
-    Fetch an NWS text product (AFD / HWO / SPS) for a CWA office.
+    Fetch an NWS text product for a CWA office.
 
     Endpoint: ``/products/types/{product_type}/locations/{cwa_office}`` returns
     an ``@graph`` of product stubs; each is fetched individually via
@@ -257,8 +257,9 @@ async def get_nws_text_product(
 
     Return convention:
         - ``cwa_office`` falsy -> ``None`` (no HTTP call).
-        - AFD or HWO, empty ``@graph`` -> ``None``.
-        - AFD or HWO, products present -> single ``TextProduct`` (newest @graph entry).
+        - AFD, HWO, SRF, or similar single-product types, empty ``@graph`` -> ``None``.
+        - AFD, HWO, SRF, or similar single-product types present -> single
+          ``TextProduct`` (newest @graph entry).
         - SPS -> ``list[TextProduct]`` (possibly empty), sorted newest-first.
 
     Raises:

--- a/tests/gui/test_advanced_text_product_dialog.py
+++ b/tests/gui/test_advanced_text_product_dialog.py
@@ -154,6 +154,32 @@ def test_lookup_prefers_nws_history_for_supported_local_products():
     assert "official text" in dlg.result_text.SetValue.call_args.args[0]
 
 
+def test_srf_nws_lookup_includes_official_regional_beach_wording():
+    service = MagicMock()
+    service.get_history = AsyncMock(return_value=[_product("SRF")])
+    service.get_iem_afos = AsyncMock(return_value=_product("SRFPHI"))
+
+    dlg = AdvancedTextProductDialog(
+        parent=MagicMock(),
+        location=_location(),
+        forecast_product_service=service,
+        initial_product_type="SRF",
+    )
+    dlg.product_input.GetValue.return_value = "SRF"
+    dlg.office_choice.GetStringSelection.return_value = "Selected location office (RAH)"
+    dlg.limit_input.GetValue.return_value = "1"
+    dlg.start_input.GetValue.return_value = ""
+    dlg.end_input.GetValue.return_value = ""
+    dlg.source_choice.GetStringSelection.return_value = "Prefer NWS when available"
+
+    dlg._run_lookup_sync()
+
+    output = dlg.result_text.SetValue.call_args.args[0]
+    assert "Source: NWS" in output
+    assert "Surf Zone Forecast issued by NWS RAH for regional beaches." in output
+    service.get_iem_afos.assert_not_awaited()
+
+
 def test_lookup_uses_iem_for_national_pil_without_nws_location():
     service = MagicMock()
     service.get_history = AsyncMock(return_value=[])
@@ -294,6 +320,31 @@ def test_local_product_preset_selects_location_office_choice():
     dlg._on_product_preset(MagicMock())
 
     dlg.product_input.SetValue.assert_called_with("AFD")
+    dlg.office_choice.SetSelection.assert_called_with(0)
+
+
+def test_srf_product_preset_selects_location_office_choice():
+    service = MagicMock()
+    dlg = AdvancedTextProductDialog(
+        parent=MagicMock(),
+        location=_location(),
+        forecast_product_service=service,
+        initial_product_type="AFD",
+    )
+    dlg.product_preset_choice.GetStringSelection.return_value = (
+        "Official NWS Surf Zone Forecast for regional beaches"
+    )
+    dlg.office_choice.GetCount.return_value = 3
+    dlg.office_choice.GetString.side_effect = [
+        "Selected location office (RAH)",
+        "No office or national product",
+        "Custom office below",
+    ]
+
+    dlg._on_product_preset(MagicMock())
+
+    dlg.product_input.SetValue.assert_called_with("SRF")
+    dlg.source_choice.SetSelection.assert_called_with(0)
     dlg.office_choice.SetSelection.assert_called_with(0)
 
 

--- a/tests/gui/test_forecast_product_panel.py
+++ b/tests/gui/test_forecast_product_panel.py
@@ -338,6 +338,30 @@ class TestForecastProductPanelRendering:
             "Area Forecast Discussion not currently available for RAH."
         )
 
+    def test_official_srf_includes_regional_nws_context(self, captured_sizer):
+        srf = _make_product("SRF", text="SURF ZONE FORECAST raw text")
+        panel = _build_panel("SURF", loader_result=srf, cwa_office="PHI")
+
+        panel.product_textctrl.SetValue.assert_any_call(
+            "Surf Zone Forecast issued by NWS PHI for regional beaches.\n\n"
+            "SURF ZONE FORECAST raw text"
+        )
+
+    def test_derived_surf_conditions_keep_non_nws_label(self, captured_sizer):
+        derived = _make_product(
+            "SURF_CONDITIONS",
+            text=(
+                "Surf conditions from Open-Meteo Marine for Porto.\n"
+                "Marine/surf conditions from Open-Meteo Marine; not an official NWS "
+                "Surf Zone Forecast."
+            ),
+        )
+        panel = _build_panel("SURF", loader_result=derived, cwa_office=None)
+
+        rendered = panel.product_textctrl.SetValue.call_args.args[0]
+        assert "not an official NWS Surf Zone Forecast" in rendered
+        assert "issued by NWS" not in rendered
+
 
 class TestForecastProductPanelSPS:
     """SPS multi-product selection behaviour."""

--- a/tests/gui/test_forecast_products_dialog.py
+++ b/tests/gui/test_forecast_products_dialog.py
@@ -281,9 +281,10 @@ class TestForecastProductsDialog:
         )
 
         types = [entry["product_type"] for entry in panel_factory]
-        assert types == ["AFD", "HWO", "SPS", "CLI"]
-        assert dlg.notebook.AddPage.call_args_list[3].args[1] == "Daily Climate Report"
-        assert len(dlg.panels) == 4
+        assert types == ["AFD", "HWO", "SPS", "SURF", "CLI"]
+        assert dlg.notebook.AddPage.call_args_list[3].args[1] == "Surf/Beach Conditions"
+        assert dlg.notebook.AddPage.call_args_list[4].args[1] == "Daily Climate Report"
+        assert len(dlg.panels) == 5
 
         # Each panel got wired to the same service + explainer.
         for entry in panel_factory:
@@ -293,7 +294,8 @@ class TestForecastProductsDialog:
         assert panel_factory[0]["autoload"] is True
         assert panel_factory[1]["autoload"] is False
         assert panel_factory[2]["autoload"] is False
-        assert panel_factory[3]["autoload"] is True
+        assert panel_factory[3]["autoload"] is False
+        assert panel_factory[4]["autoload"] is True
 
     def test_loader_invokes_service_get(self, notebook_factory, panel_factory, sample_us_location):
         """Each panel's bound loader calls service.get(product_type, cwa_office)."""
@@ -433,7 +435,7 @@ class TestForecastProductsDialog:
         )
 
         openers = [entry["advanced_lookup_opener"] for entry in panel_factory]
-        assert len(openers) == 4
+        assert len(openers) == 5
         for opener in openers:
             assert callable(opener)
 
@@ -449,6 +451,72 @@ class TestForecastProductsDialog:
             initial_product_type="AFD",
             app=None,
         )
+
+        with patch(
+            "accessiweather.ui.dialogs.forecast_products_dialog.show_advanced_text_product_dialog"
+        ) as show_dialog:
+            openers[3]()
+
+        show_dialog.assert_called_once_with(
+            dlg,
+            sample_us_location,
+            service,
+            initial_product_type="SRF",
+            app=None,
+        )
+
+    def test_surf_loader_invokes_source_aware_service(
+        self, notebook_factory, panel_factory, sample_us_location
+    ):
+        import asyncio
+
+        service = MagicMock(name="ForecastProductService")
+        app = MagicMock()
+        app.weather_client = MagicMock(name="WeatherClient")
+        app.run_async.side_effect = lambda coro: coro.close()
+
+        async def _fake_surf(location, **kwargs):
+            return SimpleNamespace(location=location, kwargs=kwargs)
+
+        service.get_surf_conditions_for_location.side_effect = _fake_surf
+
+        dlg = ForecastProductsDialog(
+            parent=MagicMock(),
+            location=sample_us_location,
+            forecast_product_service=service,
+            ai_explainer=None,
+            app=app,
+        )
+
+        surf_tab = next(tab for tab in ForecastProductsDialog._TABS if tab.product_type == "SURF")
+        result = asyncio.run(dlg._make_loader(surf_tab)())
+
+        assert result.location is sample_us_location
+        assert result.kwargs == {"weather_client": app.weather_client}
+
+    def test_non_us_location_builds_global_surf_tab(self, notebook_factory, panel_factory):
+        service = MagicMock(name="ForecastProductService")
+        location = Location(
+            name="Porto",
+            latitude=41.15,
+            longitude=-8.63,
+            country_code="PT",
+            cwa_office=None,
+        )
+
+        dlg = ForecastProductsDialog(
+            parent=MagicMock(),
+            location=location,
+            forecast_product_service=service,
+            ai_explainer=None,
+        )
+
+        types = [entry["product_type"] for entry in panel_factory]
+        assert "AFD" not in types
+        assert "HWO" not in types
+        assert "SPS" not in types
+        assert types[0] == "SURF"
+        assert dlg.notebook.AddPage.call_args_list[0].args[1] == "Surf/Beach Conditions"
 
     def test_national_products_button_opens_dedicated_dialog(
         self, notebook_factory, panel_factory, sample_us_location
@@ -652,8 +720,8 @@ class TestMainWindowWiring:
         mw.discussion_button.Enable.assert_called()
         mw.forecast_products_us_only_label.Hide.assert_called()
 
-    def test_update_button_state_non_us_disables(self):
-        """Non-US location: button disabled, US-only label shown (adjacent StaticText)."""
+    def test_update_button_state_non_us_keeps_forecaster_notes_available(self):
+        """Non-US location: button stays enabled for global surf/beach conditions."""
         from accessiweather.ui import main_window
 
         mw = MagicMock(spec=main_window.MainWindow)
@@ -668,5 +736,5 @@ class TestMainWindowWiring:
         mw.forecast_products_us_only_label = MagicMock()
 
         main_window.MainWindow._update_forecast_products_button_state(mw)
-        mw.discussion_button.Disable.assert_called()
-        mw.forecast_products_us_only_label.Show.assert_called()
+        mw.discussion_button.Enable.assert_called()
+        mw.forecast_products_us_only_label.Hide.assert_called()

--- a/tests/test_discussion_routing.py
+++ b/tests/test_discussion_routing.py
@@ -51,7 +51,7 @@ class TestDiscussionRouting:
         When current location is set, _on_forecast_products should run.
 
         Unit 8 rerouted this branch from the old single-AFD DiscussionDialog to
-        the new tabbed ForecastProductsDialog (AFD + HWO + SPS).
+        the tabbed ForecastProductsDialog.
         """
         from accessiweather.ui.main_window import MainWindow
 

--- a/tests/test_forecast_product_service.py
+++ b/tests/test_forecast_product_service.py
@@ -250,6 +250,66 @@ class TestForecastProductServiceSurfConditions:
         assert "Beach-weather context from Pirate Weather" in result.product_text
         pirate.assert_awaited_once_with(location, weather_client=weather_client)
 
+    @pytest.mark.asyncio
+    async def test_surf_conditions_cache_hit_returns_cached_none(self):
+        cache = Cache()
+        location = type("Location", (), {"name": "Nowhere", "cwa_office": ""})()
+        cache.set(ForecastProductService._surf_conditions_cache_key(location), None, ttl=3600)
+        openmeteo = AsyncMock(return_value=_srf())
+        service = ForecastProductService(cache, openmeteo_marine_fetcher=openmeteo)
+
+        result = await service.get_surf_conditions_for_location(location)
+
+        assert result is None
+        openmeteo.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_srf_fetch_error_falls_back_to_openmeteo(self):
+        cache = Cache()
+        fetcher = AsyncMock(side_effect=TextProductFetchError("no srf"))
+        openmeteo_product = TextProduct(
+            product_type="SURF_CONDITIONS",
+            product_id="openmeteo",
+            cwa_office="Open-Meteo Marine",
+            issuance_time=None,
+            product_text="Open-Meteo fallback",
+            headline="Surf conditions from Open-Meteo Marine",
+        )
+        openmeteo = AsyncMock(return_value=openmeteo_product)
+        service = ForecastProductService(
+            cache,
+            fetcher=fetcher,
+            openmeteo_marine_fetcher=openmeteo,
+            pirate_beach_fetcher=AsyncMock(return_value=None),
+        )
+        location = type("Location", (), {"name": "Lumberton", "cwa_office": "PHI"})()
+
+        result = await service.get_surf_conditions_for_location(location)
+
+        assert result is openmeteo_product
+        fetcher.assert_awaited_once_with("SRF", "PHI")
+
+    @pytest.mark.asyncio
+    async def test_derived_fetcher_exceptions_return_none(self):
+        cache = Cache()
+
+        async def failing_openmeteo(*_args, **_kwargs):
+            raise RuntimeError("marine unavailable")
+
+        async def failing_pirate(*_args, **_kwargs):
+            raise RuntimeError("pirate unavailable")
+
+        service = ForecastProductService(
+            cache,
+            openmeteo_marine_fetcher=failing_openmeteo,
+            pirate_beach_fetcher=failing_pirate,
+        )
+        location = type("Location", (), {"name": "Porto", "cwa_office": ""})()
+
+        result = await service.get_surf_conditions_for_location(location)
+
+        assert result is None
+
 
 class TestForecastProductServiceEmpty:
     @pytest.mark.asyncio

--- a/tests/test_forecast_product_service.py
+++ b/tests/test_forecast_product_service.py
@@ -44,6 +44,17 @@ def _sps(office: str = "PHI", product_id: str = "sps-1") -> TextProduct:
     )
 
 
+def _srf(office: str = "PHI", product_id: str = "srf-1") -> TextProduct:
+    return TextProduct(
+        product_type="SRF",
+        product_id=product_id,
+        cwa_office=office,
+        issuance_time=datetime(2026, 4, 16, 14, 32, 0, tzinfo=UTC),
+        product_text="SURF ZONE FORECAST\nNew Jersey beaches...",
+        headline="Surf Zone Forecast",
+    )
+
+
 class TestForecastProductServiceCaching:
     @pytest.mark.asyncio
     async def test_repeat_calls_within_ttl_hit_cache(self):
@@ -125,11 +136,119 @@ class TestForecastProductServiceCacheKeys:
         afd = await service.get("AFD", "PHI")
         hwo = await service.get("HWO", "PHI")
         sps = await service.get("SPS", "PHI")
+        srf = await service.get("SRF", "PHI")
 
         assert isinstance(afd, TextProduct) and afd.product_type == "AFD"
         assert isinstance(hwo, TextProduct) and hwo.product_type == "HWO"
         assert isinstance(sps, list)
-        assert fetcher.call_count == 3
+        assert isinstance(srf, TextProduct) and srf.product_type == "SRF"
+        assert fetcher.call_count == 4
+
+
+class TestForecastProductServiceSurfConditions:
+    @pytest.mark.asyncio
+    async def test_official_srf_preferred_over_derived_conditions(self):
+        cache = Cache()
+        fetcher = AsyncMock(return_value=_srf())
+        openmeteo = AsyncMock(
+            return_value=TextProduct(
+                product_type="SURF_CONDITIONS",
+                product_id="openmeteo",
+                cwa_office="Open-Meteo Marine",
+                issuance_time=None,
+                product_text="derived",
+                headline="Surf conditions from Open-Meteo Marine",
+            )
+        )
+        pirate = AsyncMock(return_value=None)
+        service = ForecastProductService(
+            cache,
+            fetcher=fetcher,
+            openmeteo_marine_fetcher=openmeteo,
+            pirate_beach_fetcher=pirate,
+        )
+        location = type("Location", (), {"name": "Lumberton", "cwa_office": "PHI"})()
+
+        result = await service.get_surf_conditions_for_location(location)
+
+        assert isinstance(result, TextProduct)
+        assert result.product_type == "SRF"
+        assert "SURF ZONE FORECAST" in result.product_text
+        fetcher.assert_awaited_once_with("SRF", "PHI")
+        openmeteo.assert_not_awaited()
+        pirate.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_openmeteo_marine_used_when_official_srf_missing(self):
+        cache = Cache()
+        fetcher = AsyncMock(return_value=None)
+        openmeteo_product = TextProduct(
+            product_type="SURF_CONDITIONS",
+            product_id="openmeteo",
+            cwa_office="Open-Meteo Marine",
+            issuance_time=None,
+            product_text=(
+                "Surf conditions from Open-Meteo Marine for Porto.\n"
+                "Marine/surf conditions from Open-Meteo Marine; not an official NWS "
+                "Surf Zone Forecast."
+            ),
+            headline="Surf conditions from Open-Meteo Marine",
+        )
+        openmeteo = AsyncMock(return_value=openmeteo_product)
+        pirate = AsyncMock(return_value=None)
+        service = ForecastProductService(
+            cache,
+            fetcher=fetcher,
+            openmeteo_marine_fetcher=openmeteo,
+            pirate_beach_fetcher=pirate,
+        )
+        location = type("Location", (), {"name": "Porto", "cwa_office": ""})()
+
+        result = await service.get_surf_conditions_for_location(location)
+
+        assert result is openmeteo_product
+        assert result.product_type == "SURF_CONDITIONS"
+        assert "not an official NWS Surf Zone Forecast" in result.product_text
+        fetcher.assert_not_awaited()
+        openmeteo.assert_awaited_once_with(location)
+        pirate.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pirate_weather_used_when_openmeteo_marine_unavailable(self):
+        cache = Cache()
+        fetcher = AsyncMock(return_value=None)
+        openmeteo = AsyncMock(return_value=None)
+        pirate_product = TextProduct(
+            product_type="SURF_CONDITIONS",
+            product_id="pirate",
+            cwa_office="Pirate Weather",
+            issuance_time=None,
+            product_text=(
+                "Surf conditions from Pirate Weather for London.\n"
+                "Beach-weather context from Pirate Weather; not an official NWS Surf "
+                "Zone Forecast."
+            ),
+            headline="Surf conditions from Pirate Weather",
+        )
+        pirate = AsyncMock(return_value=pirate_product)
+        service = ForecastProductService(
+            cache,
+            fetcher=fetcher,
+            openmeteo_marine_fetcher=openmeteo,
+            pirate_beach_fetcher=pirate,
+        )
+        location = type("Location", (), {"name": "London", "cwa_office": ""})()
+        weather_client = object()
+
+        result = await service.get_surf_conditions_for_location(
+            location,
+            weather_client=weather_client,
+        )
+
+        assert result is pirate_product
+        assert result.product_type == "SURF_CONDITIONS"
+        assert "Beach-weather context from Pirate Weather" in result.product_text
+        pirate.assert_awaited_once_with(location, weather_client=weather_client)
 
 
 class TestForecastProductServiceEmpty:

--- a/tests/test_main_window_product_prewarm.py
+++ b/tests/test_main_window_product_prewarm.py
@@ -1,14 +1,14 @@
 """
 Tests for ``MainWindow._pre_warm_products_for_location``.
 
-Unit 9 adds a background pre-warm step that fetches AFD/HWO/SPS for every
+Unit 9 adds a background pre-warm step that fetches AFD/HWO/SPS/SRF for every
 saved US location with a populated ``cwa_office`` whenever the active
 location's weather refresh succeeds (and symmetrically for non-active
 locations inside ``_pre_warm_other_locations``).
 
 The tests exercise the helper directly rather than driving the full
-``_fetch_weather_data`` path — the helper is where all the policy lives
-(US-only, cwa gating, per-product failure isolation) and driving it
+``_fetch_weather_data`` path — the helper is where the official NWS text-product
+policy lives (US-only, cwa gating, per-product failure isolation) and driving it
 directly keeps the test surface narrow.
 """
 
@@ -69,14 +69,14 @@ def test_pre_warm_fetches_text_products_and_daily_climate_for_us_location():
     win = _make_window(service)
     asyncio.run(win._pre_warm_products_for_location(_us_location("Philadelphia")))
 
-    assert service.get.await_count == 3
+    assert service.get.await_count == 4
     fetched_types = {call.args[0] for call in service.get.await_args_list}
-    assert fetched_types == {"AFD", "HWO", "SPS"}
+    assert fetched_types == {"AFD", "HWO", "SPS", "SRF"}
     service.get_daily_climate_report_for_location.assert_awaited_once()
 
 
 def test_pre_warm_starts_daily_climate_without_waiting_for_other_products():
-    """CLI pre-warm should begin beside AFD/HWO/SPS so the tab opens warm."""
+    """CLI pre-warm should begin beside AFD/HWO/SPS/SRF so the tab opens warm."""
     started: list[str] = []
     release_products = asyncio.Event()
 
@@ -134,7 +134,7 @@ def test_pre_warm_skips_us_location_without_cwa_office():
 
 
 def test_pre_warm_fetch_error_isolated_to_single_product():
-    """A ``TextProductFetchError`` on HWO doesn't block AFD or SPS."""
+    """A ``TextProductFetchError`` on HWO doesn't block other NWS products."""
     service = MagicMock()
 
     async def _get(product_type: str, _cwa: str, **_kw):
@@ -148,9 +148,9 @@ def test_pre_warm_fetch_error_isolated_to_single_product():
     # Should NOT raise — failure isolation is the whole point.
     asyncio.run(win._pre_warm_products_for_location(_us_location("Philadelphia")))
 
-    assert service.get.await_count == 3
+    assert service.get.await_count == 4
     fetched_types = [call.args[0] for call in service.get.await_args_list]
-    assert fetched_types == ["AFD", "HWO", "SPS"]
+    assert fetched_types == ["AFD", "HWO", "SPS", "SRF"]
 
 
 def test_pre_warm_unexpected_exception_is_swallowed():
@@ -167,7 +167,7 @@ def test_pre_warm_unexpected_exception_is_swallowed():
     win = _make_window(service)
     asyncio.run(win._pre_warm_products_for_location(_us_location("Philadelphia")))
 
-    assert service.get.await_count == 3
+    assert service.get.await_count == 4
 
 
 class _FakeWeatherClient:
@@ -236,7 +236,7 @@ async def test_fetch_weather_data_warms_active_products_before_ui_delivery():
 
 @pytest.mark.asyncio
 async def test_pre_warm_other_locations_iterates_saved_us_locations():
-    """With three saved US locations, the non-active two each get three fetches."""
+    """With three saved US locations, the non-active two each get four fetches."""
     service = MagicMock()
     service.get = AsyncMock(return_value=None)
 
@@ -250,12 +250,17 @@ async def test_pre_warm_other_locations_iterates_saved_us_locations():
 
     await win._pre_warm_other_locations(active)
 
-    # Two non-active US locations * 3 product types = 6 fetches.
-    assert service.get.await_count == 6
+    # Two non-active US locations * 4 product types = 8 fetches.
+    assert service.get.await_count == 8
     cwas_by_product = {call.args[0]: set() for call in service.get.await_args_list}
     for call in service.get.await_args_list:
         cwas_by_product[call.args[0]].add(call.args[1])
-    assert cwas_by_product == {"AFD": {"OKX", "BOX"}, "HWO": {"OKX", "BOX"}, "SPS": {"OKX", "BOX"}}
+    assert cwas_by_product == {
+        "AFD": {"OKX", "BOX"},
+        "HWO": {"OKX", "BOX"},
+        "SPS": {"OKX", "BOX"},
+        "SRF": {"OKX", "BOX"},
+    }
 
 
 @pytest.mark.asyncio
@@ -272,7 +277,7 @@ async def test_pre_warm_other_locations_skips_non_us_peers():
 
     await win._pre_warm_other_locations(active)
 
-    # Only the US peer contributes fetches (3), the non-US one is skipped.
-    assert service.get.await_count == 3
+    # Only the US peer contributes fetches (4), the non-US one is skipped.
+    assert service.get.await_count == 4
     fetched_cwas = {call.args[1] for call in service.get.await_args_list}
     assert fetched_cwas == {"OKX"}

--- a/tests/test_surf_conditions.py
+++ b/tests/test_surf_conditions.py
@@ -1,0 +1,115 @@
+"""Tests for source-labelled surf and beach condition summaries."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from accessiweather.models import Location, TextProduct
+from accessiweather.surf_conditions import (
+    fetch_openmeteo_marine_surf_conditions,
+    fetch_pirate_weather_beach_conditions,
+    format_openmeteo_marine_report,
+)
+
+
+def _location(name: str = "Porto") -> Location:
+    return Location(name=name, latitude=41.15, longitude=-8.63, country_code="PT")
+
+
+def _resp(json_data, status_code: int = 200) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    return resp
+
+
+def test_openmeteo_marine_report_labels_derived_conditions():
+    report = format_openmeteo_marine_report(
+        {
+            "current": {
+                "time": "2026-06-07T12:00",
+                "wave_height": 1.4,
+                "wave_direction": 270,
+                "wave_period": 8,
+                "swell_wave_height": 0.9,
+                "swell_wave_direction": 250,
+                "swell_wave_period": 11,
+                "sea_surface_temperature": 18.5,
+            },
+            "current_units": {
+                "wave_height": "m",
+                "wave_period": "s",
+                "swell_wave_height": "m",
+                "swell_wave_period": "s",
+                "sea_surface_temperature": "°C",
+            },
+        },
+        _location(),
+    )
+
+    assert report is not None
+    product = report.to_text_product()
+    assert product.product_type == "SURF_CONDITIONS"
+    assert "Surf conditions from Open-Meteo Marine for Porto." in product.product_text
+    assert "not an official NWS Surf Zone Forecast" in product.product_text
+    assert "Wave height: 1.4 m." in product.product_text
+    assert "Wave direction: W (270 degrees)." in product.product_text
+
+
+@pytest.mark.asyncio
+async def test_fetch_openmeteo_marine_surf_conditions_uses_marine_endpoint():
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.get.return_value = _resp(
+        {
+            "current": {"time": "2026-06-07T12:00", "wave_height": 2.0},
+            "current_units": {"wave_height": "m"},
+        }
+    )
+
+    result = await fetch_openmeteo_marine_surf_conditions(
+        _location(),
+        marine_base_url="https://example.test/v1",
+        client=client,
+    )
+
+    assert isinstance(result, TextProduct)
+    assert result.product_type == "SURF_CONDITIONS"
+    assert result.cwa_office == "Open-Meteo Marine"
+    assert "not an official NWS Surf Zone Forecast" in result.product_text
+    client.get.assert_called_once()
+    assert client.get.call_args.args[0] == "https://example.test/v1/marine"
+    assert "wave_height" in client.get.call_args.kwargs["params"]["current"]
+
+
+@pytest.mark.asyncio
+async def test_pirate_weather_beach_conditions_use_only_available_weather_context():
+    pirate_client = MagicMock()
+    pirate_client.get_forecast_data = AsyncMock(
+        return_value={
+            "currently": {
+                "summary": "Breezy",
+                "temperature": 70,
+                "apparentTemperature": 68,
+                "windSpeed": 14,
+                "windGust": 24,
+                "windBearing": 180,
+                "uvIndex": 6,
+                "visibility": 9,
+                "precipProbability": 0.2,
+            }
+        }
+    )
+    weather_client = MagicMock()
+    weather_client._pirate_weather_client_for_location.return_value = pirate_client
+
+    result = await fetch_pirate_weather_beach_conditions(_location("Brighton"), weather_client)
+
+    assert isinstance(result, TextProduct)
+    assert result.product_type == "SURF_CONDITIONS"
+    assert "Surf conditions from Pirate Weather for Brighton." in result.product_text
+    assert "not an official NWS Surf Zone Forecast" in result.product_text
+    assert "wave data is not available from this source" in result.product_text
+    assert "Wind direction: S (180 degrees)." in result.product_text

--- a/tests/test_surf_conditions.py
+++ b/tests/test_surf_conditions.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
+from accessiweather import surf_conditions
 from accessiweather.models import Location, TextProduct
 from accessiweather.surf_conditions import (
     fetch_openmeteo_marine_surf_conditions,
@@ -24,6 +25,17 @@ def _resp(json_data, status_code: int = 200) -> MagicMock:
     resp.status_code = status_code
     resp.json.return_value = json_data
     return resp
+
+
+class _AsyncClientContext:
+    def __init__(self, client):
+        self.client = client
+
+    async def __aenter__(self):
+        return self.client
+
+    async def __aexit__(self, *_exc_info):
+        return False
 
 
 def test_openmeteo_marine_report_labels_derived_conditions():
@@ -60,6 +72,41 @@ def test_openmeteo_marine_report_labels_derived_conditions():
 
 
 @pytest.mark.asyncio
+async def test_client_get_accepts_synchronous_test_double():
+    client = MagicMock(spec=httpx.AsyncClient)
+    response = _resp({"ok": True})
+    client.get.return_value = response
+
+    result = await surf_conditions._client_get(client, "https://example.test")
+
+    assert result is response
+
+
+def test_openmeteo_format_helpers_ignore_empty_values():
+    assert surf_conditions._first_present({"wave_height": []}, "wave_height") is None
+    assert surf_conditions._format_value("   ", "m") is None
+    assert surf_conditions._format_direction("offshore") == "offshore"
+
+
+def test_openmeteo_marine_report_requires_current_marine_values():
+    assert format_openmeteo_marine_report({"current": {}}, _location()) is None
+    assert (
+        format_openmeteo_marine_report({"current": {"time": "2026-06-07T12:00"}}, _location())
+        is None
+    )
+
+
+def test_openmeteo_marine_report_tolerates_invalid_time():
+    report = format_openmeteo_marine_report(
+        {"current": {"time": "not-a-time", "wave_height": 1.2}},
+        _location(),
+    )
+
+    assert report is not None
+    assert report.issued_at is not None
+
+
+@pytest.mark.asyncio
 async def test_fetch_openmeteo_marine_surf_conditions_uses_marine_endpoint():
     client = MagicMock(spec=httpx.AsyncClient)
     client.get.return_value = _resp(
@@ -82,6 +129,57 @@ async def test_fetch_openmeteo_marine_surf_conditions_uses_marine_endpoint():
     client.get.assert_called_once()
     assert client.get.call_args.args[0] == "https://example.test/v1/marine"
     assert "wave_height" in client.get.call_args.kwargs["params"]["current"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_openmeteo_marine_surf_conditions_requires_coordinates():
+    location = type("Location", (), {"name": "Unknown", "latitude": None, "longitude": -8.63})()
+
+    result = await fetch_openmeteo_marine_surf_conditions(location)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_openmeteo_marine_surf_conditions_handles_unavailable_response():
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.get.return_value = _resp({}, status_code=500)
+
+    result = await fetch_openmeteo_marine_surf_conditions(_location(), client=client)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_openmeteo_marine_surf_conditions_handles_transport_errors():
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.get.side_effect = httpx.TransportError("offline")
+
+    result = await fetch_openmeteo_marine_surf_conditions(_location(), client=client)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_openmeteo_marine_surf_conditions_creates_client(monkeypatch):
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.get.return_value = _resp(
+        {
+            "current": {"time": "2026-06-07T12:00", "wave_height": 1.0},
+            "current_units": {"wave_height": "m"},
+        }
+    )
+
+    def fake_async_client(**kwargs):
+        assert kwargs == {"timeout": 3.0, "follow_redirects": True}
+        return _AsyncClientContext(client)
+
+    monkeypatch.setattr(surf_conditions.httpx, "AsyncClient", fake_async_client)
+
+    result = await fetch_openmeteo_marine_surf_conditions(_location(), timeout=3.0)
+
+    assert isinstance(result, TextProduct)
+    client.get.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -113,3 +211,45 @@ async def test_pirate_weather_beach_conditions_use_only_available_weather_contex
     assert "not an official NWS Surf Zone Forecast" in result.product_text
     assert "wave data is not available from this source" in result.product_text
     assert "Wind direction: S (180 degrees)." in result.product_text
+
+
+@pytest.mark.asyncio
+async def test_pirate_weather_beach_conditions_require_available_client():
+    assert await fetch_pirate_weather_beach_conditions(_location()) is None
+    assert await fetch_pirate_weather_beach_conditions(_location(), MagicMock()) is None
+
+
+@pytest.mark.asyncio
+async def test_pirate_weather_beach_conditions_use_fallback_client_attribute():
+    pirate_client = MagicMock()
+    pirate_client.get_forecast_data = AsyncMock(
+        return_value={"currently": {"summary": "Clear", "windSpeed": 8}}
+    )
+    weather_client = MagicMock()
+    weather_client._pirate_weather_client_for_location.return_value = None
+    weather_client.pirate_weather_client = pirate_client
+
+    result = await fetch_pirate_weather_beach_conditions(_location(), weather_client)
+
+    assert isinstance(result, TextProduct)
+    assert "Conditions: Clear." in result.product_text
+    assert "Wind speed: 8 mph." in result.product_text
+
+
+@pytest.mark.asyncio
+async def test_pirate_weather_beach_conditions_handles_unavailable_payloads():
+    pirate_client = MagicMock()
+    weather_client = MagicMock()
+    weather_client._pirate_weather_client_for_location.return_value = pirate_client
+
+    pirate_client.get_forecast_data = AsyncMock(side_effect=RuntimeError("offline"))
+    assert await fetch_pirate_weather_beach_conditions(_location(), weather_client) is None
+
+    pirate_client.get_forecast_data = AsyncMock(return_value=["not", "a", "dict"])
+    assert await fetch_pirate_weather_beach_conditions(_location(), weather_client) is None
+
+    pirate_client.get_forecast_data = AsyncMock(return_value={"currently": []})
+    assert await fetch_pirate_weather_beach_conditions(_location(), weather_client) is None
+
+    pirate_client.get_forecast_data = AsyncMock(return_value={"currently": {}})
+    assert await fetch_pirate_weather_beach_conditions(_location(), weather_client) is None

--- a/tests/test_weather_client_nws_text_product.py
+++ b/tests/test_weather_client_nws_text_product.py
@@ -2,7 +2,7 @@
 Tests for the generic NWS text-product fetcher.
 
 Covers:
-- ``get_nws_text_product`` for AFD / HWO / SPS
+- ``get_nws_text_product`` for office-issued NWS text products
 - ``TextProductFetchError`` signalling network / non-200 failures
 - ``get_nws_discussion`` backward-compat wrapper preserves its tuple shape
 """
@@ -167,6 +167,35 @@ class TestGetNwsTextProductHWO:
         assert result.product_id == "hwo-001"
         assert result.cwa_office == OFFICE
         assert "HAZARDOUS WEATHER" in result.product_text
+
+
+class TestGetNwsTextProductSRF:
+    @pytest.mark.asyncio
+    async def test_srf_returns_single_official_text_product(self):
+        graph = {
+            "@graph": [
+                {"id": "srf-phi", "issuanceTime": "2026-06-07T10:00:00+00:00"},
+            ]
+        }
+        product = {
+            "productText": "SURF ZONE FORECAST\nNew Jersey and Delaware beaches...\n",
+            "issuanceTime": "2026-06-07T10:00:00+00:00",
+            "headline": "Surf Zone Forecast",
+        }
+        client = _client_for(
+            {
+                f"{NWS_BASE}/products/types/SRF/locations/{OFFICE}": _resp(graph),
+                f"{NWS_BASE}/products/srf-phi": _resp(product),
+            }
+        )
+
+        result = await get_nws_text_product("SRF", OFFICE, nws_base_url=NWS_BASE, client=client)
+
+        assert isinstance(result, TextProduct)
+        assert result.product_type == "SRF"
+        assert result.cwa_office == OFFICE
+        assert result.headline == "Surf Zone Forecast"
+        assert "SURF ZONE FORECAST" in result.product_text
 
 
 class TestGetNwsTextProductHistory:


### PR DESCRIPTION
## Summary
- add official NWS Surf Zone Forecast (SRF) support through the existing text-product service and Advanced Lookup paths
- add a Surf/Beach Conditions tab that prefers official NWS SRF and falls back to clearly labelled Open-Meteo Marine or Pirate Weather beach context
- keep non-U.S. locations able to open Forecaster Notes for supported global surf/beach conditions

## Verification
- pytest tests/test_surf_conditions.py tests/test_forecast_product_service.py tests/test_weather_client_nws_text_product.py tests/gui/test_forecast_product_panel.py tests/gui/test_forecast_products_dialog.py tests/gui/test_advanced_text_product_dialog.py tests/test_main_window_product_prewarm.py -q
- ruff check src/accessiweather/surf_conditions.py src/accessiweather/services/forecast_product_service.py src/accessiweather/weather_client_nws_forecast.py src/accessiweather/ui/dialogs/forecast_product_formatting.py src/accessiweather/ui/dialogs/forecast_product_panel.py src/accessiweather/ui/dialogs/forecast_products_dialog.py src/accessiweather/ui/dialogs/advanced_text_product_dialog.py src/accessiweather/ui/main_window_commands.py src/accessiweather/ui/main_window_refresh.py src/accessiweather/ui/main_window_ui.py tests/test_surf_conditions.py tests/test_forecast_product_service.py tests/test_weather_client_nws_text_product.py tests/gui/test_forecast_product_panel.py tests/gui/test_forecast_products_dialog.py tests/gui/test_advanced_text_product_dialog.py tests/test_main_window_product_prewarm.py

## Accessibility
- Uses existing wx.Notebook, wx.StaticText, read-only wx.TextCtrl, and labelled wx.Button controls.
- Keeps focus behavior on the notebook tab strip.
- Includes official-vs-derived surf source status inside the readable text content for screen reader users.