### PR TITLE
[codex] Fix SAME weather radio auto-tune

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Current conditions and tray text now omit feels-like or heat-index details when they are unavailable instead of announcing them as `N/A`.
+- NOAA Weather Radio auto-tune now starts only for the first issuance of a qualifying SAME alert, reliably stops after your configured playback duration, and no longer restarts for later updates or cancellations of the same alert.
 - Feels-like and heat-index readings now ignore implausibly warm provider values when the current temperature and humidity do not support them, while keeping valid humid heat-index and cold wind-chill readings.
 - Unknown or uncategorized weather alerts now have a mappable default sound, and missing custom-pack event sounds fall back to the matching default sound before generic notification audio.
 - NOAA Weather Radio Station Finder now repopulates stations when leaving an empty Favorites view, so you no longer need to reopen the radio dialog.

--- a/src/accessiweather/alert_notification_system.py
+++ b/src/accessiweather/alert_notification_system.py
@@ -36,6 +36,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _is_initial_alert_message_type(alert: WeatherAlert) -> bool:
+    """
+    Return whether alert metadata represents the initial alert issuance.
+
+    NWS supplies ``messageType`` values such as Alert, Update, and Cancel.  For
+    non-NWS/provider-neutral alerts, keep the previous behavior and allow
+    missing metadata through when the AlertManager says the alert itself is new.
+    """
+    message_type = alert.message_type
+    if message_type is None:
+        return True
+    return message_type.strip().casefold() in {"", "alert"}
+
+
 class AlertNotificationSystem:
     """Enhanced notification system with user controls and accessibility features."""
 
@@ -153,13 +167,18 @@ class AlertNotificationSystem:
         self,
         sorted_notifications: list[tuple[WeatherAlert, str]],
     ) -> None:
-        """Start or extend NOAA radio auto-tune for the eligible alert batch."""
+        """Start NOAA radio auto-tune only for newly issued alert notifications."""
         if self.radio_auto_tuner is None:
             return
+        initial_alerts = [
+            alert
+            for alert, reason in sorted_notifications
+            if reason == "new_alert" and _is_initial_alert_message_type(alert)
+        ]
+        if not initial_alerts:
+            return
         try:
-            self.radio_auto_tuner.tune_for_alerts(
-                [alert for alert, _reason in sorted_notifications]
-            )
+            self.radio_auto_tuner.tune_for_alerts(initial_alerts)
         except Exception as exc:
             logger.warning("Failed to schedule weather radio auto-tune: %s", exc)
 

--- a/src/accessiweather/noaa_radio/alert_auto_tune.py
+++ b/src/accessiweather/noaa_radio/alert_auto_tune.py
@@ -487,22 +487,17 @@ class AlertRadioAutoTuner:
                 self._wake_event.wait(min(remaining, 1.0))
                 self._wake_event.clear()
 
-                if not self._session.is_playing():
+                playing_station = self._session.playing_station
+                if playing_station is None:
                     logger.info("Weather radio auto-tune ended because playback stopped")
                     return
-
-                playing_station = self._session.playing_station
-                if playing_station is None or playing_station.call_sign != station.call_sign:
+                if playing_station.call_sign != station.call_sign:
                     logger.info("Weather radio auto-tune relinquished control to manual playback")
                     return
 
             playing_station = self._session.playing_station
-            if (
-                self._session.is_playing()
-                and playing_station is not None
-                and playing_station.call_sign == station.call_sign
-            ):
-                self._session.stop()
+            if playing_station is not None and playing_station.call_sign == station.call_sign:
+                self._stop_auto_playback()
                 self._emit_status(f"Weather radio auto-tune stopped {station.call_sign}.")
         finally:
             with self._lock:
@@ -544,6 +539,13 @@ class AlertRadioAutoTuner:
                 self._session.playing_station = None
         self._emit_status(f"Weather radio auto-tune could not start {station.call_sign}.")
         return False
+
+    def _stop_auto_playback(self) -> None:
+        """Stop playback owned by the auto-tuner without trusting backend play state."""
+        try:
+            self._session.stop()
+        except Exception as exc:
+            logger.warning("Weather radio auto-tune failed to stop playback: %s", exc)
 
     def _is_auto_tune_active_locked(self, now: float) -> bool:
         return self._worker is not None and (

--- a/tests/test_alert_notification_system.py
+++ b/tests/test_alert_notification_system.py
@@ -149,6 +149,89 @@ class TestAlertNotificationBatchSound:
             "Minor",
         ]
 
