### PR TITLE
refactor: centralize provider parser normalization

### DIFF
--- a/src/accessiweather/openmeteo_mapper.py
+++ b/src/accessiweather/openmeteo_mapper.py
@@ -15,6 +15,7 @@ from .openmeteo_forecast_mapper import (
     map_forecast as map_openmeteo_forecast,
     map_hourly_forecast as map_openmeteo_hourly_forecast,
 )
+from .provider_normalization import normalize_pressure_to_pascals
 from .utils import TemperatureUnit, calculate_dewpoint
 
 logger = logging.getLogger(__name__)
@@ -22,18 +23,7 @@ logger = logging.getLogger(__name__)
 
 def _pressure_to_pascals(value: float | int | None, unit: str | None) -> float | None:
     """Normalize Open-Meteo pressure values to the NWS-compatible Pascal unit."""
-    if value is None:
-        return None
-
-    numeric = float(value)
-    unit_text = (unit or "").strip().lower()
-    if "hpa" in unit_text or "mb" in unit_text:
-        return numeric * 100
-    if "pa" in unit_text:
-        return numeric
-    if "inch" in unit_text or unit_text in {"in", "inhg"}:
-        return numeric * 3386.39
-    return numeric * 100
+    return normalize_pressure_to_pascals(value, unit)
 
 
 def _parse_openmeteo_datetime(

--- a/src/accessiweather/pirate_weather_current.py
+++ b/src/accessiweather/pirate_weather_current.py
@@ -11,90 +11,49 @@ from .pirate_weather_parsing import (
     _normalize_precipitation_type,
     _resolve_response_timezone,
 )
-from .utils.temperature_utils import TemperatureUnit, calculate_dewpoint
-from .weather_client_parsers import convert_f_to_c, degrees_to_cardinal, describe_moon_phase
+from .provider_normalization import (
+    normalize_dewpoint_pair,
+    normalize_humidity_percent,
+    normalize_millibars,
+    normalize_speed_pair,
+    normalize_temperature_pair,
+    normalize_visibility_pair,
+    pirate_temperature_unit,
+    pirate_visibility_unit,
+    pirate_wind_unit,
+)
+from .weather_client_parsers import degrees_to_cardinal, describe_moon_phase
 
 
 def parse_current_conditions(client: Any, data: dict) -> CurrentConditions:
     """Parse Pirate Weather ``currently`` block into CurrentConditions."""
     current = data.get("currently", {})
 
-    # Temperature (PW returns °F in "us" units, °C otherwise)
-    temp = current.get("temperature")
-    using_us = client.units == "us"
+    temperature_unit = pirate_temperature_unit(client.units)
+    wind_unit = pirate_wind_unit(client.units)
+    visibility_unit = pirate_visibility_unit(client.units)
+    temperature = normalize_temperature_pair(current.get("temperature"), temperature_unit)
 
-    if using_us:
-        temp_f = float(temp) if temp is not None else None
-        temp_c = convert_f_to_c(temp_f)
-    else:
-        temp_c = float(temp) if temp is not None else None
-        temp_f = (temp_c * 9 / 5 + 32) if temp_c is not None else None
+    humidity = normalize_humidity_percent(current.get("humidity"), fraction=True)
 
-    # Humidity (0-1 in PW → 0-100)
-    humidity_raw = current.get("humidity")
-    humidity = round(humidity_raw * 100) if humidity_raw is not None else None
+    dewpoint = normalize_dewpoint_pair(
+        current.get("dewPoint"),
+        temperature_unit,
+        fallback_temperature_f=temperature.fahrenheit,
+        humidity_percent=humidity,
+    )
 
-    # Dew point
-    dewpoint = current.get("dewPoint")
-    if using_us:
-        dewpoint_f = float(dewpoint) if dewpoint is not None else None
-        dewpoint_c = convert_f_to_c(dewpoint_f)
-        if dewpoint_f is None and temp_f is not None and humidity is not None:
-            dewpoint_f = calculate_dewpoint(temp_f, humidity, unit=TemperatureUnit.FAHRENHEIT)
-            dewpoint_c = convert_f_to_c(dewpoint_f)
-    else:
-        dewpoint_c = float(dewpoint) if dewpoint is not None else None
-        dewpoint_f = (dewpoint_c * 9 / 5 + 32) if dewpoint_c is not None else None
-
-    # Wind – PW "us" = mph, "si" = m/s, "ca" = km/h, "uk2" = mph
-    wind_speed_raw = current.get("windSpeed")
-    if using_us or client.units == "uk2":
-        wind_speed_mph = float(wind_speed_raw) if wind_speed_raw is not None else None
-        wind_speed_kph = wind_speed_mph * 1.60934 if wind_speed_mph is not None else None
-    elif client.units == "ca":
-        wind_speed_kph = float(wind_speed_raw) if wind_speed_raw is not None else None
-        wind_speed_mph = wind_speed_kph / 1.60934 if wind_speed_kph is not None else None
-    else:  # si: m/s
-        wind_mps = float(wind_speed_raw) if wind_speed_raw is not None else None
-        wind_speed_mph = wind_mps * 2.23694 if wind_mps is not None else None
-        wind_speed_kph = wind_mps * 3.6 if wind_mps is not None else None
+    wind_speed = normalize_speed_pair(current.get("windSpeed"), wind_unit)
 
     wind_direction = current.get("windBearing")  # degrees
 
-    # Pressure – PW returns mb in all unit groups
-    pressure_mb = current.get("pressure")
-    pressure_in = pressure_mb / 33.8639 if pressure_mb is not None else None
+    pressure = normalize_millibars(current.get("pressure"))
 
-    # Visibility – PW "us" = miles, others = km
-    visibility_raw = current.get("visibility")
-    if using_us or client.units == "uk2":
-        visibility_miles = float(visibility_raw) if visibility_raw is not None else None
-        visibility_km = visibility_miles * 1.60934 if visibility_miles is not None else None
-    else:
-        visibility_km = float(visibility_raw) if visibility_raw is not None else None
-        visibility_miles = visibility_km / 1.60934 if visibility_km is not None else None
+    visibility = normalize_visibility_pair(current.get("visibility"), visibility_unit)
 
-    # Feels like (apparent temperature)
-    apparent = current.get("apparentTemperature")
-    if using_us:
-        feels_like_f = float(apparent) if apparent is not None else None
-        feels_like_c = convert_f_to_c(feels_like_f)
-    else:
-        feels_like_c = float(apparent) if apparent is not None else None
-        feels_like_f = (feels_like_c * 9 / 5 + 32) if feels_like_c is not None else None
+    feels_like = normalize_temperature_pair(current.get("apparentTemperature"), temperature_unit)
 
-    # Wind gust
-    wind_gust_raw = current.get("windGust")
-    if using_us or client.units == "uk2":
-        wind_gust_mph = float(wind_gust_raw) if wind_gust_raw is not None else None
-        wind_gust_kph = wind_gust_mph * 1.60934 if wind_gust_mph is not None else None
-    elif client.units == "ca":
-        wind_gust_kph = float(wind_gust_raw) if wind_gust_raw is not None else None
-        wind_gust_mph = wind_gust_kph / 1.60934 if wind_gust_kph is not None else None
-    else:
-        wind_gust_mps = float(wind_gust_raw) if wind_gust_raw is not None else None
-        wind_gust_mph = wind_gust_mps * 2.23694 if wind_gust_mps is not None else None
-        wind_gust_kph = wind_gust_mps * 3.6 if wind_gust_mps is not None else None
+    wind_gust = normalize_speed_pair(current.get("windGust"), wind_unit)
 
     # Current-condition model fields represent accumulated amount. Pirate Weather's
     # current precipIntensity is a rate, so leave amount fields blank.
@@ -126,25 +85,25 @@ def parse_current_conditions(client: Any, data: dict) -> CurrentConditions:
     precipitation_type = _normalize_precipitation_type(current.get("precipType"))
 
     return CurrentConditions(
-        temperature_f=temp_f,
-        temperature_c=temp_c,
+        temperature_f=temperature.fahrenheit,
+        temperature_c=temperature.celsius,
         condition=condition_str,
         humidity=humidity,
-        dewpoint_f=dewpoint_f,
-        dewpoint_c=dewpoint_c,
-        wind_speed_mph=wind_speed_mph,
-        wind_speed_kph=wind_speed_kph,
+        dewpoint_f=dewpoint.fahrenheit,
+        dewpoint_c=dewpoint.celsius,
+        wind_speed_mph=wind_speed.mph,
+        wind_speed_kph=wind_speed.kph,
         wind_direction=degrees_to_cardinal(wind_direction),
-        pressure_in=pressure_in,
-        pressure_mb=pressure_mb,
-        feels_like_f=feels_like_f,
-        feels_like_c=feels_like_c,
-        visibility_miles=visibility_miles,
-        visibility_km=visibility_km,
+        pressure_in=pressure.inches,
+        pressure_mb=pressure.millibars,
+        feels_like_f=feels_like.fahrenheit,
+        feels_like_c=feels_like.celsius,
+        visibility_miles=visibility.miles,
+        visibility_km=visibility.kilometers,
         uv_index=uv_index,
         cloud_cover=cloud_cover,
-        wind_gust_mph=wind_gust_mph,
-        wind_gust_kph=wind_gust_kph,
+        wind_gust_mph=wind_gust.mph,
+        wind_gust_kph=wind_gust.kph,
         precipitation_in=precip_in,
         precipitation_mm=precip_mm,
         precipitation_type=precipitation_type,

--- a/src/accessiweather/pirate_weather_parsing.py
+++ b/src/accessiweather/pirate_weather_parsing.py
@@ -23,8 +23,19 @@ from .models import (
     WeatherAlert,
     WeatherAlerts,
 )
-from .utils.temperature_utils import TemperatureUnit, calculate_dewpoint
-from .weather_client_parsers import convert_f_to_c, degrees_to_cardinal
+from .provider_normalization import (
+    format_speed,
+    normalize_dewpoint_pair,
+    normalize_humidity_percent,
+    normalize_millibars,
+    normalize_speed_pair,
+    normalize_temperature_pair,
+    normalize_visibility_pair,
+    pirate_temperature_unit,
+    pirate_visibility_unit,
+    pirate_wind_unit,
+)
+from .weather_client_parsers import degrees_to_cardinal
 
 logger = logging.getLogger(__name__)
 
@@ -209,7 +220,8 @@ def parse_forecast(client: Any, data: dict, days: int | None = None) -> Forecast
     """
     daily_data = data.get("daily", {}).get("data", [])
     location_tz = _resolve_response_timezone(data)
-    using_us = client.units == "us"
+    temperature_unit = pirate_temperature_unit(client.units)
+    wind_unit = pirate_wind_unit(client.units)
 
     periods: list[ForecastPeriod] = []
     parsed_dates: list[date] = []
@@ -235,28 +247,8 @@ def parse_forecast(client: Any, data: dict, days: int | None = None) -> Forecast
         if temp_low is None:
             temp_low = day.get("temperatureMin")
 
-        # Wind speed formatting
-        wind_raw = day.get("windSpeed")
-        if wind_raw is not None:
-            if using_us or client.units == "uk2":
-                wind_str = f"{round(wind_raw)} mph"
-            elif client.units == "ca":
-                wind_str = f"{round(wind_raw)} km/h"
-            else:
-                wind_str = f"{round(wind_raw)} m/s"
-        else:
-            wind_str = None
-
-        wind_gust_raw = day.get("windGust")
-        if wind_gust_raw is not None:
-            if using_us or client.units == "uk2":
-                wind_gust_str = f"{round(wind_gust_raw)} mph"
-            elif client.units == "ca":
-                wind_gust_str = f"{round(wind_gust_raw)} km/h"
-            else:
-                wind_gust_str = f"{round(wind_gust_raw)} m/s"
-        else:
-            wind_gust_str = None
+        wind_str = format_speed(day.get("windSpeed"), wind_unit)
+        wind_gust_str = format_speed(day.get("windGust"), wind_unit)
 
         precip_prob_raw = day.get("precipProbability")
         precip_prob = round(precip_prob_raw * 100) if precip_prob_raw is not None else None
@@ -276,7 +268,7 @@ def parse_forecast(client: Any, data: dict, days: int | None = None) -> Forecast
             name=name,
             temperature=temp_high,
             temperature_low=temp_low,
-            temperature_unit="F" if using_us else "C",
+            temperature_unit=temperature_unit,
             short_forecast=condition,
             detailed_forecast=condition,
             wind_speed=wind_str,
@@ -309,7 +301,9 @@ def parse_hourly_forecast(client: Any, data: dict) -> HourlyForecast:
     """Parse Pirate Weather ``hourly`` block into an HourlyForecast."""
     hourly_items = data.get("hourly", {}).get("data", [])
     location_tz = _resolve_response_timezone(data)
-    using_us = client.units == "us"
+    temperature_unit = pirate_temperature_unit(client.units)
+    wind_unit = pirate_wind_unit(client.units)
+    visibility_unit = pirate_visibility_unit(client.units)
 
     periods: list[HourlyForecastPeriod] = []
     for hour in hourly_items:
@@ -319,59 +313,23 @@ def parse_hourly_forecast(client: Any, data: dict) -> HourlyForecast:
         else:
             start_time = datetime.now(UTC)
 
-        temp = hour.get("temperature")
-        if using_us:
-            temp_f = float(temp) if temp is not None else None
-        else:
-            temp_c = float(temp) if temp is not None else None
-            temp_f = (temp_c * 9 / 5 + 32) if temp_c is not None else temp_c
+        temperature = normalize_temperature_pair(hour.get("temperature"), temperature_unit)
 
-        humidity_raw = hour.get("humidity")
-        humidity = round(humidity_raw * 100) if humidity_raw is not None else None
+        humidity = normalize_humidity_percent(hour.get("humidity"), fraction=True)
+        dewpoint = normalize_dewpoint_pair(
+            hour.get("dewPoint"),
+            temperature_unit,
+            fallback_temperature_f=temperature.fahrenheit,
+            humidity_percent=humidity,
+        )
 
-        dewpoint = hour.get("dewPoint")
-        if using_us:
-            dewpoint_f = float(dewpoint) if dewpoint is not None else None
-            dewpoint_c = convert_f_to_c(dewpoint_f)
-            if dewpoint_f is None and temp_f is not None and humidity is not None:
-                dewpoint_f = calculate_dewpoint(
-                    temp_f,
-                    humidity,
-                    unit=TemperatureUnit.FAHRENHEIT,
-                )
-                dewpoint_c = convert_f_to_c(dewpoint_f)
-        else:
-            dewpoint_c = float(dewpoint) if dewpoint is not None else None
-            dewpoint_f = (dewpoint_c * 9 / 5 + 32) if dewpoint_c is not None else None
-
-        # Pressure in mb (all unit groups)
-        pressure_mb = hour.get("pressure")
-        pressure_in = pressure_mb / 33.8639 if pressure_mb is not None else None
+        pressure = normalize_millibars(hour.get("pressure"))
 
         wind_raw = hour.get("windSpeed")
-        wind_speed_mph: float | None = None
-        if wind_raw is not None:
-            if using_us or client.units == "uk2":
-                wind_str = f"{round(wind_raw)} mph"
-                wind_speed_mph = float(wind_raw)
-            elif client.units == "ca":
-                wind_str = f"{round(wind_raw)} km/h"
-                wind_speed_mph = float(wind_raw) / 1.60934
-            else:
-                wind_str = f"{round(wind_raw)} m/s"
-                wind_speed_mph = float(wind_raw) * 2.23694
-        else:
-            wind_str = None
+        wind_str = format_speed(wind_raw, wind_unit)
+        wind_speed = normalize_speed_pair(wind_raw, wind_unit)
 
-        wind_gust_raw = hour.get("windGust")
-        wind_gust_mph: float | None = None
-        if wind_gust_raw is not None:
-            if using_us or client.units == "uk2":
-                wind_gust_mph = float(wind_gust_raw)
-            elif client.units == "ca":
-                wind_gust_mph = float(wind_gust_raw) / 1.60934
-            else:
-                wind_gust_mph = float(wind_gust_raw) * 2.23694
+        wind_gust = normalize_speed_pair(hour.get("windGust"), wind_unit)
 
         precip_prob_raw = hour.get("precipProbability")
         precip_prob = round(precip_prob_raw * 100) if precip_prob_raw is not None else None
@@ -384,51 +342,36 @@ def parse_hourly_forecast(client: Any, data: dict) -> HourlyForecast:
 
         uv_index = hour.get("uvIndex")
 
-        visibility_raw = hour.get("visibility")
-        if visibility_raw is not None:
-            if using_us or client.units == "uk2":
-                visibility_miles = float(visibility_raw)
-                visibility_km = visibility_miles * 1.60934
-            else:
-                visibility_km = float(visibility_raw)
-                visibility_miles = visibility_km / 1.60934
-        else:
-            visibility_miles = None
-            visibility_km = None
+        visibility = normalize_visibility_pair(hour.get("visibility"), visibility_unit)
 
-        apparent = hour.get("apparentTemperature")
-        if using_us:
-            feels_like_f = float(apparent) if apparent is not None else None
-        else:
-            feels_like_c = float(apparent) if apparent is not None else None
-            feels_like_f = (feels_like_c * 9 / 5 + 32) if feels_like_c is not None else None
+        feels_like = normalize_temperature_pair(hour.get("apparentTemperature"), temperature_unit)
 
         condition = _data_point_condition(hour)
         precipitation_type = _normalize_precipitation_type(hour.get("precipType"))
 
         period = HourlyForecastPeriod(
             start_time=start_time,
-            temperature=temp_f,
+            temperature=temperature.fahrenheit,
             temperature_unit="F",
             short_forecast=condition,
             wind_speed=wind_str,
-            wind_speed_mph=wind_speed_mph,
+            wind_speed_mph=wind_speed.mph,
             wind_direction=degrees_to_cardinal(hour.get("windBearing")),
             humidity=humidity,
-            dewpoint_f=dewpoint_f,
-            dewpoint_c=dewpoint_c,
-            pressure_mb=pressure_mb,
-            pressure_in=pressure_in,
+            dewpoint_f=dewpoint.fahrenheit,
+            dewpoint_c=dewpoint.celsius,
+            pressure_mb=pressure.millibars,
+            pressure_in=pressure.inches,
             precipitation_probability=precip_prob,
             snowfall=snowfall,
             uv_index=uv_index,
             cloud_cover=cloud_cover,
-            wind_gust_mph=wind_gust_mph,
+            wind_gust_mph=wind_gust.mph,
             precipitation_amount=precip_amount,
             precipitation_type=precipitation_type,
-            feels_like=feels_like_f,
-            visibility_miles=visibility_miles,
-            visibility_km=visibility_km,
+            feels_like=feels_like.fahrenheit,
+            visibility_miles=visibility.miles,
+            visibility_km=visibility.kilometers,
         )
         periods.append(period)
 

--- a/src/accessiweather/provider_normalization.py
+++ b/src/accessiweather/provider_normalization.py
@@ -187,16 +187,21 @@ def normalize_visibility_pair(
     unit_text = (unit or "").strip().lower().replace(" ", "_")
     if "ft" in unit_text or "feet" in unit_text:
         miles = numeric / 5280
+        kilometers = miles * KM_PER_MILE
     elif "km" in unit_text or "kilometer" in unit_text or "kilometre" in unit_text:
         miles = numeric / KM_PER_MILE
+        kilometers = numeric
     elif unit_text in {"mi", "mile", "miles"}:
         miles = numeric
+        kilometers = numeric * KM_PER_MILE
     else:
         miles = numeric / 1609.344
+        kilometers = numeric / 1000
 
     if cap_miles is not None:
         miles = min(miles, cap_miles)
-    return VisibilityPair(miles, miles * KM_PER_MILE)
+        kilometers = miles * KM_PER_MILE
+    return VisibilityPair(miles, kilometers)
 
 
 def classify_apparent_temperature(

--- a/src/accessiweather/provider_normalization.py
+++ b/src/accessiweather/provider_normalization.py
@@ -1,0 +1,233 @@
+"""Provider-neutral normalization helpers for weather API adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .utils.temperature_utils import TemperatureUnit, calculate_dewpoint
+from .weather_client_parsers import (
+    convert_f_to_c,
+    convert_wind_speed_to_mph_and_kph,
+    normalize_pressure,
+    normalize_temperature,
+)
+
+KM_PER_MILE = 1.609344
+MB_PER_INHG = 33.8639
+
+
+@dataclass(frozen=True)
+class TemperaturePair:
+    """A temperature represented in both AccessiWeather display units."""
+
+    fahrenheit: float | None
+    celsius: float | None
+
+
+@dataclass(frozen=True)
+class SpeedPair:
+    """A speed represented in both AccessiWeather display units."""
+
+    mph: float | None
+    kph: float | None
+
+
+@dataclass(frozen=True)
+class PressurePair:
+    """A pressure represented in both AccessiWeather display units."""
+
+    inches: float | None
+    millibars: float | None
+
+
+@dataclass(frozen=True)
+class VisibilityPair:
+    """A visibility distance represented in both AccessiWeather display units."""
+
+    miles: float | None
+    kilometers: float | None
+
+
+@dataclass(frozen=True)
+class ApparentTemperatureClassification:
+    """Feels-like temperature split into chill/index fields."""
+
+    wind_chill_f: float | None = None
+    wind_chill_c: float | None = None
+    heat_index_f: float | None = None
+    heat_index_c: float | None = None
+
+
+def as_float(value: object) -> float | None:
+    """Return ``value`` as a float, treating missing or invalid values as absent."""
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize_humidity_percent(value: object, *, fraction: bool = False) -> int | None:
+    """Normalize humidity to a rounded 0-100 percentage."""
+    numeric = as_float(value)
+    if numeric is None:
+        return None
+    if fraction:
+        numeric *= 100
+    return round(numeric)
+
+
+def normalize_temperature_pair(value: object, unit: str | None) -> TemperaturePair:
+    """Normalize a provider temperature value to Fahrenheit and Celsius."""
+    numeric = as_float(value)
+    if numeric is None:
+        return TemperaturePair(None, None)
+    temp_f, temp_c = normalize_temperature(numeric, unit)
+    return TemperaturePair(temp_f, temp_c)
+
+
+def normalize_dewpoint_pair(
+    dewpoint_value: object,
+    dewpoint_unit: str | None,
+    *,
+    fallback_temperature_f: float | None,
+    humidity_percent: int | None,
+) -> TemperaturePair:
+    """Normalize dewpoint, calculating it from temperature and humidity when absent."""
+    dewpoint = normalize_temperature_pair(dewpoint_value, dewpoint_unit)
+    if dewpoint.fahrenheit is not None or dewpoint.celsius is not None:
+        return dewpoint
+
+    if fallback_temperature_f is None or humidity_percent is None:
+        return TemperaturePair(None, None)
+
+    dewpoint_f = calculate_dewpoint(
+        fallback_temperature_f,
+        humidity_percent,
+        unit=TemperatureUnit.FAHRENHEIT,
+    )
+    return TemperaturePair(dewpoint_f, convert_f_to_c(dewpoint_f))
+
+
+def normalize_pressure_pair(value: object, unit: str | None) -> PressurePair:
+    """Normalize pressure to inches of mercury and millibars."""
+    numeric = as_float(value)
+    if numeric is None:
+        return PressurePair(None, None)
+    pressure_in, pressure_mb = normalize_pressure(numeric, unit)
+    return PressurePair(pressure_in, pressure_mb)
+
+
+def normalize_pressure_to_pascals(value: object, unit: str | None) -> float | None:
+    """Normalize a pressure value to Pascals for NWS-compatible mapped payloads."""
+    numeric = as_float(value)
+    if numeric is None:
+        return None
+
+    unit_text = (unit or "").strip().lower()
+    if "hpa" in unit_text or "mb" in unit_text:
+        return numeric * 100
+    if "pa" in unit_text:
+        return numeric
+    if "inch" in unit_text or unit_text in {"in", "inhg"}:
+        return numeric * 3386.39
+    return numeric * 100
+
+
+def normalize_millibars(value: object) -> PressurePair:
+    """Normalize provider values that are already millibars/hectopascals."""
+    numeric = as_float(value)
+    if numeric is None:
+        return PressurePair(None, None)
+    return PressurePair(numeric / MB_PER_INHG, numeric)
+
+
+def _canonical_wind_unit(unit: str | None) -> str | None:
+    unit_text = (unit or "").strip().lower()
+    if unit_text in {"m/s", "meter/s", "meters/s", "metre/s", "metres/s"}:
+        return "wmoUnit:m_s-1"
+    if unit_text in {"km/h", "kmh", "kph"}:
+        return "wmoUnit:km_h-1"
+    if unit_text in {"mph", "mi/h"}:
+        return "wmoUnit:mi_h-1"
+    if unit_text in {"kn", "kt", "knot", "knots"}:
+        return "wmoUnit:kn"
+    return unit
+
+
+def normalize_speed_pair(value: object, unit: str | None) -> SpeedPair:
+    """Normalize wind speed to miles per hour and kilometers per hour."""
+    numeric = as_float(value)
+    if numeric is None:
+        return SpeedPair(None, None)
+    mph, kph = convert_wind_speed_to_mph_and_kph(numeric, _canonical_wind_unit(unit))
+    return SpeedPair(mph, kph)
+
+
+def format_speed(value: object, unit_label: str) -> str | None:
+    """Format provider-native speed for text forecast fields."""
+    numeric = as_float(value)
+    if numeric is None:
+        return None
+    return f"{round(numeric)} {unit_label}"
+
+
+def normalize_visibility_pair(
+    value: object,
+    unit: str | None,
+    *,
+    cap_miles: float | None = None,
+) -> VisibilityPair:
+    """Normalize visibility to miles and kilometers."""
+    numeric = as_float(value)
+    if numeric is None:
+        return VisibilityPair(None, None)
+
+    unit_text = (unit or "").strip().lower().replace(" ", "_")
+    if "ft" in unit_text or "feet" in unit_text:
+        miles = numeric / 5280
+    elif "km" in unit_text or "kilometer" in unit_text or "kilometre" in unit_text:
+        miles = numeric / KM_PER_MILE
+    elif unit_text in {"mi", "mile", "miles"}:
+        miles = numeric
+    else:
+        miles = numeric / 1609.344
+
+    if cap_miles is not None:
+        miles = min(miles, cap_miles)
+    return VisibilityPair(miles, miles * KM_PER_MILE)
+
+
+def classify_apparent_temperature(
+    temperature_f: float | None,
+    apparent_f: float | None,
+    apparent_c: float | None,
+) -> ApparentTemperatureClassification:
+    """Classify a feels-like value as wind chill or heat index when it differs."""
+    if apparent_f is None or temperature_f is None:
+        return ApparentTemperatureClassification()
+    if apparent_f < temperature_f:
+        return ApparentTemperatureClassification(wind_chill_f=apparent_f, wind_chill_c=apparent_c)
+    if apparent_f > temperature_f:
+        return ApparentTemperatureClassification(heat_index_f=apparent_f, heat_index_c=apparent_c)
+    return ApparentTemperatureClassification()
+
+
+def pirate_temperature_unit(units: str) -> str:
+    """Return the temperature unit used by a Pirate Weather unit group."""
+    return "F" if units == "us" else "C"
+
+
+def pirate_wind_unit(units: str) -> str:
+    """Return the wind-speed unit used by a Pirate Weather unit group."""
+    if units in {"us", "uk2"}:
+        return "mph"
+    if units == "ca":
+        return "km/h"
+    return "m/s"
+
+
+def pirate_visibility_unit(units: str) -> str:
+    """Return the visibility unit used by a Pirate Weather unit group."""
+    return "mi" if units in {"us", "uk2"} else "km"

--- a/src/accessiweather/weather_client_nws_parsers.py
+++ b/src/accessiweather/weather_client_nws_parsers.py
@@ -3,6 +3,11 @@
 
 from __future__ import annotations
 
+from .provider_normalization import (
+    normalize_humidity_percent,
+    normalize_pressure_pair,
+    normalize_temperature_pair,
+)
 from .weather_client_nws_common import *  # noqa: F403
 from .weather_client_parsers import normalize_pressure
 
@@ -23,14 +28,17 @@ def parse_nws_current_conditions(
     """
     props = data.get("properties", {})
 
-    temp_c = props.get("temperature", {}).get("value")
-    temp_f = (temp_c * 9 / 5) + 32 if temp_c is not None else None
+    temperature = normalize_temperature_pair(
+        props.get("temperature", {}).get("value"),
+        props.get("temperature", {}).get("unitCode") or "wmoUnit:degC",
+    )
 
-    humidity = props.get("relativeHumidity", {}).get("value")
-    humidity = round(humidity) if humidity is not None else None
+    humidity = normalize_humidity_percent(props.get("relativeHumidity", {}).get("value"))
 
-    dewpoint_c = props.get("dewpoint", {}).get("value")
-    dewpoint_f = (dewpoint_c * 9 / 5) + 32 if dewpoint_c is not None else None
+    dewpoint = normalize_temperature_pair(
+        props.get("dewpoint", {}).get("value"),
+        props.get("dewpoint", {}).get("unitCode") or "wmoUnit:degC",
+    )
 
     visibility_m = props.get("visibility", {}).get("value")
     visibility_miles = visibility_m / 1609.344 if visibility_m is not None else None
@@ -54,47 +62,60 @@ def parse_nws_current_conditions(
     wind_direction = props.get("windDirection", {}).get("value")
 
     pressure_pa = props.get("barometricPressure", {}).get("value")
-    pressure_in = convert_pa_to_inches(pressure_pa)
+    pressure = normalize_pressure_pair(
+        pressure_pa,
+        props.get("barometricPressure", {}).get("unitCode") or "wmoUnit:Pa",
+    )
 
     # Seasonal fields - wind chill and heat index
     wind_chill_c = props.get("windChill", {}).get("value")
-    wind_chill_f = (wind_chill_c * 9 / 5) + 32 if wind_chill_c is not None else None
+    wind_chill = normalize_temperature_pair(
+        wind_chill_c,
+        props.get("windChill", {}).get("unitCode") or "wmoUnit:degC",
+    )
 
     heat_index_c = props.get("heatIndex", {}).get("value")
-    heat_index_f = (heat_index_c * 9 / 5) + 32 if heat_index_c is not None else None
+    heat_index = normalize_temperature_pair(
+        heat_index_c,
+        props.get("heatIndex", {}).get("unitCode") or "wmoUnit:degC",
+    )
 
     # Determine feels_like based on wind chill or heat index
     feels_like_f = None
     feels_like_c = None
-    if wind_chill_f is not None and (temp_f is None or wind_chill_f < temp_f):
-        feels_like_f = wind_chill_f
-        feels_like_c = wind_chill_c
-    elif heat_index_f is not None and (temp_f is None or heat_index_f > temp_f):
-        feels_like_f = heat_index_f
-        feels_like_c = heat_index_c
+    if wind_chill.fahrenheit is not None and (
+        temperature.fahrenheit is None or wind_chill.fahrenheit < temperature.fahrenheit
+    ):
+        feels_like_f = wind_chill.fahrenheit
+        feels_like_c = wind_chill.celsius
+    elif heat_index.fahrenheit is not None and (
+        temperature.fahrenheit is None or heat_index.fahrenheit > temperature.fahrenheit
+    ):
+        feels_like_f = heat_index.fahrenheit
+        feels_like_c = heat_index.celsius
 
     return CurrentConditions(
-        temperature_f=temp_f,
-        temperature_c=temp_c,
+        temperature_f=temperature.fahrenheit,
+        temperature_c=temperature.celsius,
         condition=props.get("textDescription"),
         humidity=humidity,
-        dewpoint_f=dewpoint_f,
-        dewpoint_c=dewpoint_c,
+        dewpoint_f=dewpoint.fahrenheit,
+        dewpoint_c=dewpoint.celsius,
         wind_speed_mph=wind_speed_mph,
         wind_speed_kph=wind_speed_kph,
         wind_direction=wind_direction,
-        pressure_in=pressure_in,
-        pressure_mb=convert_pa_to_mb(pressure_pa),
+        pressure_in=pressure.inches,
+        pressure_mb=pressure.millibars,
         feels_like_f=feels_like_f,
         feels_like_c=feels_like_c,
         visibility_miles=visibility_miles,
         visibility_km=visibility_km,
         uv_index=uv_index,
         # Seasonal fields
-        wind_chill_f=wind_chill_f,
-        wind_chill_c=wind_chill_c,
-        heat_index_f=heat_index_f,
-        heat_index_c=heat_index_c,
+        wind_chill_f=wind_chill.fahrenheit,
+        wind_chill_c=wind_chill.celsius,
+        heat_index_f=heat_index.fahrenheit,
+        heat_index_c=heat_index.celsius,
     )
 
 

--- a/src/accessiweather/weather_client_openmeteo.py
+++ b/src/accessiweather/weather_client_openmeteo.py
@@ -18,12 +18,15 @@ from .models import (
     HourlyForecastPeriod,
     Location,
 )
+from .provider_normalization import (
+    classify_apparent_temperature,
+    normalize_dewpoint_pair,
+)
 from .utils.retry_utils import (
     RETRYABLE_EXCEPTIONS,
     async_retry_with_backoff,
     is_retryable_http_error,
 )
-from .utils.temperature_utils import TemperatureUnit, calculate_dewpoint
 from .weather_client_openmeteo_current import (
     parse_iso_datetime as _parse_iso_datetime,
     parse_openmeteo_current_conditions as parse_openmeteo_current_conditions,
@@ -410,24 +413,18 @@ def parse_openmeteo_hourly_forecast(data: dict) -> HourlyForecast:
         )
 
         apparent_temp = apparent_temps[i] if i < len(apparent_temps) else None
-        dewpoint_f = dewpoint
-        dewpoint_c = (dewpoint_f - 32) * 5 / 9 if dewpoint_f is not None else None
-        if dewpoint_f is None and temperature is not None and humidity is not None:
-            dewpoint_f = calculate_dewpoint(
-                temperature,
-                humidity,
-                unit=TemperatureUnit.FAHRENHEIT,
-            )
-            dewpoint_c = (dewpoint_f - 32) * 5 / 9 if dewpoint_f is not None else None
+        dewpoint_pair = normalize_dewpoint_pair(
+            dewpoint,
+            hourly_units.get("dew_point_2m", hourly_units.get("temperature_2m", "°F")),
+            fallback_temperature_f=temperature,
+            humidity_percent=humidity,
+        )
 
-        # Determine wind chill vs heat index from apparent temperature
-        wind_chill_f = None
-        heat_index_f = None
-        if apparent_temp is not None and temperature is not None:
-            if apparent_temp < temperature:
-                wind_chill_f = apparent_temp
-            elif apparent_temp > temperature:
-                heat_index_f = apparent_temp
+        apparent = classify_apparent_temperature(
+            temperature,
+            apparent_temp,
+            None,
+        )
 
         period = HourlyForecastPeriod(
             start_time=start_time or datetime.now(),
@@ -437,8 +434,8 @@ def parse_openmeteo_hourly_forecast(data: dict) -> HourlyForecast:
             wind_speed=_format_wind_speed_mph(wind_speed_mph),
             wind_direction=degrees_to_cardinal(wind_direction),
             humidity=humidity,
-            dewpoint_f=dewpoint_f,
-            dewpoint_c=dewpoint_c,
+            dewpoint_f=dewpoint_pair.fahrenheit,
+            dewpoint_c=dewpoint_pair.celsius,
             pressure_mb=pressure_mb,
             pressure_in=pressure_in,
             precipitation_probability=precip_prob,
@@ -451,8 +448,10 @@ def parse_openmeteo_hourly_forecast(data: dict) -> HourlyForecast:
             visibility_miles=visibility_miles,
             visibility_km=visibility_km,
             feels_like=apparent_temp,
-            wind_chill_f=wind_chill_f,
-            heat_index_f=heat_index_f,
+            wind_chill_f=apparent.wind_chill_f,
+            wind_chill_c=apparent.wind_chill_c,
+            heat_index_f=apparent.heat_index_f,
+            heat_index_c=apparent.heat_index_c,
         )
         periods.append(period)
 

--- a/src/accessiweather/weather_client_openmeteo_current.py
+++ b/src/accessiweather/weather_client_openmeteo_current.py
@@ -7,16 +7,19 @@ from datetime import UTC, datetime, timedelta, timezone
 from typing import Any
 
 from .models import CurrentConditions
-from .utils.temperature_utils import TemperatureUnit, calculate_dewpoint
+from .provider_normalization import (
+    classify_apparent_temperature,
+    normalize_dewpoint_pair,
+    normalize_humidity_percent,
+    normalize_temperature_pair,
+)
 from .weather_client_openmeteo_units import (
     normalize_snow_depth_to_inches_and_cm,
     normalize_visibility_to_miles_and_km,
 )
 from .weather_client_parsers import (
-    convert_f_to_c,
     convert_wind_speed_to_mph_and_kph,
     normalize_pressure,
-    normalize_temperature,
     weather_code_to_description,
 )
 
@@ -130,19 +133,17 @@ def parse_openmeteo_current_conditions(data: dict) -> CurrentConditions:
     daily = data.get("daily", {})
     utc_offset_seconds = data.get("utc_offset_seconds")
 
-    temp_f, temp_c = normalize_temperature(
+    temperature = normalize_temperature_pair(
         current.get("temperature_2m"), units.get("temperature_2m")
     )
 
-    humidity = current.get("relative_humidity_2m")
-    humidity = round(humidity) if humidity is not None else None
-
-    dewpoint_f = None
-    dewpoint_c = None
-    if temp_f is not None and humidity is not None:
-        dewpoint_f = calculate_dewpoint(temp_f, humidity, unit=TemperatureUnit.FAHRENHEIT)
-        if dewpoint_f is not None:
-            dewpoint_c = convert_f_to_c(dewpoint_f)
+    humidity = normalize_humidity_percent(current.get("relative_humidity_2m"))
+    dewpoint = normalize_dewpoint_pair(
+        None,
+        units.get("temperature_2m"),
+        fallback_temperature_f=temperature.fahrenheit,
+        humidity_percent=humidity,
+    )
 
     wind_speed_mph, wind_speed_kph = convert_wind_speed_to_mph_and_kph(
         current.get("wind_speed_10m"), units.get("wind_speed_10m")
@@ -152,7 +153,7 @@ def parse_openmeteo_current_conditions(data: dict) -> CurrentConditions:
         current.get("pressure_msl"), units.get("pressure_msl")
     )
 
-    feels_like_f, feels_like_c = normalize_temperature(
+    feels_like = normalize_temperature_pair(
         current.get("apparent_temperature"), units.get("apparent_temperature")
     )
 
@@ -183,32 +184,26 @@ def parse_openmeteo_current_conditions(data: dict) -> CurrentConditions:
         units.get("visibility"),
     )
 
-    wind_chill_f = None
-    wind_chill_c = None
-    heat_index_f = None
-    heat_index_c = None
-    if feels_like_f is not None and temp_f is not None:
-        if feels_like_f < temp_f:
-            wind_chill_f = feels_like_f
-            wind_chill_c = feels_like_c
-        elif feels_like_f > temp_f:
-            heat_index_f = feels_like_f
-            heat_index_c = feels_like_c
+    apparent = classify_apparent_temperature(
+        temperature.fahrenheit,
+        feels_like.fahrenheit,
+        feels_like.celsius,
+    )
 
     return CurrentConditions(
-        temperature_f=temp_f,
-        temperature_c=temp_c,
+        temperature_f=temperature.fahrenheit,
+        temperature_c=temperature.celsius,
         condition=resolve_current_condition_description(current),
         humidity=humidity,
-        dewpoint_f=dewpoint_f,
-        dewpoint_c=dewpoint_c,
+        dewpoint_f=dewpoint.fahrenheit,
+        dewpoint_c=dewpoint.celsius,
         wind_speed_mph=wind_speed_mph,
         wind_speed_kph=wind_speed_kph,
         wind_direction=current.get("wind_direction_10m"),
         pressure_in=pressure_in,
         pressure_mb=pressure_mb,
-        feels_like_f=feels_like_f,
-        feels_like_c=feels_like_c,
+        feels_like_f=feels_like.fahrenheit,
+        feels_like_c=feels_like.celsius,
         visibility_miles=visibility_miles,
         visibility_km=visibility_km,
         sunrise_time=sunrise_time,
@@ -217,9 +212,9 @@ def parse_openmeteo_current_conditions(data: dict) -> CurrentConditions:
         snowfall_rate_in=snowfall_rate,
         snow_depth_in=snow_depth_in,
         snow_depth_cm=snow_depth_cm,
-        wind_chill_f=wind_chill_f,
-        wind_chill_c=wind_chill_c,
-        heat_index_f=heat_index_f,
-        heat_index_c=heat_index_c,
+        wind_chill_f=apparent.wind_chill_f,
+        wind_chill_c=apparent.wind_chill_c,
+        heat_index_f=apparent.heat_index_f,
+        heat_index_c=apparent.heat_index_c,
         precipitation_type=precipitation_type,
     )

--- a/src/accessiweather/weather_client_openmeteo_units.py
+++ b/src/accessiweather/weather_client_openmeteo_units.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+from .provider_normalization import normalize_visibility_pair
+
 CM_PER_INCH = 2.54
 FEET_PER_METER = 3.28084
 INCHES_PER_FOOT = 12
-KM_PER_MILE = 1.609344
-METERS_PER_MILE = 1609.344
 VISIBILITY_CAP_MILES = 10.0
 
 
@@ -61,20 +61,5 @@ def normalize_visibility_to_miles_and_km(
     unit: str | None,
 ) -> tuple[float | None, float | None]:
     """Return Open-Meteo visibility normalized to capped miles and kilometers."""
-    if value is None:
-        return None, None
-
-    numeric = float(value)
-    unit_text = _unit_text(unit)
-
-    if "ft" in unit_text or "feet" in unit_text:
-        miles = numeric / 5280
-    elif "km" in unit_text or "kilometer" in unit_text or "kilometre" in unit_text:
-        miles = numeric / KM_PER_MILE
-    elif unit_text in {"mi", "mile", "miles"}:
-        miles = numeric
-    else:
-        miles = numeric / METERS_PER_MILE
-
-    miles = min(miles, VISIBILITY_CAP_MILES)
-    return miles, miles * KM_PER_MILE
+    visibility = normalize_visibility_pair(value, unit, cap_miles=VISIBILITY_CAP_MILES)
+    return visibility.miles, visibility.kilometers

--- a/tests/test_nws_current_parser.py
+++ b/tests/test_nws_current_parser.py
@@ -1,0 +1,44 @@
+"""Regression tests for NWS current-condition parsing."""
+
+from __future__ import annotations
+
+import pytest
+
+from accessiweather.weather_client_nws import parse_nws_current_conditions
+
+
+def test_parse_nws_current_conditions_normalizes_measurements_to_current_model():
+    payload = {
+        "properties": {
+            "temperature": {"value": 0.0, "unitCode": "wmoUnit:degC"},
+            "dewpoint": {"value": -5.0, "unitCode": "wmoUnit:degC"},
+            "relativeHumidity": {"value": 72.4, "unitCode": "wmoUnit:percent"},
+            "windSpeed": {"value": 10.0, "unitCode": "wmoUnit:km_h-1"},
+            "windDirection": {"value": 270},
+            "barometricPressure": {"value": 101325.0, "unitCode": "wmoUnit:Pa"},
+            "visibility": {"value": 1609.344, "unitCode": "wmoUnit:m"},
+            "windChill": {"value": -8.0, "unitCode": "wmoUnit:degC"},
+            "heatIndex": {"value": None, "unitCode": "wmoUnit:degC"},
+            "textDescription": "Mostly Cloudy",
+            "uvIndex": {"value": "2.5"},
+        }
+    }
+
+    current = parse_nws_current_conditions(payload)
+
+    assert current.temperature_f == 32.0
+    assert current.temperature_c == 0.0
+    assert current.dewpoint_f == pytest.approx(23.0)
+    assert current.humidity == 72
+    assert current.wind_speed_mph == pytest.approx(6.21, abs=0.01)
+    assert current.wind_speed_kph == 10.0
+    assert current.wind_direction == 270
+    assert current.pressure_mb == pytest.approx(1013.25)
+    assert current.pressure_in == pytest.approx(29.92, abs=0.01)
+    assert current.visibility_miles == pytest.approx(1.0)
+    assert current.visibility_km == pytest.approx(1.609344)
+    assert current.feels_like_f == pytest.approx(17.6)
+    assert current.wind_chill_f == pytest.approx(17.6)
+    assert current.heat_index_f is None
+    assert current.condition == "Mostly Cloudy"
+    assert current.uv_index == 2.5

--- a/tests/test_provider_normalization.py
+++ b/tests/test_provider_normalization.py
@@ -1,0 +1,103 @@
+"""Tests for shared provider-adapter normalization helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from accessiweather.provider_normalization import (
+    classify_apparent_temperature,
+    normalize_dewpoint_pair,
+    normalize_humidity_percent,
+    normalize_pressure_pair,
+    normalize_pressure_to_pascals,
+    normalize_speed_pair,
+    normalize_temperature_pair,
+    normalize_visibility_pair,
+    pirate_temperature_unit,
+    pirate_visibility_unit,
+    pirate_wind_unit,
+)
+
+
+def test_normalize_temperature_pair_preserves_both_units():
+    temperature = normalize_temperature_pair(20.0, "wmoUnit:degC")
+
+    assert temperature.celsius == 20.0
+    assert temperature.fahrenheit == pytest.approx(68.0)
+
+
+def test_normalize_humidity_supports_provider_fraction_and_percent_values():
+    assert normalize_humidity_percent(0.655, fraction=True) == 66
+    assert normalize_humidity_percent(65.5) == 66
+    assert normalize_humidity_percent("bad") is None
+
+
+def test_normalize_dewpoint_uses_provider_value_before_calculating_fallback():
+    explicit = normalize_dewpoint_pair(
+        10.0,
+        "degC",
+        fallback_temperature_f=80.0,
+        humidity_percent=90,
+    )
+    calculated = normalize_dewpoint_pair(
+        None,
+        "degF",
+        fallback_temperature_f=68.0,
+        humidity_percent=65,
+    )
+
+    assert explicit.celsius == 10.0
+    assert explicit.fahrenheit == pytest.approx(50.0)
+    assert calculated.fahrenheit is not None
+    assert calculated.celsius is not None
+
+
+def test_normalize_pressure_supports_display_pairs_and_pascal_mapper_units():
+    pressure = normalize_pressure_pair(1013.25, "hPa")
+
+    assert pressure.millibars == 1013.25
+    assert pressure.inches == pytest.approx(29.92, abs=0.01)
+    assert normalize_pressure_to_pascals(29.92, "inHg") == pytest.approx(101320.7888)
+
+
+def test_normalize_speed_pair_accepts_provider_unit_labels():
+    si_speed = normalize_speed_pair(10.0, "m/s")
+    ca_speed = normalize_speed_pair(16.09344, "km/h")
+
+    assert si_speed.mph == pytest.approx(22.37, abs=0.01)
+    assert si_speed.kph == pytest.approx(36.0)
+    assert ca_speed.mph == pytest.approx(10.0, abs=0.01)
+
+
+def test_normalize_visibility_supports_capped_and_uncapped_provider_paths():
+    capped = normalize_visibility_pair(52800.0, "ft", cap_miles=10.0)
+    pirate_metric = normalize_visibility_pair(16.09344, "km")
+
+    assert capped.miles == pytest.approx(10.0)
+    assert capped.kilometers == pytest.approx(16.09344)
+    assert pirate_metric.miles == pytest.approx(10.0)
+    assert pirate_metric.kilometers == pytest.approx(16.09344)
+
+
+def test_classify_apparent_temperature_splits_chill_and_heat_index():
+    chill = classify_apparent_temperature(32.0, 25.0, -3.8889)
+    heat = classify_apparent_temperature(90.0, 98.0, 36.6667)
+    neutral = classify_apparent_temperature(72.0, 72.0, 22.2222)
+
+    assert chill.wind_chill_f == 25.0
+    assert chill.heat_index_f is None
+    assert heat.heat_index_f == 98.0
+    assert heat.wind_chill_f is None
+    assert neutral.wind_chill_f is None
+    assert neutral.heat_index_f is None
+
+
+def test_pirate_unit_group_helpers_preserve_existing_adapter_contract():
+    assert pirate_temperature_unit("us") == "F"
+    assert pirate_temperature_unit("uk2") == "C"
+    assert pirate_wind_unit("uk2") == "mph"
+    assert pirate_wind_unit("ca") == "km/h"
+    assert pirate_wind_unit("si") == "m/s"
+    assert pirate_visibility_unit("us") == "mi"
+    assert pirate_visibility_unit("uk2") == "mi"
+    assert pirate_visibility_unit("si") == "km"


### PR DESCRIPTION
## Summary
- Centralizes shared provider normalization for temperature, humidity, dewpoint fallback, pressure, wind, visibility, Pirate Weather unit groups, and apparent-temperature classification.
- Wires NWS, Open-Meteo, and Pirate Weather parser/adapters through the shared helpers while preserving existing CurrentConditions, Forecast, HourlyForecast, and alert contracts.
- Keeps raw provider payload handling inside adapter/parser boundaries; no UI or notification surface changes intended.

## Behavior preserved
- Public weather model fields and provider fetch flows are unchanged.
- Existing Open-Meteo current/daily/hourly, Pirate Weather current/daily/hourly/alerts, and NWS current/forecast/hourly pressure behavior are covered by regression tests.

## Tests
- `pytest tests\\test_provider_normalization.py tests\\test_nws_current_parser.py tests\\test_weather_client_openmeteo_parser.py tests\\test_pirate_weather_client.py tests\\test_nws_high_low.py tests\\test_openmeteo_mapper.py tests\\test_parsers.py -q`
- `ruff check src\\accessiweather\\provider_normalization.py src\\accessiweather\\weather_client_openmeteo.py src\\accessiweather\\weather_client_openmeteo_current.py src\\accessiweather\\weather_client_openmeteo_units.py src\\accessiweather\\weather_client_nws_parsers.py src\\accessiweather\\pirate_weather_current.py src\\accessiweather\\pirate_weather_parsing.py src\\accessiweather\\openmeteo_mapper.py tests\\test_provider_normalization.py tests\\test_nws_current_parser.py`

## Accessibility
- Desktop accessibility impact reviewed: this is non-UI provider parsing plumbing only.
- No wx controls, focus behavior, labels, screen-reader APIs, or presentation/display modules were touched, so no deeper manual desktop UI testing was needed.

## Changelog
- Internal-only refactor; commit includes `Changelog: none`.
- Applying `skip-changelog` label for the changelog gate.