### PR TITLE
fix: sanitize implausible feels-like readings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - NOAA Weather Radio stations can now be saved as favorites, with a Favorites finder mode and optional nearby-station lookup from your saved AccessiWeather locations.
 
 ### Fixed
+- Feels-like and heat-index readings now ignore implausibly warm provider values when the current temperature and humidity do not support them, while keeping valid humid heat-index and cold wind-chill readings.
 - Unknown or uncategorized weather alerts now have a mappable default sound, and missing custom-pack event sounds fall back to the matching default sound before generic notification audio.
 - NOAA Weather Radio Station Finder now repopulates stations when leaving an empty Favorites view, so you no longer need to reopen the radio dialog.
 

--- a/src/accessiweather/display/presentation/measurement_formatters.py
+++ b/src/accessiweather/display/presentation/measurement_formatters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ...models import CurrentConditions, ForecastPeriod, HourlyForecastPeriod
+from ...thermal_comfort import sanitize_thermal_comfort_readings
 from ...units import DisplayUnitSystem
 from ...utils import (
     TemperatureUnit,
@@ -219,6 +220,17 @@ def select_feels_like_temperature(
         wind_mph = current.wind_speed_kph * 0.621371
 
     humidity = current.humidity
+    comfort = sanitize_thermal_comfort_readings(
+        temperature_f=temp_f,
+        temperature_c=current.temperature_c,
+        humidity=humidity,
+        feels_like_f=current.feels_like_f,
+        feels_like_c=current.feels_like_c,
+        wind_chill_f=current.wind_chill_f,
+        wind_chill_c=current.wind_chill_c,
+        heat_index_f=current.heat_index_f,
+        heat_index_c=current.heat_index_c,
+    )
 
     # Check for wind chill conditions: cold and windy
     if (
@@ -226,12 +238,9 @@ def select_feels_like_temperature(
         and temp_f < 50
         and wind_mph is not None
         and wind_mph > 3
-        and current.wind_chill_f is not None
+        and comfort.wind_chill_f is not None
     ):
-        wind_chill_c = current.wind_chill_c
-        if wind_chill_c is None and current.wind_chill_f is not None:
-            wind_chill_c = (current.wind_chill_f - 32) * 5 / 9
-        return current.wind_chill_f, wind_chill_c, "wind chill"
+        return comfort.wind_chill_f, comfort.wind_chill_c, "wind chill"
 
     # Check for heat index conditions: hot and humid
     if (
@@ -239,16 +248,13 @@ def select_feels_like_temperature(
         and temp_f > 80
         and humidity is not None
         and humidity > 40
-        and current.heat_index_f is not None
+        and comfort.heat_index_f is not None
     ):
-        heat_index_c = current.heat_index_c
-        if heat_index_c is None and current.heat_index_f is not None:
-            heat_index_c = (current.heat_index_f - 32) * 5 / 9
-        return current.heat_index_f, heat_index_c, "heat index"
+        return comfort.heat_index_f, comfort.heat_index_c, "heat index"
 
     # Fall back to existing feels_like or actual temperature
-    if current.feels_like_f is not None or current.feels_like_c is not None:
-        return current.feels_like_f, current.feels_like_c, None
+    if comfort.feels_like_f is not None or comfort.feels_like_c is not None:
+        return comfort.feels_like_f, comfort.feels_like_c, None
 
     return current.temperature_f, current.temperature_c, None
 

--- a/src/accessiweather/pirate_weather_current.py
+++ b/src/accessiweather/pirate_weather_current.py
@@ -22,6 +22,7 @@ from .provider_normalization import (
     pirate_visibility_unit,
     pirate_wind_unit,
 )
+from .thermal_comfort import sanitize_thermal_comfort_readings
 from .weather_client_parsers import degrees_to_cardinal, describe_moon_phase
 
 
@@ -52,6 +53,14 @@ def parse_current_conditions(client: Any, data: dict) -> CurrentConditions:
     visibility = normalize_visibility_pair(current.get("visibility"), visibility_unit)
 
     feels_like = normalize_temperature_pair(current.get("apparentTemperature"), temperature_unit)
+
+    comfort = sanitize_thermal_comfort_readings(
+        temperature_f=temperature.fahrenheit,
+        temperature_c=temperature.celsius,
+        humidity=humidity,
+        feels_like_f=feels_like.fahrenheit,
+        feels_like_c=feels_like.celsius,
+    )
 
     wind_gust = normalize_speed_pair(current.get("windGust"), wind_unit)
 
@@ -96,8 +105,8 @@ def parse_current_conditions(client: Any, data: dict) -> CurrentConditions:
         wind_direction=degrees_to_cardinal(wind_direction),
         pressure_in=pressure.inches,
         pressure_mb=pressure.millibars,
-        feels_like_f=feels_like.fahrenheit,
-        feels_like_c=feels_like.celsius,
+        feels_like_f=comfort.feels_like_f,
+        feels_like_c=comfort.feels_like_c,
         visibility_miles=visibility.miles,
         visibility_km=visibility.kilometers,
         uv_index=uv_index,
@@ -110,4 +119,8 @@ def parse_current_conditions(client: Any, data: dict) -> CurrentConditions:
         sunrise_time=sunrise_time,
         sunset_time=sunset_time,
         moon_phase=moon_phase,
+        wind_chill_f=comfort.wind_chill_f,
+        wind_chill_c=comfort.wind_chill_c,
+        heat_index_f=comfort.heat_index_f,
+        heat_index_c=comfort.heat_index_c,
     )

--- a/src/accessiweather/thermal_comfort.py
+++ b/src/accessiweather/thermal_comfort.py
@@ -1,0 +1,187 @@
+"""Sanity helpers for apparent temperature, wind chill, and heat index readings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+WARM_FEELS_LIKE_DISPLAY_THRESHOLD_F = 3.0
+HEAT_INDEX_COHERENCE_TOLERANCE_F = 2.5
+APPARENT_TEMPERATURE_SOLAR_ALLOWANCE_BASE_F = 4.0
+APPARENT_TEMPERATURE_SOLAR_ALLOWANCE_MAX_F = 5.5
+APPARENT_TEMPERATURE_SOLAR_ALLOWANCE_PER_DEGREE_F = 0.15
+HEAT_INDEX_MIN_TEMP_F = 80.0
+HEAT_INDEX_MIN_HUMIDITY = 40
+
+
+@dataclass(frozen=True)
+class ThermalComfortReadings:
+    """Normalized and sanity-checked apparent-temperature readings."""
+
+    feels_like_f: float | None = None
+    feels_like_c: float | None = None
+    wind_chill_f: float | None = None
+    wind_chill_c: float | None = None
+    heat_index_f: float | None = None
+    heat_index_c: float | None = None
+
+
+def sanitize_thermal_comfort_readings(
+    *,
+    temperature_f: float | None,
+    temperature_c: float | None = None,
+    humidity: int | float | None,
+    feels_like_f: float | None = None,
+    feels_like_c: float | None = None,
+    wind_chill_f: float | None = None,
+    wind_chill_c: float | None = None,
+    heat_index_f: float | None = None,
+    heat_index_c: float | None = None,
+) -> ThermalComfortReadings:
+    """
+    Normalize and discard internally inconsistent thermal-comfort readings.
+
+    Literal heat-index readings must remain coherent with the standard heat-index
+    envelope. Provider apparent temperatures get a small extra warm allowance for
+    non-humidity effects such as sun exposure. Cold apparent temperatures are
+    preserved so existing wind-chill behavior remains intact.
+    """
+    temp_f = _to_fahrenheit(temperature_f, temperature_c)
+    feels_f = _to_fahrenheit(feels_like_f, feels_like_c)
+    chill_f = _to_fahrenheit(wind_chill_f, wind_chill_c)
+    heat_f = _to_fahrenheit(heat_index_f, heat_index_c)
+
+    if not warm_apparent_temperature_is_coherent(temp_f, humidity, feels_f):
+        feels_f = None
+    if not warm_heat_index_is_coherent(temp_f, humidity, heat_f):
+        heat_f = None
+
+    if temp_f is not None:
+        if heat_f is not None and heat_f <= temp_f:
+            heat_f = None
+        if chill_f is not None and chill_f >= temp_f:
+            chill_f = None
+
+    if feels_f is not None and temp_f is not None:
+        if (
+            feels_f > temp_f
+            and heat_f is None
+            and warm_heat_index_is_coherent(temp_f, humidity, feels_f)
+        ):
+            heat_f = feels_f
+        elif feels_f < temp_f and chill_f is None:
+            chill_f = feels_f
+
+    if feels_f is None and temp_f is not None:
+        if chill_f is not None and chill_f < temp_f:
+            feels_f = chill_f
+        elif heat_f is not None and heat_f > temp_f:
+            feels_f = heat_f
+
+    return ThermalComfortReadings(
+        feels_like_f=feels_f,
+        feels_like_c=_to_celsius(feels_f),
+        wind_chill_f=chill_f,
+        wind_chill_c=_to_celsius(chill_f),
+        heat_index_f=heat_f,
+        heat_index_c=_to_celsius(heat_f),
+    )
+
+
+def calculate_heat_index_f(temperature_f: float, humidity: int | float) -> float | None:
+    """
+    Calculate the NOAA/NWS Rothfusz heat index in Fahrenheit when applicable.
+
+    Returns None outside the standard warm/humid heat-index range. This is used
+    as a sanity envelope, not as a replacement for source-provided readings.
+    """
+    if temperature_f < HEAT_INDEX_MIN_TEMP_F or humidity < HEAT_INDEX_MIN_HUMIDITY:
+        return None
+
+    heat_index = (
+        -42.379
+        + 2.04901523 * temperature_f
+        + 10.14333127 * humidity
+        - 0.22475541 * temperature_f * humidity
+        - 0.00683783 * temperature_f * temperature_f
+        - 0.05481717 * humidity * humidity
+        + 0.00122874 * temperature_f * temperature_f * humidity
+        + 0.00085282 * temperature_f * humidity * humidity
+        - 0.00000199 * temperature_f * temperature_f * humidity * humidity
+    )
+
+    if humidity > 85 and 80 <= temperature_f <= 87:
+        heat_index += ((humidity - 85) / 10) * ((87 - temperature_f) / 5)
+
+    return heat_index
+
+
+def warm_apparent_temperature_is_coherent(
+    temperature_f: float | None,
+    humidity: int | float | None,
+    apparent_f: float | None,
+) -> bool:
+    """Return whether a warm provider apparent temperature is plausible."""
+    if temperature_f is None or apparent_f is None or apparent_f <= temperature_f:
+        return True
+
+    if apparent_f - temperature_f < WARM_FEELS_LIKE_DISPLAY_THRESHOLD_F:
+        return True
+
+    if humidity is None:
+        return True
+
+    max_coherent = temperature_f + _solar_apparent_temperature_allowance_f(temperature_f)
+    heat_index = calculate_heat_index_f(temperature_f, humidity)
+    if heat_index is not None:
+        max_coherent = max(
+            max_coherent,
+            max(temperature_f, heat_index) + HEAT_INDEX_COHERENCE_TOLERANCE_F,
+        )
+
+    return apparent_f <= max_coherent
+
+
+def warm_heat_index_is_coherent(
+    temperature_f: float | None,
+    humidity: int | float | None,
+    heat_index_f: float | None,
+) -> bool:
+    """Return whether a literal or inferred heat-index reading is plausible."""
+    if temperature_f is None or heat_index_f is None or heat_index_f <= temperature_f:
+        return True
+
+    if heat_index_f - temperature_f < WARM_FEELS_LIKE_DISPLAY_THRESHOLD_F:
+        return True
+
+    if humidity is None:
+        return True
+
+    heat_index = calculate_heat_index_f(temperature_f, humidity)
+    if heat_index is None:
+        return False
+
+    max_coherent = max(temperature_f, heat_index) + HEAT_INDEX_COHERENCE_TOLERANCE_F
+    return heat_index_f <= max_coherent
+
+
+def _solar_apparent_temperature_allowance_f(temperature_f: float) -> float:
+    allowance = APPARENT_TEMPERATURE_SOLAR_ALLOWANCE_BASE_F
+    if temperature_f > HEAT_INDEX_MIN_TEMP_F:
+        allowance += (
+            temperature_f - HEAT_INDEX_MIN_TEMP_F
+        ) * APPARENT_TEMPERATURE_SOLAR_ALLOWANCE_PER_DEGREE_F
+    return min(allowance, APPARENT_TEMPERATURE_SOLAR_ALLOWANCE_MAX_F)
+
+
+def _to_fahrenheit(value_f: float | None, value_c: float | None) -> float | None:
+    if value_f is not None:
+        return float(value_f)
+    if value_c is not None:
+        return (float(value_c) * 9 / 5) + 32
+    return None
+
+
+def _to_celsius(value_f: float | None) -> float | None:
+    if value_f is None:
+        return None
+    return (value_f - 32) * 5 / 9

--- a/src/accessiweather/weather_client_fusion.py
+++ b/src/accessiweather/weather_client_fusion.py
@@ -43,6 +43,7 @@ from accessiweather.weather_client_fusion_values import (
     build_wind_gust_values,
     check_temperature_conflicts,
     discard_gust_if_below_wind_speed,
+    sanitize_thermal_comfort_values,
 )
 
 logger = logging.getLogger(__name__)
@@ -355,6 +356,7 @@ class DataFusionEngine:
             field_names=("heat_index_f", "heat_index_c"),
             value_builder=self._build_heat_index_values,
         )
+        self._sanitize_thermal_comfort_values(merged_values, attribution)
 
     def _apply_priority_group_selection(
         self,
@@ -483,6 +485,14 @@ class DataFusionEngine:
     ) -> None:
         """Drop wind gust when it is physically impossible."""
         discard_gust_if_below_wind_speed(merged_values, attribution)
+
+    def _sanitize_thermal_comfort_values(
+        self,
+        merged_values: dict[str, Any],
+        attribution: SourceAttribution,
+    ) -> None:
+        """Drop apparent-temperature readings that conflict with fused conditions."""
+        sanitize_thermal_comfort_values(merged_values, attribution)
 
     def _build_wind_gust_values(self, current: CurrentConditions) -> dict[str, float | None]:
         """Build aligned wind gust values from a single source."""

--- a/src/accessiweather/weather_client_fusion_values.py
+++ b/src/accessiweather/weather_client_fusion_values.py
@@ -11,6 +11,7 @@ from accessiweather.models.weather import (
     SourceAttribution,
     SourceData,
 )
+from accessiweather.thermal_comfort import sanitize_thermal_comfort_readings
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +95,71 @@ def discard_gust_if_below_wind_speed(
         merged_values.pop("wind_gust_kph", None)
         attribution.field_sources.pop("wind_gust_mph", None)
         attribution.field_sources.pop("wind_gust_kph", None)
+
+
+def sanitize_thermal_comfort_values(
+    merged_values: dict[str, Any], attribution: SourceAttribution
+) -> None:
+    """
+    Drop apparent-temperature readings that no longer fit after cross-source fusion.
+
+    Feels-like, wind-chill, and heat-index fields are selected independently from
+    temperature and humidity, so the final merged payload needs one more coherence
+    check before it is displayed.
+    """
+    comfort = sanitize_thermal_comfort_readings(
+        temperature_f=merged_values.get("temperature_f"),
+        temperature_c=merged_values.get("temperature_c"),
+        humidity=merged_values.get("humidity"),
+        feels_like_f=merged_values.get("feels_like_f"),
+        feels_like_c=merged_values.get("feels_like_c"),
+        wind_chill_f=merged_values.get("wind_chill_f"),
+        wind_chill_c=merged_values.get("wind_chill_c"),
+        heat_index_f=merged_values.get("heat_index_f"),
+        heat_index_c=merged_values.get("heat_index_c"),
+    )
+
+    _set_or_clear_thermal_field(merged_values, attribution, "feels_like_f", comfort.feels_like_f)
+    _set_or_clear_thermal_field(merged_values, attribution, "feels_like_c", comfort.feels_like_c)
+    _set_or_clear_thermal_field(merged_values, attribution, "wind_chill_f", comfort.wind_chill_f)
+    _set_or_clear_thermal_field(merged_values, attribution, "wind_chill_c", comfort.wind_chill_c)
+    _set_or_clear_thermal_field(merged_values, attribution, "heat_index_f", comfort.heat_index_f)
+    _set_or_clear_thermal_field(merged_values, attribution, "heat_index_c", comfort.heat_index_c)
+
+
+def _set_or_clear_thermal_field(
+    merged_values: dict[str, Any],
+    attribution: SourceAttribution,
+    field_name: str,
+    value: float | None,
+) -> None:
+    if value is None:
+        merged_values.pop(field_name, None)
+        attribution.field_sources.pop(field_name, None)
+    else:
+        merged_values[field_name] = value
+        source = _thermal_field_source(field_name, attribution)
+        if source is not None:
+            attribution.field_sources[field_name] = source
+
+
+def _thermal_field_source(field_name: str, attribution: SourceAttribution) -> str | None:
+    if field_name in attribution.field_sources:
+        return attribution.field_sources[field_name]
+
+    fallback_fields = {
+        "feels_like_f": ("feels_like_c", "wind_chill_f", "heat_index_f"),
+        "feels_like_c": ("feels_like_f", "wind_chill_c", "heat_index_c"),
+        "wind_chill_f": ("wind_chill_c", "feels_like_f", "feels_like_c"),
+        "wind_chill_c": ("wind_chill_f", "feels_like_c", "feels_like_f"),
+        "heat_index_f": ("heat_index_c", "feels_like_f", "feels_like_c"),
+        "heat_index_c": ("heat_index_f", "feels_like_c", "feels_like_f"),
+    }
+    for fallback_field in fallback_fields.get(field_name, ()):
+        source = attribution.field_sources.get(fallback_field)
+        if source is not None:
+            return source
+    return None
 
 
 def build_wind_gust_values(current: CurrentConditions) -> dict[str, float | None]:

--- a/src/accessiweather/weather_client_nws_parsers.py
+++ b/src/accessiweather/weather_client_nws_parsers.py
@@ -8,6 +8,7 @@ from .provider_normalization import (
     normalize_pressure_pair,
     normalize_temperature_pair,
 )
+from .thermal_comfort import sanitize_thermal_comfort_readings
 from .weather_client_nws_common import *  # noqa: F403
 from .weather_client_parsers import normalize_pressure
 
@@ -80,19 +81,15 @@ def parse_nws_current_conditions(
         props.get("heatIndex", {}).get("unitCode") or "wmoUnit:degC",
     )
 
-    # Determine feels_like based on wind chill or heat index
-    feels_like_f = None
-    feels_like_c = None
-    if wind_chill.fahrenheit is not None and (
-        temperature.fahrenheit is None or wind_chill.fahrenheit < temperature.fahrenheit
-    ):
-        feels_like_f = wind_chill.fahrenheit
-        feels_like_c = wind_chill.celsius
-    elif heat_index.fahrenheit is not None and (
-        temperature.fahrenheit is None or heat_index.fahrenheit > temperature.fahrenheit
-    ):
-        feels_like_f = heat_index.fahrenheit
-        feels_like_c = heat_index.celsius
+    comfort = sanitize_thermal_comfort_readings(
+        temperature_f=temperature.fahrenheit,
+        temperature_c=temperature.celsius,
+        humidity=humidity,
+        wind_chill_f=wind_chill.fahrenheit,
+        wind_chill_c=wind_chill.celsius,
+        heat_index_f=heat_index.fahrenheit,
+        heat_index_c=heat_index.celsius,
+    )
 
     return CurrentConditions(
         temperature_f=temperature.fahrenheit,
@@ -106,16 +103,16 @@ def parse_nws_current_conditions(
         wind_direction=wind_direction,
         pressure_in=pressure.inches,
         pressure_mb=pressure.millibars,
-        feels_like_f=feels_like_f,
-        feels_like_c=feels_like_c,
+        feels_like_f=comfort.feels_like_f,
+        feels_like_c=comfort.feels_like_c,
         visibility_miles=visibility_miles,
         visibility_km=visibility_km,
         uv_index=uv_index,
         # Seasonal fields
-        wind_chill_f=wind_chill.fahrenheit,
-        wind_chill_c=wind_chill.celsius,
-        heat_index_f=heat_index.fahrenheit,
-        heat_index_c=heat_index.celsius,
+        wind_chill_f=comfort.wind_chill_f,
+        wind_chill_c=comfort.wind_chill_c,
+        heat_index_f=comfort.heat_index_f,
+        heat_index_c=comfort.heat_index_c,
     )
 
 

--- a/src/accessiweather/weather_client_openmeteo_current.py
+++ b/src/accessiweather/weather_client_openmeteo_current.py
@@ -8,11 +8,11 @@ from typing import Any
 
 from .models import CurrentConditions
 from .provider_normalization import (
-    classify_apparent_temperature,
     normalize_dewpoint_pair,
     normalize_humidity_percent,
     normalize_temperature_pair,
 )
+from .thermal_comfort import sanitize_thermal_comfort_readings
 from .weather_client_openmeteo_units import (
     normalize_snow_depth_to_inches_and_cm,
     normalize_visibility_to_miles_and_km,
@@ -184,10 +184,12 @@ def parse_openmeteo_current_conditions(data: dict) -> CurrentConditions:
         units.get("visibility"),
     )
 
-    apparent = classify_apparent_temperature(
-        temperature.fahrenheit,
-        feels_like.fahrenheit,
-        feels_like.celsius,
+    comfort = sanitize_thermal_comfort_readings(
+        temperature_f=temperature.fahrenheit,
+        temperature_c=temperature.celsius,
+        humidity=humidity,
+        feels_like_f=feels_like.fahrenheit,
+        feels_like_c=feels_like.celsius,
     )
 
     return CurrentConditions(
@@ -202,8 +204,8 @@ def parse_openmeteo_current_conditions(data: dict) -> CurrentConditions:
         wind_direction=current.get("wind_direction_10m"),
         pressure_in=pressure_in,
         pressure_mb=pressure_mb,
-        feels_like_f=feels_like.fahrenheit,
-        feels_like_c=feels_like.celsius,
+        feels_like_f=comfort.feels_like_f,
+        feels_like_c=comfort.feels_like_c,
         visibility_miles=visibility_miles,
         visibility_km=visibility_km,
         sunrise_time=sunrise_time,
@@ -212,9 +214,9 @@ def parse_openmeteo_current_conditions(data: dict) -> CurrentConditions:
         snowfall_rate_in=snowfall_rate,
         snow_depth_in=snow_depth_in,
         snow_depth_cm=snow_depth_cm,
-        wind_chill_f=apparent.wind_chill_f,
-        wind_chill_c=apparent.wind_chill_c,
-        heat_index_f=apparent.heat_index_f,
-        heat_index_c=apparent.heat_index_c,
+        wind_chill_f=comfort.wind_chill_f,
+        wind_chill_c=comfort.wind_chill_c,
+        heat_index_f=comfort.heat_index_f,
+        heat_index_c=comfort.heat_index_c,
         precipitation_type=precipitation_type,
     )

--- a/tests/test_thermal_comfort_sanity.py
+++ b/tests/test_thermal_comfort_sanity.py
@@ -1,0 +1,270 @@
+"""Regression tests for feels-like and heat-index sanity checks."""
+
+from __future__ import annotations
+
+import pytest
+
+from accessiweather.display.presentation.measurement_formatters import (
+    format_temperature_with_feels_like,
+)
+from accessiweather.models.weather import CurrentConditions, Location, SourceData
+from accessiweather.pirate_weather_client import PirateWeatherClient
+from accessiweather.utils.temperature_utils import TemperatureUnit
+from accessiweather.weather_client_fusion import DataFusionEngine
+from accessiweather.weather_client_nws_parsers import parse_nws_current_conditions
+from accessiweather.weather_client_openmeteo import parse_openmeteo_current_conditions
+
+
+def _f_to_c(value_f: float) -> float:
+    return (value_f - 32) * 5 / 9
+
+
+def _nws_observation_payload(
+    *,
+    temperature_f: float,
+    humidity: int,
+    heat_index_f: float | None = None,
+    wind_chill_f: float | None = None,
+) -> dict:
+    return {
+        "properties": {
+            "temperature": {"value": _f_to_c(temperature_f)},
+            "relativeHumidity": {"value": humidity},
+            "windSpeed": {"value": 7.0, "unitCode": "wmoUnit:mi_h-1"},
+            "heatIndex": {"value": _f_to_c(heat_index_f) if heat_index_f is not None else None},
+            "windChill": {"value": _f_to_c(wind_chill_f) if wind_chill_f is not None else None},
+            "textDescription": "Clear",
+        }
+    }
+
+
+def _openmeteo_current_payload(
+    *,
+    temperature_f: float,
+    humidity: int,
+    apparent_f: float,
+) -> dict:
+    return {
+        "current": {
+            "temperature_2m": temperature_f,
+            "relative_humidity_2m": humidity,
+            "apparent_temperature": apparent_f,
+            "weather_code": 0,
+            "wind_speed_10m": 7.0,
+            "pressure_msl": 1015.0,
+            "rain": 0.0,
+            "showers": 0.0,
+            "snowfall": 0.0,
+            "snow_depth": 0.0,
+            "visibility": 10.0,
+        },
+        "current_units": {
+            "temperature_2m": "°F",
+            "apparent_temperature": "°F",
+            "wind_speed_10m": "mph",
+            "pressure_msl": "hPa",
+            "snow_depth": "in",
+            "visibility": "mi",
+        },
+        "daily": {"sunrise": [], "sunset": [], "uv_index_max": []},
+    }
+
+
+def _pirate_payload(
+    *,
+    temperature_f: float,
+    humidity: float,
+    apparent_f: float,
+) -> dict:
+    return {
+        "currently": {
+            "temperature": temperature_f,
+            "humidity": humidity,
+            "apparentTemperature": apparent_f,
+            "summary": "Clear",
+            "windSpeed": 7.0,
+            "pressure": 1015.0,
+        },
+        "daily": {"data": []},
+    }
+
+
+def _source(name: str, current: CurrentConditions) -> SourceData:
+    return SourceData(source=name, current=current, success=True)
+
+
+def test_nws_drops_low_humidity_heat_index_reported_case() -> None:
+    current = parse_nws_current_conditions(
+        _nws_observation_payload(temperature_f=81.0, humidity=36, heat_index_f=87.0)
+    )
+
+    assert current.temperature_f == pytest.approx(81.0)
+    assert current.humidity == 36
+    assert current.feels_like_f is None
+    assert current.heat_index_f is None
+
+
+def test_nws_drops_low_humidity_heat_index_even_within_solar_apparent_range() -> None:
+    current = parse_nws_current_conditions(
+        _nws_observation_payload(temperature_f=81.0, humidity=36, heat_index_f=85.0)
+    )
+
+    assert current.feels_like_f is None
+    assert current.heat_index_f is None
+
+
+def test_nws_keeps_coherent_humid_heat_index() -> None:
+    current = parse_nws_current_conditions(
+        _nws_observation_payload(temperature_f=90.0, humidity=70, heat_index_f=106.0)
+    )
+
+    assert current.feels_like_f == pytest.approx(106.0)
+    assert current.heat_index_f == pytest.approx(106.0)
+
+
+def test_openmeteo_drops_low_humidity_warm_apparent_temperature() -> None:
+    current = parse_openmeteo_current_conditions(
+        _openmeteo_current_payload(temperature_f=81.0, humidity=36, apparent_f=87.0)
+    )
+
+    assert current.feels_like_f is None
+    assert current.heat_index_f is None
+
+
+def test_openmeteo_keeps_plausible_low_humidity_solar_apparent_temperature() -> None:
+    current = parse_openmeteo_current_conditions(
+        _openmeteo_current_payload(temperature_f=81.0, humidity=36, apparent_f=85.0)
+    )
+
+    assert current.feels_like_f == pytest.approx(85.0)
+    assert current.heat_index_f is None
+
+
+def test_openmeteo_drops_clearly_implausible_low_humidity_apparent_temperature() -> None:
+    current = parse_openmeteo_current_conditions(
+        _openmeteo_current_payload(temperature_f=90.0, humidity=35, apparent_f=99.0)
+    )
+
+    assert current.feels_like_f is None
+    assert current.heat_index_f is None
+
+
+def test_openmeteo_keeps_coherent_humid_heat_index() -> None:
+    current = parse_openmeteo_current_conditions(
+        _openmeteo_current_payload(temperature_f=90.0, humidity=70, apparent_f=106.0)
+    )
+
+    assert current.feels_like_f == pytest.approx(106.0)
+    assert current.heat_index_f == pytest.approx(106.0)
+
+
+def test_pirate_weather_drops_low_humidity_warm_apparent_temperature() -> None:
+    client = PirateWeatherClient(api_key="test", units="us")
+
+    current = client._parse_current_conditions(
+        _pirate_payload(temperature_f=81.0, humidity=0.36, apparent_f=87.0)
+    )
+
+    assert current.feels_like_f is None
+    assert current.heat_index_f is None
+
+
+def test_pirate_weather_keeps_plausible_low_humidity_solar_apparent_temperature() -> None:
+    client = PirateWeatherClient(api_key="test", units="us")
+
+    current = client._parse_current_conditions(
+        _pirate_payload(temperature_f=90.0, humidity=0.30, apparent_f=95.0)
+    )
+
+    assert current.feels_like_f == pytest.approx(95.0)
+    assert current.heat_index_f is None
+
+
+def test_pirate_weather_keeps_coherent_humid_heat_index() -> None:
+    client = PirateWeatherClient(api_key="test", units="us")
+
+    current = client._parse_current_conditions(
+        _pirate_payload(temperature_f=90.0, humidity=0.70, apparent_f=106.0)
+    )
+
+    assert current.feels_like_f == pytest.approx(106.0)
+    assert current.heat_index_f == pytest.approx(106.0)
+
+
+def test_fusion_drops_cross_source_implausible_feels_like() -> None:
+    engine = DataFusionEngine()
+    location = Location(name="Lansing", latitude=42.7, longitude=-84.6, country_code="US")
+    nws_current = CurrentConditions(temperature_f=81.0, temperature_c=27.2, humidity=36)
+    pirate_current = CurrentConditions(feels_like_f=87.0, feels_like_c=30.6)
+
+    current, attribution = engine.merge_current_conditions(
+        [_source("nws", nws_current), _source("pirateweather", pirate_current)],
+        location,
+    )
+
+    assert current is not None
+    assert current.temperature_f == pytest.approx(81.0)
+    assert current.humidity == 36
+    assert current.feels_like_f is None
+    assert "feels_like_f" not in attribution.field_sources
+
+
+def test_fusion_keeps_cross_source_plausible_solar_apparent_temperature() -> None:
+    engine = DataFusionEngine()
+    location = Location(name="Lansing", latitude=42.7, longitude=-84.6, country_code="US")
+    nws_current = CurrentConditions(temperature_f=81.0, temperature_c=27.2, humidity=36)
+    pirate_current = CurrentConditions(feels_like_f=85.0, feels_like_c=29.4)
+
+    current, attribution = engine.merge_current_conditions(
+        [_source("nws", nws_current), _source("pirateweather", pirate_current)],
+        location,
+    )
+
+    assert current is not None
+    assert current.feels_like_f == pytest.approx(85.0)
+    assert current.heat_index_f is None
+    assert attribution.field_sources["feels_like_f"] == "pirateweather"
+    assert "heat_index_f" not in attribution.field_sources
+
+
+def test_fusion_keeps_cross_source_coherent_humid_heat_index() -> None:
+    engine = DataFusionEngine()
+    location = Location(name="Houston", latitude=29.76, longitude=-95.37, country_code="US")
+    nws_current = CurrentConditions(temperature_f=90.0, temperature_c=32.2, humidity=70)
+    pirate_current = CurrentConditions(feels_like_f=106.0, feels_like_c=41.1)
+
+    current, attribution = engine.merge_current_conditions(
+        [_source("nws", nws_current), _source("pirateweather", pirate_current)],
+        location,
+    )
+
+    assert current is not None
+    assert current.feels_like_f == pytest.approx(106.0)
+    assert current.heat_index_f == pytest.approx(106.0)
+    assert attribution.field_sources["feels_like_f"] == "pirateweather"
+
+
+def test_presentation_ignores_implausible_warm_feels_like_fallback() -> None:
+    current = CurrentConditions(temperature_f=81.0, humidity=36, feels_like_f=87.0)
+
+    temperature, reason = format_temperature_with_feels_like(
+        current,
+        TemperatureUnit.FAHRENHEIT,
+        precision=1,
+    )
+
+    assert temperature == "81°F"
+    assert reason is None
+
+
+def test_presentation_shows_plausible_low_humidity_solar_feels_like() -> None:
+    current = CurrentConditions(temperature_f=81.0, humidity=36, feels_like_f=85.0)
+
+    temperature, reason = format_temperature_with_feels_like(
+        current,
+        TemperatureUnit.FAHRENHEIT,
+        precision=1,
+    )
+
+    assert temperature == "81°F (feels like 85°F)"
+    assert reason is None


### PR DESCRIPTION
## Summary
- Add shared thermal comfort sanity checks for current feels-like, wind-chill, and heat-index readings.
- Reject implausible warm heat-index/apparent values like 81°F with 36% humidity feeling like 87°F, while preserving valid humid heat-index and cold wind-chill behavior.
- Allow modest low-humidity provider apparent-temperature warmth for non-humidity effects such as solar radiation, without relabeling those readings as heat index.
- Recheck fused current conditions so cross-source temperature/humidity/feels-like combinations cannot display incoherent results.

## Tests
- `pytest tests\\test_thermal_comfort_sanity.py tests\\test_weather_client_openmeteo_parser.py tests\\test_pirate_weather_client.py tests\\test_weather_client_fusion.py -q`
- `pytest -q`
- `ruff check ...` and `ruff format --check ...` on touched Python files
- `python scripts\\changelog_tools.py check --base dev`

## Accessibility
- Non-UI data and presentation logic only; no wx controls, labels, roles, focus behavior, or keyboard paths changed.
- Existing screen-reader-visible current-condition text becomes more accurate, so no deeper manual desktop UI traversal was needed.