+    def test_radio_auto_tune_receives_only_new_initial_alert_notifications(
+        self, alert_manager, mock_notifier
+    ):
+        """Update/cancel notifications should not re-trigger NOAA radio auto-tune."""
+        radio_auto_tuner = MagicMock()
+        notification_system = AlertNotificationSystem(
+            alert_manager=alert_manager,
+            notifier=mock_notifier,
+            radio_auto_tuner=radio_auto_tuner,
+        )
+        now = datetime.now(UTC)
+        initial_alert = WeatherAlert(
+            id="nws-alert-1",
+            title="Tornado Warning",
+            description="Take shelter now.",
+            severity="Extreme",
+            urgency="Immediate",
+            certainty="Observed",
+            event="Tornado Warning",
+            message_type="Alert",
+            expires=now + timedelta(hours=1),
+        )
+        updated_alert = WeatherAlert(
+            id="nws-alert-1",
+            title="Tornado Warning",
+            description="Updated shelter instruction.",
+            severity="Extreme",
+            urgency="Immediate",
+            certainty="Observed",
+            event="Tornado Warning",
+            message_type="Update",
+            expires=now + timedelta(hours=1),
+        )
+        cancelled_alert = WeatherAlert(
+            id="nws-alert-1",
+            title="Tornado Warning",
+            description="Cancelled.",
+            severity="Extreme",
+            urgency="Immediate",
+            certainty="Observed",
+            event="Tornado Warning",
+            message_type="Cancel",
+            expires=now + timedelta(hours=1),
+        )
+
+        notification_system._trigger_radio_auto_tune_if_enabled(
+            [
+                (updated_alert, "content_changed"),
+                (cancelled_alert, "new_alert"),
+                (initial_alert, "new_alert"),
+            ]
+        )
+
+        radio_auto_tuner.tune_for_alerts.assert_called_once_with([initial_alert])
+
+    def test_radio_auto_tune_skips_changed_notification_for_same_alert(
+        self, alert_manager, mock_notifier
+    ):
+        """A later update for the same alert ID should not start a new radio tune."""
+        radio_auto_tuner = MagicMock()
+        notification_system = AlertNotificationSystem(
+            alert_manager=alert_manager,
+            notifier=mock_notifier,
+            radio_auto_tuner=radio_auto_tuner,
+        )
+        updated_alert = WeatherAlert(
+            id="nws-alert-2",
+            title="Severe Thunderstorm Warning",
+            description="Updated warning text.",
+            severity="Severe",
+            urgency="Immediate",
+            certainty="Observed",
+            event="Severe Thunderstorm Warning",
+            message_type="Update",
+            expires=datetime.now(UTC) + timedelta(hours=1),
+        )
+
+        notification_system._trigger_radio_auto_tune_if_enabled(
+            [(updated_alert, "content_changed")]
+        )
+
+        radio_auto_tuner.tune_for_alerts.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_most_severe_alert_plays_sound(
         self, notification_system, mock_notifier, multiple_alerts

--- a/tests/test_alert_radio_auto_tune.py
+++ b/tests/test_alert_radio_auto_tune.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
@@ -28,6 +29,23 @@ class _FakeThread:
 
     def start(self):
         self._started.append(self._target)
+
+
+class _FakeWakeEvent:
+    def __init__(self) -> None:
+        self.wait_calls = []
+        self.set_calls = 0
+        self.clear_calls = 0
+
+    def wait(self, timeout: float | None = None) -> bool:
+        self.wait_calls.append(timeout)
+        return False
+
+    def set(self) -> None:
+        self.set_calls += 1
+
+    def clear(self) -> None:
+        self.clear_calls += 1
 
 
 class _FakePlayer:
@@ -143,6 +161,7 @@ def _make_tuner(
     session: _FakeSession | None = None,
     resolver=None,
     started: list | None = None,
+    monotonic=None,
 ):
     started = started if started is not None else []
     session = session or _FakeSession()
@@ -158,6 +177,7 @@ def _make_tuner(
         station_resolver=resolver,
         url_provider=url_provider,
         thread_factory=lambda target: _FakeThread(target, started),
+        monotonic=monotonic or time.monotonic,
     )
     return tuner, session, started, url_provider, resolver
 
@@ -482,14 +502,45 @@ def test_auto_tune_invalid_duration_defaults_to_five_minutes_and_stops_playback(
     times = iter([100.0, 401.0])
     tuner, session, started, _url_provider, _resolver = _make_tuner(
         settings=_settings(auto_tune_weather_radio_duration_minutes=0),
+        monotonic=lambda: next(times),
     )
-    tuner._monotonic = lambda: next(times)
 
     tuner.tune_for_alerts([_alert()])
     started[0]()
 
     session.stop.assert_called_once_with()
     assert session.is_playing() is False
+
+
+def test_auto_tune_uses_configured_duration_for_stop_deadline():
+    times = iter([100.0, 579.0, 580.0])
+    tuner, session, started, _url_provider, _resolver = _make_tuner(
+        settings=_settings(auto_tune_weather_radio_duration_minutes=8),
+        monotonic=lambda: next(times),
+    )
+    wake_event = _FakeWakeEvent()
+    tuner._wake_event = wake_event
+
+    tuner.tune_for_alerts([_alert()])
+    started[0]()
+
+    assert wake_event.wait_calls == [1.0]
+    session.stop.assert_called_once_with()
+
+
+def test_auto_tune_timer_stops_even_when_backend_play_state_is_stale_false():
+    times = iter([100.0, 101.0, 401.0])
+    tuner, session, started, _url_provider, _resolver = _make_tuner(monotonic=lambda: next(times))
+    session.player = _FakePlayer()
+    wake_event = _FakeWakeEvent()
+    tuner._wake_event = wake_event
+
+    tuner.tune_for_alerts([_alert()])
+    started[0]()
+
+    assert wake_event.wait_calls == [1.0]
+    session.stop.assert_called_once_with()
+    assert session.playing_station is None
 
 
 def test_stop_cancels_pending_auto_tune_before_stream_starts():
@@ -541,6 +592,35 @@ def test_duplicate_alert_batch_extends_existing_auto_tune_without_overlap():
     tuner.tune_for_alerts([_alert()])
 
     assert len(started) == 1
+
+
+def test_duplicate_alert_batch_extends_existing_auto_tune_deadline():
+    times = iter([100.0, 150.0, 399.0, 450.0])
+    tuner, session, started, _url_provider, _resolver = _make_tuner(monotonic=lambda: next(times))
+    wake_event = _FakeWakeEvent()
+    tuner._wake_event = wake_event
+
+    tuner.tune_for_alerts([_alert()])
+    tuner.tune_for_alerts([_alert()])
+    started[0]()
+
+    assert len(started) == 1
+    assert wake_event.set_calls == 1
+    assert wake_event.wait_calls == [1.0]
+    session.stop.assert_called_once_with()
+
+
+def test_auto_tune_timer_cleans_up_when_stop_raises():
+    times = iter([100.0, 401.0])
+    tuner, session, started, _url_provider, _resolver = _make_tuner(monotonic=lambda: next(times))
+    session.stop = MagicMock(side_effect=RuntimeError("stop failed"))
+
+    tuner.tune_for_alerts([_alert()])
+    started[0]()
+
+    session.stop.assert_called_once_with()
+    assert tuner._worker is None
+    assert tuner._stop_at_monotonic is None
 
 
 def test_manual_playback_is_respected_and_not_interrupted():

--- a/tests/test_current_location.py
+++ b/tests/test_current_location.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -12,6 +14,20 @@ import pytest
 from accessiweather.config.config_manager import ConfigManager
 from accessiweather.config.locations import LocationOperations
 from accessiweather.models import AppConfig, AppSettings
+
+
+def _current_location_module():
+    """Return the real module even if the package attribute was shadowed."""
+    module = sys.modules.get("accessiweather.current_location")
+    if not isinstance(module, ModuleType):
+        sys.modules.pop("accessiweather.current_location", None)
+        module = importlib.import_module("accessiweather.current_location")
+
+    import accessiweather
+
+    if getattr(accessiweather, "current_location", None) is not module:
+        accessiweather.current_location = module
+    return module
 
 
 class _FakeConfigManager:
@@ -152,7 +168,7 @@ class TestCurrentLocationProviders:
     async def test_factory_returns_unsupported_provider_on_linux(self, monkeypatch):
         from accessiweather.current_location import UnsupportedLocationProvider, get_native_provider
 
-        monkeypatch.setattr("accessiweather.current_location.sys.platform", "linux")
+        monkeypatch.setattr(_current_location_module().sys, "platform", "linux")
 
         provider = get_native_provider()
 
@@ -161,7 +177,7 @@ class TestCurrentLocationProviders:
     async def test_factory_returns_windows_provider_on_windows(self, monkeypatch):
         from accessiweather.current_location import WindowsLocationProvider, get_native_provider
 
-        monkeypatch.setattr("accessiweather.current_location.sys.platform", "win32")
+        monkeypatch.setattr(_current_location_module().sys, "platform", "win32")
 
         provider = get_native_provider()
 
@@ -170,7 +186,7 @@ class TestCurrentLocationProviders:
     async def test_factory_returns_macos_provider_on_macos(self, monkeypatch):
         from accessiweather.current_location import MacOSLocationProvider, get_native_provider
 
-        monkeypatch.setattr("accessiweather.current_location.sys.platform", "darwin")
+        monkeypatch.setattr(_current_location_module().sys, "platform", "darwin")
 
         provider = get_native_provider()
 
@@ -323,7 +339,7 @@ class TestWindowsCurrentLocationProvider:
                 raise ModuleNotFoundError(name)
             raise AssertionError(name)
 
-        monkeypatch.setattr("accessiweather.current_location.importlib.import_module", fake_import)
+        monkeypatch.setattr(_current_location_module().importlib, "import_module", fake_import)
 
         with pytest.raises(CurrentLocationError) as exc_info:
             await WindowsLocationProvider().detect()
@@ -344,7 +360,8 @@ class TestWindowsCurrentLocationProvider:
 
         fake_geolocation = SimpleNamespace(Geolocator=FakeGeolocator)
         monkeypatch.setattr(
-            "accessiweather.current_location.importlib.import_module",
+            _current_location_module().importlib,
+            "import_module",
             lambda name: fake_geolocation,
         )
 
@@ -371,10 +388,11 @@ class TestWindowsCurrentLocationProvider:
 
         fake_geolocation = SimpleNamespace(Geolocator=FakeGeolocator)
         monkeypatch.setattr(
-            "accessiweather.current_location.importlib.import_module",
+            _current_location_module().importlib,
+            "import_module",
             lambda name: fake_geolocation,
         )
-        monkeypatch.setattr("accessiweather.current_location.asyncio.wait_for", fake_wait_for)
+        monkeypatch.setattr(_current_location_module().asyncio, "wait_for", fake_wait_for)
 
         with pytest.raises(CurrentLocationError) as exc_info:
             await WindowsLocationProvider().detect()
@@ -409,10 +427,11 @@ class TestWindowsCurrentLocationProvider:
 
         fake_geolocation = SimpleNamespace(Geolocator=FakeGeolocator)
         monkeypatch.setattr(
-            "accessiweather.current_location.importlib.import_module",
+            _current_location_module().importlib,
+            "import_module",
             lambda name: fake_geolocation,
         )
-        monkeypatch.setattr("accessiweather.current_location.asyncio.wait_for", fake_wait_for)
+        monkeypatch.setattr(_current_location_module().asyncio, "wait_for", fake_wait_for)
 
         with pytest.raises(CurrentLocationError) as exc_info:
             await WindowsLocationProvider().detect()
@@ -440,7 +459,8 @@ class TestWindowsCurrentLocationProvider:
             PositionAccuracy=SimpleNamespace(DEFAULT="default"),
         )
         monkeypatch.setattr(
-            "accessiweather.current_location.importlib.import_module",
+            _current_location_module().importlib,
+            "import_module",
             lambda name: fake_geolocation,
         )
 
@@ -464,7 +484,7 @@ class TestMacOSCurrentLocationProvider:
                 raise ModuleNotFoundError(name)
             raise AssertionError(name)
 
-        monkeypatch.setattr("accessiweather.current_location.importlib.import_module", fake_import)
+        monkeypatch.setattr(_current_location_module().importlib, "import_module", fake_import)
 
         with pytest.raises(CurrentLocationError) as exc_info:
             await MacOSLocationProvider().detect()
@@ -478,10 +498,11 @@ class TestMacOSCurrentLocationProvider:
             "success-request-location"
         )
         monkeypatch.setattr(
-            "accessiweather.current_location.importlib.import_module",
+            _current_location_module().importlib,
+            "import_module",
             lambda name: fake_core_location if name == "CoreLocation" else fake_foundation,
         )
