### PR TITLE
fix: avoid missing feels-like tray text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,9 @@ asyncio.create_task(background_refresh())
 - GUI-focused tests may use the wx stub or live wx under xvfb/Windows only when needed.
 - Integration tests live under `tests/integration/` and should avoid live API dependence unless explicitly intended.
 - Use Hypothesis for broad input-space edge cases.
+- Use the Hypothesis testing framework to good effect for bugs involving many
+  combinations of provider data, missing fields, units, priorities, or fallback
+  behavior.
 
 ### Test Quality Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Unknown or uncategorized weather alerts now have a mappable default sound, and missing custom-pack event sounds fall back to the matching default sound before generic notification audio.
 - NOAA Weather Radio Station Finder now repopulates stations when leaving an empty Favorites view, so you no longer need to reopen the radio dialog.
+- Feels-like temperatures now keep showing in tray text when only one temperature unit is available, instead of falling back to `N/A`.
 
 ## [0.7.2] - 2026-05-30
 

--- a/src/accessiweather/taskbar_icon_updater.py
+++ b/src/accessiweather/taskbar_icon_updater.py
@@ -219,21 +219,21 @@ class TaskbarIconUpdater:
         if feels_f is None and feels_c is None:
             return PLACEHOLDER_NA
 
+        if feels_f is None and feels_c is not None:
+            feels_f = celsius_to_fahrenheit(feels_c)
+        if feels_c is None and feels_f is not None:
+            feels_c = fahrenheit_to_celsius(feels_f)
+
+        assert feels_f is not None
+        assert feels_c is not None
+
         effective_unit = self._resolve_temperature_unit()
 
         if effective_unit == TemperatureUnit.FAHRENHEIT:
             return self._format_temp_value(feels_f, "F")
         if effective_unit == TemperatureUnit.CELSIUS:
-            if feels_c is not None:
-                return self._format_temp_value(feels_c, "C")
-            return PLACEHOLDER_NA
-        if feels_f is not None and feels_c is not None:
-            return f"{feels_f:.0f}F/{feels_c:.0f}C"
-        if feels_f is not None:
-            return f"{feels_f:.0f}F"
-        if feels_c is not None:
-            return f"{feels_c:.0f}C"
-        return PLACEHOLDER_NA
+            return self._format_temp_value(feels_c, "C")
+        return f"{feels_f:.0f}F/{feels_c:.0f}C"
 
     def _format_temp_value(self, value: float | None, suffix: str) -> str:
         """Format a single temperature value."""

--- a/tests/test_system_tray.py
+++ b/tests/test_system_tray.py
@@ -10,6 +10,10 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from hypothesis import (
+    given,
+    strategies as st,
+)
 
 from accessiweather.models import AppSettings, CurrentConditions, Location, WeatherData
 
@@ -614,6 +618,85 @@ class TestFormatterUnitPreferencePlaceholders:
         result = updater.format_tooltip(weather_data, "Test City")
 
         assert result == "N/A / N/A"