-        monkeypatch.setattr("accessiweather.current_location.threading.Thread", _ImmediateThread)
+        monkeypatch.setattr(_current_location_module().threading, "Thread", _ImmediateThread)
 
         coordinates = await MacOSLocationProvider().detect(timeout_seconds=0.1)
 
@@ -494,10 +515,11 @@ class TestMacOSCurrentLocationProvider:
 
         fake_foundation, fake_core_location = _fake_core_location_modules("success-start-updating")
         monkeypatch.setattr(
-            "accessiweather.current_location.importlib.import_module",
+            _current_location_module().importlib,
+            "import_module",
             lambda name: fake_core_location if name == "CoreLocation" else fake_foundation,
         )
-        monkeypatch.setattr("accessiweather.current_location.threading.Thread", _ImmediateThread)
+        monkeypatch.setattr(_current_location_module().threading, "Thread", _ImmediateThread)
 
         coordinates = await MacOSLocationProvider().detect(timeout_seconds=0.1)
 
@@ -514,10 +536,11 @@ class TestMacOSCurrentLocationProvider:
 
         fake_foundation, fake_core_location = _fake_core_location_modules("failure")
         monkeypatch.setattr(
-            "accessiweather.current_location.importlib.import_module",
+            _current_location_module().importlib,
+            "import_module",
             lambda name: fake_core_location if name == "CoreLocation" else fake_foundation,
         )