+
+
+def _weather_data_with_feels_like(
+    *,
+    feels_like_f: float | None = None,
+    feels_like_c: float | None = None,
+) -> WeatherData:
+    return WeatherData(
+        location=Location(name="Test City", latitude=40.0, longitude=-74.0),
+        current=CurrentConditions(
+            temperature_f=72.0,
+            temperature_c=22.2,
+            condition="Sunny",
+            feels_like_f=feels_like_f,
+            feels_like_c=feels_like_c,
+        ),
+    )
+
+
+def _expected_feels_like_text(value: float, source_unit: str, temperature_unit: str) -> str:
+    feels_f = value if source_unit == "f" else (value * 9 / 5) + 32
+    feels_c = value if source_unit == "c" else (value - 32) * 5 / 9
+    if temperature_unit == "f":
+        return f"{feels_f:.0f}F"
+    if temperature_unit == "c":
+        return f"{feels_c:.0f}C"
+    return f"{feels_f:.0f}F/{feels_c:.0f}C"
+
+
+class TestFeelsLikeFormatterFallbacks:
+    """Regression tests for partially populated feels-like values in tray text."""
+
+    @pytest.mark.parametrize(
+        ("temperature_unit", "weather_data", "expected"),
+        [
+            ("f", _weather_data_with_feels_like(feels_like_c=20.0), "68F"),
+            ("c", _weather_data_with_feels_like(feels_like_f=68.0), "20C"),
+            ("both", _weather_data_with_feels_like(feels_like_c=20.0), "68F/20C"),
+            ("both", _weather_data_with_feels_like(feels_like_f=68.0), "68F/20C"),
+            ("f", _weather_data_with_feels_like(), "N/A"),
+        ],
+    )
+    def test_feels_like_converts_missing_counterpart_unit(
+        self, temperature_unit, weather_data, expected
+    ):
+        from accessiweather.taskbar_icon_updater import TaskbarIconUpdater
+
+        updater = TaskbarIconUpdater(
+            text_enabled=True,
+            format_string="{feels_like}",
+            temperature_unit=temperature_unit,
+        )
+
+        result = updater.format_tooltip(weather_data, "Test City")
+
+        assert result == expected
+
+    @given(
+        value=st.floats(min_value=-80.0, max_value=130.0, allow_nan=False, allow_infinity=False),
+        source_unit=st.sampled_from(("f", "c")),
+        temperature_unit=st.sampled_from(("f", "c", "both")),
+    )
+    def test_feels_like_partial_unit_property(self, value, source_unit, temperature_unit):
+        from accessiweather.taskbar_icon_updater import TaskbarIconUpdater
+
+        weather_data = _weather_data_with_feels_like(
+            feels_like_f=value if source_unit == "f" else None,
+            feels_like_c=value if source_unit == "c" else None,
+        )
+        updater = TaskbarIconUpdater(
+            text_enabled=True,
+            format_string="{feels_like}",
+            temperature_unit=temperature_unit,
+        )
+
+        result = updater.format_tooltip(weather_data, "Test City")
+
+        assert result == _expected_feels_like_text(value, source_unit, temperature_unit)
+        assert result.lower() != "n/a"
 
 
 class TestPopupMenu:

--- a/tests/test_weather_client_fusion.py
+++ b/tests/test_weather_client_fusion.py
@@ -340,6 +340,23 @@ class TestMergeCurrentConditions:
         assert attr.field_sources["wind_speed_mph"] == "openmeteo"
         assert attr.field_sources["wind_speed_kph"] == "openmeteo"
 
+    def test_feels_like_falls_back_when_nws_omits_apparent_temperature(self, engine, us_location):
+        """NWS may omit feels-like, but that must not hide Open-Meteo apparent temperature."""
+        nws_cc = CurrentConditions(temperature_f=72.0, temperature_c=22.2)
+        om_cc = CurrentConditions(temperature_f=70.0, temperature_c=21.1, feels_like_c=19.0)
+        sources = [
+            _make_source("nws", current=nws_cc),
+            _make_source("openmeteo", current=om_cc),
+        ]
+
+        result, attr = engine.merge_current_conditions(sources, us_location)
+
+        assert result is not None
+        assert result.feels_like_f == pytest.approx(66.2)
+        assert result.feels_like_c == pytest.approx(19.0)
+        assert attr.field_sources["feels_like_f"] == "openmeteo"
+        assert attr.field_sources["feels_like_c"] == "openmeteo"
+
     def test_us_strips_openmeteo_snow_depth(self, engine, us_location):
         """Open-Meteo snow depth (ERA5/GFS model) is stripped for US locations."""
         nws_cc = CurrentConditions(temperature_f=32.0, snow_depth_in=None, snow_depth_cm=None)


### PR DESCRIPTION
## Summary
- Convert one-sided feels-like values in tray text so Fahrenheit, Celsius, and both-units preferences do not fall back to `N/A` when either unit is available.
- Add regression coverage for F-only/C-only feels-like formatting, including Hypothesis coverage for partial-unit inputs.
- Add a Smart Auto fusion guard for NWS missing feels-like while another source supplies apparent temperature.
- Document that Hypothesis should be used for provider-data, missing-field, unit, priority, and fallback edge cases.

## Verification
- `pytest tests\test_weather_client_fusion.py tests\test_system_tray.py tests\test_current_conditions.py tests\test_tray_text_format_dialog.py -v` -> 237 passed
- `ruff check src\accessiweather\taskbar_icon_updater.py tests\test_weather_client_fusion.py tests\test_system_tray.py` -> passed
- `ruff format --check src\accessiweather\taskbar_icon_updater.py tests\test_weather_client_fusion.py tests\test_system_tray.py` -> passed
- `git --no-pager diff --check --cached` -> passed before commit

## Accessibility
No wx control structure, keyboard path, focus behavior, or accessible names changed. This improves screen-reader-facing tray/status text by avoiding false `N/A` when a feels-like temperature exists in one unit. No deeper live screen-reader traversal was needed for this text-only formatter change.