-        monkeypatch.setattr("accessiweather.current_location.threading.Thread", _ImmediateThread)
+        monkeypatch.setattr(_current_location_module().threading, "Thread", _ImmediateThread)
 
         with pytest.raises(CurrentLocationError) as exc_info:
             await MacOSLocationProvider().detect(timeout_seconds=0.1)
@@ -533,10 +556,11 @@ class TestMacOSCurrentLocationProvider:
 
         fake_foundation, fake_core_location = _fake_core_location_modules("denied")
         monkeypatch.setattr(
-            "accessiweather.current_location.importlib.import_module",
+            _current_location_module().importlib,
+            "import_module",
             lambda name: fake_core_location if name == "CoreLocation" else fake_foundation,
         )
-        monkeypatch.setattr("accessiweather.current_location.threading.Thread", _ImmediateThread)
+        monkeypatch.setattr(_current_location_module().threading, "Thread", _ImmediateThread)
 
         with pytest.raises(CurrentLocationError) as exc_info:
             await MacOSLocationProvider().detect(timeout_seconds=0.1)
@@ -556,11 +580,12 @@ class TestMacOSCurrentLocationProvider:
             raise TimeoutError
 
         monkeypatch.setattr(
-            "accessiweather.current_location.importlib.import_module",
+            _current_location_module().importlib,
+            "import_module",
             lambda name: fake_core_location if name == "CoreLocation" else fake_foundation,
         )
-        monkeypatch.setattr("accessiweather.current_location.threading.Thread", _ImmediateThread)
-        monkeypatch.setattr("accessiweather.current_location.asyncio.wait_for", fake_wait_for)
+        monkeypatch.setattr(_current_location_module().threading, "Thread", _ImmediateThread)
+        monkeypatch.setattr(_current_location_module().asyncio, "wait_for", fake_wait_for)
 
         with pytest.raises(CurrentLocationError) as exc_info:
             await MacOSLocationProvider().detect(timeout_seconds=0.1)


### PR DESCRIPTION
## Summary

Fixes NOAA Weather Radio auto-tune behavior for SAME alerts.

- Auto-tune now starts only for newly issued SAME alerts, not updates or cancellations for the same alert.
- The auto-tune worker no longer abandons its stop deadline when the backend play-state flag is stale.
- Auto-tuned playback stops after the configured `auto_tune_weather_radio_duration_minutes` value; five minutes remains only the default/fallback for invalid settings.
- Adds focused regression coverage for SAME update/cancel filtering, stale playback state, configured duration, deadline extension, and stop cleanup.

## Root Cause

The notification system passed every alert notification batch to the radio auto-tuner, including `content_changed` update notifications. The worker also trusted `session.is_playing()` during its countdown, so stale backend state could make it exit without stopping the stream it started.

## Verification

- `uv run pytest tests/test_alert_notification_system.py::TestAlertNotificationBatchSound tests/test_alert_radio_auto_tune.py -v` -> 40 passed
- `uv run ruff check src/accessiweather/noaa_radio/alert_auto_tune.py tests/test_alert_radio_auto_tune.py src/accessiweather/alert_notification_system.py tests/test_alert_notification_system.py` -> passed
- `uv run python -m compileall src/accessiweather/alert_notification_system.py src/accessiweather/noaa_radio/alert_auto_tune.py` -> passed
- `uv run python scripts/changelog_tools.py check --base dev` -> passed
- `git --no-pager diff --check` -> passed

## Accessibility Impact

Logic-only background playback and notification routing change. No wx controls, labels, focus behavior, or screen reader announcements changed, so no deeper manual UI or screen reader pass was needed.